### PR TITLE
Update network retry behavior to extend retries, add jitter

### DIFF
--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/KlaviyoApiClient.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/KlaviyoApiClient.kt
@@ -14,6 +14,9 @@ import com.klaviyo.analytics.networking.requests.PushTokenApiRequest
 import com.klaviyo.core.Registry
 import com.klaviyo.core.lifecycle.ActivityEvent
 import java.util.concurrent.ConcurrentLinkedDeque
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.pow
 import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
@@ -38,9 +41,18 @@ internal object KlaviyoApiClient : ApiClient {
             when (r.state) {
                 Status.Unsent.name -> Registry.log.verbose("${r.type} Request enqueued")
                 Status.Inflight.name -> Registry.log.verbose("${r.type} Request inflight")
-                Status.PendingRetry.name -> Registry.log.debug("${r.type} Request retrying")
-                Status.Complete.name -> Registry.log.verbose("${r.type} Request completed")
-                else -> Registry.log.debug("${r.type} Request failed")
+                Status.PendingRetry.name -> {
+                    val attemptsRemaining = Registry.config.networkMaxAttempts - r.attempts
+                    Registry.log.warning(
+                        "${r.type} Request failed with code ${r.responseCode}, and will be retried up to $attemptsRemaining more times."
+                    )
+                }
+                Status.Complete.name -> Registry.log.verbose(
+                    "${r.type} Request succeeded with code ${r.responseCode}"
+                )
+                else -> Registry.log.error(
+                    "${r.type} Request failed with code ${r.responseCode}, and will be dropped"
+                )
             }
 
             r.responseBody?.let { response ->
@@ -143,9 +155,9 @@ internal object KlaviyoApiClient : ApiClient {
         // Keep track if there's any errors restoring from persistent store
         var wasMutated = false
 
-        Registry.log.verbose("Restoring persisted queue")
-
         Registry.dataStore.fetch(QUEUE_KEY)?.let {
+            Registry.log.verbose("Restoring persisted queue")
+
             try {
                 val queue = JSONArray(it)
                 Array(queue.length()) { i -> queue.optString(i) }
@@ -227,16 +239,18 @@ internal object KlaviyoApiClient : ApiClient {
      */
     private fun startBatch(force: Boolean = false) {
         stopBatch() // we only ever want one batch job running
-        handler?.post(NetworkRunnable(force))
-        Registry.log.verbose("Started background handler")
+        handler?.post(NetworkRunnable(force)).also {
+            Registry.log.verbose("Posted job to network handler message queue")
+        }
     }
 
     /**
      * Stop all jobs on our handler thread
      */
     private fun stopBatch() {
-        handler?.removeCallbacksAndMessages(null)
-        Registry.log.verbose("Stopped background handler")
+        handler?.removeCallbacksAndMessages(null).also {
+            Registry.log.verbose("Cleared jobs from network handler message queue")
+        }
     }
 
     /**
@@ -251,11 +265,11 @@ internal object KlaviyoApiClient : ApiClient {
         var force = force
             private set
 
-        private val queueInitTime = Registry.clock.currentTimeMillis()
+        private var enqueuedTime = Registry.clock.currentTimeMillis()
 
         private var networkType: Int = Registry.networkMonitor.getNetworkType().position
 
-        private var flushInterval: Long = Registry.config.networkFlushIntervals[networkType].toLong()
+        private var flushInterval: Long = Registry.config.networkFlushIntervals[networkType]
 
         private val flushDepth: Int = Registry.config.networkFlushDepth
 
@@ -265,7 +279,7 @@ internal object KlaviyoApiClient : ApiClient {
          * Posts another delayed batch job if requests remains
          */
         override fun run() {
-            val queueTimePassed = Registry.clock.currentTimeMillis() - queueInitTime
+            val queueTimePassed = Registry.clock.currentTimeMillis() - enqueuedTime
 
             if (getQueueSize() < flushDepth && queueTimePassed < flushInterval && !force) {
                 return requeue()
@@ -286,14 +300,14 @@ internal object KlaviyoApiClient : ApiClient {
                         // On success or absolute failure, remove from queue and persistent store
                         Registry.dataStore.clear(request.uuid)
                         // Reset the flush interval, in case we had done any exp backoff
-                        flushInterval = Registry.config.networkFlushIntervals[networkType].toLong()
+                        flushInterval = Registry.config.networkFlushIntervals[networkType]
                         broadcastApiRequest(request)
                     }
                     Status.PendingRetry -> {
                         // Encountered a retryable error
-                        // Put this back on top of the queue and we'll try again with backoff
+                        // Put this back on top of the queue, and we'll try again with backoff
                         apiQueue.offerFirst(request)
-                        flushInterval *= request.attempts + 1
+                        flushInterval = computeRetryInterval(request.attempts)
                         broadcastApiRequest(request)
                         break
                     }
@@ -318,9 +332,21 @@ internal object KlaviyoApiClient : ApiClient {
          * Re-queue the job to run again after [flushInterval] milliseconds
          */
         private fun requeue() {
-            Registry.log.verbose("Retrying network batch in $flushInterval")
+            Registry.log.verbose("Network batch will run in $flushInterval ms")
             force = false
+            enqueuedTime = Registry.clock.currentTimeMillis()
             handler?.postDelayed(this, flushInterval)
+        }
+
+        private fun computeRetryInterval(attempts: Int): Long {
+            val minRetryInterval = flushInterval
+            val jitterSeconds = Registry.config.networkJitterRange.random()
+            val exponentialBackoff = (2.0.pow(attempts).toLong() + jitterSeconds).times(1_000)
+            val maxRetryInterval = Registry.config.networkMaxRetryInterval
+            return min(
+                max(minRetryInterval, exponentialBackoff),
+                maxRetryInterval
+            )
         }
     }
 

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/ApiRequest.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/ApiRequest.kt
@@ -28,6 +28,11 @@ interface ApiRequest {
     val queuedTime: Long
 
     /**
+     * Number of send attempts
+     */
+    val attempts: Int
+
+    /**
      * Time the request was made
      */
     val startTime: Long?

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequest.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequest.kt
@@ -170,7 +170,7 @@ internal open class KlaviyoApiRequest(
     /**
      * Tracks number of attempts to limit retries
      */
-    var attempts = 0
+    final override var attempts = 0
         private set
 
     /**
@@ -319,7 +319,7 @@ internal open class KlaviyoApiRequest(
         status = when (responseCode) {
             in successCodes -> Status.Complete
             HTTP_RETRY -> {
-                if (attempts <= Registry.config.networkMaxRetries) {
+                if (attempts < Registry.config.networkMaxAttempts) {
                     Status.PendingRetry
                 } else {
                     Status.Failed

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/KlaviyoApiClientTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/KlaviyoApiClientTest.kt
@@ -101,7 +101,7 @@ internal class KlaviyoApiClientTest : BaseRequestTest() {
                     KlaviyoApiRequest.Status.Complete.name -> KlaviyoApiRequest.Status.Complete
                     KlaviyoApiRequest.Status.Failed.name -> KlaviyoApiRequest.Status.Failed
                     else -> error("Invalid state")
-                } 
+                }
             }
 
             // Initial attempts value
@@ -124,7 +124,7 @@ internal class KlaviyoApiClientTest : BaseRequestTest() {
                     KlaviyoApiRequest.Status.Complete -> 202
                     KlaviyoApiRequest.Status.Failed -> 500
                     else -> null
-                } 
+                }
             }
             every { it.attempts } answers { attempts }
             every { it.toJson() } returns JSONObject(
@@ -379,7 +379,7 @@ internal class KlaviyoApiClientTest : BaseRequestTest() {
                 0 -> KlaviyoApiRequest.Status.Unsent.name
                 50 -> KlaviyoApiRequest.Status.Failed.name
                 else -> KlaviyoApiRequest.Status.PendingRetry.name
-            } 
+            }
         }
 
         // Second unset request in queue to ensure which shouldn't sent until first has failed

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequestTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequestTest.kt
@@ -47,7 +47,7 @@ internal class KlaviyoApiRequestTest : BaseRequestTest() {
 
         every { networkMonitorMock.isNetworkConnected() } returns true
         every { configMock.networkTimeout } returns 1
-        every { configMock.networkFlushIntervals } returns intArrayOf(10_000, 30_000, 60_000)
+        every { configMock.networkFlushIntervals } returns longArrayOf(10_000L, 30_000L, 60_000L)
     }
 
     @Test
@@ -177,14 +177,14 @@ internal class KlaviyoApiRequestTest : BaseRequestTest() {
 
         val request = KlaviyoApiRequest(stubUrlPath, RequestMethod.GET)
 
-        repeat(configMock.networkMaxRetries) {
+        repeat(configMock.networkMaxAttempts - 1) {
             // Should be retryable until max attempts hit
             assertEquals(KlaviyoApiRequest.Status.PendingRetry, request.send())
         }
 
         // Final attempt should return fail
         assertEquals(KlaviyoApiRequest.Status.Failed, request.send())
-        assertEquals(configMock.networkMaxRetries + 1, request.attempts)
+        assertEquals(configMock.networkMaxAttempts, request.attempts)
     }
 
     @Test

--- a/sdk/core/src/main/java/com/klaviyo/core/config/Config.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/config/Config.kt
@@ -13,9 +13,11 @@ interface Config {
     val debounceInterval: Int
 
     val networkTimeout: Int
-    val networkFlushIntervals: IntArray
+    val networkFlushIntervals: LongArray
     val networkFlushDepth: Int
-    val networkMaxRetries: Int
+    val networkMaxAttempts: Int
+    val networkMaxRetryInterval: Long
+    val networkJitterRange: IntRange
 
     fun getManifestInt(key: String, defaultValue: Int): Int
 
@@ -25,9 +27,10 @@ interface Config {
         fun baseUrl(baseUrl: String): Builder
         fun debounceInterval(debounceInterval: Int): Builder
         fun networkTimeout(networkTimeout: Int): Builder
-        fun networkFlushInterval(networkFlushInterval: Int, type: NetworkMonitor.NetworkType): Builder
+        fun networkFlushInterval(networkFlushInterval: Long, type: NetworkMonitor.NetworkType): Builder
         fun networkFlushDepth(networkFlushDepth: Int): Builder
-        fun networkMaxRetries(networkMaxRetries: Int): Builder
+        fun networkMaxAttempts(networkMaxAttempts: Int): Builder
+        fun networkMaxRetryInterval(networkMaxRetryInterval: Long): Builder
         fun build(): Config
     }
 }

--- a/sdk/core/src/main/java/com/klaviyo/core/config/KlaviyoConfig.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/config/KlaviyoConfig.kt
@@ -64,9 +64,9 @@ object KlaviyoConfig : Config {
      * Reasoning: A 30-second interval should give radios time to go back to sleep between batches,
      * four retries with a typical backoff pattern would then be 30s, 60s, 3m, 12m.
      */
-    private const val NETWORK_FLUSH_INTERVAL_WIFI_DEFAULT: Int = 10_000
-    private const val NETWORK_FLUSH_INTERVAL_CELL_DEFAULT: Int = 30_000
-    private const val NETWORK_FLUSH_INTERVAL_OFFLINE_DEFAULT: Int = 60_000
+    private const val NETWORK_FLUSH_INTERVAL_WIFI_DEFAULT = 10_000L
+    private const val NETWORK_FLUSH_INTERVAL_CELL_DEFAULT = 30_000L
+    private const val NETWORK_FLUSH_INTERVAL_OFFLINE_DEFAULT = 60_000L
 
     /**
      * How many API requests can be enqueued before flush
@@ -79,10 +79,16 @@ object KlaviyoConfig : Config {
     /**
      * How many retries to allow an API request before permanent failure
      *
-     * Reasoning: Most likely the rate limit should be cleared within 2 retries with exp backoff.
-     * However, I wanted some extra padding for edge cases, since the consequence is lost data.
+     * Reasoning: Most likely the rate limit should be cleared within 2-3 retries with exp backoff.
      */
-    private const val NETWORK_MAX_RETRIES_DEFAULT: Int = 4
+    private const val NETWORK_MAX_RETRIES_DEFAULT: Int = 50
+
+    /**
+     * Maximum interval between retries for the exponential backoff
+     *
+     * Reasoning: We don't want to wait so long that the user has left the app.
+     */
+    private const val NETWORK_MAX_RETRY_INTERVAL_DEFAULT: Long = 180_000
 
     override val isDebugBuild = BuildConfig.DEBUG
 
@@ -94,7 +100,7 @@ object KlaviyoConfig : Config {
         private set
     override var networkTimeout = NETWORK_TIMEOUT_DEFAULT
         private set
-    override var networkFlushIntervals = intArrayOf(
+    override var networkFlushIntervals = longArrayOf(
         NETWORK_FLUSH_INTERVAL_WIFI_DEFAULT,
         NETWORK_FLUSH_INTERVAL_CELL_DEFAULT,
         NETWORK_FLUSH_INTERVAL_OFFLINE_DEFAULT
@@ -102,8 +108,11 @@ object KlaviyoConfig : Config {
         private set
     override var networkFlushDepth = NETWORK_FLUSH_DEPTH_DEFAULT
         private set
-    override var networkMaxRetries = NETWORK_MAX_RETRIES_DEFAULT
+    override var networkMaxAttempts = NETWORK_MAX_RETRIES_DEFAULT
         private set
+    override var networkMaxRetryInterval = NETWORK_MAX_RETRY_INTERVAL_DEFAULT
+        private set
+    override val networkJitterRange = 0..10
 
     override fun getManifestInt(key: String, defaultValue: Int): Int = if (!this::applicationContext.isInitialized) {
         defaultValue
@@ -120,13 +129,14 @@ object KlaviyoConfig : Config {
         private var baseUrl: String? = null
         private var debounceInterval: Int = DEBOUNCE_INTERVAL
         private var networkTimeout: Int = NETWORK_TIMEOUT_DEFAULT
-        private var networkFlushIntervals: IntArray = intArrayOf(
+        private var networkFlushIntervals = longArrayOf(
             NETWORK_FLUSH_INTERVAL_WIFI_DEFAULT,
             NETWORK_FLUSH_INTERVAL_CELL_DEFAULT,
             NETWORK_FLUSH_INTERVAL_OFFLINE_DEFAULT
         )
         private var networkFlushDepth = NETWORK_FLUSH_DEPTH_DEFAULT
-        private var networkMaxRetries = NETWORK_MAX_RETRIES_DEFAULT
+        private var networkMaxAttempts = NETWORK_MAX_RETRIES_DEFAULT
+        private var networkMaxRetryInterval = NETWORK_MAX_RETRY_INTERVAL_DEFAULT
 
         private val requiredPermissions = arrayOf(
             Manifest.permission.ACCESS_NETWORK_STATE,
@@ -166,7 +176,7 @@ object KlaviyoConfig : Config {
         }
 
         override fun networkFlushInterval(
-            networkFlushInterval: Int,
+            networkFlushInterval: Long,
             type: NetworkMonitor.NetworkType
         ) = apply {
             if (networkFlushInterval >= 0) {
@@ -188,12 +198,22 @@ object KlaviyoConfig : Config {
             }
         }
 
-        override fun networkMaxRetries(networkMaxRetries: Int) = apply {
-            if (networkMaxRetries >= 0) {
-                this.networkMaxRetries = networkMaxRetries
+        override fun networkMaxAttempts(networkMaxAttempts: Int) = apply {
+            if (networkMaxAttempts >= 0) {
+                this.networkMaxAttempts = networkMaxAttempts
             } else {
                 Registry.log.error(
-                    "${KlaviyoConfig::networkMaxRetries.name} must be greater or equal to 0"
+                    "${KlaviyoConfig::networkMaxAttempts.name} must be greater or equal to 0"
+                )
+            }
+        }
+
+        override fun networkMaxRetryInterval(networkMaxRetryInterval: Long) = apply {
+            if (networkMaxRetryInterval >= 0) {
+                this.networkMaxRetryInterval = networkMaxRetryInterval
+            } else {
+                Registry.log.error(
+                    "${KlaviyoConfig::networkMaxRetryInterval.name} must be greater or equal to 0"
                 )
             }
         }
@@ -218,7 +238,8 @@ object KlaviyoConfig : Config {
             KlaviyoConfig.networkTimeout = networkTimeout
             KlaviyoConfig.networkFlushIntervals = networkFlushIntervals
             KlaviyoConfig.networkFlushDepth = networkFlushDepth
-            KlaviyoConfig.networkMaxRetries = networkMaxRetries
+            KlaviyoConfig.networkMaxAttempts = networkMaxAttempts
+            KlaviyoConfig.networkMaxRetryInterval = networkMaxRetryInterval
 
             return KlaviyoConfig
         }

--- a/sdk/core/src/main/java/com/klaviyo/core/config/KlaviyoConfig.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/config/KlaviyoConfig.kt
@@ -84,7 +84,7 @@ object KlaviyoConfig : Config {
     private const val NETWORK_MAX_RETRIES_DEFAULT: Int = 50
 
     /**
-     * Maximum interval between retries for the exponential backoff
+     * Maximum interval between retries for the exponential backoff, in milliseconds (3 minutes)
      *
      * Reasoning: We don't want to wait so long that the user has left the app.
      */

--- a/sdk/core/src/test/java/com/klaviyo/core/config/KlaviyoConfigTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/config/KlaviyoConfigTest.kt
@@ -64,7 +64,8 @@ internal class KlaviyoConfigTest : BaseTest() {
             .networkFlushInterval(3, NetworkMonitor.NetworkType.Cell)
             .networkFlushInterval(6, NetworkMonitor.NetworkType.Offline)
             .networkFlushDepth(4)
-            .networkMaxRetries(5)
+            .networkMaxAttempts(5)
+            .networkMaxRetryInterval(7)
             .build()
 
         assertEquals(API_KEY, KlaviyoConfig.apiKey)
@@ -85,7 +86,8 @@ internal class KlaviyoConfigTest : BaseTest() {
             KlaviyoConfig.networkFlushIntervals[NetworkMonitor.NetworkType.Offline.position]
         )
         assertEquals(4, KlaviyoConfig.networkFlushDepth)
-        assertEquals(5, KlaviyoConfig.networkMaxRetries)
+        assertEquals(5, KlaviyoConfig.networkMaxAttempts)
+        assertEquals(7, KlaviyoConfig.networkMaxRetryInterval)
     }
 
     @Test
@@ -99,19 +101,20 @@ internal class KlaviyoConfigTest : BaseTest() {
         assertEquals(100, KlaviyoConfig.debounceInterval)
         assertEquals(10_000, KlaviyoConfig.networkTimeout)
         assertEquals(
-            10_000,
+            10_000L,
             KlaviyoConfig.networkFlushIntervals[NetworkMonitor.NetworkType.Wifi.position]
         )
         assertEquals(
-            30_000,
+            30_000L,
             KlaviyoConfig.networkFlushIntervals[NetworkMonitor.NetworkType.Cell.position]
         )
         assertEquals(
-            60_000,
+            60_000L,
             KlaviyoConfig.networkFlushIntervals[NetworkMonitor.NetworkType.Offline.position]
         )
         assertEquals(25, KlaviyoConfig.networkFlushDepth)
-        assertEquals(4, KlaviyoConfig.networkMaxRetries)
+        assertEquals(50, KlaviyoConfig.networkMaxAttempts)
+        assertEquals(180_000L, KlaviyoConfig.networkMaxRetryInterval)
     }
 
     @Test
@@ -125,17 +128,18 @@ internal class KlaviyoConfigTest : BaseTest() {
             .networkFlushInterval(-5000, NetworkMonitor.NetworkType.Cell)
             .networkFlushInterval(-5000, NetworkMonitor.NetworkType.Offline)
             .networkFlushDepth(-10)
-            .networkMaxRetries(-10)
+            .networkMaxAttempts(-10)
+            .networkMaxRetryInterval(-1)
             .build()
 
         assertEquals(100, KlaviyoConfig.debounceInterval)
         assertEquals(10_000, KlaviyoConfig.networkTimeout)
         assertEquals(
-            10_000,
+            10_000L,
             KlaviyoConfig.networkFlushIntervals[NetworkMonitor.NetworkType.Wifi.position]
         )
         assertEquals(
-            30_000,
+            30_000L,
             KlaviyoConfig.networkFlushIntervals[NetworkMonitor.NetworkType.Cell.position]
         )
         assertEquals(
@@ -143,10 +147,11 @@ internal class KlaviyoConfigTest : BaseTest() {
             KlaviyoConfig.networkFlushIntervals[NetworkMonitor.NetworkType.Offline.position]
         )
         assertEquals(25, KlaviyoConfig.networkFlushDepth)
-        assertEquals(4, KlaviyoConfig.networkMaxRetries)
+        assertEquals(50, KlaviyoConfig.networkMaxAttempts)
+        assertEquals(180_000, KlaviyoConfig.networkMaxRetryInterval)
 
         // Each bad call should have generated an error log
-        verify(exactly = 7) { logSpy.error(any(), null) }
+        verify(exactly = 8) { logSpy.error(any(), null) }
     }
 
     @Test(expected = MissingAPIKey::class)

--- a/sdk/fixtures/src/main/java/com/klaviyo/fixtures/BaseTest.kt
+++ b/sdk/fixtures/src/main/java/com/klaviyo/fixtures/BaseTest.kt
@@ -71,8 +71,10 @@ abstract class BaseTest {
     protected val configMock = mockk<Config>().apply {
         every { apiKey } returns API_KEY
         every { applicationContext } returns contextMock
-        every { networkMaxRetries } returns 4
-        every { networkFlushIntervals } returns intArrayOf(10_000, 30_000, 60_000)
+        every { networkMaxAttempts } returns 50
+        every { networkMaxRetryInterval } returns 180_000L
+        every { networkFlushIntervals } returns longArrayOf(10_000, 30_000, 60_000)
+        every { networkJitterRange } returns 0..0
         every { baseUrl } returns "https://test.fake-klaviyo.com"
     }
     protected val lifecycleMonitorMock = mockk<LifecycleMonitor>()


### PR DESCRIPTION
# Description
This should match the Swift SDK retry behavior as I understood it. I tried to make the test very readable, would appreciate @ndurell or @ajaysubra confirming my logic. 

First of two PRs regarding network rate limits.

# Check List

- [x] Are you changing anything with the public API?
  - No
- [x] Are your changes backwards compatible with previous SDK Versions?
  - Yes
- [x] Have you tested this change on real device?
  - Emulator is sufficient
- [x] Have you added unit test coverage for your changes?
  - Yes
- [x] Have you verified that your changes are compatible with all Android versions the SDK currently supports?
  - N/A


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->
- Retry 50 times before failure
- Updated my exponential backoff calculation
- Added jitter
- Re-worked the unit test based on better understanding of the thread Handler behavior

## Test Plan
<!-- How was this code tested / How should reviewers test it? -->
- Unit test and debugged on a device after forcing artificial 429 responses

## Related Issues/Tickets
<!-- Link to relevant issues or discussion -->
CHNL-6779
