### PR TITLE
Git status check needs doc changes to be staged

### DIFF
--- a/.github/workflows/doc-bot.yml
+++ b/.github/workflows/doc-bot.yml
@@ -37,7 +37,9 @@ jobs:
           git merge origin/master --commit --no-edit --strategy-option theirs
 
       - name: Generate Dokka documentation
-        run: ./gradlew dokkaHtmlMultiModule
+        run: |
+          ./gradlew dokkaHtmlMultiModule
+          git add ./docs
 
       - name: Commit and push documentation
         run: |
@@ -46,6 +48,5 @@ jobs:
             exit 0
           fi
           
-          git add .
           git commit -m "${{ env.CI_COMMIT_MESSAGE }}"
           git push


### PR DESCRIPTION
Minor tweak to doc bot: the git status check looks at _staged_ files, so last release doc changes weren't pushed