### PR TITLE
Downgrade Android Gradle plugin for Jitpack compatibility

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -12,7 +12,6 @@ subprojects {
         buildToolsVersion ext.buildToolsVersion
 
         compileOptions {
-            sourceCompatibility JavaVersion.VERSION_20
             targetCompatibility JavaVersion.VERSION_11
         }
 

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -11,6 +11,11 @@ subprojects {
         compileSdkVersion ext.androidCompileVersion
         buildToolsVersion ext.buildToolsVersion
 
+        compileOptions {
+            sourceCompatibility JavaVersion.VERSION_20
+            targetCompatibility JavaVersion.VERSION_11
+        }
+
         defaultConfig {
             minSdkVersion ext.minSDKVersion
             targetSdkVersion ext.targetSDKVersion

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -11,10 +11,6 @@ subprojects {
         compileSdkVersion ext.androidCompileVersion
         buildToolsVersion ext.buildToolsVersion
 
-        compileOptions {
-            targetCompatibility JavaVersion.VERSION_11
-        }
-
         defaultConfig {
             minSdkVersion ext.minSDKVersion
             targetSdkVersion ext.targetSDKVersion

--- a/versions.gradle
+++ b/versions.gradle
@@ -1,6 +1,6 @@
 ext {
     // build dependencies
-    gradleBuildToolsVersion = '7.4.0'
+    gradleBuildToolsVersion = '7.3.1'
     gradleKotlinVersion = '1.7.20'
     dokkaVersion = '1.7.20'
     gradleKtlintVersion = "11.3.1"


### PR DESCRIPTION
# Purpose
I was getting some annoying Jitpack compilation errors when trying to publish our SDK and after some research and attempting a few different fixes I landed on Android Gradle plugin 7.4.0 just not being compatible with Jitpack (or something in our project bringing the target Java version down to v8 which would not work with Android Gradle 7.4.0). The error logs were a bit confusing.

So fix I'm proposing here is to downgrade to Android Gradle plugin 7.3.1 which runs Gradle 7.4 in the background - meaning we're not downgrading so much that we're on a deprecated version or anything. But just enough to make Jitpack happy

**Type of PR**
* [ ] Bug Fix
* [ ] Feature Work
* [ ] Revert
* [ ] Refactor / Code Cleanup
* [ ] Other (fill in...)

## Short Description
<!-- Feature / Problem overview -->


## Changelog / Code Overview
<!-- What was changed / added / removed and why. If you changed the frontend please include screenshots -->


## Test Plan
<!-- How was this code tested / How should reviewers test it? -->


## What to look for
<!-- Call out what each team/reviewer should look for and a rough time estimate. -->


## Related Issues/Tickets
<!-- Any relevant links to TP / Sentry / RFC -->

