### PR TITLE
Stateful push notification API to avoid unneeded calls

### DIFF
--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/model/ProfileKey.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/model/ProfileKey.kt
@@ -11,6 +11,8 @@ sealed class ProfileKey(name: String) : Keyword(name) {
     object EMAIL : ProfileKey("email")
     object PHONE_NUMBER : ProfileKey("phone_number")
     internal object ANONYMOUS_ID : ProfileKey("anonymous_id")
+    internal object PUSH_TOKEN : ProfileKey("push_token")
+    internal object PUSH_STATE : ProfileKey("push_state")
 
     // Personal information
     object FIRST_NAME : ProfileKey("first_name")

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequest.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequest.kt
@@ -114,8 +114,8 @@ internal open class KlaviyoApiRequest(
      * Internal tracking of the request status
      * When status changes, this setter updates start and end timestamps
      */
-    protected var status: Status = Status.Unsent
-        set(value) {
+    var status: Status = Status.Unsent
+        private set(value) {
             if (field == value) return
             field = value
 

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/PushTokenApiRequest.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/PushTokenApiRequest.kt
@@ -70,17 +70,23 @@ internal class PushTokenApiRequest(
         )
     }
 
+    val notificationPermission by lazy { DeviceProperties.notificationPermission }
+
+    val backgroundData by lazy { DeviceProperties.backgroundData }
+
+    val token: String? get() = body?.optJSONObject(DATA)?.optString(TOKEN)
+
     // Update body to include Device metadata whenever the body is retrieved (typically during sending) so the latest data is included
     override val requestBody: String?
         get() = body?.apply {
             optJSONObject(DATA)?.optJSONObject(ATTRIBUTES)?.apply {
                 put(
                     ENABLEMENT_STATUS,
-                    if (DeviceProperties.notificationPermission) NOTIFICATIONS_ENABLED else NOTIFICATIONS_DISABLED
+                    if (notificationPermission) NOTIFICATIONS_ENABLED else NOTIFICATIONS_DISABLED
                 )
                 put(
                     BACKGROUND,
-                    if (DeviceProperties.backgroundData) BG_AVAILABLE else BG_UNAVAILABLE
+                    if (backgroundData) BG_AVAILABLE else BG_UNAVAILABLE
                 )
                 put(METADATA, JSONObject(DeviceProperties.buildMetaData()))
             }


### PR DESCRIPTION
# Description
This will prevent duplicate push token API calls by tracking push token state locally. 

# Check List

- [x] Are you changing anything with the public API? 
  - NO
- [x] Are your changes backwards compatible with previous SDK Versions? 
  - YES
- [ ] Have you tested this change on real device? 
  - TODO
- [x] Have you added unit test coverage for your changes? 
  - YES
- [x] Have you verified that your changes are compatible with all Android versions the SDK currently supports? 
  - N/A


## Changelog / Code Overview
To avoid duplicate/unnecessary push token API calls:
- I moved push token into UserInfo state object
- And added permission and background into state as well
- Use that prior state to tell if we need an API request when setPushToken is called

## Test Plan
Wrote unit tests already, doing manual tests on devices now. 

## Related Issues/Tickets
CHNL-6782
