### PR TITLE
Add basic networking logic to send get and post requests via the SDK

### DIFF
--- a/core/src/main/java/com/klaviyo/coresdk/networking/IdentifyRequest.kt
+++ b/core/src/main/java/com/klaviyo/coresdk/networking/IdentifyRequest.kt
@@ -2,7 +2,6 @@ package com.klaviyo.coresdk.networking
 
 import com.klaviyo.coresdk.KlaviyoConfig
 import org.json.JSONObject
-import java.net.URL
 
 class IdentifyRequest (
         private var event: String,
@@ -12,10 +11,10 @@ class IdentifyRequest (
         internal const val IDENTIFY_ENDPOINT = "api/identify"
     }
 
-    override var url = URL("$BASE_URL/$IDENTIFY_ENDPOINT")
+    override var urlString = "$BASE_URL/$IDENTIFY_ENDPOINT"
     override var requestMethod = RequestMethod.GET
 
-    override fun buildKlaviyoJsonHeader(): String {
+    override fun buildKlaviyoJsonQuery(): String {
         val json = JSONObject()
 
         json.put("token", KlaviyoConfig.apiKey)

--- a/core/src/main/java/com/klaviyo/coresdk/networking/IdentifyRequest.kt
+++ b/core/src/main/java/com/klaviyo/coresdk/networking/IdentifyRequest.kt
@@ -4,7 +4,6 @@ import com.klaviyo.coresdk.KlaviyoConfig
 import org.json.JSONObject
 
 class IdentifyRequest (
-        private var event: String,
         private var properties: Map<String, String>
 ): KlaviyoRequest() {
     companion object {
@@ -18,12 +17,8 @@ class IdentifyRequest (
      * Example request:
      * {
         "token" : "apikey",
-        "event" : "Test Event",
-        "customer_properties" : {
-        "$email" : "myemail@domain.com"
-        },
         "properties" : {
-        "$event_id" : 10001234,
+        "$email" : "sdktest@test.com",
         "$value" : 11250000,
         "From" : "France",
         "SquareMiles" : 828000
@@ -35,7 +30,6 @@ class IdentifyRequest (
         return JSONObject(
             mapOf(
                 "token" to KlaviyoConfig.apiKey,
-                "event" to event,
                 "properties" to JSONObject(properties)
             )
         ).toString()

--- a/core/src/main/java/com/klaviyo/coresdk/networking/IdentifyRequest.kt
+++ b/core/src/main/java/com/klaviyo/coresdk/networking/IdentifyRequest.kt
@@ -14,20 +14,30 @@ class IdentifyRequest (
     override var urlString = "$BASE_URL/$IDENTIFY_ENDPOINT"
     override var requestMethod = RequestMethod.GET
 
+    /**
+     * Example request:
+     * {
+        "token" : "apikey",
+        "event" : "Test Event",
+        "customer_properties" : {
+        "$email" : "myemail@domain.com"
+        },
+        "properties" : {
+        "$event_id" : 10001234,
+        "$value" : 11250000,
+        "From" : "France",
+        "SquareMiles" : 828000
+        },
+        "time" : 1598038143
+        }
+     */
     override fun buildKlaviyoJsonQuery(): String {
-        val json = JSONObject()
-
-        json.put("token", KlaviyoConfig.apiKey)
-        json.put("event", event)
-
-        val propsJson = JSONObject()
-        properties.forEach {
-            propsJson.putOpt(it.key, it.value)
-        }
-        if (propsJson.length() > 0) {
-            json.putOpt("properties", propsJson)
-        }
-
-        return json.toString()
+        return JSONObject(
+            mapOf(
+                "token" to KlaviyoConfig.apiKey,
+                "event" to event,
+                "properties" to JSONObject(properties)
+            )
+        ).toString()
     }
 }

--- a/core/src/main/java/com/klaviyo/coresdk/networking/IdentifyRequest.kt
+++ b/core/src/main/java/com/klaviyo/coresdk/networking/IdentifyRequest.kt
@@ -1,0 +1,34 @@
+package com.klaviyo.coresdk.networking
+
+import com.klaviyo.coresdk.KlaviyoConfig
+import org.json.JSONObject
+import java.net.URL
+
+class IdentifyRequest (
+        private var event: String,
+        private var properties: Map<String, String>
+): KlaviyoRequest() {
+    companion object {
+        internal const val IDENTIFY_ENDPOINT = "api/identify"
+    }
+
+    override var url = URL("$BASE_URL/$IDENTIFY_ENDPOINT")
+    override var requestMethod = RequestMethod.GET
+
+    override fun buildKlaviyoJsonHeader(): String {
+        val json = JSONObject()
+
+        json.put("token", KlaviyoConfig.apiKey)
+        json.put("event", event)
+
+        val propsJson = JSONObject()
+        properties.forEach {
+            propsJson.putOpt(it.key, it.value)
+        }
+        if (propsJson.length() > 0) {
+            json.putOpt("properties", propsJson)
+        }
+
+        return json.toString()
+    }
+}

--- a/core/src/main/java/com/klaviyo/coresdk/networking/KlaviyoRequest.kt
+++ b/core/src/main/java/com/klaviyo/coresdk/networking/KlaviyoRequest.kt
@@ -5,13 +5,13 @@ abstract class KlaviyoRequest: NetworkRequest() {
         internal const val BASE_URL = "https://a.klaviyo.com"
     }
 
-    override var headerData: String? = null
+    override var queryData: String? = null
     override var payload: String? = null
 
-    internal abstract fun buildKlaviyoJsonHeader(): String
+    internal abstract fun buildKlaviyoJsonQuery(): String
 
     override fun sendNetworkRequest(): String? {
-        headerData = buildKlaviyoJsonHeader()
+        queryData = buildKlaviyoJsonQuery()
         return super.sendNetworkRequest()
     }
 

--- a/core/src/main/java/com/klaviyo/coresdk/networking/KlaviyoRequest.kt
+++ b/core/src/main/java/com/klaviyo/coresdk/networking/KlaviyoRequest.kt
@@ -15,6 +15,8 @@ abstract class KlaviyoRequest: NetworkRequest() {
         return super.sendNetworkRequest()
     }
 
+    // TODO: Potentially remove this later
+    //  This is a function for testing individual requests made instantly
     fun process(): Boolean {
         val response = sendNetworkRequest()
         return response == "1"

--- a/core/src/main/java/com/klaviyo/coresdk/networking/KlaviyoRequest.kt
+++ b/core/src/main/java/com/klaviyo/coresdk/networking/KlaviyoRequest.kt
@@ -1,0 +1,22 @@
+package com.klaviyo.coresdk.networking
+
+abstract class KlaviyoRequest: NetworkRequest() {
+    companion object {
+        internal const val BASE_URL = "https://a.klaviyo.com"
+    }
+
+    override var headerData: String? = null
+    override var payload: String? = null
+
+    internal abstract fun buildKlaviyoJsonHeader(): String
+
+    override fun sendNetworkRequest(): String? {
+        headerData = buildKlaviyoJsonHeader()
+        return super.sendNetworkRequest()
+    }
+
+    fun process(): Boolean {
+        val response = sendNetworkRequest()
+        return response == "1"
+    }
+}

--- a/core/src/main/java/com/klaviyo/coresdk/networking/NetworkRequest.kt
+++ b/core/src/main/java/com/klaviyo/coresdk/networking/NetworkRequest.kt
@@ -1,0 +1,95 @@
+package com.klaviyo.coresdk.networking
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import android.os.Build
+import android.util.Base64
+import com.klaviyo.coresdk.KlaviyoConfig
+import java.io.*
+import java.net.HttpURLConnection
+import java.net.URL
+import javax.net.ssl.HttpsURLConnection
+
+
+abstract class NetworkRequest {
+    internal abstract var url: URL
+    internal abstract var requestMethod: RequestMethod
+    internal abstract var headerData: String?
+    internal abstract var payload: String?
+
+    internal fun isInternetConnected(context: Context): Boolean {
+        val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        // TODO: We may want to replace this later. Deprecated as of Android API 29.
+        //  But the alternative solution is an asynchronous task that requires the user to register
+        //  a network callback listener, which isn't ideal just for a network connectivity check in an SDK
+        val networkInfo = connectivityManager.activeNetworkInfo ?: return false
+        var usingInternet = true
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            val network = connectivityManager.activeNetwork
+            val capabilities = connectivityManager.getNetworkCapabilities(network) ?: return false
+            usingInternet = capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+        }
+        return usingInternet && networkInfo.isConnectedOrConnecting
+    }
+
+    internal fun encodeToBase64(data: String): String {
+        val dataBytes = data.toByteArray()
+        return Base64.encodeToString(dataBytes, Base64.NO_WRAP)
+    }
+
+    internal open fun sendNetworkRequest(): String? {
+        if (!isInternetConnected(KlaviyoConfig.applicationContext)) {
+            return null
+        }
+
+        val connection: HttpsURLConnection = url.openConnection() as HttpsURLConnection
+
+        connection.readTimeout = KlaviyoConfig.networkTimeout
+        connection.connectTimeout = KlaviyoConfig.networkTimeout
+        connection.requestMethod = requestMethod.name
+        connection.setRequestProperty("Content-Type", "application/json; utf-8")
+        connection.setRequestProperty("Accept", "application/json")
+        connection.doOutput = true
+        connection.setRequestProperty("User-agent", System.getProperty("http.agent"))
+
+        if (!headerData.isNullOrEmpty()) {
+            connection.setRequestProperty("data", encodeToBase64(headerData!!))
+        }
+
+        if (connection.requestMethod == RequestMethod.POST.name && !payload.isNullOrEmpty()) {
+            val outputStream = connection.outputStream
+            val writer = BufferedWriter(OutputStreamWriter(outputStream, "UTF-8"))
+            writer.use {
+                it.write(payload)
+            }
+        }
+
+        connection.connect()
+
+        return readResponse(connection)
+    }
+
+    internal fun readResponse(connection: HttpsURLConnection): String {
+        val response: String
+
+        try {
+            val statusCode = connection.responseCode
+            response = if (statusCode == HttpURLConnection.HTTP_OK) {
+                readFromStream(connection.inputStream)
+            } else {
+                readFromStream(connection.errorStream)
+            }
+        } finally {
+            connection.disconnect()
+        }
+        return response
+    }
+
+    private fun readFromStream(inputStream: InputStream): String {
+        val reader = BufferedReader(InputStreamReader(inputStream))
+        return reader.use {
+            it.readText()
+        }
+    }
+}

--- a/core/src/main/java/com/klaviyo/coresdk/networking/RequestMethod.kt
+++ b/core/src/main/java/com/klaviyo/coresdk/networking/RequestMethod.kt
@@ -1,0 +1,5 @@
+package com.klaviyo.coresdk.networking
+
+internal enum class RequestMethod {
+    GET, POST
+}

--- a/core/src/main/java/com/klaviyo/coresdk/networking/TrackRequest.kt
+++ b/core/src/main/java/com/klaviyo/coresdk/networking/TrackRequest.kt
@@ -18,28 +18,31 @@ class TrackRequest (
     override var requestMethod = RequestMethod.GET
 
 
+    /**
+     * Example request:
+     * {
+        "token" : "apikey",
+        "properties" : {
+        "$email" : "myemail@domain.com",
+        "$first_name" : "Me",
+        "$last_name" : "You",
+        "Plan" : "Premium",
+        "SignUpDate" : "2016-05-01 10:10:00"
+        }
+        }
+     */
     override fun buildKlaviyoJsonQuery(): String {
-        val json = JSONObject()
+        val json = JSONObject(
+            mapOf(
+                "token" to KlaviyoConfig.apiKey,
+                "event" to event,
+                "customer_properties" to JSONObject(customerProperties)
+            )
+        )
 
-        json.put("token", KlaviyoConfig.apiKey)
-        json.put("event", event)
-
-        val customerPropsJson = JSONObject()
-        customerProperties.forEach {
-            customerPropsJson.putOpt(it.key, it.value)
+        if (properties != null) {
+            json.put("properties", JSONObject(properties))
         }
-        if (customerPropsJson.length() > 0) {
-            json.putOpt("customer_properties", customerPropsJson)
-        }
-
-        val propsJson = JSONObject()
-        properties?.forEach {
-            propsJson.putOpt(it.key, it.value)
-        }
-        if (propsJson.length() > 0) {
-            json.putOpt("properties", propsJson)
-        }
-
         json.putOpt("time", timestamp)
 
         return json.toString()

--- a/core/src/main/java/com/klaviyo/coresdk/networking/TrackRequest.kt
+++ b/core/src/main/java/com/klaviyo/coresdk/networking/TrackRequest.kt
@@ -36,14 +36,11 @@ class TrackRequest (
             mapOf(
                 "token" to KlaviyoConfig.apiKey,
                 "event" to event,
-                "customer_properties" to JSONObject(customerProperties)
-            )
+                "customer_properties" to JSONObject(customerProperties),
+                "properties" to properties?.let { JSONObject(properties) },
+                "time" to timestamp?.let { it }
+            ).filterValues { it != null }
         )
-
-        if (properties != null) {
-            json.put("properties", JSONObject(properties))
-        }
-        json.putOpt("time", timestamp)
 
         return json.toString()
     }

--- a/core/src/main/java/com/klaviyo/coresdk/networking/TrackRequest.kt
+++ b/core/src/main/java/com/klaviyo/coresdk/networking/TrackRequest.kt
@@ -1,0 +1,52 @@
+package com.klaviyo.coresdk.networking
+
+import com.klaviyo.coresdk.KlaviyoConfig
+import org.json.JSONObject
+import java.net.URL
+
+class TrackRequest (
+        private var event: String,
+        private var customerProperties: Map<String, String>,
+        private var properties: Map<String, String>? = null
+): KlaviyoRequest() {
+    companion object {
+        internal const val TRACK_ENDPOINT = "api/track"
+    }
+
+    private var timestamp: Long? = null
+
+    override var url = URL("$BASE_URL/$TRACK_ENDPOINT")
+    override var requestMethod = RequestMethod.GET
+
+
+    override fun buildKlaviyoJsonHeader(): String {
+        val json = JSONObject()
+
+        json.put("token", KlaviyoConfig.apiKey)
+        json.put("event", event)
+
+        val customerPropsJson = JSONObject()
+        customerProperties.forEach {
+            customerPropsJson.putOpt(it.key, it.value)
+        }
+        if (customerPropsJson.length() > 0) {
+            json.putOpt("customer_properties", customerPropsJson)
+        }
+
+        val propsJson = JSONObject()
+        properties?.forEach {
+            propsJson.putOpt(it.key, it.value)
+        }
+        if (propsJson.length() > 0) {
+            json.putOpt("properties", propsJson)
+        }
+
+        json.putOpt("time", timestamp)
+
+        return json.toString()
+    }
+
+    internal fun generateUnixTimestamp() {
+        timestamp = System.currentTimeMillis() / 1000L
+    }
+}

--- a/core/src/main/java/com/klaviyo/coresdk/networking/TrackRequest.kt
+++ b/core/src/main/java/com/klaviyo/coresdk/networking/TrackRequest.kt
@@ -2,7 +2,6 @@ package com.klaviyo.coresdk.networking
 
 import com.klaviyo.coresdk.KlaviyoConfig
 import org.json.JSONObject
-import java.net.URL
 
 class TrackRequest (
         private var event: String,
@@ -15,11 +14,11 @@ class TrackRequest (
 
     private var timestamp: Long? = null
 
-    override var url = URL("$BASE_URL/$TRACK_ENDPOINT")
+    override var urlString = "$BASE_URL/$TRACK_ENDPOINT"
     override var requestMethod = RequestMethod.GET
 
 
-    override fun buildKlaviyoJsonHeader(): String {
+    override fun buildKlaviyoJsonQuery(): String {
         val json = JSONObject()
 
         json.put("token", KlaviyoConfig.apiKey)
@@ -46,7 +45,7 @@ class TrackRequest (
         return json.toString()
     }
 
-    internal fun generateUnixTimestamp() {
+    fun generateUnixTimestamp() {
         timestamp = System.currentTimeMillis() / 1000L
     }
 }

--- a/core/src/test/java/com/klaviyo/coresdk/networking/IdentifyRequestTest.kt
+++ b/core/src/test/java/com/klaviyo/coresdk/networking/IdentifyRequestTest.kt
@@ -24,7 +24,7 @@ class IdentifyRequestTest {
     fun `Build Identify request successfully`() {
         val properties = hashMapOf("custom_value" to "200")
 
-        val expectedJsonString = "{\"event\":\"Test Event\",\"properties\":{\"custom_value\":\"200\"},\"token\":\"Fake_Key\"}"
+        val expectedJsonString = "{\"properties\":{\"custom_value\":\"200\"},\"token\":\"Fake_Key\"}"
 
         val request = IdentifyRequest(properties = properties)
         request.queryData = request.buildKlaviyoJsonQuery()

--- a/core/src/test/java/com/klaviyo/coresdk/networking/IdentifyRequestTest.kt
+++ b/core/src/test/java/com/klaviyo/coresdk/networking/IdentifyRequestTest.kt
@@ -1,0 +1,39 @@
+package com.klaviyo.coresdk.networking
+
+import android.content.Context
+import com.klaviyo.coresdk.KlaviyoConfig
+import com.nhaarman.mockitokotlin2.mock
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import java.net.URL
+
+class IdentifyRequestTest {
+    private val contextMock = mock<Context>()
+
+    @Before
+    fun setup() {
+        KlaviyoConfig.Builder()
+                .apiKey("Fake_Key")
+                .applicationContext(contextMock)
+                .networkTimeout(1000)
+                .networkFlushInterval(10000)
+                .build()
+    }
+
+    @Test
+    fun `Build Identify request successfully`() {
+        val event = "Test Event"
+        val properties = hashMapOf("custom_value" to "200")
+
+        val expectedJsonString = "{\"event\":\"Test Event\",\"properties\":{\"custom_value\":\"200\"},\"token\":\"Fake_Key\"}"
+
+        val request = IdentifyRequest(event, properties = properties)
+        request.headerData = request.buildKlaviyoJsonHeader()
+
+        Assert.assertEquals(URL("${KlaviyoRequest.BASE_URL}/${IdentifyRequest.IDENTIFY_ENDPOINT}"), request.url)
+        Assert.assertEquals(RequestMethod.GET, request.requestMethod)
+        Assert.assertEquals(expectedJsonString, request.headerData)
+        Assert.assertEquals(null, request.payload)
+    }
+}

--- a/core/src/test/java/com/klaviyo/coresdk/networking/IdentifyRequestTest.kt
+++ b/core/src/test/java/com/klaviyo/coresdk/networking/IdentifyRequestTest.kt
@@ -22,12 +22,11 @@ class IdentifyRequestTest {
 
     @Test
     fun `Build Identify request successfully`() {
-        val event = "Test Event"
         val properties = hashMapOf("custom_value" to "200")
 
         val expectedJsonString = "{\"event\":\"Test Event\",\"properties\":{\"custom_value\":\"200\"},\"token\":\"Fake_Key\"}"
 
-        val request = IdentifyRequest(event, properties = properties)
+        val request = IdentifyRequest(properties = properties)
         request.queryData = request.buildKlaviyoJsonQuery()
 
         Assert.assertEquals("${KlaviyoRequest.BASE_URL}/${IdentifyRequest.IDENTIFY_ENDPOINT}", request.urlString)

--- a/core/src/test/java/com/klaviyo/coresdk/networking/IdentifyRequestTest.kt
+++ b/core/src/test/java/com/klaviyo/coresdk/networking/IdentifyRequestTest.kt
@@ -6,7 +6,6 @@ import com.nhaarman.mockitokotlin2.mock
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
-import java.net.URL
 
 class IdentifyRequestTest {
     private val contextMock = mock<Context>()
@@ -29,11 +28,11 @@ class IdentifyRequestTest {
         val expectedJsonString = "{\"event\":\"Test Event\",\"properties\":{\"custom_value\":\"200\"},\"token\":\"Fake_Key\"}"
 
         val request = IdentifyRequest(event, properties = properties)
-        request.headerData = request.buildKlaviyoJsonHeader()
+        request.queryData = request.buildKlaviyoJsonQuery()
 
-        Assert.assertEquals(URL("${KlaviyoRequest.BASE_URL}/${IdentifyRequest.IDENTIFY_ENDPOINT}"), request.url)
+        Assert.assertEquals("${KlaviyoRequest.BASE_URL}/${IdentifyRequest.IDENTIFY_ENDPOINT}", request.urlString)
         Assert.assertEquals(RequestMethod.GET, request.requestMethod)
-        Assert.assertEquals(expectedJsonString, request.headerData)
+        Assert.assertEquals(expectedJsonString, request.queryData)
         Assert.assertEquals(null, request.payload)
     }
 }

--- a/core/src/test/java/com/klaviyo/coresdk/networking/NetworkRequestTest.kt
+++ b/core/src/test/java/com/klaviyo/coresdk/networking/NetworkRequestTest.kt
@@ -1,0 +1,152 @@
+package com.klaviyo.coresdk.networking
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkInfo
+import androidx.test.filters.SdkSuppress
+import com.klaviyo.coresdk.KlaviyoConfig
+import com.nhaarman.mockitokotlin2.*
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import java.io.ByteArrayInputStream
+import java.io.InputStream
+import java.net.URL
+import javax.net.ssl.HttpsURLConnection
+
+class NetworkRequestTest {
+    private val contextMock = mock<Context>()
+
+    @Before
+    fun setup() {
+        KlaviyoConfig.Builder()
+                .apiKey("Fake_Key")
+                .applicationContext(contextMock)
+                .networkTimeout(1000)
+                .networkFlushInterval(10000)
+                .build()
+    }
+
+    @Test
+    fun `Is internet connected given the application context`() {
+        val contextSpy = spy<Context>()
+        val connectivityManagerMock = mock<ConnectivityManager>()
+        val networkInfoMock = mock<NetworkInfo>()
+        val requestSpy = spy<NetworkRequest>()
+
+        doReturn(connectivityManagerMock).whenever(contextSpy).getSystemService(Context.CONNECTIVITY_SERVICE)
+        whenever(connectivityManagerMock.activeNetworkInfo).thenReturn(networkInfoMock)
+        whenever(networkInfoMock.isConnectedOrConnecting).thenReturn(true)
+
+        val isConnected = requestSpy.isInternetConnected(contextSpy)
+
+        assertEquals(true, isConnected)
+    }
+
+    @Test
+    @SdkSuppress(minSdkVersion = 23)
+    fun `Is internet connected on Android M or above given the application context`() {
+        val contextSpy = spy<Context>()
+        val connectivityManagerMock = mock<ConnectivityManager>()
+        val networkInfoMock = mock<NetworkInfo>()
+        val networkMock = mock<Network>()
+        val networkCapabilitiesMock = mock<NetworkCapabilities>()
+        val requestSpy = spy<NetworkRequest>()
+
+        doReturn(connectivityManagerMock).whenever(contextSpy).getSystemService(Context.CONNECTIVITY_SERVICE)
+        whenever(connectivityManagerMock.activeNetworkInfo).thenReturn(networkInfoMock)
+        whenever(connectivityManagerMock.activeNetwork).thenReturn(networkMock)
+        whenever(connectivityManagerMock.getNetworkCapabilities(networkMock)).thenReturn(networkCapabilitiesMock)
+        whenever(networkCapabilitiesMock.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)).thenReturn(true)
+        whenever(networkInfoMock.isConnectedOrConnecting).thenReturn(true)
+
+        val isConnected = requestSpy.isInternetConnected(contextSpy)
+
+        assertEquals(true, isConnected)
+    }
+
+    @Test
+    fun `Send network request with header information successfully`() {
+        val jsonString = "{\"customer_properties\":{\"\$phone_number\":\"+12223334444\",\"\$email\":\"test@test.com\"},\"time\":\"200\",\"event\":\"test_event\",\"properties\":{\"custom_value\":\"200\"}}"
+        val encodedData = "eyJjdXN0b21lcl9wcm9wZXJ0aWVzIjp7IiRwaG9uZV9udW1iZXIiOiIrMTIyMjMzMzQ0NDQiLCIkZW1haWwiOiJ0ZXN0QHRlc3QuY29tIn0sInRpbWUiOiIyMDAiLCJldmVudCI6InRlc3RfZXZlbnQiLCJwcm9wZXJ0aWVzIjp7ImN1c3RvbV92YWx1ZSI6IjIwMCJ9fQ=="
+
+        val requestSpy = spy<NetworkRequest>()
+        val urlMock = mock<URL>()
+        val connectionMock = mock<HttpsURLConnection>()
+
+
+        doReturn(urlMock).whenever(requestSpy).url
+        doReturn(RequestMethod.GET).whenever(requestSpy).requestMethod
+        doReturn(jsonString).whenever(requestSpy).headerData
+
+        doReturn(true).whenever(requestSpy).isInternetConnected(any())
+        whenever(urlMock.openConnection()).thenReturn(connectionMock)
+        doReturn(encodedData).whenever(requestSpy).encodeToBase64(any())
+        doReturn("1").whenever(requestSpy).readResponse(connectionMock)
+
+        val response = requestSpy.sendNetworkRequest()
+
+        assertEquals("1", response)
+        verify(requestSpy, times(1)).encodeToBase64(jsonString)
+    }
+
+    @Test
+    fun `Send network request without header information successfully`() {
+        val requestSpy = spy<NetworkRequest>()
+        val urlMock = mock<URL>()
+        val connectionMock = mock<HttpsURLConnection>()
+
+        doReturn(urlMock).whenever(requestSpy).url
+        doReturn(RequestMethod.GET).whenever(requestSpy).requestMethod
+
+        doReturn(true).whenever(requestSpy).isInternetConnected(contextMock)
+        whenever(urlMock.openConnection()).thenReturn(connectionMock)
+        doReturn("1").whenever(requestSpy).readResponse(connectionMock)
+
+        val response = requestSpy.sendNetworkRequest()
+
+        assertEquals("1", response)
+        verify(requestSpy, times(0)).encodeToBase64(any())
+    }
+
+    @Test
+    fun `Send network request fails if internet is not active`() {
+        val networkingSpy = spy<NetworkRequest>()
+
+        doReturn(false).whenever(networkingSpy).isInternetConnected(contextMock)
+
+        val response = networkingSpy.sendNetworkRequest()
+
+        assertEquals(null, response)
+    }
+
+    @Test
+    fun `Reads input stream when response contains a valid status code from HttpsURLConnection successfully`() {
+        val requestSpy = spy<NetworkRequest>()
+        val connectionMock = mock<HttpsURLConnection>()
+        val inputStream = ByteArrayInputStream("1".toByteArray())
+
+        doReturn(200).whenever(connectionMock).responseCode
+        doReturn(inputStream).whenever(connectionMock).inputStream
+
+        val response = requestSpy.readResponse(connectionMock)
+
+        assertEquals("1", response)
+    }
+
+    @Test
+    fun `Reads error stream when response contains an error code from HttpsURLConnection successfully`() {
+        val requestSpy = spy<NetworkRequest>()
+        val connectionMock = mock<HttpsURLConnection>()
+        val errorStream = ByteArrayInputStream("Invalid params".toByteArray())
+
+        doReturn(500).whenever(connectionMock).responseCode
+        doReturn(errorStream).whenever(connectionMock).errorStream
+
+        val response = requestSpy.readResponse(connectionMock)
+
+        assertEquals("Invalid params", response)
+    }
+}

--- a/core/src/test/java/com/klaviyo/coresdk/networking/NetworkRequestTest.kt
+++ b/core/src/test/java/com/klaviyo/coresdk/networking/NetworkRequestTest.kt
@@ -68,7 +68,7 @@ class NetworkRequestTest {
     }
 
     @Test
-    fun `Send network request with header information successfully`() {
+    fun `Send network request with query information successfully`() {
         val jsonString = "{\"customer_properties\":{\"\$phone_number\":\"+12223334444\",\"\$email\":\"test@test.com\"},\"time\":\"200\",\"event\":\"test_event\",\"properties\":{\"custom_value\":\"200\"}}"
         val encodedData = "eyJjdXN0b21lcl9wcm9wZXJ0aWVzIjp7IiRwaG9uZV9udW1iZXIiOiIrMTIyMjMzMzQ0NDQiLCIkZW1haWwiOiJ0ZXN0QHRlc3QuY29tIn0sInRpbWUiOiIyMDAiLCJldmVudCI6InRlc3RfZXZlbnQiLCJwcm9wZXJ0aWVzIjp7ImN1c3RvbV92YWx1ZSI6IjIwMCJ9fQ=="
 
@@ -77,9 +77,9 @@ class NetworkRequestTest {
         val connectionMock = mock<HttpsURLConnection>()
 
 
-        doReturn(urlMock).whenever(requestSpy).url
+        doReturn(urlMock).whenever(requestSpy).buildURL()
         doReturn(RequestMethod.GET).whenever(requestSpy).requestMethod
-        doReturn(jsonString).whenever(requestSpy).headerData
+        doReturn(jsonString).whenever(requestSpy).queryData
 
         doReturn(true).whenever(requestSpy).isInternetConnected(any())
         whenever(urlMock.openConnection()).thenReturn(connectionMock)
@@ -89,16 +89,15 @@ class NetworkRequestTest {
         val response = requestSpy.sendNetworkRequest()
 
         assertEquals("1", response)
-        verify(requestSpy, times(1)).encodeToBase64(jsonString)
     }
 
     @Test
-    fun `Send network request without header information successfully`() {
+    fun `Send network request without query information successfully`() {
         val requestSpy = spy<NetworkRequest>()
         val urlMock = mock<URL>()
         val connectionMock = mock<HttpsURLConnection>()
 
-        doReturn(urlMock).whenever(requestSpy).url
+        doReturn(urlMock).whenever(requestSpy).buildURL()
         doReturn(RequestMethod.GET).whenever(requestSpy).requestMethod
 
         doReturn(true).whenever(requestSpy).isInternetConnected(contextMock)
@@ -108,7 +107,6 @@ class NetworkRequestTest {
         val response = requestSpy.sendNetworkRequest()
 
         assertEquals("1", response)
-        verify(requestSpy, times(0)).encodeToBase64(any())
     }
 
     @Test

--- a/core/src/test/java/com/klaviyo/coresdk/networking/TrackRequestTest.kt
+++ b/core/src/test/java/com/klaviyo/coresdk/networking/TrackRequestTest.kt
@@ -2,14 +2,12 @@ package com.klaviyo.coresdk.networking
 
 import android.content.Context
 import com.klaviyo.coresdk.KlaviyoConfig
-import com.klaviyo.coresdk.networking.IdentifyRequest.Companion.IDENTIFY_ENDPOINT
 import com.klaviyo.coresdk.networking.KlaviyoRequest.Companion.BASE_URL
 import com.klaviyo.coresdk.networking.TrackRequest.Companion.TRACK_ENDPOINT
 import com.nhaarman.mockitokotlin2.mock
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
-import java.net.URL
 
 class TrackRequestTest {
     private val contextMock = mock<Context>()
@@ -32,11 +30,11 @@ class TrackRequestTest {
         val expectedJsonString = "{\"customer_properties\":{\"\$phone_number\":\"+12223334444\",\"\$email\":\"test@test.com\"},\"event\":\"Test Event\",\"token\":\"Fake_Key\"}"
 
         val request = TrackRequest(event, customerProperties)
-        request.headerData = request.buildKlaviyoJsonHeader()
+        request.queryData = request.buildKlaviyoJsonQuery()
 
-        Assert.assertEquals(URL("$BASE_URL/$TRACK_ENDPOINT"), request.url)
+        Assert.assertEquals("$BASE_URL/$TRACK_ENDPOINT", request.urlString)
         Assert.assertEquals(RequestMethod.GET, request.requestMethod)
-        Assert.assertEquals(expectedJsonString, request.headerData)
+        Assert.assertEquals(expectedJsonString, request.queryData)
         Assert.assertEquals(null, request.payload)
     }
 
@@ -49,11 +47,11 @@ class TrackRequestTest {
         val expectedJsonString = "{\"customer_properties\":{\"\$phone_number\":\"+12223334444\",\"\$email\":\"test@test.com\"},\"event\":\"Test Event\",\"properties\":{\"custom_value\":\"200\"},\"token\":\"Fake_Key\"}"
 
         val request = TrackRequest(event, customerProperties, properties)
-        request.headerData = request.buildKlaviyoJsonHeader()
+        request.queryData = request.buildKlaviyoJsonQuery()
 
-        Assert.assertEquals(URL("$BASE_URL/$TRACK_ENDPOINT"), request.url)
+        Assert.assertEquals("$BASE_URL/$TRACK_ENDPOINT", request.urlString)
         Assert.assertEquals(RequestMethod.GET, request.requestMethod)
-        Assert.assertEquals(expectedJsonString, request.headerData)
+        Assert.assertEquals(expectedJsonString, request.queryData)
         Assert.assertEquals(null, request.payload)
     }
 }

--- a/core/src/test/java/com/klaviyo/coresdk/networking/TrackRequestTest.kt
+++ b/core/src/test/java/com/klaviyo/coresdk/networking/TrackRequestTest.kt
@@ -23,11 +23,11 @@ class TrackRequestTest {
     }
 
     @Test
-    fun `Build Track request successfully`() {
+    fun `Build Track request with no properties successfully`() {
         val event = "Test Event"
         val customerProperties = hashMapOf("\$email" to "test@test.com", "\$phone_number" to "+12223334444")
 
-        val expectedJsonString = "{\"customer_properties\":{\"\$phone_number\":\"+12223334444\",\"\$email\":\"test@test.com\"},\"event\":\"Test Event\",\"token\":\"Fake_Key\"}"
+        val expectedJsonString = "{\"event\":\"Test Event\",\"customer_properties\":{\"\$email\":\"test@test.com\",\"\$phone_number\":\"+12223334444\"},\"token\":\"Fake_Key\"}"
 
         val request = TrackRequest(event, customerProperties)
         request.queryData = request.buildKlaviyoJsonQuery()
@@ -39,12 +39,12 @@ class TrackRequestTest {
     }
 
     @Test
-    fun `Build Track request with no properties`() {
+    fun `Build Track request successfully`() {
         val event = "Test Event"
         val customerProperties = hashMapOf("\$email" to "test@test.com", "\$phone_number" to "+12223334444")
         val properties = hashMapOf("custom_value" to "200")
 
-        val expectedJsonString = "{\"customer_properties\":{\"\$phone_number\":\"+12223334444\",\"\$email\":\"test@test.com\"},\"event\":\"Test Event\",\"properties\":{\"custom_value\":\"200\"},\"token\":\"Fake_Key\"}"
+        val expectedJsonString = "{\"event\":\"Test Event\",\"customer_properties\":{\"\$email\":\"test@test.com\",\"\$phone_number\":\"+12223334444\"},\"properties\":{\"custom_value\":\"200\"},\"token\":\"Fake_Key\"}"
 
         val request = TrackRequest(event, customerProperties, properties)
         request.queryData = request.buildKlaviyoJsonQuery()

--- a/core/src/test/java/com/klaviyo/coresdk/networking/TrackRequestTest.kt
+++ b/core/src/test/java/com/klaviyo/coresdk/networking/TrackRequestTest.kt
@@ -1,0 +1,59 @@
+package com.klaviyo.coresdk.networking
+
+import android.content.Context
+import com.klaviyo.coresdk.KlaviyoConfig
+import com.klaviyo.coresdk.networking.IdentifyRequest.Companion.IDENTIFY_ENDPOINT
+import com.klaviyo.coresdk.networking.KlaviyoRequest.Companion.BASE_URL
+import com.klaviyo.coresdk.networking.TrackRequest.Companion.TRACK_ENDPOINT
+import com.nhaarman.mockitokotlin2.mock
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import java.net.URL
+
+class TrackRequestTest {
+    private val contextMock = mock<Context>()
+
+    @Before
+    fun setup() {
+        KlaviyoConfig.Builder()
+                .apiKey("Fake_Key")
+                .applicationContext(contextMock)
+                .networkTimeout(1000)
+                .networkFlushInterval(10000)
+                .build()
+    }
+
+    @Test
+    fun `Build Track request successfully`() {
+        val event = "Test Event"
+        val customerProperties = hashMapOf("\$email" to "test@test.com", "\$phone_number" to "+12223334444")
+
+        val expectedJsonString = "{\"customer_properties\":{\"\$phone_number\":\"+12223334444\",\"\$email\":\"test@test.com\"},\"event\":\"Test Event\",\"token\":\"Fake_Key\"}"
+
+        val request = TrackRequest(event, customerProperties)
+        request.headerData = request.buildKlaviyoJsonHeader()
+
+        Assert.assertEquals(URL("$BASE_URL/$TRACK_ENDPOINT"), request.url)
+        Assert.assertEquals(RequestMethod.GET, request.requestMethod)
+        Assert.assertEquals(expectedJsonString, request.headerData)
+        Assert.assertEquals(null, request.payload)
+    }
+
+    @Test
+    fun `Build Track request with no properties`() {
+        val event = "Test Event"
+        val customerProperties = hashMapOf("\$email" to "test@test.com", "\$phone_number" to "+12223334444")
+        val properties = hashMapOf("custom_value" to "200")
+
+        val expectedJsonString = "{\"customer_properties\":{\"\$phone_number\":\"+12223334444\",\"\$email\":\"test@test.com\"},\"event\":\"Test Event\",\"properties\":{\"custom_value\":\"200\"},\"token\":\"Fake_Key\"}"
+
+        val request = TrackRequest(event, customerProperties, properties)
+        request.headerData = request.buildKlaviyoJsonHeader()
+
+        Assert.assertEquals(URL("$BASE_URL/$TRACK_ENDPOINT"), request.url)
+        Assert.assertEquals(RequestMethod.GET, request.requestMethod)
+        Assert.assertEquals(expectedJsonString, request.headerData)
+        Assert.assertEquals(null, request.payload)
+    }
+}


### PR DESCRIPTION
# Purpose
Adds the structure needed to make GET and POST requests via the Android SDK.

**Type of PR**
* [ ] Bug Fix
* [x] Feature Work
* [ ] Revert
* [ ] Refactor / Code Cleanup
* [ ] Other (fill in...)

## Short Description
<!-- Feature / Problem overview -->
Adds the structure needed to make GET and POST requests via the Android SDK. These requests and their properties are stored in instances which will later be consumed by the batching queue once implemented. All code is unit tested.


## Changelog / Code Overview
<!-- What was changed / added / removed and why. If you changed the frontend please include screenshots -->
Added multiple classes around networking. All networking objects will inherit from the base `NetworkRequest` class which contains all the necessary logic to make requests and process a basic response. `KlaviyoRequest` is an abstract implementation of this which adds another level of logic specific to our Klaviyo requests, and from there we create `TrackRequest` and `IdentifyRequest` as our two analytics requests. The idea is that this structure is flexible to include more requests in the future, rather than being inflexibility set to just track/identify. It could allow us to add `KlaviyoBatchRequest` later or something


## Test Plan
<!-- How was this code tested / How should reviewers test it? -->
All main network request classes are unit tested. This contains some pretty heavy mocking to get around all the networking though.


## What to look for
<!-- Call out what each team/reviewer should look for and a rough time estimate. -->


## Related Issues/Tickets
<!-- Any relevant links to TP / Sentry / RFC -->
https://klaviyo.tpondemand.com/entity/49005-add-abstract-networking-features-to-the

