### PR TITLE
Reduce Token Requests from the same token

### DIFF
--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/EventApiRequest.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/EventApiRequest.kt
@@ -43,7 +43,7 @@ internal class EventApiRequest(
 
     override var body: JSONObject? = null
         get() {
-            // Update body to include Event metadata whenever the body is retrieved (typically during sending) so the latest data is included
+            // Update body to include Device metadata whenever the body is retrieved (typically during sending) so the latest data is included
             field?.getJSONObject(DATA)?.getJSONObject(ATTRIBUTES)?.getJSONObject(PROPERTIES)?.apply {
                 DeviceProperties.buildEventMetaData().forEach { entry ->
                     put(entry.key, entry.value)

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/ProfileApiRequest.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/ProfileApiRequest.kt
@@ -43,7 +43,6 @@ internal class ProfileApiRequest(
                         extract(ProfileKey.ORGANIZATION),
                         extract(ProfileKey.TITLE),
                         extract(ProfileKey.IMAGE),
-
                         LOCATION to filteredMapOf(
                             extract(ProfileKey.ADDRESS1),
                             extract(ProfileKey.ADDRESS2),
@@ -55,7 +54,6 @@ internal class ProfileApiRequest(
                             extract(ProfileKey.ZIP),
                             extract(ProfileKey.TIMEZONE)
                         ),
-
                         PROPERTIES to properties // Any remaining custom keys are properties
                     )
                 )
@@ -79,13 +77,6 @@ internal class ProfileApiRequest(
     override val successCodes: IntRange get() = HTTP_ACCEPTED..HTTP_ACCEPTED
 
     constructor(profile: Profile) : this() {
-        // Create a mutable copy of the profile
-        // We'll pop off all the enumerated keys as we build the body
-        // Then any remaining pairs are custom keys
-        val properties = profile.toMap().toMutableMap()
-        fun extract(key: ProfileKey): Pair<String, Serializable?> =
-            key.name to properties.remove(key.name)
-
         body = jsonMapOf(*formatBody(profile))
     }
 }

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/PushTokenApiRequest.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/PushTokenApiRequest.kt
@@ -58,7 +58,7 @@ internal class PushTokenApiRequest(
 
     override var body: JSONObject? = null
         get() {
-            // Update body to include Event metadata whenever the body is retrieved (typically during sending) so the latest data is included
+            // Update body to include Device metadata whenever the body is retrieved (typically during sending) so the latest data is included
             field?.getJSONObject(DATA)?.getJSONObject(ATTRIBUTES)?.apply {
                 put(
                     ENABLEMENT_STATUS,

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/PushTokenApiRequest.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/PushTokenApiRequest.kt
@@ -68,7 +68,7 @@ internal class PushTokenApiRequest(
                     BACKGROUND,
                     if (DeviceProperties.backgroundData) BG_AVAILABLE else BG_UNAVAILABLE
                 )
-                put(METADATA, DeviceProperties.buildMetaData())
+                put(METADATA, JSONObject(DeviceProperties.buildMetaData()))
             }
             return field
         }

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/PushTokenApiRequest.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/PushTokenApiRequest.kt
@@ -71,4 +71,15 @@ internal class PushTokenApiRequest(
             )
         )
     }
+
+    override fun equals(other: Any?): Boolean {
+        return when (other) {
+            is PushTokenApiRequest -> body.toString() == other.body.toString()
+            else -> super.equals(other)
+        }
+    }
+
+    override fun hashCode(): Int {
+        return body.toString().hashCode()
+    }
 }

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/PushTokenApiRequest.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/PushTokenApiRequest.kt
@@ -73,6 +73,8 @@ internal class PushTokenApiRequest(
             return field
         }
 
+    private lateinit var initialBody: String
+
     constructor(token: String, profile: Profile) : this() {
         body = jsonMapOf(
             DATA to mapOf(
@@ -84,17 +86,19 @@ internal class PushTokenApiRequest(
                     VENDOR to VENDOR_FCM
                 )
             )
-        )
+        ).also {
+            initialBody = it.toString()
+        }
     }
 
     override fun equals(other: Any?): Boolean {
         return when (other) {
-            is PushTokenApiRequest -> body.toString() == other.body.toString()
+            is PushTokenApiRequest -> initialBody == other.initialBody
             else -> super.equals(other)
         }
     }
 
     override fun hashCode(): Int {
-        return body.toString().hashCode()
+        return initialBody.hashCode()
     }
 }

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/PushTokenApiRequest.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/PushTokenApiRequest.kt
@@ -3,6 +3,7 @@ package com.klaviyo.analytics.networking.requests
 import com.klaviyo.analytics.DeviceProperties
 import com.klaviyo.analytics.model.Profile
 import com.klaviyo.core.Registry
+import org.json.JSONObject
 
 /**
  * Defines the content of an API request to append a push token to a [Profile]
@@ -55,18 +56,32 @@ internal class PushTokenApiRequest(
 
     override val successCodes: IntRange get() = HTTP_ACCEPTED..HTTP_ACCEPTED
 
+    override var body: JSONObject? = null
+        get() {
+            // Update body to include Event metadata whenever the body is retrieved (typically during sending) so the latest data is included
+            field?.getJSONObject(DATA)?.getJSONObject(ATTRIBUTES)?.apply {
+                put(
+                    ENABLEMENT_STATUS,
+                    if (DeviceProperties.notificationPermission) NOTIFICATIONS_ENABLED else NOTIFICATIONS_DISABLED
+                )
+                put(
+                    BACKGROUND,
+                    if (DeviceProperties.backgroundData) BG_AVAILABLE else BG_UNAVAILABLE
+                )
+                put(METADATA, DeviceProperties.buildMetaData())
+            }
+            return field
+        }
+
     constructor(token: String, profile: Profile) : this() {
         body = jsonMapOf(
             DATA to mapOf(
                 TYPE to PUSH_TOKEN,
                 ATTRIBUTES to filteredMapOf(
+                    PROFILE to mapOf(*ProfileApiRequest.formatBody(profile)),
                     TOKEN to token,
                     PLATFORM to DeviceProperties.platform,
-                    VENDOR to VENDOR_FCM,
-                    ENABLEMENT_STATUS to if (DeviceProperties.notificationPermission) NOTIFICATIONS_ENABLED else NOTIFICATIONS_DISABLED,
-                    BACKGROUND to if (DeviceProperties.backgroundData) BG_AVAILABLE else BG_UNAVAILABLE,
-                    METADATA to DeviceProperties.buildMetaData(),
-                    PROFILE to mapOf(*ProfileApiRequest.formatBody(profile))
+                    VENDOR to VENDOR_FCM
                 )
             )
         )

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/KlaviyoApiClientTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/KlaviyoApiClientTest.kt
@@ -154,6 +154,21 @@ internal class KlaviyoApiClientTest : BaseRequestTest() {
     }
 
     @Test
+    fun `Enqueuing the same push token API call multiple times only queues the first`() {
+        assertEquals(0, KlaviyoApiClient.getQueueSize())
+
+        repeat(5) {
+            KlaviyoApiClient.enqueuePushToken(
+                PUSH_TOKEN,
+                Profile().setAnonymousId(ANON_ID)
+            )
+        }
+
+        assertEquals(1, KlaviyoApiClient.getQueueSize())
+        verify(exactly = 1) { logSpy.info("Persisting queue") }
+    }
+
+    @Test
     fun `Enqueues an event API call`() {
         assertEquals(0, KlaviyoApiClient.getQueueSize())
 

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/PushTokenApiRequestTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/PushTokenApiRequestTest.kt
@@ -52,6 +52,13 @@ internal class PushTokenApiRequestTest : BaseRequestTest() {
     }
 
     @Test
+    fun `Requests are equal if the token and profile are equal`() {
+        val aRequest = PushTokenApiRequest(PUSH_TOKEN, stubProfile)
+        val bRequest = PushTokenApiRequest(PUSH_TOKEN, stubProfile)
+        assertEquals(aRequest, bRequest)
+    }
+
+    @Test
     fun `Builds body request`() {
         val expectJson = """
             {


### PR DESCRIPTION
Overrides the equals and hashcode methods on the token request class so that requests with the same provided token and profile are considered equal and do not get added to the network queue


# Description
<!-- Briefly describe the feature or bug that your pull request addresses -->

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [x] Have you tested this change on real device?
- [x] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all Android versions the SDK currently supports?


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->


## Test Plan
<!-- How was this code tested / How should reviewers test it? -->


## Related Issues/Tickets
<!-- Link to relevant issues or discussion -->

