### PR TITLE
Tweaks related to DeviceProperties enablements

### DIFF
--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/DeviceProperties.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/DeviceProperties.kt
@@ -55,11 +55,11 @@ internal object DeviceProperties {
         "android"
     }
 
-    val backgroundData: Boolean by lazy {
-        activityManager.isBackgroundRestrictedCompat()
+    val backgroundDataEnabled: Boolean by lazy {
+        !activityManager.isBackgroundRestrictedCompat()
     }
 
-    val notificationPermission: Boolean
+    val notificationPermissionGranted: Boolean
         get() = NotificationManagerCompat.from(Registry.config.applicationContext).areNotificationsEnabled()
 
     val applicationId: String by lazy {

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/PushTokenApiRequest.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/PushTokenApiRequest.kt
@@ -66,11 +66,11 @@ internal class PushTokenApiRequest(
             optJSONObject(DATA)?.optJSONObject(ATTRIBUTES)?.apply {
                 put(
                     ENABLEMENT_STATUS,
-                    if (DeviceProperties.notificationPermission) NOTIFICATIONS_ENABLED else NOTIFICATIONS_DISABLED
+                    if (DeviceProperties.notificationPermissionGranted) NOTIFICATIONS_ENABLED else NOTIFICATIONS_DISABLED
                 )
                 put(
                     BACKGROUND,
-                    if (DeviceProperties.backgroundData) BG_AVAILABLE else BG_UNAVAILABLE
+                    if (DeviceProperties.backgroundDataEnabled) BG_AVAILABLE else BG_UNAVAILABLE
                 )
                 put(METADATA, JSONObject(DeviceProperties.buildMetaData()))
             }

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/DevicePropertiesTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/DevicePropertiesTest.kt
@@ -26,8 +26,8 @@ internal class DevicePropertiesTest : BaseTest() {
             every { DeviceProperties.appVersionCode } returns "Mock Version Code"
             every { DeviceProperties.sdkName } returns "Mock SDK"
             every { DeviceProperties.sdkVersion } returns "Mock SDK Version"
-            every { DeviceProperties.backgroundData } returns true
-            every { DeviceProperties.notificationPermission } returns true
+            every { DeviceProperties.backgroundDataEnabled } returns true
+            every { DeviceProperties.notificationPermissionGranted } returns true
             every { DeviceProperties.applicationId } returns "Mock App ID"
             every { DeviceProperties.platform } returns "Android"
             every { DeviceProperties.deviceId } returns "Mock Device ID"

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
@@ -401,7 +401,7 @@ internal class KlaviyoTest : BaseTest() {
 
     @Test
     fun `Push token request is repeated if state has changed`() {
-        every { DeviceProperties.backgroundData } returns true
+        every { DeviceProperties.backgroundDataEnabled } returns true
         Klaviyo.setPushToken(PUSH_TOKEN)
         assertEquals(PUSH_TOKEN, dataStoreSpy.fetch("push_token"))
 
@@ -409,7 +409,7 @@ internal class KlaviyoTest : BaseTest() {
             apiClientMock.enqueuePushToken(PUSH_TOKEN, any())
         }
 
-        every { DeviceProperties.backgroundData } returns false
+        every { DeviceProperties.backgroundDataEnabled } returns false
         Klaviyo.setPushToken(PUSH_TOKEN)
 
         verify(exactly = 2) {


### PR DESCRIPTION
Rename these properties so it is clear what true and false mean. Fix polarity of how we check background data. 

Targeted this for version 3.0.0. If we make a backend fix we'll apply it to versions <3

CHNL-6938