### PR TITLE
Generate docs on release, not on every merge to master

### DIFF
--- a/.github/workflows/doc-bot.yml
+++ b/.github/workflows/doc-bot.yml
@@ -1,9 +1,8 @@
 name: Generate release docs and commit to documentation branch (which is published to github pages)
 
 on:
-  push:
-    branches:
-      - master
+  release:
+    types: [released]
 
 jobs:
   dokka:


### PR DESCRIPTION
So that we don't alter old version's docs while staging a new release. Else, whenever we merge to master we're falsely updating the latest released version's dokka docs. I've already corrected recent versions' documentation so I don't believe we have any current incorrect version docs on the github pages docs. 

 ## Related Issues/Tickets
<!-- Link to relevant issues or discussion -->
CHNL-6922
