### PR TITLE
Update git checkout action version for CI 

### DIFF
--- a/.github/workflows/android-feature.yml
+++ b/.github/workflows/android-feature.yml
@@ -16,8 +16,8 @@ jobs:
 
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so the job can access it
-    - uses: actions/checkout@v2
   
+    - uses: actions/checkout@v4
     # Sets up a JDK on the job so that we can run Java code
     - name: Set up JDK 11
       uses: actions/setup-java@v3
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so the job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       # Sets up a JDK on the job so that we can run Java code
       - name: Set up JDK 11

--- a/.github/workflows/android-master.yml
+++ b/.github/workflows/android-master.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so the job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       # Sets up a JDK on the job so that we can run Java code
       - name: Set up JDK 11
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so the job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       # Sets up a JDK on the job so that we can run Java code
       - name: Set up JDK 11
@@ -61,7 +61,7 @@ jobs:
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so the job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       # Sets up a JDK on the job so that we can run Java code
       - name: Set up JDK 11


### PR DESCRIPTION
Apparently this version of checkout is going to be deprecated because it runs on an old version of npm
- [x] Create a Jira ticket to check all projects
