### PR TITLE
Add rudimentary network batching thread

### DIFF
--- a/core/src/main/java/com/klaviyo/coresdk/KlaviyoConfig.kt
+++ b/core/src/main/java/com/klaviyo/coresdk/KlaviyoConfig.kt
@@ -1,6 +1,7 @@
 package com.klaviyo.coresdk
 
 import android.content.Context
+import com.klaviyo.coresdk.networking.NetworkBatcher
 import java.lang.Exception
 
 class KlaviyoMissingAPIKeyException: Exception("You must declare an API key for the Klaviyo SDK")
@@ -11,6 +12,7 @@ object KlaviyoConfig {
     private const val NETWORK_TIMEOUT_DEFAULT: Int = 500
     private const val NETWORK_FLUSH_INTERVAL_DEFAULT: Int = 60000
     private const val NETWORK_FLUSH_DEPTH_DEFAULT: Int = 20
+    private const val NETWORK_FLUSH_CHECK_INTERVAL: Long = 2000
 
     lateinit var apiKey: String
         private set
@@ -22,6 +24,8 @@ object KlaviyoConfig {
         private set
     var networkFlushDepth = NETWORK_FLUSH_DEPTH_DEFAULT
         private set
+    var networkFlushCheckInterval = NETWORK_FLUSH_CHECK_INTERVAL
+        private set
 
     class Builder {
         private var apiKey: String = ""
@@ -29,6 +33,7 @@ object KlaviyoConfig {
         private var networkTimeout: Int = NETWORK_TIMEOUT_DEFAULT
         private var networkFlushInterval: Int = NETWORK_FLUSH_INTERVAL_DEFAULT
         private var networkFlushDepth = NETWORK_FLUSH_DEPTH_DEFAULT
+        private var networkFlushCheckInterval = NETWORK_FLUSH_CHECK_INTERVAL
 
         fun apiKey(apiKey: String) = apply {
             this.apiKey = apiKey
@@ -63,6 +68,14 @@ object KlaviyoConfig {
             }
         }
 
+        fun networkFlushCheckInterval(networkFlushCheckInterval: Long) = apply {
+            if (networkFlushCheckInterval < 0) {
+                // TODO: When Timber is installed, log warning here
+            } else {
+                this.networkFlushCheckInterval = networkFlushCheckInterval
+            }
+        }
+
         fun build() {
             if (apiKey.isEmpty()) {
                 throw KlaviyoMissingAPIKeyException()
@@ -76,6 +89,7 @@ object KlaviyoConfig {
             KlaviyoConfig.networkTimeout = networkTimeout
             KlaviyoConfig.networkFlushInterval = networkFlushInterval
             KlaviyoConfig.networkFlushDepth = networkFlushDepth
+            KlaviyoConfig.networkFlushCheckInterval = networkFlushCheckInterval
         }
     }
 }

--- a/core/src/main/java/com/klaviyo/coresdk/KlaviyoLifecycleCallbackListener.kt
+++ b/core/src/main/java/com/klaviyo/coresdk/KlaviyoLifecycleCallbackListener.kt
@@ -1,0 +1,37 @@
+package com.klaviyo.coresdk
+
+import android.app.Activity
+import android.app.Application
+import android.os.Bundle
+import com.klaviyo.coresdk.networking.NetworkBatcher
+
+class KlaviyoLifecycleCallbackListener: Application.ActivityLifecycleCallbacks {
+    private var activitiesActive = 0
+
+    override fun onActivityPaused(p0: Activity) {
+    }
+
+    override fun onActivityStarted(p0: Activity) {
+    }
+
+    override fun onActivityDestroyed(p0: Activity) {
+    }
+
+    override fun onActivitySaveInstanceState(p0: Activity, p1: Bundle) {
+    }
+
+    override fun onActivityStopped(p0: Activity) {
+        activitiesActive--
+        if (activitiesActive == 0) {
+            NetworkBatcher.forceEmptyQueue()
+        }
+    }
+
+    override fun onActivityCreated(p0: Activity, p1: Bundle?) {
+        activitiesActive++
+    }
+
+    override fun onActivityResumed(p0: Activity) {
+    }
+
+}

--- a/core/src/main/java/com/klaviyo/coresdk/KlaviyoLifecycleCallbackListener.kt
+++ b/core/src/main/java/com/klaviyo/coresdk/KlaviyoLifecycleCallbackListener.kt
@@ -8,30 +8,29 @@ import com.klaviyo.coresdk.networking.NetworkBatcher
 class KlaviyoLifecycleCallbackListener: Application.ActivityLifecycleCallbacks {
     private var activitiesActive = 0
 
-    override fun onActivityPaused(p0: Activity) {
+    override fun onActivityCreated(activity: Activity, bundle: Bundle?) {
     }
 
-    override fun onActivityStarted(p0: Activity) {
+    override fun onActivityStarted(activity: Activity) {
+        activitiesActive++
     }
 
-    override fun onActivityDestroyed(p0: Activity) {
+    override fun onActivityResumed(activity: Activity) {
     }
 
-    override fun onActivitySaveInstanceState(p0: Activity, p1: Bundle) {
+    override fun onActivitySaveInstanceState(activity: Activity, bundle: Bundle) {
     }
 
-    override fun onActivityStopped(p0: Activity) {
+    override fun onActivityPaused(activity: Activity) {
+    }
+
+    override fun onActivityStopped(activity: Activity) {
         activitiesActive--
         if (activitiesActive == 0) {
             NetworkBatcher.forceEmptyQueue()
         }
     }
 
-    override fun onActivityCreated(p0: Activity, p1: Bundle?) {
-        activitiesActive++
+    override fun onActivityDestroyed(activity: Activity) {
     }
-
-    override fun onActivityResumed(p0: Activity) {
-    }
-
 }

--- a/core/src/main/java/com/klaviyo/coresdk/networking/NetworkBatcher.kt
+++ b/core/src/main/java/com/klaviyo/coresdk/networking/NetworkBatcher.kt
@@ -32,7 +32,6 @@ object NetworkBatcher {
         if (batchQueue.isEmpty()) {
             initBatcher()
             queueInitTime = System.currentTimeMillis()
-
         }
 
         for (request in requests) {

--- a/core/src/main/java/com/klaviyo/coresdk/networking/NetworkBatcher.kt
+++ b/core/src/main/java/com/klaviyo/coresdk/networking/NetworkBatcher.kt
@@ -1,0 +1,67 @@
+package com.klaviyo.coresdk.networking
+
+import android.os.Handler
+import android.os.HandlerThread
+import com.klaviyo.coresdk.KlaviyoConfig
+import java.util.concurrent.ConcurrentLinkedQueue
+
+object NetworkBatcher {
+    private val handlerThread = HandlerThread("Klaviyo Network Batcher")
+    private var handler: Handler? = null
+    private var batchQueue = ConcurrentLinkedQueue<NetworkRequest>()
+    private var queueInitTime = 0L
+
+    internal fun initBatcher() {
+        if (!handlerThread.isAlive) {
+            handlerThread.start()
+            handler = Handler(handlerThread.looper)
+        }
+        handler?.post(NetworkRunnable())
+    }
+
+    internal fun forceEmptyQueue() {
+        handler?.removeCallbacksAndMessages(null)
+        handler?.post(NetworkRunnable(true))
+    }
+
+    internal fun getBatchQueueSize(): Int {
+        return batchQueue.size
+    }
+
+    internal fun batchRequests(vararg requests: NetworkRequest) {
+        if (batchQueue.size == 0) {
+            initBatcher()
+            queueInitTime = System.currentTimeMillis()
+
+        }
+
+        for (request in requests) {
+            if (request is TrackRequest) {
+                request.generateUnixTimestamp()
+            }
+            batchQueue.add(request)
+        }
+    }
+
+    internal class NetworkRunnable(private val forceEmpty: Boolean = false): Runnable {
+        override fun run() {
+            val emptied = emptyRequestQueue(forceEmpty)
+            if (!emptied) {
+                handler?.postDelayed(this, 2000)
+            }
+        }
+
+        private fun emptyRequestQueue(forceEmpty: Boolean = false): Boolean {
+            val queueTimePassed = System.currentTimeMillis() - queueInitTime
+            val readyToEmpty = batchQueue.size >= KlaviyoConfig.networkFlushDepth || queueTimePassed >= KlaviyoConfig.networkFlushInterval
+            if (forceEmpty || readyToEmpty) {
+                while(batchQueue.size > 0) {
+                    val request = batchQueue.remove()
+                    request?.sendNetworkRequest()
+                }
+                return true
+            }
+            return false
+        }
+    }
+}

--- a/core/src/test/java/com/klaviyo/coresdk/networking/NetworkBatcherTest.kt
+++ b/core/src/test/java/com/klaviyo/coresdk/networking/NetworkBatcherTest.kt
@@ -24,7 +24,7 @@ class NetworkBatcherTest {
     fun `Network Batcher empties the queue when full`() {
         val batcherSpy = spy<NetworkBatcher>()
 
-        doNothing().`when`(batcherSpy).initBatcher()
+        doNothing().whenever(batcherSpy).initBatcher()
 
         for (i in 0..8) {
             val requestMock = mock<KlaviyoRequest>()
@@ -47,7 +47,7 @@ class NetworkBatcherTest {
         val batcherSpy = spy<NetworkBatcher>()
         val requestMock = mock<KlaviyoRequest>()
 
-        doNothing().`when`(batcherSpy).initBatcher()
+        doNothing().whenever(batcherSpy).initBatcher()
 
         batcherSpy.batchRequests(requestMock)
         Thread.sleep(1000)
@@ -64,7 +64,7 @@ class NetworkBatcherTest {
         val requestMock2 = mock<KlaviyoRequest>()
         val requestMock3 = mock<KlaviyoRequest>()
 
-        doNothing().`when`(batcherSpy).initBatcher()
+        doNothing().whenever(batcherSpy).initBatcher()
 
         batcherSpy.batchRequests(requestMock, requestMock2, requestMock3)
         assertEquals(3, NetworkBatcher.getBatchQueueSize())

--- a/core/src/test/java/com/klaviyo/coresdk/networking/NetworkBatcherTest.kt
+++ b/core/src/test/java/com/klaviyo/coresdk/networking/NetworkBatcherTest.kt
@@ -1,0 +1,72 @@
+package com.klaviyo.coresdk.networking
+
+import android.content.Context
+import com.klaviyo.coresdk.KlaviyoConfig
+import com.nhaarman.mockitokotlin2.*
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class NetworkBatcherTest {
+    private val contextMock = mock<Context>()
+
+    @Before
+    fun setup() {
+        KlaviyoConfig.Builder()
+                .apiKey("Fake_Key")
+                .applicationContext(contextMock)
+                .networkFlushInterval(1000)
+                .networkFlushDepth(10)
+                .build()
+    }
+
+    @Test
+    fun `Network Batcher empties the queue when full`() {
+        val batcherSpy = spy<NetworkBatcher>()
+
+        doNothing().`when`(batcherSpy).initBatcher()
+
+        for (i in 0..8) {
+            val requestMock = mock<KlaviyoRequest>()
+
+            batcherSpy.batchRequests(requestMock)
+
+            assertEquals(i + 1, batcherSpy.getBatchQueueSize())
+        }
+
+        val requestMock = mock<KlaviyoRequest>()
+
+        batcherSpy.batchRequests(requestMock)
+        NetworkBatcher.NetworkRunnable().run()
+
+        assertEquals(0, batcherSpy.getBatchQueueSize())
+    }
+
+    @Test
+    fun `Network Batcher empties the queue after timeout`() {
+        val batcherSpy = spy<NetworkBatcher>()
+        val requestMock = mock<KlaviyoRequest>()
+
+        doNothing().`when`(batcherSpy).initBatcher()
+
+        batcherSpy.batchRequests(requestMock)
+        Thread.sleep(1000)
+        NetworkBatcher.NetworkRunnable().run()
+
+        assertEquals(0, batcherSpy.getBatchQueueSize())
+    }
+
+    @Test
+    fun `Network Batcher accepts multiple requests per call`() {
+        val batcherSpy = spy<NetworkBatcher>()
+
+        val requestMock = mock<KlaviyoRequest>()
+        val requestMock2 = mock<KlaviyoRequest>()
+        val requestMock3 = mock<KlaviyoRequest>()
+
+        doNothing().`when`(batcherSpy).initBatcher()
+
+        batcherSpy.batchRequests(requestMock, requestMock2, requestMock3)
+        assertEquals(3, NetworkBatcher.getBatchQueueSize())
+    }
+}


### PR DESCRIPTION
# Purpose
Adds a very basic network batcher which will use the existing information in the `KlaviyoConfig` class to determine the triggers for emptying the queue. This does not hit any special batch endpoints in Klaviyo yet, instead it just sends off all network requests in the queue one by one so that we only activate the Android network radio once and conserve on the device's battery power.

**Type of PR**
* [ ] Bug Fix
* [x] Feature Work
* [ ] Revert
* [ ] Refactor / Code Cleanup
* [ ] Other (fill in...)

## Short Description
<!-- Feature / Problem overview -->
Adds a network batcher and accompanying tests. This batcher creates a HandlerThread which executes a runnable for monitoring the batch queue. The batch queue is a ConcurrentLinkedQueue of network requests for thread safety. The threading employed here is really basic stuff so we shouldn't need to worry much about synchronization, we just kick it off whenever the batch queue is populated and end it whenever the queue is empty.
This also includes a `KlaviyoLifecycleCallbackListener` class which can be implemented by the user's Application class to monitor the lifecycle of their application so that we can empty out the batch queue before they terminate the application.


## Changelog / Code Overview
<!-- What was changed / added / removed and why. If you changed the frontend please include screenshots -->
- Added `KlaviyoLifecycleCallbackListener` to monitor the lifecycle of the parent application and empty out our batch queue when the application is stopping.
- Added `NetworkBatcher` to handle batching of our analytics calls
- Added `NetworkBatcherTest` to unit test the batch queue


## Test Plan
<!-- How was this code tested / How should reviewers test it? -->
Unit tested and run against the test application to verify that the queue triggers on both timeouts and when reaching max capacity. Also tested the custom lifecycle callbacks in the test application to verify that the batch queue will be emptied when the application is stoped but before the process is terminated.


## What to look for
<!-- Call out what each team/reviewer should look for and a rough time estimate. -->
Make sure there won't be an synchronization issues here. How would we handle the case where the batching thread is prematurely terminated. We'd lose those customer metrics, can we back them up somewhere? Use a different threading API?


## Related Issues/Tickets
<!-- Any relevant links to TP / Sentry / RFC -->
https://klaviyo.tpondemand.com/entity/49095-create-basic-batching-queue

