### PR TITLE
Ensure SDK sends device_id properly

### DIFF
--- a/sdk/core/src/main/java/com/klaviyo/core/model/DataStore.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/model/DataStore.kt
@@ -56,4 +56,6 @@ interface DataStore {
  * @param fallback
  */
 fun DataStore.fetchOrCreate(key: String, fallback: () -> String): String =
-    fetch(key) ?: fallback().also { store(key, it) }
+    fetch(key) ?: fallback().also {
+        store(key, it)
+    }

--- a/sdk/core/src/main/java/com/klaviyo/core/model/SharedPreferencesDataStore.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/model/SharedPreferencesDataStore.kt
@@ -74,7 +74,7 @@ internal object SharedPreferencesDataStore : DataStore {
      * @return The value read from the shared preferences for the given key
      */
     override fun fetch(key: String): String? {
-        return openSharedPreferences().getString(key, "")
+        return openSharedPreferences().getString(key, null)
     }
 
     /**

--- a/sdk/core/src/test/java/com/klaviyo/core/model/SharedPreferencesDataStoreTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/model/SharedPreferencesDataStoreTest.kt
@@ -57,12 +57,12 @@ internal class SharedPreferencesDataStoreTest : BaseTest() {
     fun `Fetch or create uses Klaviyo preferences`() {
         withPreferenceMock()
         withWriteStringMock(stubKey, stubValue)
-        every { preferenceMock.getString(stubKey, "") } returns null
+        every { preferenceMock.getString(stubKey, null) } returns null
 
         SharedPreferencesDataStore.fetchOrCreate(stubKey) { stubValue }
 
         verify { contextMock.getSharedPreferences(KLAVIYO_PREFS_NAME, Context.MODE_PRIVATE) }
-        verify { preferenceMock.getString(stubKey, "") }
+        verify { preferenceMock.getString(stubKey, null) }
         verify { preferenceMock.edit() }
         verify { editorMock.putString(stubKey, stubValue) }
         verify { editorMock.apply() }
@@ -92,13 +92,13 @@ internal class SharedPreferencesDataStoreTest : BaseTest() {
         val expectedString = "123" + Math.random().toString()
 
         withPreferenceMock()
-        every { preferenceMock.getString(stubKey, "") } returns expectedString
+        every { preferenceMock.getString(stubKey, null) } returns expectedString
 
         val actualString = SharedPreferencesDataStore.fetch(key = stubKey)
 
         assertEquals(expectedString, actualString)
         verify { contextMock.getSharedPreferences(KLAVIYO_PREFS_NAME, Context.MODE_PRIVATE) }
-        verify { preferenceMock.getString(stubKey, "") }
+        verify { preferenceMock.getString(stubKey, null) }
         verify(inverse = true) { editorMock.apply() }
     }
 }


### PR DESCRIPTION
# Description
Device id was being returned as "" which resulted in it not being set properly.

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you tested this change on real device?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all Android versions the SDK currently supports?


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->


## Test Plan
Tested locally with changes to ensure device gets perisisted.


## Related Issues/Tickets
<!-- Link to relevant issues or discussion -->

