### PR TITLE
Change Event.Value to a double

### DIFF
--- a/.github/workflows/android-feature.yml
+++ b/.github/workflows/android-feature.yml
@@ -10,14 +10,14 @@ jobs:
   # A job for running our tests
   test:
     name: Run Unit Tests
-    
+
     # The type of runner that the job will run on
     runs-on: ubuntu-22.04
 
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so the job can access it
     - uses: actions/checkout@v2
-  
+
     # Sets up a JDK on the job so that we can run Java code
     - name: Set up JDK 11
       uses: actions/setup-java@v3

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -2,6 +2,11 @@
 This document provides guidance on how to migrate from the old version of the SDK to a newer version. 
 It will be updated as new versions are released including deprecations or breaking changes.
 
+## 2.0.0 Breaking Changes
+*Type of `Event.value` has been correct to `Double`*
+In version 1.x, `Event.value` was incorrectly typed as `String`. Klaviyo's API expects `value` to be numeric, and 
+while the backend will implicitly convert a numeric string to a number, it is better to be explicit about the type.
+
 ## 1.4.0 Deprecations
 *`EventType` is deprecated in favor of `EventMetric`.* `EventType` will be removed in the next major release.
 

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -6,6 +6,19 @@ It will be updated as new versions are released including deprecations or breaki
 *Type of `Event.value` has been correct to `Double`*
 In version 1.x, `Event.value` was incorrectly typed as `String`. Klaviyo's API expects `value` to be numeric, and 
 while the backend will implicitly convert a numeric string to a number, it is better to be explicit about the type.
+```kotlin
+// Old code: accepted strings (though still would be converted to a number on the server)
+val event = Event("Test").setValue("1.0")
+// Or
+val event = Event("Test")
+event.value = "1.0"
+
+//New code: type has been corrected to Double
+val event = Event("Test").setValue(1.0)
+// Or
+val event = Event("Test")
+event.value = 1.0
+```
 
 ## 1.4.0 Deprecations
 *`EventType` is deprecated in favor of `EventMetric`.* `EventType` will be removed in the next major release.

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Additional event properties can be specified as part of `EventModel`
 
 ```kotlin
 val event = Event(EventMetric.VIEWED_PRODUCT)
-    .setProperty(EventKey.VALUE, "10")
+    .setProperty(EventKey.VALUE, 10)
     .setProperty(EventKey.CUSTOM("custom_key"), "value")
 Klaviyo.createEvent(event)
 ```

--- a/README.md
+++ b/README.md
@@ -141,8 +141,8 @@ Additional event properties can be specified as part of `EventModel`
 
 ```kotlin
 val event = Event(EventMetric.VIEWED_PRODUCT)
-    .setProperty(EventKey.VALUE, 10)
-    .setProperty(EventKey.CUSTOM("custom_key"), "value")
+    .setProperty(EventKey.CUSTOM("Product"), "Coffee Mug")
+    .setValue(10.0)
 Klaviyo.createEvent(event)
 ```
 

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -271,12 +271,14 @@ object Klaviyo {
     /**
      * Creates an [Event] associated with the currently tracked profile
      *
-     * Convenience method for creating an event with no other properties
+     * Convenience method for creating an event with a metric, optional value, and no other properties
      *
      * @param metric [EventMetric] to create
+     * @param value [Double?] value to assign the event
      * @return Returns [Klaviyo] for call chaining
      */
-    fun createEvent(metric: EventMetric): Klaviyo = createEvent(Event(metric))
+    fun createEvent(metric: EventMetric, value: Double? = null): Klaviyo =
+        createEvent(Event(metric).setValue(value))
 
     /**
      * Creates an [Event] associated with the currently tracked profile

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/model/Event.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/model/Event.kt
@@ -23,9 +23,16 @@ class Event(val type: EventMetric, properties: Map<EventKey, Serializable>?) :
         properties
     )
 
-    fun setValue(value: String?) = apply { this.value = value }
-    var value: String?
-        get() = this[EventKey.VALUE]?.toString()
+    fun setValue(value: Double?) = apply { this.value = value }
+    var value: Double?
+        get() = when (val value = this[EventKey.VALUE]) {
+            is Double -> value
+            else -> try {
+                value.toString().toDouble()
+            } catch (e: NumberFormatException) {
+                null
+            }
+        }
         set(value) {
             this[EventKey.VALUE] = value
         }
@@ -34,7 +41,6 @@ class Event(val type: EventMetric, properties: Map<EventKey, Serializable>?) :
         this[key] = value
     }
 
-    override fun setProperty(key: String, value: Serializable?) = apply {
-        this[EventKey.CUSTOM(key)] = value
-    }
+    override fun setProperty(key: String, value: Serializable?) =
+        setProperty(EventKey.CUSTOM(key), value)
 }

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/model/ModelTests.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/model/ModelTests.kt
@@ -94,13 +94,13 @@ internal class ModelTests : BaseTest() {
         assertEquals("0", profile.phoneNumber)
 
         val event = Event("test", mapOf(EventKey.VALUE to 0))
-        assertEquals("0", event.value)
+        assertEquals(0.0, event.value)
     }
 
     @Test
     fun `Event properties are reflected in toMap representation`() {
         val event = Event("test").also {
-            it.setValue("$1")
+            it.setValue(1.0)
             it.setProperty(EventKey.EVENT_ID, "id")
             it.setProperty(EventKey.CUSTOM("custom"), "custom")
         }
@@ -108,10 +108,10 @@ internal class ModelTests : BaseTest() {
         val eventMap = event.toMap()
 
         assertEquals("test", event.type.name)
-        assertEquals("$1", event.value)
+        assertEquals(1.0, event.value)
         assertNull(eventMap["type"])
         assertEquals("id", eventMap[EventKey.EVENT_ID.name])
-        assertEquals("$1", eventMap[EventKey.VALUE.name])
+        assertEquals(1.0, eventMap[EventKey.VALUE.name])
         assertEquals("custom", eventMap["custom"])
     }
 


### PR DESCRIPTION
# Description
<!-- Briefly describe the feature or bug that your pull request addresses -->
Corrects the type of `Event.value` property from string to double. 
Adds value as an optional arg to the `createEvent` convenience method.

# Check List

- [x] Are you changing anything with the public API?
- [x] Are your changes backwards compatible with previous SDK Versions?
- [x] Have you tested this change on real device?
- [x] Have you added unit test coverage for your changes?
- [x] Have you verified that your changes are compatible with all Android versions the SDK currently supports?


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->


## Test Plan
<!-- How was this code tested / How should reviewers test it? -->


## Related Issues/Tickets
<!-- Link to relevant issues or discussion -->

