### PR TITLE
Some very minor release prep things

### DIFF
--- a/flavors.gradle
+++ b/flavors.gradle
@@ -1,13 +1,13 @@
 ext {
+    def localProperties = new Properties()
+    if (rootProject.file("local.properties").canRead()) {
+        localProperties.load(new FileInputStream(rootProject.file("local.properties")))
+    }
+
     /**
      * Extracted product flavor as a closure to be applied for all android projects
      */
     flavorConfig = {
-        def localProperties = new Properties()
-        if (rootProject.file("local.properties").canRead()) {
-            localProperties.load(new FileInputStream(rootProject.file("local.properties")))
-        }
-
         //Using build flavor as a convenient way to toggle between local and production servers
         // using the "Active Build Variant" feature in Android Studio.
         // You must also add localKlaviyoServerUrl to local.properties (untracked in git)
@@ -25,6 +25,6 @@ ext {
         }
     }
 
-    //Name of build variant that we actually publish
-    publishBuildVariant="productionRelease"
+    //Name of build variant that we actually publish, pulled from gradle.properties or local.properties override
+    publishBuildVariant = "${localProperties['publishBuildVariant'] ?: "productionRelease"}"
 }

--- a/sdk/analytics/build.gradle
+++ b/sdk/analytics/build.gradle
@@ -17,7 +17,6 @@ android {
 dependencies {
     implementation project(':sdk:core')
     testImplementation project(':sdk:fixtures')
-
 }
 
 afterEvaluate {

--- a/sdk/push-fcm/build.gradle
+++ b/sdk/push-fcm/build.gradle
@@ -19,7 +19,6 @@ dependencies {
     implementation project(':sdk:analytics')
     implementation "com.google.firebase:firebase-messaging:$ext.fcmVersion"
     testImplementation project(':sdk:fixtures')
-
 }
 
 afterEvaluate {

--- a/versions.gradle
+++ b/versions.gradle
@@ -13,7 +13,7 @@ ext {
 
     // project versioning
     versionCode = 1
-    versionName = '1.0.1'
+    versionName = '1.0.0'
 
     // dependencies
     coreKTXVersion = '1.9.0'


### PR DESCRIPTION
I don't know why I put 1.0.1 for the first version, should be 1.0.0
Also added a local.properties override for the publish variant, so we can use `localDebug` while working on the tester app