### PR TITLE
This should fix the $external_id behavior

### DIFF
--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/model/ProfileKey.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/model/ProfileKey.kt
@@ -40,7 +40,8 @@ sealed class ProfileKey(name: String) : Keyword(name) {
      */
     internal fun specialKey(): String = when (this) {
         ANONYMOUS_ID -> "\$anonymous"
-        EXTERNAL_ID, EMAIL, PHONE_NUMBER -> "$$name"
+        EXTERNAL_ID -> "\$id"
+        EMAIL, PHONE_NUMBER -> "$$name"
         else -> name
     }
 }

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/model/KeywordsTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/model/KeywordsTest.kt
@@ -34,7 +34,7 @@ class KeywordsTest {
         assert(custom != ProfileKey.CUSTOM(expectedCustomKey + "1"))
 
         assertEquals("\$anonymous", ProfileKey.ANONYMOUS_ID.specialKey())
-        assertEquals("\$external_id", ProfileKey.EXTERNAL_ID.specialKey())
+        assertEquals("\$id", ProfileKey.EXTERNAL_ID.specialKey())
         assertEquals("\$email", ProfileKey.EMAIL.specialKey())
         assertEquals("\$phone_number", ProfileKey.PHONE_NUMBER.specialKey())
         assertEquals("custom", ProfileKey.CUSTOM("custom").specialKey())

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/EventApiRequestTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/EventApiRequestTest.kt
@@ -24,6 +24,7 @@ internal class EventApiRequestTest : BaseTest() {
     private val stubEvent: Event = Event(EventType.CUSTOM("Test Event"))
 
     private val stubProfile = Profile()
+        .setExternalId(EXTERNAL_ID)
         .setAnonymousId(ANON_ID)
         .setEmail(EMAIL)
         .setPhoneNumber(PHONE)
@@ -57,6 +58,7 @@ internal class EventApiRequestTest : BaseTest() {
         compareJson(requestJson, revivedRequest.toJson())
     }
 
+    private val externalId = "\$id"
     private val emailKey = "\$email"
     private val anonKey = "\$anonymous"
     private val phoneKey = "\$phone_number"
@@ -72,6 +74,7 @@ internal class EventApiRequestTest : BaseTest() {
                     "name": "${stubEvent.type}"
                   },
                   "profile": {
+                    "$externalId": "$EXTERNAL_ID",
                     "$emailKey": "$EMAIL",
                     "$anonKey": "$ANON_ID",
                     "$phoneKey": "$PHONE"
@@ -98,6 +101,7 @@ internal class EventApiRequestTest : BaseTest() {
                     "name": "${stubEvent.type}"
                   },
                   "profile": {
+                    "$externalId": "$EXTERNAL_ID",
                     "$emailKey": "$EMAIL",
                     "$anonKey": "$ANON_ID",
                     "$phoneKey": "$PHONE"
@@ -128,6 +132,7 @@ internal class EventApiRequestTest : BaseTest() {
                     "name": "${stubEvent.type}"
                   },
                   "profile": {
+                    "$externalId": "$EXTERNAL_ID",
                     "$emailKey": "$EMAIL",
                     "$anonKey": "$ANON_ID",
                     "$phoneKey": "$PHONE"

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/PushTokenApiRequestTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/PushTokenApiRequestTest.kt
@@ -64,7 +64,7 @@ internal class PushTokenApiRequestTest : BaseTest() {
         val props = request.body?.optJSONObject("properties")
 
         assertEquals(API_KEY, request.body?.optString("token"))
-        assertEquals(EXTERNAL_ID, props?.optString("\$external_id"))
+        assertEquals(EXTERNAL_ID, props?.optString("\$id"))
         assertEquals(EMAIL, props?.optString("\$email"))
         assertEquals(PHONE, props?.optString("\$phone_number"))
         assertEquals(ANON_ID, props?.optString("\$anonymous"))


### PR DESCRIPTION
# Description
<!-- Briefly describe the feature or bug that your pull request addresses -->

# Check List

- [x] Are you changing anything with the public API? -- No
- [x] Are your changes backwards compatible with previous SDK Versions? -- Yes
- [x] Have you tested this change on real device?
- [x] Have you added unit test coverage for your changes?
- [x] Have you verified that your changes are compatible with all Android versions the SDK currently supports?


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->
Fixed a mistake in the external ID key for event and push notification API payloads. Older API versions use a $ prefixed key, and external ID is `$id` not `$external_id`.  

## Test Plan
<!-- How was this code tested / How should reviewers test it? -->
Add external ID to a new profile. Create profile, add push token, add event. Check on the web, the profile should have an external ID, but no `$external_id` custom property

## Related Issues/Tickets
<!-- Link to relevant issues or discussion -->
#85 

