### PR TITLE
Fix nullable model properties

### DIFF
--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/model/BaseModel.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/model/BaseModel.kt
@@ -25,7 +25,7 @@ abstract class BaseModel<Key, Self>(properties: Map<Key, Serializable>?)
         }
     }
 
-    operator fun set(key: String, value: Serializable) {
+    operator fun set(key: String, value: Serializable?) {
         this.setProperty(key, value)
     }
 
@@ -38,13 +38,13 @@ abstract class BaseModel<Key, Self>(properties: Map<Key, Serializable>?)
      * Adds a custom property to the map.
      * Custom attributes can define any key name that isn't already reserved by Klaviyo
      */
-    abstract fun setProperty(key: Key, value: Serializable): BaseModel<Key, Self>
+    abstract fun setProperty(key: Key, value: Serializable?): BaseModel<Key, Self>
 
     /**
      * Add a custom property to the map.
      * Custom attributes can define any key name that isn't already reserved by Klaviyo
      */
-    abstract fun setProperty(key: String, value: Serializable): BaseModel<Key, Self>
+    abstract fun setProperty(key: String, value: Serializable?): BaseModel<Key, Self>
 
     /**
      * Merges attributes from another object into this one

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/model/Event.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/model/Event.kt
@@ -17,18 +17,18 @@ class Event(val type: EventType, properties: Map<EventKey, Serializable>?) :
 
     constructor(type: String) : this(type, null)
 
-    fun setValue(value: String) = apply { this.value = value }
-    var value: String
-        get() = (this[EventKey.VALUE] ?: "") as String
+    fun setValue(value: String?) = apply { this.value = value }
+    var value: String?
+        get() = this[EventKey.VALUE]?.toString()
         set(value) {
             this[EventKey.VALUE] = value
         }
 
-    override fun setProperty(key: EventKey, value: Serializable) = apply {
+    override fun setProperty(key: EventKey, value: Serializable?) = apply {
         this[key] = value
     }
 
-    override fun setProperty(key: String, value: Serializable) = apply {
+    override fun setProperty(key: String, value: Serializable?) = apply {
         this[EventKey.CUSTOM(key)] = value
     }
 }

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/model/Profile.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/model/Profile.kt
@@ -10,51 +10,41 @@ class Profile(properties: Map<ProfileKey, Serializable>?) :
 
     constructor() : this(null)
 
-    fun setExternalId(identifier: String) = apply { this.externalId = identifier }
+    fun setExternalId(identifier: String?) = apply { this.externalId = identifier }
     var externalId: String?
-        get() = (this[ProfileKey.EXTERNAL_ID]) as String?
+        get() = (this[ProfileKey.EXTERNAL_ID])?.toString()
         set(value) {
             this[ProfileKey.EXTERNAL_ID] = value
         }
 
-    fun setEmail(email: String) = apply { this.email = email }
+    fun setEmail(email: String?) = apply { this.email = email }
     var email: String?
-        get() = (this[ProfileKey.EMAIL]) as String?
+        get() = (this[ProfileKey.EMAIL])?.toString()
         set(value) {
             this[ProfileKey.EMAIL] = value
         }
 
-    fun setPhoneNumber(phoneNumber: String) = apply { this.phoneNumber = phoneNumber }
+    fun setPhoneNumber(phoneNumber: String?) = apply { this.phoneNumber = phoneNumber }
     var phoneNumber: String?
-        get() = (this[ProfileKey.PHONE_NUMBER]) as String?
+        get() = (this[ProfileKey.PHONE_NUMBER])?.toString()
         set(value) {
             this[ProfileKey.PHONE_NUMBER] = value
         }
 
-    internal fun setAnonymousId(anonymousId: String) = apply { this.anonymousId = anonymousId }
+    internal fun setAnonymousId(anonymousId: String?) = apply { this.anonymousId = anonymousId }
     internal var anonymousId: String?
-        get() = (this[ProfileKey.ANONYMOUS_ID]) as String
+        get() = (this[ProfileKey.ANONYMOUS_ID])?.toString()
         set(value) {
             this[ProfileKey.ANONYMOUS_ID] = value
         }
 
-    override fun setProperty(key: ProfileKey, value: Serializable) = apply {
+    override fun setProperty(key: ProfileKey, value: Serializable?) = apply {
         this[key] = value
     }
 
-    override fun setProperty(key: String, value: Serializable) = apply {
+    override fun setProperty(key: String, value: Serializable?) = apply {
         this[ProfileKey.CUSTOM(key)] = value
     }
 
     override fun merge(other: Profile) = apply { super.merge(other) }
-
-    /**
-     * Get a map of just the unique identifiers of this profile
-     */
-    internal fun getIdentifiers(): Map<ProfileKey, String> = mapOf(
-        ProfileKey.EXTERNAL_ID to (this.externalId ?: ""),
-        ProfileKey.EMAIL to (this.email ?: ""),
-        ProfileKey.PHONE_NUMBER to (this.phoneNumber ?: ""),
-        ProfileKey.ANONYMOUS_ID to (this.anonymousId ?: "")
-    ).filter { it.value.isNotEmpty() }
 }

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/model/ModelTests.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/model/ModelTests.kt
@@ -80,6 +80,24 @@ internal class ModelTests : BaseTest() {
     }
 
     @Test
+    fun `Profile identifiers type is enforced without crashing`() {
+        val profile = Profile(
+            mapOf(
+                ProfileKey.EXTERNAL_ID to 0,
+                ProfileKey.EMAIL to 0,
+                ProfileKey.PHONE_NUMBER to 0
+            )
+        )
+
+        assertEquals("0", profile.externalId)
+        assertEquals("0", profile.email)
+        assertEquals("0", profile.phoneNumber)
+
+        val event = Event("test", mapOf(EventKey.VALUE to 0))
+        assertEquals("0", event.value)
+    }
+
+    @Test
     fun `Event properties are reflected in toMap representation`() {
         val event = Event("test").also {
             it.setValue("$1")

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/model/ModelTests.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/model/ModelTests.kt
@@ -80,7 +80,7 @@ internal class ModelTests : BaseTest() {
     }
 
     @Test
-    fun `Profile identifiers type is enforced without crashing`() {
+    fun `Type of special model properties is enforced without crashing`() {
         val profile = Profile(
             mapOf(
                 ProfileKey.EXTERNAL_ID to 0,

--- a/sdk/fixtures/src/main/java/com/klaviyo/fixtures/BaseTest.kt
+++ b/sdk/fixtures/src/main/java/com/klaviyo/fixtures/BaseTest.kt
@@ -97,6 +97,9 @@ abstract class BaseTest {
     /**
      * Gross way to modify a final static field through reflection
      *
+     * NOTE This will break in future Java versions, but is the only way to mock
+     * SDK version and retain compiler verification of our compatibility tests
+     *
      * @param field
      * @param newValue
      */


### PR DESCRIPTION
# Description
<!-- Briefly describe the feature or bug that your pull request addresses -->
Fixes a potential edge case that could cause a crash in case of type mismatch for any of these named properties. Discovered while changing `Event.value` from string to double.

This can go into the next minor release

# Check List

- [x] Are you changing anything with the public API? - Yes but adding nullability is backward compatible.
- [x] Are your changes backwards compatible with previous SDK Versions? Yes
- [x] Have you tested this change on real device? - With the test app
- [x] Have you added unit test coverage for your changes? 
- [x] Have you verified that your changes are compatible with all Android versions the SDK currently supports?


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->
- Added nullability to all the setter methods in our models, to be more consistent
- Fixed the type casting on any named properties so that they can't cause a crash in case of type mismatch

## Test Plan
<!-- How was this code tested / How should reviewers test it? -->
Added unit tests

## Related Issues/Tickets
<!-- Link to relevant issues or discussion -->
CHNL-4540
