### PR TITLE
Add test for requesting a new token

### DIFF
--- a/sdk/push/src/test/java/com/klaviyo/push/KlaviyoPushServiceTest.kt
+++ b/sdk/push/src/test/java/com/klaviyo/push/KlaviyoPushServiceTest.kt
@@ -2,10 +2,12 @@ package com.klaviyo.push
 
 import android.content.Context
 import android.content.SharedPreferences
+import com.klaviyo.coresdk.Klaviyo
 import com.klaviyo.coresdk.KlaviyoConfig
+import com.klaviyo.coresdk.networking.KlaviyoCustomerProperties
+import com.klaviyo.coresdk.utils.KlaviyoPreferenceUtils
 import com.klaviyo.push.KlaviyoPushService.Companion.PUSH_TOKEN_PREFERENCE_KEY
-import io.mockk.every
-import io.mockk.mockk
+import io.mockk.*
 import junit.framework.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -13,6 +15,7 @@ import org.junit.Test
 class KlaviyoPushServiceTest {
     private val contextMock = mockk<Context>()
     private val preferenceMock = mockk<SharedPreferences>()
+    private val editorMock = mockk<SharedPreferences.Editor>()
 
     @Before
     fun setup() {
@@ -24,6 +27,12 @@ class KlaviyoPushServiceTest {
 
     private fun withPreferenceMock(preferenceName: String, mode: Int) {
         every { contextMock.getSharedPreferences(preferenceName, mode) } returns preferenceMock
+    }
+
+    private fun withWriteStringMock(key: String, value: String) {
+        every { preferenceMock.edit() } returns editorMock
+        every { editorMock.putString(key, value) } returns editorMock
+        every { editorMock.apply() } returns Unit
     }
 
     private fun withReadStringMock(key: String, default: String?, string: String) {
@@ -40,5 +49,28 @@ class KlaviyoPushServiceTest {
         val actualToken = KlaviyoPushService.getCurrentPushToken()
 
         assertEquals(pushToken, actualToken)
+    }
+
+    @Test
+    fun `Appends a new push token to customer properties`() {
+        val pushToken = "TK1"
+
+        withPreferenceMock("KlaviyoSDKPreferences", Context.MODE_PRIVATE)
+        withWriteStringMock(PUSH_TOKEN_PREFERENCE_KEY, pushToken)
+
+        mockkObject(Klaviyo)
+        mockkObject(KlaviyoPreferenceUtils)
+        every { Klaviyo.identify(any()) } returns Unit
+
+        val pushService = KlaviyoPushService()
+        pushService.onNewToken(pushToken)
+
+        verifyAll {
+            contextMock.getSharedPreferences("KlaviyoSDKPreferences", Context.MODE_PRIVATE)
+            preferenceMock.edit()
+            editorMock.putString(PUSH_TOKEN_PREFERENCE_KEY, pushToken)
+            editorMock.apply()
+            Klaviyo.identify(any())
+        }
     }
 }


### PR DESCRIPTION
# Purpose
Just adds one more test to boost coverage a bit. Test covers the case where a new push token has been generated by FCM and is sent as part of an identify call before being popped into the shared preferences for the SDK.

**Type of PR**
* [ ] Bug Fix
* [ ] Feature Work
* [ ] Revert
* [ ] Refactor / Code Cleanup
* [x] Other (tests)

## Short Description
<!-- Feature / Problem overview -->


## Changelog / Code Overview
<!-- What was changed / added / removed and why. If you changed the frontend please include screenshots -->


## Test Plan
<!-- How was this code tested / How should reviewers test it? -->


## What to look for
<!-- Call out what each team/reviewer should look for and a rough time estimate. -->


## Related Issues/Tickets
<!-- Any relevant links to TP / Sentry / RFC -->

