### PR TITLE
Takes out my hacky attempt to "disassociate" push tokens on reset profile

### DIFF
--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -238,8 +238,8 @@ object Klaviyo {
     /**
      * Clears all stored profile identifiers (e.g. email or phone) and starts a new tracked profile
      *
-     * NOTE: if a push token was registered to the current profile, Klaviyo will disassociate it
-     * from the current profile. Call `setPushToken` again to associate this device to a new profile
+     * NOTE: if a push token was registered to the current profile, you will need to
+     * call `setPushToken` again to associate this device to a new profile
      *
      * This should be called whenever an active user in your app is removed
      * (e.g. after a logout)

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -252,16 +252,8 @@ object Klaviyo {
         // Clear profile identifiers from state
         UserInfo.reset()
 
-        // If we had a push token, re-associate it with an anonymous ID, then erase the local copy
-        // Someday we'll just have a delete token API endpoint -- this is a workaround.
-        getPushToken()?.let { pushToken ->
-            Registry.get<ApiClient>().enqueuePushToken(pushToken, UserInfo.getAsProfile())
-            Registry.dataStore.clear(EventKey.PUSH_TOKEN.name)
-
-            // Reset that anonymous ID too so that we don't inadvertently use this token push
-            // on a new profile created later without the app developer's say-so
-            UserInfo.reset()
-        }
+        // If we had a push token, erase the local copy
+        Registry.dataStore.clear(EventKey.PUSH_TOKEN.name)
     }
 
     /**

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
@@ -197,7 +197,7 @@ internal class KlaviyoTest : BaseTest() {
     }
 
     @Test
-    fun `Reset re-associates push token to new anonymous profile and removes from store`() {
+    fun `Reset removes push token from store`() {
         UserInfo.email = EMAIL
         dataStoreSpy.store("push_token", PUSH_TOKEN)
 
@@ -205,7 +205,6 @@ internal class KlaviyoTest : BaseTest() {
 
         assertEquals("", UserInfo.email)
         assertEquals(null, dataStoreSpy.fetch("push_token"))
-        verify(exactly = 1) { apiClientMock.enqueuePushToken(any(), any()) }
     }
 
     @Test


### PR DESCRIPTION
# Purpose

**Type of PR**
* [x] Bug Fix
* [ ] Feature Work
* [ ] Revert
* [ ] Refactor / Code Cleanup
* [ ] Other (fill in...)

## Short Description
<!-- Feature / Problem overview -->
The reset profile functionality now matches iOS, doesn't create dangling anonymous profiles, but it does clear push token from state at least. 

## Changelog / Code Overview
<!-- What was changed / added / removed and why. If you changed the frontend please include screenshots -->


## Test Plan
<!-- How was this code tested / How should reviewers test it? -->
Updated a unit test, and I tested android and ios apps together and they behave the same now. 

## What to look for
<!-- Call out what each team/reviewer should look for and a rough time estimate. -->


## Related Issues/Tickets
<!-- Any relevant links to TP / Sentry / RFC -->

