### PR TITLE
Add profile getters and other minor cleanup of the public API

### DIFF
--- a/sdk/core/src/main/java/com/klaviyo/coresdk/Klaviyo.kt
+++ b/sdk/core/src/main/java/com/klaviyo/coresdk/Klaviyo.kt
@@ -18,7 +18,7 @@ object Klaviyo {
      * Configure Klaviyo SDK with your account's public API Key and application context.
      * This must be called to before using any other SDK functionality
      *
-     * @param apiKey - Your Klaviyo account's public API Key
+     * @param apiKey Your Klaviyo account's public API Key
      * @param applicationContext
      * @return
      */
@@ -30,7 +30,7 @@ object Klaviyo {
     }
 
     /**
-     * Assigns an email address to the current internally tracked profile
+     * Assigns an email address to the currently tracked Klaviyo profile
      *
      * The SDK keeps track of current profile details to
      * build analytics requests with profile identifiers
@@ -41,10 +41,15 @@ object Klaviyo {
      * @param email Email address for active user
      * @return
      */
-    fun setEmail(email: String): Klaviyo = this.setProfile(Profile().setEmail(email))
+    fun setEmail(email: String): Klaviyo = this.setProfileAttribute(ProfileKey.EMAIL, email)
 
     /**
-     * Assigns a phone number to the current internally tracked profile
+     * @return The email of the currently tracked profile, if set
+     */
+    fun getEmail(): String? = UserInfo.email.ifEmpty { null }
+
+    /**
+     * Assigns a phone number to the currently tracked Klaviyo profile
      *
      * The SDK keeps track of current profile details to
      * build analytics requests with profile identifiers
@@ -53,12 +58,19 @@ object Klaviyo {
      * (e.g. after a fresh login)
      *
      * @param phoneNumber Phone number for active user
+     * @return
      */
     fun setPhoneNumber(phoneNumber: String): Klaviyo =
-        this.setProfile(Profile().setPhoneNumber(phoneNumber))
+        this.setProfileAttribute(ProfileKey.PHONE_NUMBER, phoneNumber)
 
     /**
-     * Assigns an external ID to the current internally tracked profile
+     * @return The phone number of the currently tracked profile, if set
+     */
+    fun getPhoneNumber(): String? = UserInfo.phoneNumber.ifEmpty { null }
+
+    /**
+     * Assigns a unique identifier to associate the currently tracked Klaviyo profile
+     * with a profile in an external system, such as a point-of-sale system.
      *
      * The SDK keeps track of current profile details to
      * build analytics requests with profile identifiers
@@ -66,49 +78,90 @@ object Klaviyo {
      * This should be called whenever the active user in your app changes
      * (e.g. after a fresh login)
      *
-     * @param id Phone number for active user
+     * @param externalId Unique identifier from external system
      * @return
      */
-    fun setExternalId(id: String): Klaviyo = this.setProfile(Profile().setExternalId(id))
+    fun setExternalId(externalId: String): Klaviyo =
+        this.setProfileAttribute(ProfileKey.EXTERNAL_ID, externalId)
 
     /**
-     * Assign arbitrary attributes to the current profile by key
+     * @return The external ID of the currently tracked profile, if set
+     */
+    fun getExternalId(): String? = UserInfo.externalId.ifEmpty { null }
+
+    /**
+     * Assign an attribute to the currently tracked profile by key/value pair
+     *
+     * The SDK keeps track of current profile details to
+     * build analytics requests with profile identifiers
      *
      * This should be called when you collect additional data about your user
-     * (e.g. first and last name, or an address)
+     * (e.g. first and last name, or location)
      *
      * @param propertyKey
      * @param value
      * @return
      */
-    fun setProfileAttribute(propertyKey: ProfileKey, value: String): Klaviyo =
-        setProfile(Profile().also { it[propertyKey] = value })
+    fun setProfileAttribute(propertyKey: ProfileKey, value: String): Klaviyo = apply {
+        when (propertyKey) {
+            ProfileKey.EMAIL -> {
+                UserInfo.email = value
+                debouncedProfileUpdate(UserInfo.getAsProfile())
+            }
+            ProfileKey.EXTERNAL_ID -> {
+                UserInfo.externalId = value
+                debouncedProfileUpdate(UserInfo.getAsProfile())
+            }
+            ProfileKey.PHONE_NUMBER -> {
+                UserInfo.phoneNumber = value
+                debouncedProfileUpdate(UserInfo.getAsProfile())
+            }
+            else -> {
+                debouncedProfileUpdate(Profile(mapOf(propertyKey to value)))
+            }
+        }
+    }
 
     /**
-     * Debounce timer for enqueuing profile API calls
-     */
-    private var timer: Clock.Cancellable? = null
-    private var pendingProfile: Profile? = null
-
-    /**
-     * Queues a request to identify profile properties to the Klaviyo API
+     * Updates the currently tracked profile from a map-like [Profile] object
+     * Saves identifying attributes (externalId, email, phone) to the currently tracked profile.
      *
-     * Any new identifying properties (externalId, email, phone) will be saved to the current
-     * internally tracked profile. Otherwise any identifiers missing from [profile] will be
-     * populated from the current internally tracked profile info.
-     *
-     * Identify requests track specific properties about a user without triggering an event
+     * The SDK keeps track of current profile details to
+     * build analytics requests with profile identifiers
      *
      * @param profile A map of properties that define the user
      * @return
      */
     fun setProfile(profile: Profile): Klaviyo = apply {
-        // Update user identifiers in state
+        // Update UserInfo in case the incoming profile contains any identifiers
         UserInfo.updateFromProfile(profile)
+        debouncedProfileUpdate(profile)
+    }
 
-        // Start or update a pending profile object for API call
-        pendingProfile = UserInfo.getAsProfile().merge(pendingProfile?.merge(profile) ?: profile)
+    /**
+     * Debounce timer for enqueuing profile API calls
+     */
+    private var timer: Clock.Cancellable? = null
 
+    /**
+     * Pending batch of profile updates to be merged into one API call
+     */
+    private var pendingProfile: Profile? = null
+
+    /**
+     * Uses debounce mechanism to merge profile changes
+     * within a short span of time into one API transaction
+     *
+     * @param profile Incoming profile attribute changes
+     */
+    private fun debouncedProfileUpdate(profile: Profile) {
+        // Merge new changes into pending transaction
+        pendingProfile = pendingProfile?.merge(profile) ?: profile
+
+        // Add current identifiers from UserInfo to pending transaction
+        pendingProfile = UserInfo.getAsProfile().merge(pendingProfile!!)
+
+        // Reset timer
         timer?.cancel()
         timer = Registry.clock.schedule(Registry.config.debounceInterval.toLong()) {
             pendingProfile?.let {
@@ -119,7 +172,7 @@ object Klaviyo {
     }
 
     /**
-     * Clears all stored profile identifiers (e.g. email or phone)
+     * Clears all stored profile identifiers (e.g. email or phone) and starts a new tracked profile
      *
      * This should be called whenever an active user in your app is removed
      * (e.g. after a logout)
@@ -132,12 +185,9 @@ object Klaviyo {
     }
 
     /**
-     * Queues a request to track an [Event] to the Klaviyo API
-     * The event will be associated with the profile specified by the [Profile]
-     * If profile is not set, this will fallback on the current profile identifiers
+     * Creates an an [Event] associated with the currently tracked profile
      *
-     * @param event Name of the event metric
-     * @param event Additional properties associated to the event that are not for identifying the profile
+     * @param event A map-like object representing the event attributes
      * @return
      */
     fun createEvent(event: Event): Klaviyo = apply {

--- a/sdk/core/src/main/java/com/klaviyo/coresdk/Klaviyo.kt
+++ b/sdk/core/src/main/java/com/klaviyo/coresdk/Klaviyo.kt
@@ -20,7 +20,6 @@ object Klaviyo {
      *
      * @param apiKey Your Klaviyo account's public API Key
      * @param applicationContext
-     * @return
      */
     fun initialize(apiKey: String, applicationContext: Context) {
         Registry.config = Registry.configBuilder
@@ -39,7 +38,7 @@ object Klaviyo {
      * (e.g. after a fresh login)
      *
      * @param email Email address for active user
-     * @return
+     * @return Returns [Klaviyo] for call chaining
      */
     fun setEmail(email: String): Klaviyo = this.setProfileAttribute(ProfileKey.EMAIL, email)
 
@@ -58,7 +57,7 @@ object Klaviyo {
      * (e.g. after a fresh login)
      *
      * @param phoneNumber Phone number for active user
-     * @return
+     * @return Returns [Klaviyo] for call chaining
      */
     fun setPhoneNumber(phoneNumber: String): Klaviyo =
         this.setProfileAttribute(ProfileKey.PHONE_NUMBER, phoneNumber)
@@ -79,7 +78,7 @@ object Klaviyo {
      * (e.g. after a fresh login)
      *
      * @param externalId Unique identifier from external system
-     * @return
+     * @return Returns [Klaviyo] for call chaining
      */
     fun setExternalId(externalId: String): Klaviyo =
         this.setProfileAttribute(ProfileKey.EXTERNAL_ID, externalId)
@@ -100,7 +99,7 @@ object Klaviyo {
      *
      * @param propertyKey
      * @param value
-     * @return
+     * @return Returns [Klaviyo] for call chaining
      */
     fun setProfileAttribute(propertyKey: ProfileKey, value: String): Klaviyo = apply {
         when (propertyKey) {
@@ -130,7 +129,7 @@ object Klaviyo {
      * build analytics requests with profile identifiers
      *
      * @param profile A map of properties that define the user
-     * @return
+     * @return Returns [Klaviyo] for call chaining
      */
     fun setProfile(profile: Profile): Klaviyo = apply {
         // Update UserInfo in case the incoming profile contains any identifiers
@@ -177,7 +176,7 @@ object Klaviyo {
      * This should be called whenever an active user in your app is removed
      * (e.g. after a logout)
      *
-     * @return
+     * @return Returns [Klaviyo] for call chaining
      */
     fun resetProfile(): Klaviyo = apply {
         UserInfo.reset()
@@ -188,7 +187,7 @@ object Klaviyo {
      * Creates an an [Event] associated with the currently tracked profile
      *
      * @param event A map-like object representing the event attributes
-     * @return
+     * @return Returns [Klaviyo] for call chaining
      */
     fun createEvent(event: Event): Klaviyo = apply {
         Registry.apiClient.enqueueEvent(event, UserInfo.getAsProfile())

--- a/sdk/core/src/test/java/com/klaviyo/coresdk/KlaviyoTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/coresdk/KlaviyoTest.kt
@@ -14,6 +14,7 @@ import io.mockk.slot
 import io.mockk.verify
 import io.mockk.verifyAll
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 internal class KlaviyoTest : BaseTest() {
@@ -141,6 +142,21 @@ internal class KlaviyoTest : BaseTest() {
         assert(UserInfo.externalId == "")
 
         verify(exactly = 1) { apiClientMock.enqueueProfile(any()) }
+    }
+
+    @Test
+    fun `Gets identifiers out of user info`() {
+        assertNull(Klaviyo.getEmail())
+        assertNull(Klaviyo.getPhoneNumber())
+        assertNull(Klaviyo.getExternalId())
+
+        UserInfo.email = EMAIL
+        UserInfo.phoneNumber = PHONE
+        UserInfo.externalId = EXTERNAL_ID
+
+        assertEquals(EMAIL, Klaviyo.getEmail())
+        assertEquals(PHONE, Klaviyo.getPhoneNumber())
+        assertEquals(EXTERNAL_ID, Klaviyo.getExternalId())
     }
 
     @Test

--- a/sdk/core/src/test/java/com/klaviyo/coresdk/model/KeywordsTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/coresdk/model/KeywordsTest.kt
@@ -30,6 +30,8 @@ class KeywordsTest {
         val custom = ProfileKey.CUSTOM(expectedCustomKey)
         assert(custom == ProfileKey.CUSTOM(expectedCustomKey))
         assert(custom != ProfileKey.CUSTOM(expectedCustomKey + "1"))
+
+        assertEquals(ProfileKey.EMAIL, ProfileKey.CUSTOM("\$email"))
     }
 
     @Test


### PR DESCRIPTION
# Purpose

**Type of PR**
* [ ] Bug Fix
* [x] Feature Work
* [ ] Revert
* [ ] Refactor / Code Cleanup
* [ ] Other (fill in...)

## Short Description
<!-- Feature / Problem overview -->
Added getter methods for email, phone and external ID to public API per spec (and tests)
Addressed, I think, some code-readability concerns. Extracted the debouncing logic into a private method. 
Made some fixes to the API comments for clarity or just fix out of date comments

## Changelog / Code Overview
<!-- What was changed / added / removed and why. If you changed the frontend please include screenshots -->


## Test Plan
<!-- How was this code tested / How should reviewers test it? -->


## What to look for
<!-- Call out what each team/reviewer should look for and a rough time estimate. -->
Agreed with @jordan-griffin that the readability on some of the profile setter methods wasn't great. I think this makes it more self-evident how these methods behave. 

## Related Issues/Tickets
<!-- Any relevant links to TP / Sentry / RFC -->
https://klaviyo.tpondemand.com/entity/164289-expose-profile-getters-from-android-sdk
