### PR TITLE
Decouple notification display from the SDK Config

### DIFF
--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoNotification.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoNotification.kt
@@ -23,11 +23,11 @@ import com.klaviyo.pushFcm.KlaviyoRemoteMessage.channel_importance
 import com.klaviyo.pushFcm.KlaviyoRemoteMessage.channel_name
 import com.klaviyo.pushFcm.KlaviyoRemoteMessage.clickAction
 import com.klaviyo.pushFcm.KlaviyoRemoteMessage.deepLink
+import com.klaviyo.pushFcm.KlaviyoRemoteMessage.getSmallIcon
 import com.klaviyo.pushFcm.KlaviyoRemoteMessage.imageUrl
 import com.klaviyo.pushFcm.KlaviyoRemoteMessage.isKlaviyoNotification
 import com.klaviyo.pushFcm.KlaviyoRemoteMessage.notificationCount
 import com.klaviyo.pushFcm.KlaviyoRemoteMessage.notificationPriority
-import com.klaviyo.pushFcm.KlaviyoRemoteMessage.smallIcon
 import com.klaviyo.pushFcm.KlaviyoRemoteMessage.sound
 import com.klaviyo.pushFcm.KlaviyoRemoteMessage.title
 import java.net.URL
@@ -132,7 +132,7 @@ class KlaviyoNotification(private val message: RemoteMessage) {
     private fun buildNotification(context: Context): NotificationCompat.Builder =
         NotificationCompat.Builder(context, message.channel_id)
             .setContentIntent(createIntent(context))
-            .setSmallIcon(message.smallIcon)
+            .setSmallIcon(message.getSmallIcon(context))
             .setContentTitle(message.title)
             .setContentText(message.body)
             .setSound(message.sound)
@@ -189,7 +189,7 @@ class KlaviyoNotification(private val message: RemoteMessage) {
      * @return [PendingIntent]
      */
     private fun createIntent(context: Context): PendingIntent {
-        val pkgName = Registry.config.applicationContext.packageName
+        val pkgName = context.packageName
 
         // Create intent to open the activity and/or deep link if specified
         // Else fall back on the default launcher intent for the package

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoRemoteMessage.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoRemoteMessage.kt
@@ -1,6 +1,7 @@
 package com.klaviyo.pushFcm
 
 import android.annotation.SuppressLint
+import android.content.Context
 import android.content.Intent
 import android.content.res.Resources
 import android.graphics.drawable.AdaptiveIconDrawable
@@ -11,8 +12,10 @@ import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.res.ResourcesCompat
 import com.google.firebase.messaging.CommonNotificationBuilder
 import com.google.firebase.messaging.RemoteMessage
+import com.klaviyo.core.KlaviyoException
 import com.klaviyo.core.Registry
 import com.klaviyo.core.config.getApplicationInfoCompat
+import com.klaviyo.core.config.getManifestInt
 import java.net.URL
 
 /**
@@ -124,57 +127,39 @@ object KlaviyoRemoteMessage {
     val RemoteMessage.notificationCount: Int
         get() = this.data[KlaviyoNotification.NOTIFICATION_COUNT_KEY]?.toInt() ?: 1
 
+    @Deprecated("Use getSmallIcon(context: Context) instead")
+    val RemoteMessage.smallIcon: Int
+        get() = try {
+            getSmallIcon(Registry.config.applicationContext)
+        } catch (e: KlaviyoException) {
+            Registry.log.warning(
+                "Klaviyo SDK is uninitialized, can't get icon without application context"
+            )
+            android.R.drawable.sym_def_app_icon
+        }
+
     /**
-     * Determine the resource ID of the small icon
+     * Determine the resource ID of the small icon from provided context
      *
      * NOTE: We have to use a discouraged API because we can't expect
      *  developers to know the Int value of their icon resources
-     *
-     * @return
      */
-    val RemoteMessage.smallIcon: Int
-        @SuppressLint("DiscouragedApi")
-        get() = this.data[KlaviyoNotification.SMALL_ICON_KEY].let { resourceKey ->
-            val packageManager = Registry.config.applicationContext.packageManager
-            val pkgName = Registry.config.applicationContext.packageName
-            val resources = Registry.config.applicationContext.resources
-
-            /**
-             * API 26 contains a bug that causes the System UI process to crash-loop (which leads to
-             * a factory reset!) if the notification icon is an adaptive icon with a gradient.
-             *
-             * @see [CommonNotificationBuilder.isValidIcon] - FCM method that I am emulating here
-             */
-            fun isValidIcon(resId: Int): Boolean = if (resId == 0) {
-                false
-            } else if (Build.VERSION.SDK_INT != Build.VERSION_CODES.O) {
-                true
-            } else {
-                try {
-                    val icon = ResourcesCompat.getDrawable(resources, resId, null)
-                    if (icon is AdaptiveIconDrawable) {
-                        Registry.log.warning(
-                            "Adaptive icon $resId is not supported for notification"
-                        )
-                        false
-                    } else {
-                        true
-                    }
-                } catch (ex: Resources.NotFoundException) {
-                    Registry.log.warning("Couldn't find resource $resId for notification")
-                    false
-                }
-            }
+    @SuppressLint("DiscouragedApi")
+    fun RemoteMessage.getSmallIcon(context: Context): Int =
+        this.data[KlaviyoNotification.SMALL_ICON_KEY].let { resourceKey ->
+            val packageManager = context.packageManager
+            val pkgName = context.packageName
+            val resources = context.resources
 
             if (!resourceKey.isNullOrEmpty()) {
                 var iconId = resources.getIdentifier(resourceKey, "drawable", pkgName)
-                if (isValidIcon(iconId)) {
+                if (isValidIcon(iconId, context)) {
                     // Drawable icon was found by identifier in resources
                     return iconId
                 }
 
                 iconId = resources.getIdentifier(resourceKey, "mipmap", pkgName)
-                if (isValidIcon(iconId)) {
+                if (isValidIcon(iconId, context)) {
                     // Mipmap icon was found by identifier in resources
                     return iconId
                 }
@@ -185,20 +170,20 @@ object KlaviyoRemoteMessage {
             }
 
             // We allow default icon to be specified in the manifest
-            var iconId = Registry.config.getManifestInt(
+            var iconId = context.getManifestInt(
                 KlaviyoPushService.METADATA_DEFAULT_ICON,
                 // We can also try to get default icon configured for FCM
-                Registry.config.getManifestInt(CommonNotificationBuilder.METADATA_DEFAULT_ICON, 0)
+                context.getManifestInt(CommonNotificationBuilder.METADATA_DEFAULT_ICON, 0)
             )
 
-            if (isValidIcon(iconId)) {
+            if (isValidIcon(iconId, context)) {
                 // Icon found via manifest
                 return iconId
             }
 
             iconId = packageManager.getApplicationInfoCompat(pkgName)?.icon ?: 0
 
-            if (isValidIcon(iconId)) {
+            if (isValidIcon(iconId, context)) {
                 // Icon found via manifest
                 return iconId
             }
@@ -206,4 +191,31 @@ object KlaviyoRemoteMessage {
             // Fall back on icon-placeholder used by the OS.
             return android.R.drawable.sym_def_app_icon
         }
+
+    /**
+     * API 26 contains a bug that causes the System UI process to crash-loop (which leads to
+     * a factory reset!) if the notification icon is an adaptive icon with a gradient.
+     *
+     * @see [CommonNotificationBuilder.isValidIcon] - FCM method that I am emulating here
+     */
+    private fun isValidIcon(resId: Int, context: Context): Boolean = if (resId == 0) {
+        false
+    } else if (Build.VERSION.SDK_INT != Build.VERSION_CODES.O) {
+        true
+    } else {
+        try {
+            val icon = ResourcesCompat.getDrawable(context.resources, resId, null)
+            if (icon is AdaptiveIconDrawable) {
+                Registry.log.warning(
+                    "Adaptive icon $resId is not supported for notification"
+                )
+                false
+            } else {
+                true
+            }
+        } catch (ex: Resources.NotFoundException) {
+            Registry.log.warning("Couldn't find resource $resId for notification")
+            false
+        }
+    }
 }


### PR DESCRIPTION
# Description
Thanks in part to #100 I discovered that displaying a notification does not have to be dependent upon initialization. We were using the `applicationContext` passed in from initializing to do things like build the notification's intent, and get its icon. However, we already have access to the context from the Push Service itself. 

Importantly: this was _not_ causing any bugs to users who were following our README instructions, because initialization should have been done in `Application.onCreate` which occurs before the service gets invoked, even if the app was unlaunched. It could present a problem to our React Native users who are initializing from typescript code though.

# Check List

- [x] Are you changing anything with the public API?
- [x] Are your changes backwards compatible with previous SDK Versions?
- [x] Have you tested this change on real device?
- [ ] Have you added unit test coverage for your changes?
- [x] Have you verified that your changes are compatible with all Android versions the SDK currently supports?


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->
The one public facing change is I am deprecating the notification extension property `smallIcon` in favor of a method that can take a context as an argument. 

## Test Plan
<!-- How was this code tested / How should reviewers test it? -->
I tested with a sample app where I initialized from Activity instead of Application. From a cold boot, send a push notification from Klaviyo. Prior to this fix, it would not display a notification (and see an exception in logcat). With this fix, notification displays as expected.

## Related Issues/Tickets
<!-- Link to relevant issues or discussion -->
CHNL-6476