### PR TITLE
Fix event metric names - backward compatible

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -1,0 +1,32 @@
+# Migration Guide
+This document provides guidance on how to migrate from the old version of the SDK to a newer version. 
+It will be updated as new versions are released including deprecations or breaking changes.
+
+## 1.4.0 Deprecations
+*`EventType` is deprecated in favor of `EventMetric`.* `EventType` will be removed in the next major release.
+
+It was recently discovered that the Android SDK was using legacy event names for some common events, 
+like "Viewed Product" and some events that are associated with server actions, like "Ordered Product."
+As a result, if your account used these standard events, they were being logged with names like "$viewed_product"
+in contrast to website generated events which are logged as "Viewed Product."
+
+In order to bring the Android SDK in line with Klaviyo's other integrations, we deprecated `EventType` and introduced 
+`EventMetric` with corrected spellings. The old `EventType` values will still compile with a deprecation warning.
+
+```kotlin
+// Old code: Will log the legacy event names
+import com.klaviyo.analytics.model.EventType
+
+Klaviyo.createEvent(Event(EventType.VIEWED_PRODUCT))
+Klaviyo.createEvent(Event(EventType.SEARCHED_PRODUCTS))
+```
+
+```kotlin
+// New code: Will log the corrected event metric name
+import com.klaviyo.analytics.model.EventMetric
+
+Klaviyo.createEvent(Event(EventMetric.VIEWED_PRODUCT))
+// If you still require old event names, you can use the CUSTOM metric e.g. 
+Klaviyo.createEvent(Event(EventMetric.CUSTOM("\$viewed_product")))
+Klaviyo.createEvent(Event(EventMetric.CUSTOM("\$searched_products")))
+```

--- a/README.md
+++ b/README.md
@@ -135,12 +135,12 @@ Klaviyo.setEmail("robin@example.com")
 ### Tracking Events
 
 The SDK also provides tools for tracking analytics events to the Klaviyo API.
-A list of common Klaviyo-defined event names is provided in [EventType](https://klaviyo.github.io/klaviyo-android-sdk/1.0.0/sdk/analytics/com.klaviyo.analytics.model/-event-type/), or
-you can use `EventType.CUSTOM("name")` for custom event names.
+A list of common Klaviyo-defined event names is provided in [MetricName](https://klaviyo.github.io/klaviyo-android-sdk/1.0.0/sdk/analytics/com.klaviyo.analytics.model/-event-type/), or
+you can use `MetricName.CUSTOM("name")` for custom event names.
 Additional event properties can be specified as part of `EventModel`
 
 ```kotlin
-val event = Event(EventType.VIEWED_PRODUCT)
+val event = Event(MetricName.VIEWED_PRODUCT)
     .setProperty(EventKey.VALUE, "10")
     .setProperty(EventKey.CUSTOM("custom_key"), "value")
 Klaviyo.createEvent(event)

--- a/README.md
+++ b/README.md
@@ -135,12 +135,12 @@ Klaviyo.setEmail("robin@example.com")
 ### Tracking Events
 
 The SDK also provides tools for tracking analytics events to the Klaviyo API.
-A list of common Klaviyo-defined event names is provided in [MetricName](https://klaviyo.github.io/klaviyo-android-sdk/1.0.0/sdk/analytics/com.klaviyo.analytics.model/-event-type/), or
-you can use `MetricName.CUSTOM("name")` for custom event names.
+A list of common Klaviyo-defined event metrics is provided in `EventMetric`, or
+you can use `EventMetric.CUSTOM("name")` for custom event metric names.
 Additional event properties can be specified as part of `EventModel`
 
 ```kotlin
-val event = Event(MetricName.VIEWED_PRODUCT)
+val event = Event(EventMetric.VIEWED_PRODUCT)
     .setProperty(EventKey.VALUE, "10")
     .setProperty(EventKey.CUSTOM("custom_key"), "value")
 Klaviyo.createEvent(event)

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -5,7 +5,7 @@ import android.content.Context
 import android.content.Intent
 import com.klaviyo.analytics.model.Event
 import com.klaviyo.analytics.model.EventKey
-import com.klaviyo.analytics.model.EventType
+import com.klaviyo.analytics.model.MetricName
 import com.klaviyo.analytics.model.Profile
 import com.klaviyo.analytics.model.ProfileKey
 import com.klaviyo.analytics.networking.ApiClient
@@ -272,13 +272,13 @@ object Klaviyo {
      *
      * Convenience method for creating an event with no other properties
      *
-     * @param eventType [EventType] to create
+     * @param eventType [MetricName] to create
      * @return Returns [Klaviyo] for call chaining
      */
-    fun createEvent(eventType: EventType): Klaviyo = createEvent(Event(eventType))
+    fun createEvent(eventType: MetricName): Klaviyo = createEvent(Event(eventType))
 
     /**
-     * From an opened push Intent, creates an [EventType.OPENED_PUSH] [Event]
+     * From an opened push Intent, creates an [MetricName.OPENED_PUSH] [Event]
      * containing appropriate tracking parameters
      *
      * @param intent the [Intent] from opening a notification
@@ -289,7 +289,7 @@ object Klaviyo {
             return@apply
         }
 
-        val event = Event(EventType.OPENED_PUSH)
+        val event = Event(MetricName.OPENED_PUSH)
         val extras = intent.extras
 
         extras?.keySet()?.forEach { key ->

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -5,7 +5,7 @@ import android.content.Context
 import android.content.Intent
 import com.klaviyo.analytics.model.Event
 import com.klaviyo.analytics.model.EventKey
-import com.klaviyo.analytics.model.MetricName
+import com.klaviyo.analytics.model.EventMetric
 import com.klaviyo.analytics.model.Profile
 import com.klaviyo.analytics.model.ProfileKey
 import com.klaviyo.analytics.networking.ApiClient
@@ -272,13 +272,13 @@ object Klaviyo {
      *
      * Convenience method for creating an event with no other properties
      *
-     * @param eventType [MetricName] to create
+     * @param eventType [EventMetric] to create
      * @return Returns [Klaviyo] for call chaining
      */
-    fun createEvent(eventType: MetricName): Klaviyo = createEvent(Event(eventType))
+    fun createEvent(eventType: EventMetric): Klaviyo = createEvent(Event(eventType))
 
     /**
-     * From an opened push Intent, creates an [MetricName.OPENED_PUSH] [Event]
+     * From an opened push Intent, creates an [EventMetric.OPENED_PUSH] [Event]
      * containing appropriate tracking parameters
      *
      * @param intent the [Intent] from opening a notification
@@ -289,7 +289,7 @@ object Klaviyo {
             return@apply
         }
 
-        val event = Event(MetricName.OPENED_PUSH)
+        val event = Event(EventMetric.OPENED_PUSH)
         val extras = intent.extras
 
         extras?.keySet()?.forEach { key ->

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import com.klaviyo.analytics.model.Event
 import com.klaviyo.analytics.model.EventKey
 import com.klaviyo.analytics.model.EventMetric
+import com.klaviyo.analytics.model.EventType
 import com.klaviyo.analytics.model.Profile
 import com.klaviyo.analytics.model.ProfileKey
 import com.klaviyo.analytics.networking.ApiClient
@@ -272,10 +273,24 @@ object Klaviyo {
      *
      * Convenience method for creating an event with no other properties
      *
-     * @param eventType [EventMetric] to create
+     * @param metric [EventMetric] to create
      * @return Returns [Klaviyo] for call chaining
      */
-    fun createEvent(eventType: EventMetric): Klaviyo = createEvent(Event(eventType))
+    fun createEvent(metric: EventMetric): Klaviyo = createEvent(Event(metric))
+
+    /**
+     * Creates an [Event] associated with the currently tracked profile
+     *
+     * Convenience method for creating an event with no other properties
+     *
+     * @param eventType [EventType] to create
+     * @return Returns [Klaviyo] for call chaining
+     */
+    @Deprecated(
+        "EventType is deprecated in favor of EventMetric. See migration guide for details.",
+        ReplaceWith("com.klaviyo.analytics.Klaviyo.createEvent(metric)")
+    )
+    fun createEvent(eventType: EventType): Klaviyo = createEvent(Event(eventType))
 
     /**
      * From an opened push Intent, creates an [EventMetric.OPENED_PUSH] [Event]

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/model/Event.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/model/Event.kt
@@ -5,15 +5,15 @@ import java.io.Serializable
 /**
  * Controls the data that can be input into a map of event attributes recognised by Klaviyo
  */
-class Event(val type: MetricName, properties: Map<EventKey, Serializable>?) :
+class Event(val type: EventMetric, properties: Map<EventKey, Serializable>?) :
     BaseModel<EventKey, Event>(properties) {
 
     constructor(type: String, properties: Map<EventKey, Serializable>?) : this(
-        MetricName.CUSTOM(type),
+        EventMetric.CUSTOM(type),
         properties
     )
 
-    constructor(type: MetricName) : this(type, null)
+    constructor(type: EventMetric) : this(type, null)
 
     constructor(type: String) : this(type, null)
 

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/model/Event.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/model/Event.kt
@@ -5,15 +5,15 @@ import java.io.Serializable
 /**
  * Controls the data that can be input into a map of event attributes recognised by Klaviyo
  */
-class Event(val type: EventType, properties: Map<EventKey, Serializable>?) :
+class Event(val type: MetricName, properties: Map<EventKey, Serializable>?) :
     BaseModel<EventKey, Event>(properties) {
 
     constructor(type: String, properties: Map<EventKey, Serializable>?) : this(
-        EventType.CUSTOM(type),
+        MetricName.CUSTOM(type),
         properties
     )
 
-    constructor(type: EventType) : this(type, null)
+    constructor(type: MetricName) : this(type, null)
 
     constructor(type: String) : this(type, null)
 

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/model/Event.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/model/Event.kt
@@ -8,14 +8,20 @@ import java.io.Serializable
 class Event(val type: EventMetric, properties: Map<EventKey, Serializable>?) :
     BaseModel<EventKey, Event>(properties) {
 
+    constructor(metric: EventMetric) : this(metric, null)
+
+    @Deprecated(
+        "Use Event constructor with EventMetric instead. See migration guide for details.",
+        ReplaceWith("Event(metric)")
+    )
+    constructor(type: EventType) : this(type, null)
+
+    constructor(type: String) : this(type, null)
+
     constructor(type: String, properties: Map<EventKey, Serializable>?) : this(
         EventMetric.CUSTOM(type),
         properties
     )
-
-    constructor(type: EventMetric) : this(type, null)
-
-    constructor(type: String) : this(type, null)
 
     fun setValue(value: String?) = apply { this.value = value }
     var value: String?

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/model/EventKey.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/model/EventKey.kt
@@ -9,7 +9,7 @@ sealed class EventKey(name: String) : Keyword(name) {
     object VALUE : EventKey("\$value")
 
     /**
-     * For [MetricName.OPENED_PUSH] events, append the device token as an event property
+     * For [EventMetric.OPENED_PUSH] events, append the device token as an event property
      */
     internal object PUSH_TOKEN : EventKey("push_token")
 

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/model/EventKey.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/model/EventKey.kt
@@ -9,7 +9,7 @@ sealed class EventKey(name: String) : Keyword(name) {
     object VALUE : EventKey("\$value")
 
     /**
-     * For [EventType.OPENED_PUSH] events, append the device token as an event property
+     * For [MetricName.OPENED_PUSH] events, append the device token as an event property
      */
     internal object PUSH_TOKEN : EventKey("push_token")
 

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/model/EventMetric.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/model/EventMetric.kt
@@ -28,11 +28,11 @@ sealed class EventMetric(name: String) : Keyword(name) {
     These metric names were erroneously provided in the first version of the SDK. 
     The keywords are spelled incorrectly, and many of are intended to be used serverside only.
     To better match Klaviyo's on-site integrations, the metric keywords have been corrected. 
-    Use MetricName for corrected values, or use MetricName.CUSTOM to define other metric names.
+    Use EventMetric for corrected values, or use EventMetric.CUSTOM to define other metric names.
     
     EventType will be removed in the next major release. 
 """,
-    replaceWith = ReplaceWith("com.klaviyo.analytics.model.MetricName")
+    replaceWith = ReplaceWith("com.klaviyo.analytics.model.EventMetric")
 )
 sealed class EventType(name: String) : EventMetric(name) {
 

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/model/EventMetric.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/model/EventMetric.kt
@@ -6,15 +6,15 @@ package com.klaviyo.analytics.model
  *
  * @property name String that represents the name of the metric
  */
-sealed class MetricName(name: String) : Keyword(name) {
-    internal object OPENED_PUSH : MetricName("\$opened_push")
+sealed class EventMetric(name: String) : Keyword(name) {
+    internal object OPENED_PUSH : EventMetric("\$opened_push")
 
-    object OPENED_APP : MetricName("Opened App")
-    object VIEWED_PRODUCT : MetricName("Viewed Product")
-    object ADDED_TO_CART : MetricName("Added to Cart")
-    object STARTED_CHECKOUT : MetricName("Started Checkout")
+    object OPENED_APP : EventMetric("Opened App")
+    object VIEWED_PRODUCT : EventMetric("Viewed Product")
+    object ADDED_TO_CART : EventMetric("Added to Cart")
+    object STARTED_CHECKOUT : EventMetric("Started Checkout")
 
-    class CUSTOM(name: String) : MetricName(name)
+    class CUSTOM(name: String) : EventMetric(name)
 }
 
 /**
@@ -34,10 +34,10 @@ sealed class MetricName(name: String) : Keyword(name) {
 """,
     replaceWith = ReplaceWith("com.klaviyo.analytics.model.MetricName")
 )
-sealed class EventType(name: String) : MetricName(name) {
+sealed class EventType(name: String) : EventMetric(name) {
 
     // Push-related
-    internal object OPENED_PUSH : EventType(MetricName.OPENED_PUSH.name)
+    internal object OPENED_PUSH : EventType(EventMetric.OPENED_PUSH.name)
 
     // Product viewing events
     object VIEWED_PRODUCT : EventType("\$viewed_product")

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/model/MetricName.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/model/MetricName.kt
@@ -6,10 +6,36 @@ package com.klaviyo.analytics.model
  *
  * @property name String value of the event which is recognized by Klaviyo as a registered event
  */
-sealed class EventType(name: String) : Keyword(name) {
+sealed class MetricName(name: String) : Keyword(name) {
+    internal object OPENED_PUSH : MetricName("\$opened_push")
+
+    object OPENED_APP : MetricName("Opened App")
+    object VIEWED_PRODUCT : MetricName("Viewed Product")
+    object ADDED_TO_CART : MetricName("Added to Cart")
+    object STARTED_CHECKOUT : MetricName("Started Checkout")
+
+    class CUSTOM(name: String) : MetricName(name)
+}
+
+/**
+ * Events recognized by Klaviyo
+ * Custom events can be defined using the [CUSTOM] inner class
+ *
+ * @property name String value of the event which is recognized by Klaviyo as a registered event
+ */
+@Deprecated(
+    """
+    These event metric names were erroneously included in the first version of the SDK. 
+    To better match with Klaviyo's on-site integrations the event name values have been corrected. 
+    See MetricName for the newly corrected values.
+    EventType will be removed in the next major release
+""",
+    replaceWith = ReplaceWith("com.klaviyo.analytics.model.MetricName")
+)
+sealed class EventType(name: String) : MetricName(name) {
 
     // Push-related
-    internal object OPENED_PUSH : EventType("\$opened_push")
+    internal object OPENED_PUSH : EventType(MetricName.OPENED_PUSH.name)
 
     // Product viewing events
     object VIEWED_PRODUCT : EventType("\$viewed_product")

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/model/MetricName.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/model/MetricName.kt
@@ -1,10 +1,10 @@
 package com.klaviyo.analytics.model
 
 /**
- * Events recognized by Klaviyo
- * Custom events can be defined using the [CUSTOM] inner class
+ * Common clientside event metrics recognized by Klaviyo
+ * Custom metrics can be defined with the [CUSTOM] inner class
  *
- * @property name String value of the event which is recognized by Klaviyo as a registered event
+ * @property name String that represents the name of the metric
  */
 sealed class MetricName(name: String) : Keyword(name) {
     internal object OPENED_PUSH : MetricName("\$opened_push")
@@ -18,17 +18,19 @@ sealed class MetricName(name: String) : Keyword(name) {
 }
 
 /**
- * Events recognized by Klaviyo
+ * Events recognized by Klaviyo (Deprecated)
  * Custom events can be defined using the [CUSTOM] inner class
  *
  * @property name String value of the event which is recognized by Klaviyo as a registered event
  */
 @Deprecated(
     """
-    These event metric names were erroneously included in the first version of the SDK. 
-    To better match with Klaviyo's on-site integrations the event name values have been corrected. 
-    See MetricName for the newly corrected values.
-    EventType will be removed in the next major release
+    These metric names were erroneously provided in the first version of the SDK. 
+    The keywords are spelled incorrectly, and many of are intended to be used serverside only.
+    To better match Klaviyo's on-site integrations, the metric keywords have been corrected. 
+    Use MetricName for corrected values, or use MetricName.CUSTOM to define other metric names.
+    
+    EventType will be removed in the next major release. 
 """,
     replaceWith = ReplaceWith("com.klaviyo.analytics.model.MetricName")
 )

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
@@ -5,7 +5,7 @@ import android.content.Intent
 import android.os.Bundle
 import com.klaviyo.analytics.model.Event
 import com.klaviyo.analytics.model.EventKey
-import com.klaviyo.analytics.model.EventType
+import com.klaviyo.analytics.model.MetricName
 import com.klaviyo.analytics.model.Profile
 import com.klaviyo.analytics.model.ProfileKey
 import com.klaviyo.analytics.networking.ApiClient
@@ -310,7 +310,7 @@ internal class KlaviyoTest : BaseTest() {
 
     @Test
     fun `Enqueue an event API call`() {
-        val stubEvent = Event(EventType.VIEWED_PRODUCT).also { it[EventKey.VALUE] = 1 }
+        val stubEvent = Event(MetricName.VIEWED_PRODUCT).also { it[EventKey.VALUE] = 1 }
         Klaviyo.createEvent(stubEvent)
 
         verify(exactly = 1) {
@@ -320,10 +320,10 @@ internal class KlaviyoTest : BaseTest() {
 
     @Test
     fun `Enqueue an event API call conveniently`() {
-        Klaviyo.createEvent(EventType.VIEWED_PRODUCT)
+        Klaviyo.createEvent(MetricName.VIEWED_PRODUCT)
 
         verify(exactly = 1) {
-            apiClientMock.enqueueEvent(match { it.type == EventType.VIEWED_PRODUCT }, any())
+            apiClientMock.enqueueEvent(match { it.type == MetricName.VIEWED_PRODUCT }, any())
         }
     }
 }

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import com.klaviyo.analytics.model.Event
 import com.klaviyo.analytics.model.EventKey
 import com.klaviyo.analytics.model.EventMetric
+import com.klaviyo.analytics.model.EventType
 import com.klaviyo.analytics.model.Profile
 import com.klaviyo.analytics.model.ProfileKey
 import com.klaviyo.analytics.networking.ApiClient
@@ -310,7 +311,14 @@ internal class KlaviyoTest : BaseTest() {
 
     @Test
     fun `Enqueue an event API call`() {
-        val stubEvent = Event(EventMetric.VIEWED_PRODUCT).also { it[EventKey.VALUE] = 1 }
+        var stubEvent = Event(EventMetric.VIEWED_PRODUCT).also { it[EventKey.VALUE] = 1 }
+        Klaviyo.createEvent(stubEvent)
+
+        verify(exactly = 1) {
+            apiClientMock.enqueueEvent(stubEvent, any())
+        }
+
+        stubEvent = Event(EventType.VIEWED_PRODUCT).also { it[EventKey.VALUE] = 1 }
         Klaviyo.createEvent(stubEvent)
 
         verify(exactly = 1) {
@@ -321,6 +329,12 @@ internal class KlaviyoTest : BaseTest() {
     @Test
     fun `Enqueue an event API call conveniently`() {
         Klaviyo.createEvent(EventMetric.VIEWED_PRODUCT)
+
+        verify(exactly = 1) {
+            apiClientMock.enqueueEvent(match { it.type == EventMetric.VIEWED_PRODUCT }, any())
+        }
+
+        Klaviyo.createEvent(EventType.VIEWED_PRODUCT)
 
         verify(exactly = 1) {
             apiClientMock.enqueueEvent(match { it.type == EventMetric.VIEWED_PRODUCT }, any())

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
@@ -5,7 +5,7 @@ import android.content.Intent
 import android.os.Bundle
 import com.klaviyo.analytics.model.Event
 import com.klaviyo.analytics.model.EventKey
-import com.klaviyo.analytics.model.MetricName
+import com.klaviyo.analytics.model.EventMetric
 import com.klaviyo.analytics.model.Profile
 import com.klaviyo.analytics.model.ProfileKey
 import com.klaviyo.analytics.networking.ApiClient
@@ -310,7 +310,7 @@ internal class KlaviyoTest : BaseTest() {
 
     @Test
     fun `Enqueue an event API call`() {
-        val stubEvent = Event(MetricName.VIEWED_PRODUCT).also { it[EventKey.VALUE] = 1 }
+        val stubEvent = Event(EventMetric.VIEWED_PRODUCT).also { it[EventKey.VALUE] = 1 }
         Klaviyo.createEvent(stubEvent)
 
         verify(exactly = 1) {
@@ -320,10 +320,10 @@ internal class KlaviyoTest : BaseTest() {
 
     @Test
     fun `Enqueue an event API call conveniently`() {
-        Klaviyo.createEvent(MetricName.VIEWED_PRODUCT)
+        Klaviyo.createEvent(EventMetric.VIEWED_PRODUCT)
 
         verify(exactly = 1) {
-            apiClientMock.enqueueEvent(match { it.type == MetricName.VIEWED_PRODUCT }, any())
+            apiClientMock.enqueueEvent(match { it.type == EventMetric.VIEWED_PRODUCT }, any())
         }
     }
 }

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/model/KeywordsTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/model/KeywordsTest.kt
@@ -44,6 +44,13 @@ class KeywordsTest {
 
     @Test
     fun `Event type keys`() {
+        assertEquals("\$opened_push", MetricName.OPENED_PUSH.name)
+        assertEquals("Opened App", MetricName.OPENED_APP.name)
+        assertEquals("Viewed Product", MetricName.VIEWED_PRODUCT.name)
+        assertEquals("Added to Cart", MetricName.ADDED_TO_CART.name)
+        assertEquals("Started Checkout", MetricName.STARTED_CHECKOUT.name)
+        assertEquals("custom", MetricName.CUSTOM("custom").name)
+
         assertEquals("\$opened_push", EventType.OPENED_PUSH.name)
         assertEquals("\$viewed_product", EventType.VIEWED_PRODUCT.name)
         assertEquals("\$searched_products", EventType.SEARCHED_PRODUCTS.name)
@@ -63,7 +70,12 @@ class KeywordsTest {
         assertEquals(expectedCustomKey, EventType.CUSTOM(expectedCustomKey).name)
 
         // Test the equals operator works properly on custom keys
-        val custom = EventType.CUSTOM(expectedCustomKey)
+        var custom: MetricName = MetricName.CUSTOM(expectedCustomKey)
+        assert(custom == MetricName.CUSTOM(expectedCustomKey))
+        assert(custom != MetricName.CUSTOM(expectedCustomKey + "1"))
+
+        // Test the equals operator works properly on custom keys
+        custom = EventType.CUSTOM(expectedCustomKey)
         assert(custom == EventType.CUSTOM(expectedCustomKey))
         assert(custom != EventType.CUSTOM(expectedCustomKey + "1"))
     }

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/model/KeywordsTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/model/KeywordsTest.kt
@@ -44,12 +44,12 @@ class KeywordsTest {
 
     @Test
     fun `Event type keys`() {
-        assertEquals("\$opened_push", MetricName.OPENED_PUSH.name)
-        assertEquals("Opened App", MetricName.OPENED_APP.name)
-        assertEquals("Viewed Product", MetricName.VIEWED_PRODUCT.name)
-        assertEquals("Added to Cart", MetricName.ADDED_TO_CART.name)
-        assertEquals("Started Checkout", MetricName.STARTED_CHECKOUT.name)
-        assertEquals("custom", MetricName.CUSTOM("custom").name)
+        assertEquals("\$opened_push", EventMetric.OPENED_PUSH.name)
+        assertEquals("Opened App", EventMetric.OPENED_APP.name)
+        assertEquals("Viewed Product", EventMetric.VIEWED_PRODUCT.name)
+        assertEquals("Added to Cart", EventMetric.ADDED_TO_CART.name)
+        assertEquals("Started Checkout", EventMetric.STARTED_CHECKOUT.name)
+        assertEquals("custom", EventMetric.CUSTOM("custom").name)
 
         assertEquals("\$opened_push", EventType.OPENED_PUSH.name)
         assertEquals("\$viewed_product", EventType.VIEWED_PRODUCT.name)
@@ -67,13 +67,13 @@ class KeywordsTest {
         assertEquals("\$failed_payment", EventType.FAILED_PAYMENT.name)
 
         val expectedCustomKey = Math.random().toString() + "_key"
-        assertEquals(expectedCustomKey, MetricName.CUSTOM(expectedCustomKey).name)
+        assertEquals(expectedCustomKey, EventMetric.CUSTOM(expectedCustomKey).name)
         assertEquals(expectedCustomKey, EventType.CUSTOM(expectedCustomKey).name)
 
         // Test the equals operator works properly on custom keys
-        var custom: MetricName = MetricName.CUSTOM(expectedCustomKey)
-        assert(custom == MetricName.CUSTOM(expectedCustomKey))
-        assert(custom != MetricName.CUSTOM(expectedCustomKey + "1"))
+        var custom: EventMetric = EventMetric.CUSTOM(expectedCustomKey)
+        assert(custom == EventMetric.CUSTOM(expectedCustomKey))
+        assert(custom != EventMetric.CUSTOM(expectedCustomKey + "1"))
 
         // Test the equals operator works properly on custom keys
         custom = EventType.CUSTOM(expectedCustomKey)

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/model/KeywordsTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/model/KeywordsTest.kt
@@ -67,6 +67,7 @@ class KeywordsTest {
         assertEquals("\$failed_payment", EventType.FAILED_PAYMENT.name)
 
         val expectedCustomKey = Math.random().toString() + "_key"
+        assertEquals(expectedCustomKey, MetricName.CUSTOM(expectedCustomKey).name)
         assertEquals(expectedCustomKey, EventType.CUSTOM(expectedCustomKey).name)
 
         // Test the equals operator works properly on custom keys

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/KlaviyoApiClientTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/KlaviyoApiClientTest.kt
@@ -4,7 +4,7 @@ import android.os.Handler
 import android.os.HandlerThread
 import com.klaviyo.analytics.DeviceProperties
 import com.klaviyo.analytics.model.Event
-import com.klaviyo.analytics.model.EventType
+import com.klaviyo.analytics.model.MetricName
 import com.klaviyo.analytics.model.Profile
 import com.klaviyo.analytics.networking.KlaviyoApiClient.HandlerUtil as HandlerUtil
 import com.klaviyo.analytics.networking.requests.ApiRequest
@@ -173,7 +173,7 @@ internal class KlaviyoApiClientTest : BaseRequestTest() {
         assertEquals(0, KlaviyoApiClient.getQueueSize())
 
         KlaviyoApiClient.enqueueEvent(
-            Event(EventType.CUSTOM("mock")),
+            Event(MetricName.CUSTOM("mock")),
             Profile().setAnonymousId(ANON_ID)
         )
 

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/KlaviyoApiClientTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/KlaviyoApiClientTest.kt
@@ -4,7 +4,7 @@ import android.os.Handler
 import android.os.HandlerThread
 import com.klaviyo.analytics.DeviceProperties
 import com.klaviyo.analytics.model.Event
-import com.klaviyo.analytics.model.MetricName
+import com.klaviyo.analytics.model.EventMetric
 import com.klaviyo.analytics.model.Profile
 import com.klaviyo.analytics.networking.KlaviyoApiClient.HandlerUtil as HandlerUtil
 import com.klaviyo.analytics.networking.requests.ApiRequest
@@ -173,7 +173,7 @@ internal class KlaviyoApiClientTest : BaseRequestTest() {
         assertEquals(0, KlaviyoApiClient.getQueueSize())
 
         KlaviyoApiClient.enqueueEvent(
-            Event(MetricName.CUSTOM("mock")),
+            Event(EventMetric.CUSTOM("mock")),
             Profile().setAnonymousId(ANON_ID)
         )
 

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/EventApiRequestTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/EventApiRequestTest.kt
@@ -2,7 +2,7 @@ package com.klaviyo.analytics.networking.requests
 
 import com.klaviyo.analytics.Klaviyo
 import com.klaviyo.analytics.model.Event
-import com.klaviyo.analytics.model.EventType
+import com.klaviyo.analytics.model.MetricName
 import com.klaviyo.analytics.model.Profile
 import io.mockk.every
 import org.json.JSONObject
@@ -22,7 +22,7 @@ internal class EventApiRequestTest : BaseRequestTest() {
         "User-Agent" to "Mock User Agent"
     )
 
-    private val stubEvent: Event = Event(EventType.CUSTOM("Test Event"))
+    private val stubEvent: Event = Event(MetricName.CUSTOM("Test Event"))
 
     private val stubProfile = Profile()
         .setExternalId(EXTERNAL_ID)

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/EventApiRequestTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/EventApiRequestTest.kt
@@ -2,7 +2,7 @@ package com.klaviyo.analytics.networking.requests
 
 import com.klaviyo.analytics.Klaviyo
 import com.klaviyo.analytics.model.Event
-import com.klaviyo.analytics.model.MetricName
+import com.klaviyo.analytics.model.EventMetric
 import com.klaviyo.analytics.model.Profile
 import io.mockk.every
 import org.json.JSONObject
@@ -22,7 +22,7 @@ internal class EventApiRequestTest : BaseRequestTest() {
         "User-Agent" to "Mock User Agent"
     )
 
-    private val stubEvent: Event = Event(MetricName.CUSTOM("Test Event"))
+    private val stubEvent: Event = Event(EventMetric.CUSTOM("Test Event"))
 
     private val stubProfile = Profile()
         .setExternalId(EXTERNAL_ID)


### PR DESCRIPTION
# Description
<!-- Briefly describe the feature or bug that your pull request addresses -->
This PR adds new `EventMetric` class with corrected/removed metrics, and deprecates the old one. I used a superclass so that the old one is still backwards compatible. I've tested with the test app, and there's no breaking changes. Deprecation warnings provide guidance, and there is a migration guide with an explanation. I introduce _new_ non-breaking API methods, but expect 2.0 to have breaking API changes including argument re-labelling.

# Check List

- [x] Are you changing anything with the public API? - YES, but only new methods in this PR
- [x] Are your changes backwards compatible with previous SDK Versions? - YES
- [ ] Have you tested this change on real device? - 50% - I have tested the test app as-is. Will also update test app according to migration guide and test again. 
- [x] Have you added unit test coverage for your changes? - YES
- [x] Have you verified that your changes are compatible with all Android versions the SDK currently supports? - No android compatibility concerns


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->
- `EventMetric` superclass will replace `EventType`
- `EventType` is marked deprecated
- Added migration guide with explanation and instructions
- Where possible, added new overloads that explicitly take the new `EventMetric` with new argument labels, to reduce friction when upgrading to 2.0 later on.
- Introduces some missing event types like Added to Cart (`EventMetric` only)

## Test Plan
<!-- How was this code tested / How should reviewers test it? -->
Test with test app as-is.
Update test app according to deprecation warnings and test again. 

## Related Issues/Tickets
https://github.com/klaviyo/klaviyo-swift-sdk/issues/124
https://github.com/klaviyo/klaviyo-swift-sdk/issues/119