### PR TITLE
Adds a basic configuration builder

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.31'
+    ext.kotlin_version = '1.3.72'
     repositories {
         google()
         jcenter()

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,15 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
+    ext.kotlin_version = '1.3.31'
     repositories {
         google()
         jcenter()
-        
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.4.2'
-        
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -22,12 +22,24 @@ android {
 }
 
 dependencies {
+    /***** Main Dependencies *****/
     implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation 'androidx.appcompat:appcompat:1.2.0'
+    //Kotlin Dependencies
     implementation "androidx.core:core-ktx:1.3.1"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.72"
-    implementation 'androidx.appcompat:appcompat:1.2.0'
+
+    /***** Testing Dependencies *****/
     testImplementation 'junit:junit:4.12'
+    testImplementation 'androidx.test:runner:1.2.0'
+    testImplementation 'androidx.test:rules:1.2.0'
+    // Mocking Dependencies - Mockito-inline is needed to navigate around Kotlin final class errors
+    testImplementation 'org.mockito:mockito-inline:3.4.0'
     testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0"
+    // JSON is bundled with the Android SDK so we need real objects to test against
+    testImplementation "org.json:json:20200518"
+
+    /***** Instrumentation Testing Dependencies *****/
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -24,7 +24,7 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "androidx.core:core-ktx:1.0.1"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.72"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.72"
     implementation 'androidx.appcompat:appcompat:1.1.0'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.2.0'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.72"
     implementation 'androidx.appcompat:appcompat:1.2.0'
     testImplementation 'junit:junit:4.12'
+    testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0"
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,4 +1,6 @@
 apply plugin: 'com.android.application'
+apply plugin: 'kotlin-android-extensions'
+apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 29
@@ -21,6 +23,8 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation "androidx.core:core-ktx:1.0.1"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.72"
     implementation 'androidx.appcompat:appcompat:1.1.0'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.2.0'

--- a/core/src/main/AndroidManifest.xml
+++ b/core/src/main/AndroidManifest.xml
@@ -1,1 +1,4 @@
-<manifest package="com.klaviyo.coresdk" />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.klaviyo.coresdk">
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+</manifest>

--- a/core/src/main/java/com/klaviyo/coresdk/KlaviyoConfig.kt
+++ b/core/src/main/java/com/klaviyo/coresdk/KlaviyoConfig.kt
@@ -7,33 +7,15 @@ class KlaviyoMissingAPIKeyException: Exception("You must declare an API key for 
 
 class KlaviyoMissingContextException: Exception("You must add your application context to the Klaviyo SDK")
 
-class KlaviyoConfig private constructor(
-        apiKey: String,
-        applicationContext: Context?,
-        networkTimeout: Int,
-        networkFlushInterval: Int) {
-    companion object {
+class KlaviyoConfig {
+    internal companion object {
         private const val NETWORK_TIMEOUT_DEFAULT: Int = 500
         private const val NETWORK_FLUSH_INTERVAL_DEFAULT: Int = 60000
-    }
 
-    val apiKey: String
-    val applicationContext: Context?
-    val networkTimeout: Int
-    val networkFlushInterval: Int
-
-    init {
-        if (apiKey.isNullOrEmpty()) {
-            throw KlaviyoMissingAPIKeyException()
-        }
-        if (applicationContext == null) {
-            throw KlaviyoMissingContextException()
-        }
-
-        this.apiKey = apiKey
-        this.applicationContext = applicationContext
-        this.networkTimeout = networkTimeout
-        this.networkFlushInterval = networkFlushInterval
+        var apiKey: String = ""
+        var applicationContext: Context? = null
+        var networkTimeout = NETWORK_TIMEOUT_DEFAULT
+        var networkFlushInterval = NETWORK_FLUSH_INTERVAL_DEFAULT
     }
 
     class Builder {
@@ -67,11 +49,18 @@ class KlaviyoConfig private constructor(
             }
         }
 
-        fun build() = KlaviyoConfig(
-                apiKey,
-                applicationContext,
-                networkTimeout,
-                networkFlushInterval
-        )
+        fun build() {
+            if (apiKey.isEmpty()) {
+                throw KlaviyoMissingAPIKeyException()
+            }
+            if (applicationContext == null) {
+                throw KlaviyoMissingContextException()
+            }
+
+            KlaviyoConfig.apiKey = apiKey
+            KlaviyoConfig.applicationContext = applicationContext
+            KlaviyoConfig.networkTimeout = networkTimeout
+            KlaviyoConfig.networkFlushInterval = networkFlushInterval
+        }
     }
 }

--- a/core/src/main/java/com/klaviyo/coresdk/KlaviyoConfig.kt
+++ b/core/src/main/java/com/klaviyo/coresdk/KlaviyoConfig.kt
@@ -1,15 +1,39 @@
 package com.klaviyo.coresdk
 
-data class KlaviyoConfig (
-        val apiKey: String,
-        val networkTimeout: Int,
-        val networkFlushInterval: Int
-    ) {
+import java.lang.Exception
+
+class KlaviyoMissingAPIKeyException: Exception("You must declare an API key for the Klaviyo SDK")
+
+class KlaviyoConfig private constructor(
+        apiKey: String,
+        networkTimeout: Int,
+        networkFlushInterval: Int) {
+
+    val apiKey: String
+    val networkTimeout: Int
+    val networkFlushInterval: Int
+
+    init {
+        if (apiKey.isNullOrEmpty()) {
+            throw KlaviyoMissingAPIKeyException()
+        }
+        if (networkTimeout < 0) {
+            // TODO: When Timber is installed, log warning here
+        }
+        if (networkFlushInterval < 0) {
+            // TODO: When Timber is installed, log warning here
+        }
+
+        this.apiKey = apiKey
+        this.networkTimeout = networkTimeout
+        this.networkFlushInterval = networkFlushInterval
+    }
+
     class Builder {
         private val NETWORK_TIMEOUT_DEFAULT: Int = 500
         private val NETWORK_FLUSH_INTERVAL_DEFAULT: Int = 60000
 
-        private lateinit var apiKey: String
+        private var apiKey: String = ""
         private var networkTimeout: Int = NETWORK_TIMEOUT_DEFAULT
         private var networkFlushInterval: Int = NETWORK_FLUSH_INTERVAL_DEFAULT
 

--- a/core/src/main/java/com/klaviyo/coresdk/KlaviyoConfig.kt
+++ b/core/src/main/java/com/klaviyo/coresdk/KlaviyoConfig.kt
@@ -1,21 +1,33 @@
 package com.klaviyo.coresdk
 
+import android.content.Context
 import java.lang.Exception
 
 class KlaviyoMissingAPIKeyException: Exception("You must declare an API key for the Klaviyo SDK")
 
+class KlaviyoMissingContextException: Exception("You must add your application context to the Klaviyo SDK")
+
 class KlaviyoConfig private constructor(
         apiKey: String,
+        applicationContext: Context?,
         networkTimeout: Int,
         networkFlushInterval: Int) {
+    companion object {
+        private const val NETWORK_TIMEOUT_DEFAULT: Int = 500
+        private const val NETWORK_FLUSH_INTERVAL_DEFAULT: Int = 60000
+    }
 
     val apiKey: String
+    val applicationContext: Context?
     val networkTimeout: Int
     val networkFlushInterval: Int
 
     init {
         if (apiKey.isNullOrEmpty()) {
             throw KlaviyoMissingAPIKeyException()
+        }
+        if (applicationContext == null) {
+            throw KlaviyoMissingContextException()
         }
         if (networkTimeout < 0) {
             // TODO: When Timber is installed, log warning here
@@ -25,20 +37,23 @@ class KlaviyoConfig private constructor(
         }
 
         this.apiKey = apiKey
+        this.applicationContext = applicationContext
         this.networkTimeout = networkTimeout
         this.networkFlushInterval = networkFlushInterval
     }
 
     class Builder {
-        private val NETWORK_TIMEOUT_DEFAULT: Int = 500
-        private val NETWORK_FLUSH_INTERVAL_DEFAULT: Int = 60000
-
         private var apiKey: String = ""
+        private var applicationContext: Context? = null
         private var networkTimeout: Int = NETWORK_TIMEOUT_DEFAULT
         private var networkFlushInterval: Int = NETWORK_FLUSH_INTERVAL_DEFAULT
 
         fun apiKey(apiKey: String) = apply {
             this.apiKey = apiKey
+        }
+
+        fun applicationContext(context: Context) = apply {
+            this.applicationContext = context
         }
 
         fun networkTimeout(networkTimeout: Int)  = apply {
@@ -51,6 +66,7 @@ class KlaviyoConfig private constructor(
 
         fun build() = KlaviyoConfig(
                 apiKey,
+                applicationContext,
                 networkTimeout,
                 networkFlushInterval
         )

--- a/core/src/main/java/com/klaviyo/coresdk/KlaviyoConfig.kt
+++ b/core/src/main/java/com/klaviyo/coresdk/KlaviyoConfig.kt
@@ -13,10 +13,15 @@ object KlaviyoConfig {
     private const val NETWORK_FLUSH_DEPTH_DEFAULT: Int = 20
 
     lateinit var apiKey: String
+        private set
     lateinit var applicationContext: Context
+        private set
     var networkTimeout = NETWORK_TIMEOUT_DEFAULT
+        private set
     var networkFlushInterval = NETWORK_FLUSH_INTERVAL_DEFAULT
+        private set
     var networkFlushDepth = NETWORK_FLUSH_DEPTH_DEFAULT
+        private set
 
     class Builder {
         private var apiKey: String = ""

--- a/core/src/main/java/com/klaviyo/coresdk/KlaviyoConfig.kt
+++ b/core/src/main/java/com/klaviyo/coresdk/KlaviyoConfig.kt
@@ -7,22 +7,23 @@ class KlaviyoMissingAPIKeyException: Exception("You must declare an API key for 
 
 class KlaviyoMissingContextException: Exception("You must add your application context to the Klaviyo SDK")
 
-class KlaviyoConfig {
-    internal companion object {
-        private const val NETWORK_TIMEOUT_DEFAULT: Int = 500
-        private const val NETWORK_FLUSH_INTERVAL_DEFAULT: Int = 60000
+object KlaviyoConfig {
+    private const val NETWORK_TIMEOUT_DEFAULT: Int = 500
+    private const val NETWORK_FLUSH_INTERVAL_DEFAULT: Int = 60000
+    private const val NETWORK_FLUSH_DEPTH_DEFAULT: Int = 20
 
-        lateinit var apiKey: String
-        lateinit var applicationContext: Context
-        var networkTimeout = NETWORK_TIMEOUT_DEFAULT
-        var networkFlushInterval = NETWORK_FLUSH_INTERVAL_DEFAULT
-    }
+    lateinit var apiKey: String
+    lateinit var applicationContext: Context
+    var networkTimeout = NETWORK_TIMEOUT_DEFAULT
+    var networkFlushInterval = NETWORK_FLUSH_INTERVAL_DEFAULT
+    var networkFlushDepth = NETWORK_FLUSH_DEPTH_DEFAULT
 
     class Builder {
         private var apiKey: String = ""
         private var applicationContext: Context? = null
         private var networkTimeout: Int = NETWORK_TIMEOUT_DEFAULT
         private var networkFlushInterval: Int = NETWORK_FLUSH_INTERVAL_DEFAULT
+        private var networkFlushDepth = NETWORK_FLUSH_DEPTH_DEFAULT
 
         fun apiKey(apiKey: String) = apply {
             this.apiKey = apiKey
@@ -49,6 +50,14 @@ class KlaviyoConfig {
             }
         }
 
+        fun networkFlushDepth(networkFlushDepth: Int) = apply {
+            if (networkFlushDepth < 0) {
+                // TODO: When Timber is installed, log warning here
+            } else {
+                this.networkFlushDepth = networkFlushDepth
+            }
+        }
+
         fun build() {
             if (apiKey.isEmpty()) {
                 throw KlaviyoMissingAPIKeyException()
@@ -61,6 +70,7 @@ class KlaviyoConfig {
             KlaviyoConfig.applicationContext = applicationContext as Context
             KlaviyoConfig.networkTimeout = networkTimeout
             KlaviyoConfig.networkFlushInterval = networkFlushInterval
+            KlaviyoConfig.networkFlushDepth = networkFlushDepth
         }
     }
 }

--- a/core/src/main/java/com/klaviyo/coresdk/KlaviyoConfig.kt
+++ b/core/src/main/java/com/klaviyo/coresdk/KlaviyoConfig.kt
@@ -12,8 +12,8 @@ class KlaviyoConfig {
         private const val NETWORK_TIMEOUT_DEFAULT: Int = 500
         private const val NETWORK_FLUSH_INTERVAL_DEFAULT: Int = 60000
 
-        var apiKey: String = ""
-        var applicationContext: Context? = null
+        lateinit var apiKey: String
+        lateinit var applicationContext: Context
         var networkTimeout = NETWORK_TIMEOUT_DEFAULT
         var networkFlushInterval = NETWORK_FLUSH_INTERVAL_DEFAULT
     }
@@ -58,7 +58,7 @@ class KlaviyoConfig {
             }
 
             KlaviyoConfig.apiKey = apiKey
-            KlaviyoConfig.applicationContext = applicationContext
+            KlaviyoConfig.applicationContext = applicationContext as Context
             KlaviyoConfig.networkTimeout = networkTimeout
             KlaviyoConfig.networkFlushInterval = networkFlushInterval
         }

--- a/core/src/main/java/com/klaviyo/coresdk/KlaviyoConfig.kt
+++ b/core/src/main/java/com/klaviyo/coresdk/KlaviyoConfig.kt
@@ -56,7 +56,7 @@ object KlaviyoConfig {
         }
 
         fun networkFlushDepth(networkFlushDepth: Int) = apply {
-            if (networkFlushDepth < 0) {
+            if (networkFlushDepth <= 0) {
                 // TODO: When Timber is installed, log warning here
             } else {
                 this.networkFlushDepth = networkFlushDepth

--- a/core/src/main/java/com/klaviyo/coresdk/KlaviyoConfig.kt
+++ b/core/src/main/java/com/klaviyo/coresdk/KlaviyoConfig.kt
@@ -29,12 +29,6 @@ class KlaviyoConfig private constructor(
         if (applicationContext == null) {
             throw KlaviyoMissingContextException()
         }
-        if (networkTimeout < 0) {
-            // TODO: When Timber is installed, log warning here
-        }
-        if (networkFlushInterval < 0) {
-            // TODO: When Timber is installed, log warning here
-        }
 
         this.apiKey = apiKey
         this.applicationContext = applicationContext
@@ -57,11 +51,20 @@ class KlaviyoConfig private constructor(
         }
 
         fun networkTimeout(networkTimeout: Int)  = apply {
-            this.networkTimeout = networkTimeout
+            if (networkTimeout < 0) {
+                // TODO: When Timber is installed, log warning here
+            } else {
+                this.networkTimeout = networkTimeout
+            }
         }
 
         fun networkFlushInterval(networkFlushInterval: Int)  = apply {
-            this.networkFlushInterval = networkFlushInterval
+            if (networkFlushInterval < 0) {
+                // TODO: When Timber is installed, log warning here
+
+            } else {
+                this.networkFlushInterval = networkFlushInterval
+            }
         }
 
         fun build() = KlaviyoConfig(

--- a/core/src/main/java/com/klaviyo/coresdk/KlaviyoConfig.kt
+++ b/core/src/main/java/com/klaviyo/coresdk/KlaviyoConfig.kt
@@ -1,0 +1,34 @@
+package com.klaviyo.coresdk
+
+data class KlaviyoConfig (
+        val apiKey: String,
+        val networkTimeout: Int,
+        val networkFlushInterval: Int
+    ) {
+    class Builder {
+        private val NETWORK_TIMEOUT_DEFAULT: Int = 500
+        private val NETWORK_FLUSH_INTERVAL_DEFAULT: Int = 60000
+
+        private lateinit var apiKey: String
+        private var networkTimeout: Int = NETWORK_TIMEOUT_DEFAULT
+        private var networkFlushInterval: Int = NETWORK_FLUSH_INTERVAL_DEFAULT
+
+        fun apiKey(apiKey: String) = apply {
+            this.apiKey = apiKey
+        }
+
+        fun networkTimeout(networkTimeout: Int)  = apply {
+            this.networkTimeout = networkTimeout
+        }
+
+        fun networkFlushInterval(networkFlushInterval: Int)  = apply {
+            this.networkFlushInterval = networkFlushInterval
+        }
+
+        fun build() = KlaviyoConfig(
+                apiKey,
+                networkTimeout,
+                networkFlushInterval
+        )
+    }
+}

--- a/core/src/test/java/com/klaviyo/androidsdk/KlaviyoConfigTest.kt
+++ b/core/src/test/java/com/klaviyo/androidsdk/KlaviyoConfigTest.kt
@@ -1,0 +1,38 @@
+package com.klaviyo.androidsdk
+
+import com.klaviyo.coresdk.KlaviyoConfig
+import org.junit.Test
+
+class KlaviyoConfigTest {
+    @Test
+    fun `Build Configuration works properly!`() {
+        val config = KlaviyoConfig.Builder()
+                .apiKey("Fake_Key")
+                .networkTimeout(1000)
+                .networkFlushInterval(10000)
+                .build()
+
+        assert(config.apiKey == "Fake_Key")
+        assert(config.networkTimeout == 1000)
+        assert(config.networkFlushInterval == 10000)
+    }
+
+    @Test
+    fun `Build Configuration networking defaults work properly!`() {
+        val config = KlaviyoConfig.Builder()
+                .apiKey("Fake_Key")
+                .build()
+
+        assert(config.apiKey == "Fake_Key")
+        assert(config.networkTimeout == 500)
+        assert(config.networkFlushInterval == 60000)
+    }
+
+    @Test(expected = UninitializedPropertyAccessException::class)
+    fun `Build Configuration throws expected exception on missing API key!`() {
+        KlaviyoConfig.Builder()
+                .networkTimeout(500)
+                .networkFlushInterval(60000)
+                .build()
+    }
+}

--- a/core/src/test/java/com/klaviyo/androidsdk/KlaviyoConfigTest.kt
+++ b/core/src/test/java/com/klaviyo/androidsdk/KlaviyoConfigTest.kt
@@ -6,7 +6,7 @@ import org.junit.Test
 
 class KlaviyoConfigTest {
     @Test
-    fun `Build Configuration works properly!`() {
+    fun `KlaviyoConfig Builder sets variables successfully`() {
         val config = KlaviyoConfig.Builder()
                 .apiKey("Fake_Key")
                 .networkTimeout(1000)
@@ -19,7 +19,7 @@ class KlaviyoConfigTest {
     }
 
     @Test
-    fun `Build Configuration networking defaults work properly!`() {
+    fun `KlaviyoConfig Builder missing variables uses default values successfully`() {
         val config = KlaviyoConfig.Builder()
                 .apiKey("Fake_Key")
                 .build()
@@ -30,7 +30,7 @@ class KlaviyoConfigTest {
     }
 
     @Test(expected = KlaviyoMissingAPIKeyException::class)
-    fun `Build Configuration throws expected exception on missing API key!`() {
+    fun `KlaviyoConfig Builder missing API key throws expected exception`() {
         KlaviyoConfig.Builder()
                 .networkTimeout(500)
                 .networkFlushInterval(60000)

--- a/core/src/test/java/com/klaviyo/androidsdk/KlaviyoConfigTest.kt
+++ b/core/src/test/java/com/klaviyo/androidsdk/KlaviyoConfigTest.kt
@@ -1,6 +1,7 @@
 package com.klaviyo.androidsdk
 
 import com.klaviyo.coresdk.KlaviyoConfig
+import com.klaviyo.coresdk.KlaviyoMissingAPIKeyException
 import org.junit.Test
 
 class KlaviyoConfigTest {
@@ -28,7 +29,7 @@ class KlaviyoConfigTest {
         assert(config.networkFlushInterval == 60000)
     }
 
-    @Test(expected = UninitializedPropertyAccessException::class)
+    @Test(expected = KlaviyoMissingAPIKeyException::class)
     fun `Build Configuration throws expected exception on missing API key!`() {
         KlaviyoConfig.Builder()
                 .networkTimeout(500)

--- a/core/src/test/java/com/klaviyo/coresdk/KlaviyoConfigTest.kt
+++ b/core/src/test/java/com/klaviyo/coresdk/KlaviyoConfigTest.kt
@@ -14,11 +14,13 @@ class KlaviyoConfigTest {
                 .applicationContext(contextMock)
                 .networkTimeout(1000)
                 .networkFlushInterval(10000)
+                .networkFlushDepth(10)
                 .build()
 
         assert(KlaviyoConfig.apiKey == "Fake_Key")
         assert(KlaviyoConfig.networkTimeout == 1000)
         assert(KlaviyoConfig.networkFlushInterval == 10000)
+        assert(KlaviyoConfig.networkFlushDepth == 10)
     }
 
     @Test
@@ -31,6 +33,7 @@ class KlaviyoConfigTest {
         assert(KlaviyoConfig.apiKey == "Fake_Key")
         assert(KlaviyoConfig.networkTimeout == 500)
         assert(KlaviyoConfig.networkFlushInterval == 60000)
+        assert(KlaviyoConfig.networkFlushDepth == 20)
     }
 
     @Test
@@ -40,11 +43,13 @@ class KlaviyoConfigTest {
                 .applicationContext(contextMock)
                 .networkTimeout(-5000)
                 .networkFlushInterval(-5000)
+                .networkFlushDepth(-10)
                 .build()
 
         assert(KlaviyoConfig.apiKey == "Fake_Key")
         assert(KlaviyoConfig.networkTimeout == 500)
         assert(KlaviyoConfig.networkFlushInterval == 60000)
+        assert(KlaviyoConfig.networkFlushDepth == 20)
     }
 
     @Test(expected = KlaviyoMissingAPIKeyException::class)
@@ -53,6 +58,7 @@ class KlaviyoConfigTest {
                 .applicationContext(contextMock)
                 .networkTimeout(500)
                 .networkFlushInterval(60000)
+                .networkFlushDepth(20)
                 .build()
     }
 
@@ -62,6 +68,7 @@ class KlaviyoConfigTest {
                 .apiKey("Fake_Key")
                 .networkTimeout(500)
                 .networkFlushInterval(60000)
+                .networkFlushDepth(20)
                 .build()
     }
 }

--- a/core/src/test/java/com/klaviyo/coresdk/KlaviyoConfigTest.kt
+++ b/core/src/test/java/com/klaviyo/coresdk/KlaviyoConfigTest.kt
@@ -1,7 +1,5 @@
-package com.klaviyo.androidsdk
+package com.klaviyo.coresdk
 
-import com.klaviyo.coresdk.KlaviyoConfig
-import com.klaviyo.coresdk.KlaviyoMissingAPIKeyException
 import org.junit.Test
 
 class KlaviyoConfigTest {

--- a/core/src/test/java/com/klaviyo/coresdk/KlaviyoConfigTest.kt
+++ b/core/src/test/java/com/klaviyo/coresdk/KlaviyoConfigTest.kt
@@ -27,6 +27,19 @@ class KlaviyoConfigTest {
         assert(config.networkFlushInterval == 60000)
     }
 
+    @Test
+    fun `KlaviyoConfig Builder negative variables uses default values successfully`() {
+        val config = KlaviyoConfig.Builder()
+                .apiKey("Fake_Key")
+                .networkTimeout(-5000)
+                .networkFlushInterval(-5000)
+                .build()
+
+        assert(config.apiKey == "Fake_Key")
+        assert(config.networkTimeout == 500)
+        assert(config.networkFlushInterval == 60000)
+    }
+
     @Test(expected = KlaviyoMissingAPIKeyException::class)
     fun `KlaviyoConfig Builder missing API key throws expected exception`() {
         KlaviyoConfig.Builder()

--- a/core/src/test/java/com/klaviyo/coresdk/KlaviyoConfigTest.kt
+++ b/core/src/test/java/com/klaviyo/coresdk/KlaviyoConfigTest.kt
@@ -9,42 +9,42 @@ class KlaviyoConfigTest {
 
     @Test
     fun `KlaviyoConfig Builder sets variables successfully`() {
-        val config = KlaviyoConfig.Builder()
+        KlaviyoConfig.Builder()
                 .apiKey("Fake_Key")
                 .applicationContext(contextMock)
                 .networkTimeout(1000)
                 .networkFlushInterval(10000)
                 .build()
 
-        assert(config.apiKey == "Fake_Key")
-        assert(config.networkTimeout == 1000)
-        assert(config.networkFlushInterval == 10000)
+        assert(KlaviyoConfig.apiKey == "Fake_Key")
+        assert(KlaviyoConfig.networkTimeout == 1000)
+        assert(KlaviyoConfig.networkFlushInterval == 10000)
     }
 
     @Test
     fun `KlaviyoConfig Builder missing variables uses default values successfully`() {
-        val config = KlaviyoConfig.Builder()
+        KlaviyoConfig.Builder()
                 .apiKey("Fake_Key")
                 .applicationContext(contextMock)
                 .build()
 
-        assert(config.apiKey == "Fake_Key")
-        assert(config.networkTimeout == 500)
-        assert(config.networkFlushInterval == 60000)
+        assert(KlaviyoConfig.apiKey == "Fake_Key")
+        assert(KlaviyoConfig.networkTimeout == 500)
+        assert(KlaviyoConfig.networkFlushInterval == 60000)
     }
 
     @Test
     fun `KlaviyoConfig Builder negative variables uses default values successfully`() {
-        val config = KlaviyoConfig.Builder()
+        KlaviyoConfig.Builder()
                 .apiKey("Fake_Key")
                 .applicationContext(contextMock)
                 .networkTimeout(-5000)
                 .networkFlushInterval(-5000)
                 .build()
 
-        assert(config.apiKey == "Fake_Key")
-        assert(config.networkTimeout == 500)
-        assert(config.networkFlushInterval == 60000)
+        assert(KlaviyoConfig.apiKey == "Fake_Key")
+        assert(KlaviyoConfig.networkTimeout == 500)
+        assert(KlaviyoConfig.networkFlushInterval == 60000)
     }
 
     @Test(expected = KlaviyoMissingAPIKeyException::class)

--- a/core/src/test/java/com/klaviyo/coresdk/KlaviyoConfigTest.kt
+++ b/core/src/test/java/com/klaviyo/coresdk/KlaviyoConfigTest.kt
@@ -1,12 +1,17 @@
 package com.klaviyo.coresdk
 
+import android.content.Context
+import com.nhaarman.mockitokotlin2.mock
 import org.junit.Test
 
 class KlaviyoConfigTest {
+    private val contextMock: Context = mock()
+
     @Test
     fun `KlaviyoConfig Builder sets variables successfully`() {
         val config = KlaviyoConfig.Builder()
                 .apiKey("Fake_Key")
+                .applicationContext(contextMock)
                 .networkTimeout(1000)
                 .networkFlushInterval(10000)
                 .build()
@@ -20,6 +25,7 @@ class KlaviyoConfigTest {
     fun `KlaviyoConfig Builder missing variables uses default values successfully`() {
         val config = KlaviyoConfig.Builder()
                 .apiKey("Fake_Key")
+                .applicationContext(contextMock)
                 .build()
 
         assert(config.apiKey == "Fake_Key")
@@ -31,6 +37,7 @@ class KlaviyoConfigTest {
     fun `KlaviyoConfig Builder negative variables uses default values successfully`() {
         val config = KlaviyoConfig.Builder()
                 .apiKey("Fake_Key")
+                .applicationContext(contextMock)
                 .networkTimeout(-5000)
                 .networkFlushInterval(-5000)
                 .build()
@@ -43,6 +50,16 @@ class KlaviyoConfigTest {
     @Test(expected = KlaviyoMissingAPIKeyException::class)
     fun `KlaviyoConfig Builder missing API key throws expected exception`() {
         KlaviyoConfig.Builder()
+                .applicationContext(contextMock)
+                .networkTimeout(500)
+                .networkFlushInterval(60000)
+                .build()
+    }
+
+    @Test(expected = KlaviyoMissingContextException::class)
+    fun `KlaviyoConfig Builder missing application context throws expected exception`() {
+        KlaviyoConfig.Builder()
+                .apiKey("Fake_Key")
                 .networkTimeout(500)
                 .networkFlushInterval(60000)
                 .build()


### PR DESCRIPTION
# Purpose
We want to provide the user with the easiest means of configuring the SDK before use. One means of doing this which would be relatively clean would be with a Builder pattern constructing a configuration class for us. That configuration class can then be passed into whatever KlaviyoInstance we create to control the application.

**Type of PR**
* [ ] Bug Fix
* [x] Feature Work
* [ ] Revert
* [ ] Refactor / Code Cleanup
* [ ] Other (fill in...)

## Short Description
<!-- Feature / Problem overview -->


## Changelog / Code Overview
<!-- What was changed / added / removed and why. If you changed the frontend please include screenshots -->
- Added a KlaviyoConfig class with an internal builder class
- Added Kotlin dependencies to the Gradle build for the core SDK
- Added basic test cases for the KlaviyoConfig class.

## Test Plan
<!-- How was this code tested / How should reviewers test it? -->


## What to look for
<!-- Call out what each team/reviewer should look for and a rough time estimate. -->


## Related Issues/Tickets
<!-- Any relevant links to TP / Sentry / RFC -->
https://klaviyo.tpondemand.com/entity/49008-add-a-basic-configuration-builder

