### PR TITLE
Upgrade to V3 push token API

### DIFF
--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/DeviceProperties.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/DeviceProperties.kt
@@ -1,5 +1,6 @@
 package com.klaviyo.analytics
 
+import android.content.pm.ApplicationInfo
 import android.content.pm.PackageInfo
 import android.os.Build
 import com.klaviyo.core.BuildConfig
@@ -69,7 +70,7 @@ internal object DeviceProperties {
         Registry.config.applicationContext.packageManager.getPackageInfoCompat(applicationId)
     }
 
-    fun buildMetaData(): Map<String, String?> = mapOf(
+    fun buildEventMetaData(): Map<String, String?> = mapOf(
         "Device ID" to device_id,
         "Device Manufacturer" to manufacturer,
         "Device Model" to model,
@@ -83,6 +84,28 @@ internal object DeviceProperties {
         "App Build" to appVersionCode,
         "Push Token" to Klaviyo.getPushToken()
     )
+
+    fun buildMetaData(): Map<String, String?> = mapOf(
+        "device_id" to device_id,
+        "manufacturer" to manufacturer,
+        "device_model" to model,
+        "os_name" to platform,
+        "os_version" to osVersion,
+        "klaviyo_sdk" to sdkName,
+        "sdk_version" to sdkVersion,
+        "app_name" to applicationLabel,
+        "app_id" to applicationId,
+        "app_version" to appVersion,
+        "app_build" to appVersionCode,
+        "environment" to getEnvironment()
+    )
+
+    private fun getEnvironment(): String =
+        if (Registry.config.applicationContext.applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE != 0) {
+            "debug"
+        } else {
+            "release"
+        }
 }
 
 internal fun PackageInfo.getVersionCodeCompat(): Int =

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/EventApiRequest.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/EventApiRequest.kt
@@ -49,7 +49,7 @@ internal class EventApiRequest(
                     METRIC to mapOf(NAME to event.type.name),
                     VALUE to event.value,
                     TIME to Registry.clock.isoTime(queuedTime),
-                    PROPERTIES to event.toMap() + DeviceProperties.buildMetaData(),
+                    PROPERTIES to event.toMap() + DeviceProperties.buildEventMetaData(),
                     allowEmptyMaps = true
                 )
             )

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequest.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequest.kt
@@ -40,6 +40,7 @@ internal open class KlaviyoApiRequest(
         const val COMPANY_ID = "company_id"
         const val PROFILE = "profile"
         const val EVENT = "event"
+        const val PUSH_TOKEN = "push-token"
 
         // Headers
         const val HEADER_CONTENT = "Content-Type"
@@ -47,7 +48,7 @@ internal open class KlaviyoApiRequest(
         const val HEADER_ACCEPT = "Accept"
         const val HEADER_REVISION = "Revision"
         const val TYPE_JSON = "application/json"
-        const val V3_REVISION = "2023-01-24"
+        const val V3_REVISION = "2023-06-06"
 
         const val HTTP_OK = HttpURLConnection.HTTP_OK
         const val HTTP_ACCEPTED = HttpURLConnection.HTTP_ACCEPTED

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequest.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequest.kt
@@ -48,7 +48,7 @@ internal open class KlaviyoApiRequest(
         const val HEADER_ACCEPT = "Accept"
         const val HEADER_REVISION = "Revision"
         const val TYPE_JSON = "application/json"
-        const val V3_REVISION = "2023-06-06"
+        const val V3_REVISION = "2023-06-06.pre"
 
         const val HTTP_OK = HttpURLConnection.HTTP_OK
         const val HTTP_ACCEPTED = HttpURLConnection.HTTP_ACCEPTED

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/PushTokenApiRequest.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/PushTokenApiRequest.kt
@@ -21,7 +21,7 @@ internal class PushTokenApiRequest(
         const val METADATA = "device_metadata"
     }
 
-    override val type: String = "Push Tokens"
+    override val type: String = "Push Token"
 
     /**
      * HTTP request headers
@@ -56,7 +56,7 @@ internal class PushTokenApiRequest(
                     PROFILE to mapOf(
                         DATA to mapOf(
                             TYPE to PROFILE,
-                            ATTRIBUTES to profile.getIdentifiers()
+                            ATTRIBUTES to profile.getIdentifiers().mapKeys { it.key.name }
                         )
                     )
                 )

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/KlaviyoApiClientTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/KlaviyoApiClientTest.kt
@@ -52,6 +52,7 @@ internal class KlaviyoApiClientTest : BaseTest() {
 
         mockkObject(DeviceProperties)
         every { DeviceProperties.userAgent } returns "Mock User Agent"
+        every { DeviceProperties.buildEventMetaData() } returns emptyMap()
         every { DeviceProperties.buildMetaData() } returns emptyMap()
 
         delayedRunner = null

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/BaseRequestTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/BaseRequestTest.kt
@@ -21,7 +21,7 @@ internal open class BaseRequestTest : BaseTest() {
         every { DeviceProperties.sdkName } returns "Mock SDK"
         every { DeviceProperties.sdkVersion } returns "Mock SDK Version"
         every { DeviceProperties.applicationId } returns "Mock App ID"
-        every { DeviceProperties.platform } returns "Mock Platform"
+        every { DeviceProperties.platform } returns "Android"
         every { DeviceProperties.device_id } returns "Mock Device ID"
         every { DeviceProperties.manufacturer } returns "Mock Manufacturer"
         every { DeviceProperties.osVersion } returns "Mock OS Version"

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/EventApiRequestTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/EventApiRequestTest.kt
@@ -16,7 +16,7 @@ internal class EventApiRequestTest : BaseRequestTest() {
     private val expectedHeaders = mapOf(
         "Content-Type" to "application/json",
         "Accept" to "application/json",
-        "Revision" to "2023-01-24",
+        "Revision" to "2023-06-06",
         "User-Agent" to "Mock User Agent"
     )
 
@@ -79,7 +79,7 @@ internal class EventApiRequestTest : BaseRequestTest() {
                     "Device ID": "Mock Device ID",
                     "Device Manufacturer": "Mock Manufacturer",
                     "Device Model": "Mock Model",
-                    "OS Name": "Mock Platform",
+                    "OS Name": "Android",
                     "OS Version": "Mock OS Version",
                     "SDK Name": "Mock SDK",
                     "SDK Version": "Mock SDK Version",
@@ -119,7 +119,7 @@ internal class EventApiRequestTest : BaseRequestTest() {
                     "Device ID": "Mock Device ID",
                     "Device Manufacturer": "Mock Manufacturer",
                     "Device Model": "Mock Model",
-                    "OS Name": "Mock Platform",
+                    "OS Name": "Android",
                     "OS Version": "Mock OS Version",
                     "SDK Name": "Mock SDK",
                     "SDK Version": "Mock SDK Version",
@@ -161,7 +161,7 @@ internal class EventApiRequestTest : BaseRequestTest() {
                     "Device ID": "Mock Device ID",
                     "Device Manufacturer": "Mock Manufacturer",
                     "Device Model": "Mock Model",
-                    "OS Name": "Mock Platform",
+                    "OS Name": "Android",
                     "OS Version": "Mock OS Version",
                     "SDK Name": "Mock SDK",
                     "SDK Version": "Mock SDK Version",

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/EventApiRequestTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/EventApiRequestTest.kt
@@ -16,7 +16,7 @@ internal class EventApiRequestTest : BaseRequestTest() {
     private val expectedHeaders = mapOf(
         "Content-Type" to "application/json",
         "Accept" to "application/json",
-        "Revision" to "2023-06-06",
+        "Revision" to "2023-06-06.pre",
         "User-Agent" to "Mock User Agent"
     )
 

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/ProfileApiRequestTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/ProfileApiRequestTest.kt
@@ -15,7 +15,7 @@ internal class ProfileApiRequestTest : BaseRequestTest() {
     private val expectedHeaders = mapOf(
         "Content-Type" to "application/json",
         "Accept" to "application/json",
-        "Revision" to "2023-01-24",
+        "Revision" to "2023-06-06",
         "User-Agent" to "Mock User Agent"
     )
 

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/ProfileApiRequestTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/ProfileApiRequestTest.kt
@@ -15,7 +15,7 @@ internal class ProfileApiRequestTest : BaseRequestTest() {
     private val expectedHeaders = mapOf(
         "Content-Type" to "application/json",
         "Accept" to "application/json",
-        "Revision" to "2023-06-06",
+        "Revision" to "2023-06-06.pre",
         "User-Agent" to "Mock User Agent"
     )
 

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/PushTokenApiRequestTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/PushTokenApiRequestTest.kt
@@ -12,7 +12,7 @@ internal class PushTokenApiRequestTest : BaseRequestTest() {
     private val expectedHeaders = mapOf(
         "Content-Type" to "application/json",
         "Accept" to "application/json",
-        "Revision" to "2023-06-06",
+        "Revision" to "2023-06-06.pre",
         "User-Agent" to "Mock User Agent"
     )
 

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/PushTokenApiRequestTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/PushTokenApiRequestTest.kt
@@ -1,49 +1,49 @@
 package com.klaviyo.analytics.networking.requests
 
 import com.klaviyo.analytics.model.Profile
-import com.klaviyo.analytics.model.ProfileKey
-import io.mockk.every
-import io.mockk.mockkObject
-import io.mockk.spyk
-import java.io.ByteArrayInputStream
-import java.net.HttpURLConnection
-import java.net.URL
+import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 internal class PushTokenApiRequestTest : BaseRequestTest() {
-    private val expectedUrlPath = "api/identify"
-    private val expectedMethod = RequestMethod.POST
-    private var profile = Profile().setAnonymousId(ANON_ID)
+    private val expectedUrlPath = "client/push-tokens"
+    private val expectedQueryData = mapOf("company_id" to API_KEY)
 
     private val expectedHeaders = mapOf(
         "Content-Type" to "application/json",
+        "Accept" to "application/json",
+        "Revision" to "2023-06-06",
         "User-Agent" to "Mock User Agent"
     )
 
+    private val stubProfile = Profile()
+        .setAnonymousId(ANON_ID)
+        .setEmail(EMAIL)
+        .setPhoneNumber(PHONE)
+
     @Test
-    fun `Uses the correct endpoint`() {
-        assertEquals(expectedUrlPath, PushTokenApiRequest(PUSH_TOKEN, profile).urlPath)
+    fun `Uses correct endpoint`() {
+        assertEquals(expectedUrlPath, PushTokenApiRequest(PUSH_TOKEN, stubProfile).urlPath)
     }
 
     @Test
-    fun `Uses the correct method`() {
-        assertEquals(expectedMethod, PushTokenApiRequest(PUSH_TOKEN, profile).method)
+    fun `Uses correct method`() {
+        assertEquals(RequestMethod.POST, PushTokenApiRequest(PUSH_TOKEN, stubProfile).method)
     }
 
     @Test
-    fun `Sets proper headers`() {
-        assertEquals(expectedHeaders, PushTokenApiRequest(PUSH_TOKEN, profile).headers)
+    fun `Uses correct headers`() {
+        assertEquals(expectedHeaders, PushTokenApiRequest(PUSH_TOKEN, stubProfile).headers)
     }
 
     @Test
-    fun `Does not set a query`() {
-        assert(PushTokenApiRequest(PUSH_TOKEN, profile).query.isEmpty())
+    fun `Uses API Key in query`() {
+        assertEquals(expectedQueryData, PushTokenApiRequest(PUSH_TOKEN, stubProfile).query)
     }
 
     @Test
     fun `JSON interoperability`() {
-        val request = PushTokenApiRequest(PUSH_TOKEN, profile)
+        val request = PushTokenApiRequest(PUSH_TOKEN, stubProfile)
         val requestJson = request.toJson()
         val revivedRequest = KlaviyoApiRequestDecoder.fromJson(requestJson)
         assert(revivedRequest is PushTokenApiRequest)
@@ -51,54 +51,47 @@ internal class PushTokenApiRequestTest : BaseRequestTest() {
     }
 
     @Test
-    fun `Body includes only API key, profile identifiers, and push token`() {
-        profile
-            .setExternalId(EXTERNAL_ID)
-            .setEmail(EMAIL)
-            .setPhoneNumber(PHONE)
-            .setProperty(ProfileKey.FIRST_NAME, "Kermit")
-            .setProperty("type", "muppet")
+    fun `Builds body request without properties`() {
+        val expectJson = """
+            {
+              "data": {
+                "type": "push-token",
+                "attributes": {
+                  "token_id": "$PUSH_TOKEN",
+                  "platform": "Android",
+                  "vendor": "FCM",
+                  "enablement_status": "AUTHORIZED",
+                  "background": "AVAILABLE",
+                  "profile": {
+                    "data": {
+                      "type": "profile",
+                      "attributes": {
+                        "anonymous_id": "$ANON_ID",
+                        "email": "$EMAIL",
+                        "phone_number": "$PHONE"
+                      }
+                    }
+                  },
+                  "device_metadata": {
+                    "device_id": "Mock Device ID",
+                    "manufacturer": "Mock Manufacturer",
+                    "device_model": "Mock Model",
+                    "os_name": "Android",
+                    "os_version": "Mock OS Version",
+                    "klaviyo_sdk": "Mock SDK",
+                    "sdk_version": "Mock SDK Version",
+                    "app_id": "Mock App ID",
+                    "app_name": "Mock Application Label",
+                    "app_version": "Mock App Version",
+                    "app_build": "Mock Version Code",
+                    "environment": "release"
+                  }
+                }
+              }
+            }
+        """
 
-        val request = PushTokenApiRequest(PUSH_TOKEN, profile)
-        val props = request.body?.optJSONObject("properties")
-
-        assertEquals(API_KEY, request.body?.optString("token"))
-        assertEquals(EXTERNAL_ID, props?.optString("\$external_id"))
-        assertEquals(EMAIL, props?.optString("\$email"))
-        assertEquals(PHONE, props?.optString("\$phone_number"))
-        assertEquals(ANON_ID, props?.optString("\$anonymous"))
-        assertEquals(PUSH_TOKEN, props?.optJSONObject("\$append")?.optString("\$android_tokens"))
-        assertEquals(5, props?.length()) // no other fields!
-
-        // Already confirmed the contents, just confirm that the body doesn't add anything else
-        assertEquals(request.requestBody, "${request.body}")
-    }
-
-    @Test
-    fun `Parses response string for errors`() {
-        // V2 API returns a 200 status code with "0" or "1" in the payload where
-        // "0" = failures that would typically be a 400 status code
-        // "1" = success
-        val successStream = ByteArrayInputStream("1".toByteArray())
-        val errorStream = ByteArrayInputStream("0".toByteArray())
-        val expectedUrl = URL(configMock.baseUrl + "/$expectedUrlPath")
-        val connectionMock = spyk(expectedUrl.openConnection()) as HttpURLConnection
-
-        mockkObject(HttpUtil)
-        every { HttpUtil.openConnection(any()) } returns connectionMock
-        every { HttpUtil.writeToConnection(any(), any()) } returns Unit
-        every { connectionMock.connect() } returns Unit
-        every { networkMonitorMock.isNetworkConnected() } returns true
-        every { configMock.networkTimeout } returns 1
-
-        val request = PushTokenApiRequest(PUSH_TOKEN, profile)
-
-        // Set up a 200 response with different bodies
-        every { connectionMock.responseCode } returns 200
-        every { connectionMock.inputStream } returns successStream
-        assertEquals(KlaviyoApiRequest.Status.Complete, request.send())
-
-        every { connectionMock.inputStream } returns errorStream
-        assertEquals(KlaviyoApiRequest.Status.Failed, request.send())
+        val request = PushTokenApiRequest(PUSH_TOKEN, stubProfile)
+        compareJson(JSONObject(expectJson), JSONObject(request.requestBody!!))
     }
 }


### PR DESCRIPTION
# Description
<!-- Briefly describe the feature or bug that your pull request addresses -->
Upgrade android SDK to upcoming V3 push tokens API. This feature requires the metadata work from #76 so is branched off that.

# Check List

- [x] Are you changing anything with the public API? - NO
- [x] Are your changes backwards compatible with previous SDK Versions? YES
- [ ] Have you tested this change on real device?
- [x] Have you added unit test coverage for your changes? YES
- [x] Have you verified that your changes are compatible with all Android versions the SDK currently supports? YES


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->

- Converted from the V2 client/profiles endpoint that supported push tokens, to new V3 push tokens API exclusively meant for registering push tokens and device metadata
- Added environment detection (debug/release)

## Test Plan
<!-- How was this code tested / How should reviewers test it? -->

- [x] Unit tests against a stub of JSON from API spec
- [ ] Manual tests on a physical device

## Related Issues/Tickets
<!-- Link to relevant issues or discussion -->

