### PR TITLE
Quick fix to bug with push token request equality operator

### DIFF
--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/ProfileApiRequest.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/ProfileApiRequest.kt
@@ -33,7 +33,7 @@ internal class ProfileApiRequest(
             return arrayOf(
                 DATA to mapOf(
                     TYPE to PROFILE,
-                    ATTRIBUTES to filteredMapOf( // All of the enumerated keys are "attributes"
+                    ATTRIBUTES to filteredMapOf( // All the enumerated keys are "attributes"
                         extract(ProfileKey.EMAIL),
                         extract(ProfileKey.PHONE_NUMBER),
                         extract(ProfileKey.EXTERNAL_ID),

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/PushTokenApiRequest.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/PushTokenApiRequest.kt
@@ -57,6 +57,13 @@ internal class PushTokenApiRequest(
     override val successCodes: IntRange get() = HTTP_ACCEPTED..HTTP_ACCEPTED
 
     override var body: JSONObject? = null
+        set(value) {
+            if (!this::initialBody.isInitialized) {
+                initialBody = value?.toString() ?: ""
+            }
+
+            field = value
+        }
         get() {
             // Update body to include Device metadata whenever the body is retrieved (typically during sending) so the latest data is included
             field?.getJSONObject(DATA)?.getJSONObject(ATTRIBUTES)?.apply {
@@ -86,9 +93,7 @@ internal class PushTokenApiRequest(
                     VENDOR to VENDOR_FCM
                 )
             )
-        ).also {
-            initialBody = it.toString()
-        }
+        )
     }
 
     override fun equals(other: Any?): Boolean {

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/PushTokenApiRequestTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/PushTokenApiRequestTest.kt
@@ -3,6 +3,7 @@ package com.klaviyo.analytics.networking.requests
 import com.klaviyo.analytics.model.Profile
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Test
 
 internal class PushTokenApiRequestTest : BaseRequestTest() {
@@ -21,6 +22,18 @@ internal class PushTokenApiRequestTest : BaseRequestTest() {
         .setEmail(EMAIL)
         .setPhoneNumber(PHONE)
         .setExternalId(EXTERNAL_ID)
+
+    @Test
+    fun `Equality operator`() {
+        val aRequest = PushTokenApiRequest(PUSH_TOKEN, stubProfile)
+        val bRequest = PushTokenApiRequest(PUSH_TOKEN, stubProfile)
+        assertEquals(aRequest, bRequest)
+
+        // At this time, decoding from JSON does not preserve equality check for push token requests
+        // But at least it should not crash to compare them
+        val bRequestDecoded = KlaviyoApiRequestDecoder.fromJson(bRequest.toJson())
+        assertNotEquals(aRequest, bRequestDecoded)
+    }
 
     @Test
     fun `Uses correct endpoint`() {


### PR DESCRIPTION
# Description
<!-- Briefly describe the feature or bug that your pull request addresses -->
First pass at fixing #116 by moving the setter of that lateinit property. However, after deserializing from the persistent queue, the equality operator won't work the same way since body is already mutated.

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you tested this change on real device?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all Android versions the SDK currently supports?


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->


## Test Plan
<!-- How was this code tested / How should reviewers test it? -->


## Related Issues/Tickets
<!-- Link to relevant issues or discussion -->

