### PR TITLE
Improve notification display styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,9 +199,10 @@ In your `AndroidManifest.xml` file, register `KlaviyoPushService` to receive `ME
 </manifest>
 ``` 
 
-To specify an icon for Klaviyo notifications, add the following metadata element to the application component
-of `AndroidManifest.xml`. Absent this, the firebase key `com.google.firebase.messaging.default_notification_icon` 
-will be used if present, else we fall back on the application's launcher icon.   
+To specify an icon and/or color for Klaviyo notifications, add the following optional metadata elements to the
+application component of `AndroidManifest.xml`. Absent these keys, the firebase keys
+`com.google.firebase.messaging.default_notification_icon` and `com.google.firebase.messaging.default_notification_color` 
+will be used if present, else we fall back on the application's launcher icon, and omit setting a color.   
 
 ```xml
 <!-- AndroidManifest.xml -->
@@ -211,6 +212,8 @@ will be used if present, else we fall back on the application's launcher icon.
         <!-- ... -->
         <meta-data android:name="com.klaviyo.push.default_notification_icon"
             android:resource="{YOUR_ICON_RESOURCE}" />
+        <meta-data android:name="com.klaviyo.push.default_notification_color"
+            android:resource="{YOUR_COLOR}" />
     </application>
 </manifest>
 ```

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoNotification.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoNotification.kt
@@ -135,6 +135,7 @@ class KlaviyoNotification(private val message: RemoteMessage) {
             .setSmallIcon(message.smallIcon)
             .setContentTitle(message.title)
             .setContentText(message.body)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(message.body))
             .setSound(message.sound)
             .setNumber(message.notificationCount)
             .setPriority(message.notificationPriority)

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoNotification.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoNotification.kt
@@ -23,6 +23,7 @@ import com.klaviyo.pushFcm.KlaviyoRemoteMessage.channel_importance
 import com.klaviyo.pushFcm.KlaviyoRemoteMessage.channel_name
 import com.klaviyo.pushFcm.KlaviyoRemoteMessage.clickAction
 import com.klaviyo.pushFcm.KlaviyoRemoteMessage.deepLink
+import com.klaviyo.pushFcm.KlaviyoRemoteMessage.getColor
 import com.klaviyo.pushFcm.KlaviyoRemoteMessage.getSmallIcon
 import com.klaviyo.pushFcm.KlaviyoRemoteMessage.imageUrl
 import com.klaviyo.pushFcm.KlaviyoRemoteMessage.isKlaviyoNotification
@@ -58,6 +59,7 @@ class KlaviyoNotification(private val message: RemoteMessage) {
         internal const val IMAGE_KEY = "image_url"
         internal const val CLICK_ACTION_KEY = "click_action"
         internal const val SOUND_KEY = "sound"
+        internal const val COLOR_KEY = "color"
         internal const val NOTIFICATION_COUNT_KEY = "notification_count"
         internal const val NOTIFICATION_PRIORITY = "notification_priority"
         private const val DOWNLOAD_TIMEOUT_MS = 5_000
@@ -133,6 +135,7 @@ class KlaviyoNotification(private val message: RemoteMessage) {
         NotificationCompat.Builder(context, message.channel_id)
             .setContentIntent(createIntent(context))
             .setSmallIcon(message.getSmallIcon(context))
+            .also { message.getColor(context)?.let { color -> it.setColor(color) } }
             .setContentTitle(message.title)
             .setContentText(message.body)
             .setStyle(NotificationCompat.BigTextStyle().bigText(message.body))

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoPushService.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoPushService.kt
@@ -17,6 +17,7 @@ open class KlaviyoPushService : FirebaseMessagingService() {
 
     companion object {
         const val METADATA_DEFAULT_ICON = "com.klaviyo.push.default_notification_icon"
+        const val METADATA_DEFAULT_COLOR = "com.klaviyo.push.default_notification_color"
     }
 
     /**


### PR DESCRIPTION
# Description
Added `bigText` style and the ability to specify notification color from the manifest.
To head off conflicts, I had to branch off #144 

# Check List

- [x] Are you changing anything with the public API?
  - NO
- [x] Are your changes backwards compatible with previous SDK Versions?
  - YES
- [x] Have you tested this change on real device?
  - YES
- [x] Have you added unit test coverage for your changes?
  - Can't 
- [x] Have you verified that your changes are compatible with all Android versions the SDK currently supports?
  - YES


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->
- Changed default notification display style to use bigText.
- Added an option to specify notification icon color the same way we do icon itself. 

## Test Plan
<!-- How was this code tested / How should reviewers test it? -->
- Tested with the test app: 
![Screenshot_20240314_122322](https://github.com/klaviyo/klaviyo-android-sdk/assets/5167687/c16c32c6-e8fc-43ae-94a7-43a7734a977c)


## Related Issues/Tickets
<!-- Link to relevant issues or discussion -->
#104 
CHNL-4086
CHNL-1425