### PR TITLE
Streamlining setters to avoid network call when identifiers are empty

### DIFF
--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -72,6 +72,8 @@ object Klaviyo {
      * The SDK keeps track of current profile details to
      * build analytics requests with profile identifiers
      *
+     * if empty profile identifiers are passed they will be ignored
+     *
      * @param profile A map-like object representing properties of the new user
      * @return Returns [Klaviyo] for call chaining
      */
@@ -145,6 +147,9 @@ object Klaviyo {
      * This should be called whenever the active user in your app changes
      * (e.g. after a fresh login)
      *
+     * note that if the phone number is empty then the SDK will ignore it.
+     * use `resetProfile` to clear the phone number from the profile
+     *
      * @param phoneNumber Phone number for active user
      * @return Returns [Klaviyo] for call chaining
      */
@@ -174,6 +179,9 @@ object Klaviyo {
      *
      * This should be called whenever the active user in your app changes
      * (e.g. after a fresh login)
+     *
+     * note that if the external id is empty then the SDK will ignore it.
+     * use `resetProfile` to clear the external id from the profile
      *
      * @param externalId Unique identifier from external system
      * @return Returns [Klaviyo] for call chaining

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -82,9 +82,27 @@ object Klaviyo {
             resetProfile()
         }
 
-        UserInfo.externalId = profile.externalId ?: ""
-        UserInfo.email = profile.email ?: ""
-        UserInfo.phoneNumber = profile.phoneNumber ?: ""
+        if (profile.email != null &&
+            profile.email!!.isNotEmpty() &&
+            profile.email != UserInfo.email
+        ) {
+            UserInfo.email = profile.email!!
+        }
+
+        if (profile.phoneNumber != null &&
+            profile.phoneNumber!!.isNotEmpty() &&
+            profile.phoneNumber != UserInfo.phoneNumber
+        ) {
+            UserInfo.phoneNumber = profile.phoneNumber!!
+        }
+
+        if (profile.externalId != null &&
+            profile.externalId!!.isNotEmpty() &&
+            profile.externalId != UserInfo.externalId
+        ) {
+            UserInfo.externalId = profile.externalId!!
+        }
+
         profileOperationQueue.debounceProfileUpdate(profile)
     }
 
@@ -97,10 +115,18 @@ object Klaviyo {
      * This should be called whenever the active user in your app changes
      * (e.g. after a fresh login)
      *
+     * note that if the email is empty then the SDK will ignore the email.
+     * use `resetProfile` to clear the email from the profile
+     *
      * @param email Email address for active user
      * @return Returns [Klaviyo] for call chaining
      */
-    fun setEmail(email: String): Klaviyo = this.setProfileAttribute(ProfileKey.EMAIL, email)
+    fun setEmail(email: String): Klaviyo =
+        if (email.isNotEmpty() && email != UserInfo.email) {
+            this.setProfileAttribute(ProfileKey.EMAIL, email)
+        } else {
+            this
+        }
 
     /**
      * @return The email of the currently tracked profile, if set
@@ -123,7 +149,11 @@ object Klaviyo {
      * @return Returns [Klaviyo] for call chaining
      */
     fun setPhoneNumber(phoneNumber: String): Klaviyo =
-        this.setProfileAttribute(ProfileKey.PHONE_NUMBER, phoneNumber)
+        if (phoneNumber.isNotEmpty() && phoneNumber != UserInfo.phoneNumber) {
+            this.setProfileAttribute(ProfileKey.PHONE_NUMBER, phoneNumber)
+        } else {
+            this
+        }
 
     /**
      * @return The phone number of the currently tracked profile, if set
@@ -149,7 +179,11 @@ object Klaviyo {
      * @return Returns [Klaviyo] for call chaining
      */
     fun setExternalId(externalId: String): Klaviyo =
-        this.setProfileAttribute(ProfileKey.EXTERNAL_ID, externalId)
+        if (externalId.isNotEmpty() && externalId != UserInfo.externalId) {
+            this.setProfileAttribute(ProfileKey.EXTERNAL_ID, externalId)
+        } else {
+            this
+        }
 
     /**
      * @return The external ID of the currently tracked profile, if set

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/model/Profile.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/model/Profile.kt
@@ -14,21 +14,27 @@ class Profile(properties: Map<ProfileKey, Serializable>?) :
     var externalId: String?
         get() = (this[ProfileKey.EXTERNAL_ID])?.toString()
         set(value) {
-            this[ProfileKey.EXTERNAL_ID] = value
+            if (!value.isNullOrEmpty()) {
+                this[ProfileKey.EXTERNAL_ID] = value
+            }
         }
 
     fun setEmail(email: String?) = apply { this.email = email }
     var email: String?
         get() = (this[ProfileKey.EMAIL])?.toString()
         set(value) {
-            this[ProfileKey.EMAIL] = value
+            if (!value.isNullOrEmpty()) {
+                this[ProfileKey.EMAIL] = value
+            }
         }
 
     fun setPhoneNumber(phoneNumber: String?) = apply { this.phoneNumber = phoneNumber }
     var phoneNumber: String?
         get() = (this[ProfileKey.PHONE_NUMBER])?.toString()
         set(value) {
-            this[ProfileKey.PHONE_NUMBER] = value
+            if (!value.isNullOrEmpty()) {
+                this[ProfileKey.PHONE_NUMBER] = value
+            }
         }
 
     internal fun setAnonymousId(anonymousId: String?) = apply { this.anonymousId = anonymousId }

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
@@ -189,6 +189,36 @@ internal class KlaviyoTest : BaseTest() {
     }
 
     @Test
+    fun `SetProfile with same identifiers doesn't enqueue profile request`() {
+        UserInfo.email = EMAIL
+        UserInfo.phoneNumber = PHONE
+        UserInfo.externalId = EXTERNAL_ID
+
+        val profile = Profile(
+            mapOf(
+                ProfileKey.EMAIL to EMAIL,
+                ProfileKey.PHONE_NUMBER to PHONE,
+                ProfileKey.EXTERNAL_ID to EXTERNAL_ID
+            )
+        )
+
+        Klaviyo.setProfile(profile)
+
+        verify(exactly = 0) { apiClientMock.enqueueProfile(any()) }
+
+        verifyProfileDebounced()
+    }
+
+    @Test
+    fun `SetProfile's fluent setters ignores empty strings and doesn't enqueue profile request`() {
+        Klaviyo.setProfile(Profile().setEmail("").setPhoneNumber("").setExternalId(""))
+
+        assertEquals(Klaviyo.getEmail(), null)
+        assertEquals(Klaviyo.getPhoneNumber(), null)
+        assertEquals(Klaviyo.getExternalId(), null)
+    }
+
+    @Test
     fun `setProfile merges into an anonymous profile`() {
         val anonId = UserInfo.anonymousId
 
@@ -220,6 +250,26 @@ internal class KlaviyoTest : BaseTest() {
     }
 
     @Test
+    fun `Sets empty external id doesn't enqueue profile request`() {
+        UserInfo.externalId = EXTERNAL_ID
+
+        Klaviyo.setExternalId("")
+        assertEquals(EXTERNAL_ID, UserInfo.externalId)
+
+        verify(exactly = 0) { apiClientMock.enqueueProfile(any()) }
+    }
+
+    @Test
+    fun `Sets external id doesn't enqueue profile request if it's the same`() {
+        UserInfo.externalId = EXTERNAL_ID
+
+        Klaviyo.setExternalId(EXTERNAL_ID)
+        assertEquals(EXTERNAL_ID, UserInfo.externalId)
+
+        verify(exactly = 0) { apiClientMock.enqueueProfile(any()) }
+    }
+
+    @Test
     fun `Sets user email into info`() {
         Klaviyo.setEmail(EMAIL)
 
@@ -228,11 +278,51 @@ internal class KlaviyoTest : BaseTest() {
     }
 
     @Test
+    fun `Sets empty email into info doesn't enqueue profile request`() {
+        UserInfo.email = EMAIL
+
+        Klaviyo.setEmail("")
+        assertEquals(EMAIL, UserInfo.email)
+
+        verify(exactly = 0) { apiClientMock.enqueueProfile(any()) }
+    }
+
+    @Test
+    fun `setEmail does not update UserInfo when called with the same email`() {
+        val initialEmail = "test@example.com"
+        UserInfo.email = initialEmail
+
+        Klaviyo.setEmail(initialEmail)
+
+        verify(exactly = 0) { apiClientMock.enqueueProfile(any()) }
+    }
+
+    @Test
     fun `Sets user phone into info`() {
         Klaviyo.setPhoneNumber(PHONE)
 
         assertEquals(PHONE, UserInfo.phoneNumber)
         verifyProfileDebounced()
+    }
+
+    @Test
+    fun `setPhoneNumber does not update UserInfo when called with the empty phone number`() {
+        val initialPhone = "+12223334444"
+        UserInfo.phoneNumber = initialPhone
+
+        Klaviyo.setPhoneNumber("")
+
+        verify(exactly = 0) { apiClientMock.enqueueProfile(any()) }
+    }
+
+    @Test
+    fun `setPhoneNumber does not update UserInfo when called with the same phone number`() {
+        val initialPhone = "+12223334444"
+        UserInfo.phoneNumber = initialPhone
+
+        Klaviyo.setPhoneNumber(initialPhone)
+
+        verify(exactly = 0) { apiClientMock.enqueueProfile(any()) }
     }
 
     @Test


### PR DESCRIPTION
# Description

Not making network request when email, phone number and external id is empty or the same as what is in the SDK state.

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you tested this change on real device?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all Android versions the SDK currently supports?


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->


## Test Plan
<!-- How was this code tested / How should reviewers test it? -->


## Related Issues/Tickets
<!-- Link to relevant issues or discussion -->
CHNL-7046