### PR TITLE
Deprecate duplicative profile key constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,12 +112,15 @@ Identifiers are persisted to local storage so that the SDK can keep track of the
 Profile identifiers and other attributes can be set all at once using the `Profile` data class:
 
 ```kotlin
-val profile = Profile()
-    .setEmail("kermit@example.com")
-    .setPhoneNumber("+12223334444")
-    .setExternalId("USER_IDENTIFIER")
-    .setProperty(ProfileKey.FIRST_NAME, "Kermit")
-    .setProperty(ProfileKey.CUSTOM("instrument"), "banjo")
+val profile = Profile(
+    externalId = "USER_IDENTIFIER",
+    email = "kermit@example.com",
+    phoneNumber = "+12223334444",
+    properties = mapOf(
+        ProfileKey.FIRST_NAME to "Kermit",
+        ProfileKey.CUSTOM("instrument") to "banjo"
+    )
+)
 
 Klaviyo.setProfile(profile)
 ```
@@ -125,9 +128,9 @@ Klaviyo.setProfile(profile)
 Or individually with additive fluent setters:
 
 ```kotlin
-Klaviyo.setEmail("kermit@example.com")
+Klaviyo.setExternalId("USER_IDENTIFIER")
+    .setEmail("kermit@example.com")
     .setPhoneNumber("+12223334444")
-    .setExternalId("USER_IDENTIFIER")
     .setProfileAttribute(ProfileKey.FIRST_NAME, "Kermit")
     .setProfileAttribute(ProfileKey.CUSTOM("instrument"), "banjo")
 ```

--- a/README.md
+++ b/README.md
@@ -109,15 +109,16 @@ A profile can be identified by any combination of the following:
 
 Identifiers are persisted to local storage so that the SDK can keep track of the current profile.
 
-Profile identifiers and other attributes can be set all at once as a `map`:
+Profile identifiers and other attributes can be set all at once using the `Profile` data class:
 
 ```kotlin
-val profile = Profile(
-    mapOf(
-        ProfileKey.EMAIL to "kermit@example.com",
-        ProfileKey.FIRST_NAME to "Kermit"
-    )
-)
+val profile = Profile()
+    .setEmail("kermit@example.com")
+    .setPhoneNumber("+12223334444")
+    .setExternalId("USER_IDENTIFIER")
+    .setProperty(ProfileKey.FIRST_NAME, "Kermit")
+    .setProperty(ProfileKey.CUSTOM("instrument"), "banjo")
+
 Klaviyo.setProfile(profile)
 ```
 

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/model/Profile.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/model/Profile.kt
@@ -8,7 +8,16 @@ import java.io.Serializable
 class Profile(properties: Map<ProfileKey, Serializable>?) :
     BaseModel<ProfileKey, Profile>(properties) {
 
-    constructor() : this(null)
+    constructor(
+        externalId: String? = null,
+        email: String? = null,
+        phoneNumber: String? = null,
+        properties: Map<ProfileKey, Serializable>? = null
+    ) : this(properties) {
+        this.externalId = externalId
+        this.email = email
+        this.phoneNumber = phoneNumber
+    }
 
     fun setExternalId(identifier: String?) = apply { this.externalId = identifier }
     var externalId: String?

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/model/ProfileKey.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/model/ProfileKey.kt
@@ -7,8 +7,19 @@ package com.klaviyo.analytics.model
 sealed class ProfileKey(name: String) : Keyword(name) {
 
     // Identifiers
+    @Deprecated(
+        "The key for external_id will be made private in an upcoming release, use explicit setter instead."
+    )
     object EXTERNAL_ID : ProfileKey("external_id")
+
+    @Deprecated(
+        "The key for email will be made private in an upcoming release, use explicit setter instead."
+    )
     object EMAIL : ProfileKey("email")
+
+    @Deprecated(
+        "The key for phone_number will be made private in an upcoming release, use explicit setter instead."
+    )
     object PHONE_NUMBER : ProfileKey("phone_number")
     internal object ANONYMOUS_ID : ProfileKey("anonymous_id")
 


### PR DESCRIPTION
# Description
Mark these keys deprecated in advance of next major release in which we can change them to internal. They're inconsistent with iOS and duplicative of explicit setter methods anyway. 

# Check List

- [x] Are you changing anything with the public API? - YES, deprecating public constants
- [x] Are your changes backwards compatible with previous SDK Versions? - YES, deprecating = no change required yet.
- [x] Have you tested this change on real device?
- [x] Have you added unit test coverage for your changes? N/A
- [x] Have you verified that your changes are compatible with all Android versions the SDK currently supports?


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->
Deprecate the profile keys that correspond to identifiers, which have their own setter methods. 
- [ ] TODO add new constructor so identifiers can optionally be set from constructor

## Test Plan
<!-- How was this code tested / How should reviewers test it? -->


## Related Issues/Tickets
<!-- Link to relevant issues or discussion -->
CHNL-6547
