### PR TITLE
Publish old value tests

### DIFF
--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/state/KlaviyoState.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/state/KlaviyoState.kt
@@ -117,6 +117,8 @@ internal class KlaviyoState : State {
      * A new anonymous ID will be generated next time it is accessed.
      */
     override fun reset() {
+        val oldProfile = getAsProfile(true)
+
         _externalId.reset()
         _email.reset()
         _phoneNumber.reset()
@@ -125,15 +127,17 @@ internal class KlaviyoState : State {
         _pushToken.reset()
         _pushState.reset()
 
-        broadcastChange()
+        broadcastChange(null, oldProfile)
         Registry.log.verbose("Reset internal user state")
     }
 
     /**
      * Clear user's attributes from internal state, leaving profile identifiers intact
      */
-    override fun resetAttributes() = _attributes.reset().also {
-        broadcastChange(PROFILE_ATTRIBUTES)
+    override fun resetAttributes() {
+        val oldAttributes = attributes?.copy()
+        _attributes.reset()
+        broadcastChange(PROFILE_ATTRIBUTES, oldAttributes)
     }
 
     private fun <T> broadcastChange(property: PersistentObservableProperty<T>?, oldValue: T?) =

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/state/KlaviyoStateTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/state/KlaviyoStateTest.kt
@@ -1,6 +1,8 @@
 package com.klaviyo.analytics.state
 
 import com.klaviyo.analytics.model.Keyword
+import com.klaviyo.analytics.model.PROFILE_ATTRIBUTES
+import com.klaviyo.analytics.model.Profile
 import com.klaviyo.analytics.model.ProfileKey
 import com.klaviyo.fixtures.BaseTest
 import io.mockk.verify
@@ -121,5 +123,66 @@ internal class KlaviyoStateTest : BaseTest() {
         state.phoneNumber = "new_phone"
         assertEquals(ProfileKey.PHONE_NUMBER, broadcastKey)
         assertEquals(PHONE, broadcastValue)
+    }
+
+    @Test
+    fun `Broadcasts on set attributes`() {
+        var broadcastKey: Keyword? = null
+        var broadcastValue: Any? = null
+
+        state.onStateChange { k, v ->
+            broadcastKey = k
+            broadcastValue = v
+        }
+
+        state.setAttribute(ProfileKey.FIRST_NAME, "Kermit")
+        state.setAttribute(ProfileKey.LAST_NAME, "Frog")
+
+        assertEquals(PROFILE_ATTRIBUTES, broadcastKey)
+        assertEquals("Kermit", (broadcastValue as? Profile)?.get(ProfileKey.FIRST_NAME))
+    }
+
+    @Test
+    fun `Broadcasts on reset attributes`() {
+        var broadcastKey: Keyword? = null
+        var broadcastValue: Any? = null
+
+        state.onStateChange { k, v ->
+            broadcastKey = k
+            broadcastValue = v
+        }
+
+        state.resetAttributes()
+
+        assertEquals(PROFILE_ATTRIBUTES, broadcastKey)
+        assertNull(broadcastValue)
+    }
+
+    @Test
+    fun `Broadcasts on reset profile`() {
+        state.externalId = EXTERNAL_ID
+        state.email = EMAIL
+        state.phoneNumber = PHONE
+        state.setAttribute(ProfileKey.FIRST_NAME, "Kermit")
+        state.setAttribute(ProfileKey.LAST_NAME, "Frog")
+
+        var broadcastKey: Keyword? = null
+        var broadcastValue: Any? = null
+
+        state.onStateChange { k, v ->
+            broadcastKey = k
+            broadcastValue = v
+        }
+
+        state.reset()
+
+        val broadcastProfile = broadcastValue as Profile
+
+        assertEquals(null, broadcastKey)
+        assertEquals(EXTERNAL_ID, broadcastProfile.externalId)
+        assertEquals(EMAIL, broadcastProfile.email)
+        assertEquals(PHONE, broadcastProfile.phoneNumber)
+        assertEquals("Kermit", broadcastProfile[ProfileKey.FIRST_NAME])
+        assertEquals("Frog", broadcastProfile[ProfileKey.FIRST_NAME])
     }
 }

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/state/KlaviyoStateTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/state/KlaviyoStateTest.kt
@@ -6,6 +6,7 @@ import com.klaviyo.analytics.model.Profile
 import com.klaviyo.analytics.model.ProfileKey
 import com.klaviyo.fixtures.BaseTest
 import io.mockk.verify
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
@@ -19,7 +20,13 @@ internal class KlaviyoStateTest : BaseTest() {
     @Before
     override fun setup() {
         super.setup()
-        state = KlaviyoState().apply { reset() }
+        state = KlaviyoState()
+    }
+
+    @After
+    override fun cleanup() {
+        state.reset()
+        super.cleanup()
     }
 
     @Test
@@ -183,6 +190,6 @@ internal class KlaviyoStateTest : BaseTest() {
         assertEquals(EMAIL, broadcastProfile.email)
         assertEquals(PHONE, broadcastProfile.phoneNumber)
         assertEquals("Kermit", broadcastProfile[ProfileKey.FIRST_NAME])
-        assertEquals("Frog", broadcastProfile[ProfileKey.FIRST_NAME])
+        assertEquals("Frog", broadcastProfile[ProfileKey.LAST_NAME])
     }
 }


### PR DESCRIPTION
Follow up on earlier PR
- Added tests to cover how `oldValue` should be published with a state change 
- Publish old value from reset methods