### PR TITLE
Add a list of Klaviyo recognised events to the Android SDK

### DIFF
--- a/core/src/main/java/com/klaviyo/coresdk/networking/KlaviyoEvent.kt
+++ b/core/src/main/java/com/klaviyo/coresdk/networking/KlaviyoEvent.kt
@@ -6,7 +6,7 @@ sealed class KlaviyoEvent(val name: String) {
     object SEARCHED_PRODUCTS: KlaviyoEvent("\$searched_products")
 
     // Checkout events
-    object CHECKOUT_STARTED: KlaviyoEvent("\$started_checkout")
+    object STARTED_CHECKOUT: KlaviyoEvent("\$started_checkout")
 
     // Order events
     object PLACED_ORDER: KlaviyoEvent("\$placed_order")

--- a/core/src/main/java/com/klaviyo/coresdk/networking/KlaviyoEvent.kt
+++ b/core/src/main/java/com/klaviyo/coresdk/networking/KlaviyoEvent.kt
@@ -1,7 +1,43 @@
 package com.klaviyo.coresdk.networking
 
 sealed class KlaviyoEvent(val name: String) {
-    object CHECKOUT_STARTED: KlaviyoEvent("checkout_started")
-    object ORDER_PLACED: KlaviyoEvent("order_placed")
+    // Product viewing events
+    object VIEWED_PRODUCT: KlaviyoEvent("\$viewed_product")
+    object SEARCHED_PRODUCTS: KlaviyoEvent("\$searched_products")
+
+    // Checkout events
+    object CHECKOUT_STARTED: KlaviyoEvent("\$started_checkout")
+
+    // Order events
+    object PLACED_ORDER: KlaviyoEvent("\$placed_order")
+    object ORDERED_PRODUCT: KlaviyoEvent("\$ordered_product")
+    object CANCELLED_ORDER: KlaviyoEvent("\$cancelled_order")
+    object REFUNDED_ORDER: KlaviyoEvent("\$refunded_order")
+    object PAID_FOR_ORDER: KlaviyoEvent("\$paid_for_order")
+
+    // Order complete events
+    object FULFILLED_ORDER: KlaviyoEvent("\$fulfilled_order")
+    object FULLFILLED_SHIPMENT: KlaviyoEvent("\$fulfilled_shipment")
+    object FULFILLED_PRODUCT: KlaviyoEvent("\$fulfilled_product")
+    object COMPLETED_ORDER: KlaviyoEvent("\$completed_order")
+    object SHIPPED_ORDER: KlaviyoEvent("\$shipped_order")
+
+    // Subscription events
+    object SUBSCRIBED_TO_BACK_IN_STOCK: KlaviyoEvent("\$subscribed_to_back_in_stock")
+    object SUBSCRIBED_TO_COMING_SOON: KlaviyoEvent("\$subscribed_to_coming_soon")
+    object SUBSCRIBED_TO_LIST: KlaviyoEvent("\$subscribed_to_list")
+
+    // Payment events
+    object SUCCESSFUL_PAYMENT: KlaviyoEvent("\$successful_payment")
+    object FAILED_PAYMENT: KlaviyoEvent("\$failed_payment")
+    object REFUNDED_PAYMENT: KlaviyoEvent("\$refunded_payment")
+    object ISSUED_INVOICE: KlaviyoEvent("\$issued_invoice")
+    object CREATED_SUBSCRIPTION: KlaviyoEvent("\$created_subscription")
+    object ACTIVATED_SUBSCRIPTION: KlaviyoEvent("\$activated_subscription")
+    object CANCELLED_SUBSCRIPTION: KlaviyoEvent("\$cancelled_subscription")
+    object EXPIRED_SUBSCRIPTION: KlaviyoEvent("\$expired_subscription")
+    object CLOSED_SUBSCRIPTION: KlaviyoEvent("\$closed_subscription")
+
+    // Custom events
     class CUSTOM_EVENT(eventName: String): KlaviyoEvent(eventName)
 }


### PR DESCRIPTION
# Purpose
Adds a bunch of Klaviyo events to the Android SDK, identified by the strings that the backend should recognise.

**Type of PR**
* [ ] Bug Fix
* [x] Feature Work
* [ ] Revert
* [ ] Refactor / Code Cleanup
* [ ] Other (fill in...)

## Short Description
<!-- Feature / Problem overview -->
Adds a bunch of Klaviyo events to the Android SDK, identified by the strings that the backend should recognise.

## Changelog / Code Overview
<!-- What was changed / added / removed and why. If you changed the frontend please include screenshots -->
- Added a bunch of event objects to the `KlaviyoEvents` sealed class that acts as our programmable enum.


## Test Plan
<!-- How was this code tested / How should reviewers test it? -->


## What to look for
<!-- Call out what each team/reviewer should look for and a rough time estimate. -->
Make sure there are no typos in the event keys


## Related Issues/Tickets
<!-- Any relevant links to TP / Sentry / RFC -->

