### PR TITLE
Helper methods for developers who use a custom workflow to handle notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,12 @@ open class YourPushService : FirebaseMessagingService() {
 }
 ```
 
+#### Custom Notification Display
+If you wish to fully customize the display of notifications, we provide a set of `RemoteMessage` 
+extensions such as `import com.klaviyo.pushFcm.KlaviyoRemoteMessage.body` to access all the properties sent from Klaviyo.
+We also provide an `Intent.appendKlaviyoExtras(RemoteMessage)` extension method, which attaches the data to your
+notification intent that the Klaviyo SDK requires in order to track opens when you call `Klaviyo.handlePush(intent)`.
+
 **A note on push tokens and multiple profiles:** Klaviyo SDK will disassociate the device push token
 from the current profile whenever it is reset by calling `setProfile` or `resetProfile`.
 You should call `setPushToken` again after resetting the currently tracked profile

--- a/README.md
+++ b/README.md
@@ -283,8 +283,8 @@ extensions such as `import com.klaviyo.pushFcm.KlaviyoRemoteMessage.body` to acc
 We also provide an `Intent.appendKlaviyoExtras(RemoteMessage)` extension method, which attaches the data to your
 notification intent that the Klaviyo SDK requires in order to track opens when you call `Klaviyo.handlePush(intent)`.
 
-**A note on push tokens and multiple profiles:** Klaviyo SDK will disassociate the device push token
-from the current profile whenever it is reset by calling `setProfile` or `resetProfile`.
+#### Push tokens and multiple profiles
+Klaviyo SDK will disassociate the device push token from the current profile whenever it is reset by calling `setProfile` or `resetProfile`.
 You should call `setPushToken` again after resetting the currently tracked profile
 to explicitly associate the device token to the new profile.
 

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -285,7 +285,7 @@ object Klaviyo {
      */
     fun handlePush(intent: Intent?) = apply {
         if (intent?.isKlaviyoIntent != true) {
-            Registry.log.info("Non-klaviyo intent ignored")
+            Registry.log.info("Non-Klaviyo intent ignored")
             return@apply
         }
 

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/model/EventKey.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/model/EventKey.kt
@@ -11,7 +11,7 @@ sealed class EventKey(name: String) : Keyword(name) {
     /**
      * For [EventType.OPENED_PUSH] events, append the device token as an event property
      */
-    object PUSH_TOKEN : EventKey("push_token")
+    internal object PUSH_TOKEN : EventKey("push_token")
 
     class CUSTOM(propertyName: String) : EventKey(propertyName)
 }

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/model/EventType.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/model/EventType.kt
@@ -9,7 +9,7 @@ package com.klaviyo.analytics.model
 sealed class EventType(name: String) : Keyword(name) {
 
     // Push-related
-    object OPENED_PUSH : EventType("\$opened_push")
+    internal object OPENED_PUSH : EventType("\$opened_push")
 
     // Product viewing events
     object VIEWED_PRODUCT : EventType("\$viewed_product")

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoNotification.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoNotification.kt
@@ -12,6 +12,7 @@ import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import com.google.firebase.messaging.RemoteMessage
 import com.klaviyo.core.Registry
+import com.klaviyo.pushFcm.KlaviyoRemoteMessage.appendKlaviyoExtras
 import com.klaviyo.pushFcm.KlaviyoRemoteMessage.body
 import com.klaviyo.pushFcm.KlaviyoRemoteMessage.channel_description
 import com.klaviyo.pushFcm.KlaviyoRemoteMessage.channel_id
@@ -143,14 +144,14 @@ class KlaviyoNotification(private val message: RemoteMessage) {
         // Create intent to open the activity and/or deep link if specified
         // Else fall back on the default launcher intent for the package
         val action = message.clickAction?.let {
-            message.toIntent().apply {
+            Intent().appendKlaviyoExtras(message).apply {
                 action = message.clickAction
                 data = message.deepLink
                 setPackage(pkgName)
                 addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
             }
         } ?: Registry.config.applicationContext.packageManager.getLaunchIntentForPackage(pkgName)?.apply {
-            putExtras(message.toIntent())
+            appendKlaviyoExtras(message)
             addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
         }
 

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoRemoteMessage.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoRemoteMessage.kt
@@ -32,7 +32,7 @@ object KlaviyoRemoteMessage {
     fun Intent.appendKlaviyoExtras(message: RemoteMessage) = apply {
         if (message.isKlaviyoMessage) {
             message.data.forEach {
-                this.putExtra(it.key, it.value)
+                this.putExtra("com.klaviyo.${it.key}", it.value)
             }
         }
     }

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoRemoteMessage.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoRemoteMessage.kt
@@ -24,6 +24,20 @@ import com.klaviyo.core.Registry
 object KlaviyoRemoteMessage {
 
     /**
+     * Append requisite data from a remote message to an intent
+     * for displaying a notification
+     *
+     * @param message
+     */
+    fun Intent.appendKlaviyoExtras(message: RemoteMessage) = apply {
+        if (message.isKlaviyoMessage) {
+            message.data.forEach {
+                this.putExtra(it.key, it.value)
+            }
+        }
+    }
+
+    /**
      * Parse channel ID or fallback on default
      */
     val RemoteMessage.channel_id: String

--- a/versions.gradle
+++ b/versions.gradle
@@ -12,8 +12,8 @@ ext {
     targetSDKVersion = 33
 
     // project versioning
-    versionCode = 3
-    versionName = '1.1.0'
+    versionCode = 4
+    versionName = '1.1.1'
 
     // dependencies
     coreKTXVersion = '1.9.0'


### PR DESCRIPTION
# Description
<!-- Briefly describe the feature or bug that your pull request addresses -->
Created extension methods as helpers for displaying klaviyo notifications and handling the opened event.

# Check List

- [x] Are you changing anything with the public API? -- No, but this adds extension methods to `Intent` that devs can acces
- [x] Are your changes backwards compatible with previous SDK Versions? Yes
- [x] Have you tested this change on real device? Yes
- [x] Have you added unit test coverage for your changes? Yes - updated existing coverage
- [x] Have you verified that your changes are compatible with all Android versions the SDK currently supports? Yes


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->
- extension method to `Intent` for passing on `RemoteMessage` data in the intent
- extension property to identify whether an intent has klaviyo tracking params
- the opened push event keys `internal`

## Test Plan
<!-- How was this code tested / How should reviewers test it? -->
- Tested with flow from prod to confirm notifications still display properly and opens log properly.

## Related Issues/Tickets
<!-- Link to relevant issues or discussion -->
#78 
