### PR TITLE
Move UserInfo listeners out of its initializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ send them timely push notifications via [FCM (Firebase Cloud Messaging)](https:/
       ```kotlin
       // build.gradle.kts
       dependencies {
-          implementation("com.github.klaviyo.klaviyo-android-sdk:analytics:2.2.0")
-          implementation("com.github.klaviyo.klaviyo-android-sdk:push-fcm:2.2.0")
+          implementation("com.github.klaviyo.klaviyo-android-sdk:analytics:2.2.1")
+          implementation("com.github.klaviyo.klaviyo-android-sdk:push-fcm:2.2.1")
       }
       ```
    </details>
@@ -63,8 +63,8 @@ send them timely push notifications via [FCM (Firebase Cloud Messaging)](https:/
       ```groovy
        // build.gradle
        dependencies {
-           implementation "com.github.klaviyo.klaviyo-android-sdk:analytics:2.2.0"
-           implementation "com.github.klaviyo.klaviyo-android-sdk:push-fcm:2.2.0"
+           implementation "com.github.klaviyo.klaviyo-android-sdk:analytics:2.2.1"
+           implementation "com.github.klaviyo.klaviyo-android-sdk:push-fcm:2.2.1"
        }
       ```
    </details>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,2 +1,2 @@
 <!-- Redirect to latest version -->
-<meta HTTP-EQUIV="REFRESH" content="0; url=./2.2.0/index.html">
+<meta HTTP-EQUIV="REFRESH" content="0; url=./2.2.1/index.html">

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -61,6 +61,8 @@ object Klaviyo {
             unregisterActivityLifecycleCallbacks(Registry.lifecycleCallbacks)
             registerActivityLifecycleCallbacks(Registry.lifecycleCallbacks)
         } ?: throw LifecycleException()
+
+        UserInfo.startObservers()
     }
 
     /**

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/UserInfo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/UserInfo.kt
@@ -19,7 +19,7 @@ import java.util.UUID
  */
 internal object UserInfo {
 
-    init {
+    fun startObservers() {
         Registry.get<ApiClient>().onApiRequest { request ->
             // If push token request totally fails, we must remove it from state
             if (request is PushTokenApiRequest && request.status == Failed) {

--- a/versions.properties
+++ b/versions.properties
@@ -11,9 +11,9 @@
 
 # Project versioning, run the following gradle command to update version numbers automatically:
 # ./gradlew bumpVersion --nextVersion=X.Y.Z
-version.klaviyo.versionCode=15
+version.klaviyo.versionCode=16
 
-version.klaviyo.versionName=2.2.0
+version.klaviyo.versionName=2.2.1
 
 # Android versioning
 


### PR DESCRIPTION
# Description
Too risky to attach this listener in the initializer, instead attach it when SDK is initialized.
Bump to 2.2.1 for the patch.

# Check List

- [x] Are you changing anything with the public API?
- [x] Are your changes backwards compatible with previous SDK Versions?
- [x] Have you tested this change on real device?
- [x] Have you added unit test coverage for your changes?
- [x] Have you verified that your changes are compatible with all Android versions the SDK currently supports?


## Changelog / Code Overview
There was a timing risk for RN SDK users who initialize from the RN layer here. While we do catch `KlaviyoException`s to avoid that crashing their app, if any exception is thrown from an initializer it winds up re-thrown as `ExceptionInInitializerError` which we do not catch. 

## Test Plan
Unit tests still pass because we were already doing proper setup. 
Tested from android test app with all calls to klaviyo commented out so that `setPushToken` was the first thing to be called.

## Related Issues/Tickets
CHNL-6782 

