### PR TITLE
v3 API expects time to be iso 8601 format, not an int timestamp.

### DIFF
--- a/sdk/core/src/main/java/com/klaviyo/coresdk/networking/requests/KlaviyoRequest.kt
+++ b/sdk/core/src/main/java/com/klaviyo/coresdk/networking/requests/KlaviyoRequest.kt
@@ -4,6 +4,8 @@ import android.util.Base64
 import com.klaviyo.coresdk.BuildConfig
 import com.klaviyo.coresdk.KlaviyoConfig
 import com.klaviyo.coresdk.networking.NetworkBatcher
+import java.text.SimpleDateFormat
+import java.util.Date
 
 /**
  * Abstract class which defines much of the logic common to requests that will be reaching Klaviyo
@@ -21,6 +23,11 @@ internal abstract class KlaviyoRequest : NetworkRequest() {
      * A timestamp that can be used to track when this request was created
      */
     internal val timestamp: Long = KlaviyoConfig.clock.currentTimeMillis() / 1000
+
+    internal fun getTimeString(): String {
+        val format = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZZZZZ")
+        return format.format(Date(timestamp * 1000))
+    }
 
     /**
      * Encodes the given string into a non-wrapping base64 string

--- a/sdk/core/src/main/java/com/klaviyo/coresdk/networking/requests/KlaviyoRequest.kt
+++ b/sdk/core/src/main/java/com/klaviyo/coresdk/networking/requests/KlaviyoRequest.kt
@@ -6,6 +6,7 @@ import com.klaviyo.coresdk.KlaviyoConfig
 import com.klaviyo.coresdk.networking.NetworkBatcher
 import java.text.SimpleDateFormat
 import java.util.Date
+import java.util.TimeZone
 
 /**
  * Abstract class which defines much of the logic common to requests that will be reaching Klaviyo
@@ -25,7 +26,8 @@ internal abstract class KlaviyoRequest : NetworkRequest() {
     internal val timestamp: Long = KlaviyoConfig.clock.currentTimeMillis() / 1000
 
     internal fun getTimeString(): String {
-        val format = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZZZZZ")
+        val format = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ")
+        format.timeZone = TimeZone.getTimeZone("UTC")
         return format.format(Date(timestamp * 1000))
     }
 

--- a/sdk/core/src/main/java/com/klaviyo/coresdk/networking/requests/TrackRequest.kt
+++ b/sdk/core/src/main/java/com/klaviyo/coresdk/networking/requests/TrackRequest.kt
@@ -47,7 +47,7 @@ internal class TrackRequest(
                         ),
                         "profile" to JSONObject(customerProperties.setAnonymousId().toMap()),
                         "properties" to properties?.let { JSONObject(it.toMap()) },
-                        "time" to timestamp,
+                        "time" to getTimeString(),
                     ).filterValues { it != null }
                 )
             )

--- a/sdk/core/src/test/java/com/klaviyo/coresdk/networking/requests/TrackRequestTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/coresdk/networking/requests/TrackRequestTest.kt
@@ -22,7 +22,7 @@ import org.junit.Test
 class TrackRequestTest {
 
     private val currentTimeMillis = 1234567890000L
-    private val timestamp = 1234567890L
+    private val isoTime = "2009-02-13T23:31:30+0000"
     private val apiKey = "Fake_Key"
     private val uuid = "a123"
 
@@ -58,7 +58,7 @@ class TrackRequestTest {
             "company_id" to "Fake_Key"
         )
         val expectedJsonString =
-            "{\"data\":{\"type\":\"event\",\"attributes\":{\"metric\":{\"name\":\"Test Event\"},\"profile\":{\"\$email\":\"test@test.com\",\"\$anonymous\":\"a123\",\"\$phone_number\":\"+12223334444\"},\"time\":$timestamp}}}"
+            "{\"data\":{\"type\":\"event\",\"attributes\":{\"metric\":{\"name\":\"Test Event\"},\"profile\":{\"\$email\":\"test@test.com\",\"\$anonymous\":\"a123\",\"\$phone_number\":\"+12223334444\"},\"time\":\"$isoTime\"}}}"
         val expectedHeaderKeys = listOf("Content-Type", "Accept", "Revision")
         val expectedHeaderValues = listOf("application/json", "application/json", "2022-10-17")
 
@@ -94,7 +94,7 @@ class TrackRequestTest {
             "company_id" to "Fake_Key"
         )
         val expectedJsonString =
-            "{\"data\":{\"type\":\"event\",\"attributes\":{\"time\":$timestamp,\"metric\":{\"name\":\"Test Event\"},\"properties\":{\"custom_value\":\"200\"},\"profile\":{\"\$email\":\"test@test.com\",\"\$anonymous\":\"a123\",\"\$phone_number\":\"+12223334444\"}}}}"
+            "{\"data\":{\"type\":\"event\",\"attributes\":{\"time\":\"$isoTime\",\"metric\":{\"name\":\"Test Event\"},\"properties\":{\"custom_value\":\"200\"},\"profile\":{\"\$email\":\"test@test.com\",\"\$anonymous\":\"a123\",\"\$phone_number\":\"+12223334444\"}}}}"
         val expectedHeaderKeys = listOf("Content-Type", "Accept", "Revision")
         val expectedHeaderValues = listOf("application/json", "application/json", "2022-10-17")
 


### PR DESCRIPTION
# Purpose
Fix time format in v3 track api 

**Type of PR**
* [x] Bug Fix
* [ ] Feature Work
* [ ] Revert
* [ ] Refactor / Code Cleanup
* [ ] Other (fill in...)

## Short Description
<!-- Feature / Problem overview -->
Using a timestamp results in a 400. 

## Changelog / Code Overview
<!-- What was changed / added / removed and why. If you changed the frontend please include screenshots -->
Changed to iso8601 date format

## Test Plan
<!-- How was this code tested / How should reviewers test it? -->


## What to look for
<!-- Call out what each team/reviewer should look for and a rough time estimate. -->


## Related Issues/Tickets
<!-- Any relevant links to TP / Sentry / RFC -->

