### PR TITLE
Using token endpoint for profile requests when a push token is present in SDK state

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,9 +257,9 @@ if you are only using the SDK for push notifications and not analytics.
  provide code examples for requesting permission and handling the user's response.
 
 #### Push tokens and multiple profiles
-Klaviyo SDK will disassociate the device push token from the current profile whenever it is reset by calling 
-`setProfile` or `resetProfile`. You should call `setPushToken` again after resetting the currently tracked profile
-to explicitly associate the device token to the new profile.
+If a new profile was set using `setProfile` or if `resetProfile` was called and a new anonymous 
+profile was created, the push token will be automatically associated with the new profile without 
+any additional action (like setting token again) required. This functionality was added in release `3.0.0`. 
 
 ### Receiving Push Notifications
 `KlaviyoPushService` will handle displaying all notifications via the `onMessageReceived` method regardless of

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -188,9 +188,6 @@ object Klaviyo {
     /**
      * Clears all stored profile identifiers (e.g. email or phone) and starts a new tracked profile
      *
-     * NOTE: if a push token was registered to the current profile, you will need to
-     * call `setPushToken` again to associate this device to a new profile
-     *
      * This should be called whenever an active user in your app is removed
      * (e.g. after a logout)
      */

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/state/KlaviyoState.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/state/KlaviyoState.kt
@@ -128,7 +128,6 @@ internal class KlaviyoState : State {
         _phoneNumber.reset()
         _anonymousId.reset()
         _attributes.reset()
-        _pushToken.reset()
         _pushState.reset()
 
         broadcastChange(null, oldProfile)

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/state/KlaviyoState.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/state/KlaviyoState.kt
@@ -128,7 +128,6 @@ internal class KlaviyoState : State {
         _phoneNumber.reset()
         _anonymousId.reset()
         _attributes.reset()
-        _pushState.reset()
 
         broadcastChange(null, oldProfile)
         Registry.log.verbose("Reset internal user state")

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/state/StateSideEffects.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/state/StateSideEffects.kt
@@ -87,7 +87,9 @@ internal class StateSideEffects(
     private fun flushProfile() = pendingProfile?.let {
         timer?.cancel()
         Registry.log.verbose("Flushing profile update")
-        apiClient.enqueueProfile(it.copy())
+        state.pushToken?.let {
+            apiClient.enqueuePushToken(it, state.getAsProfile())
+        } ?: apiClient.enqueueProfile(it.copy())
         state.resetAttributes() // Once captured in a request, we don't keep profile attributes in state/on disk
         pendingProfile = null
     }

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
@@ -337,7 +337,6 @@ internal class KlaviyoTest : BaseTest() {
         Klaviyo.resetProfile()
 
         assertNull(null, Registry.get<State>().email)
-        assertNull(null, dataStoreSpy.fetch("push_token"))
     }
 
     @Test

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
@@ -399,6 +399,54 @@ internal class KlaviyoTest : BaseTest() {
     }
 
     @Test
+    fun `Push token request is made if profile identifiers change and token is set`() {
+        Klaviyo.setPushToken(PUSH_TOKEN)
+        assertEquals(PUSH_TOKEN, dataStoreSpy.fetch("push_token"))
+
+        verify(exactly = 1) {
+            apiClientMock.enqueuePushToken(PUSH_TOKEN, any())
+        }
+
+        Klaviyo.setEmail(EMAIL)
+            .setPhoneNumber(PHONE)
+            .setExternalId(EXTERNAL_ID)
+
+        staticClock.execute(debounceTime.toLong())
+        verify(exactly = 2) { apiClientMock.enqueuePushToken(PUSH_TOKEN, any()) }
+    }
+
+    @Test
+    fun `Push token request is made if profile changes and token is set`() {
+        Klaviyo.setPushToken(PUSH_TOKEN)
+        assertEquals(PUSH_TOKEN, dataStoreSpy.fetch("push_token"))
+
+        verify(exactly = 1) {
+            apiClientMock.enqueuePushToken(PUSH_TOKEN, any())
+        }
+
+        Klaviyo.setProfile(Profile().setEmail(EMAIL))
+
+        staticClock.execute(debounceTime.toLong())
+        verify(exactly = 2) { apiClientMock.enqueuePushToken(PUSH_TOKEN, any()) }
+    }
+
+    @Test
+    fun `Push token request is made for profile attributes when token is set`() {
+        Klaviyo.setPushToken(PUSH_TOKEN)
+        assertEquals(PUSH_TOKEN, dataStoreSpy.fetch("push_token"))
+
+        verify(exactly = 1) {
+            apiClientMock.enqueuePushToken(PUSH_TOKEN, any())
+        }
+
+        Klaviyo.setProfileAttribute(ProfileKey.FIRST_NAME, "Larry")
+        Klaviyo.setProfileAttribute(ProfileKey.LAST_NAME, "David")
+
+        staticClock.execute(debounceTime.toLong())
+        verify(exactly = 2) { apiClientMock.enqueuePushToken(PUSH_TOKEN, any()) }
+    }
+
+    @Test
     fun `Retrieve saved push token from data store`() {
         assertNull(Klaviyo.getPushToken())
         Klaviyo.setPushToken(PUSH_TOKEN)

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
@@ -10,6 +10,7 @@ import com.klaviyo.analytics.model.Profile
 import com.klaviyo.analytics.model.ProfileKey
 import com.klaviyo.analytics.networking.ApiClient
 import com.klaviyo.analytics.state.State
+import com.klaviyo.analytics.state.StateSideEffects
 import com.klaviyo.core.Registry
 import com.klaviyo.core.config.Config
 import com.klaviyo.fixtures.BaseTest
@@ -61,7 +62,6 @@ internal class KlaviyoTest : BaseTest() {
 
     private val capturedProfile = slot<Profile>()
     private val apiClientMock: ApiClient = mockk<ApiClient>().apply {
-        Registry.register<ApiClient>(this)
         every { onApiRequest(any(), any()) } returns Unit
         every { enqueueProfile(capture(capturedProfile)) } returns Unit
         every { enqueueEvent(any(), any()) } returns Unit
@@ -84,6 +84,7 @@ internal class KlaviyoTest : BaseTest() {
     override fun setup() {
         super.setup()
         every { Registry.configBuilder } returns builderMock
+        Registry.register<ApiClient>(apiClientMock)
         DevicePropertiesTest.mockDeviceProperties()
         Klaviyo.initialize(
             apiKey = API_KEY,
@@ -94,6 +95,10 @@ internal class KlaviyoTest : BaseTest() {
     @After
     override fun cleanup() {
         Registry.get<State>().reset()
+        Registry.unregister<Config>()
+        Registry.unregister<State>()
+        Registry.unregister<StateSideEffects>()
+        Registry.unregister<ApiClient>()
         super.cleanup()
         DevicePropertiesTest.unmockDeviceProperties()
     }

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoUninitializedTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoUninitializedTest.kt
@@ -6,7 +6,6 @@ import com.klaviyo.analytics.model.ProfileKey
 import com.klaviyo.analytics.networking.ApiClient
 import com.klaviyo.core.MissingConfig
 import com.klaviyo.core.Registry
-import com.klaviyo.core.config.Config
 import com.klaviyo.core.config.Log
 import com.klaviyo.fixtures.BaseTest
 import com.klaviyo.fixtures.LogFixture
@@ -14,28 +13,34 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
+import org.junit.After
 import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 
 internal class KlaviyoUninitializedTest {
-    companion object {
-        private val logger = spyk(LogFixture()).apply {
-            every { error(any(), any<Throwable>()) } answers {
-                println(firstArg<String>())
-                secondArg<Throwable>().printStackTrace()
-            }
-        }
 
-        private val mockApiClient = mockk<ApiClient>()
+    private val logger = spyk(LogFixture()).apply {
+        every { error(any(), any<Throwable>()) } answers {
+            println(firstArg<String>())
+            secondArg<Throwable>().printStackTrace()
+        }
+    }
+
+    private val mockApiClient = mockk<ApiClient>().apply {
+        every { onApiRequest(any(), any()) } returns Unit
     }
 
     @Before
     fun setup() {
-        Registry.unregister<Config>()
         Registry.register<Log>(logger)
         Registry.register<ApiClient>(mockApiClient)
-        every { mockApiClient.onApiRequest(any(), any()) } returns Unit
+    }
+
+    @After
+    fun cleanup() {
+        Registry.unregister<Log>()
+        Registry.unregister<ApiClient>()
     }
 
     private inline fun <reified T> assertCaught() where T : Throwable {

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoUninitializedTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoUninitializedTest.kt
@@ -92,7 +92,7 @@ internal class KlaviyoUninitializedTest {
 
     @Test
     fun `Push token getter is protected`() {
-        assertNull(Klaviyo.getPushToken())
+        Klaviyo.getPushToken()
         assertCaught<MissingConfig>()
     }
 

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/state/SideEffectTests.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/state/SideEffectTests.kt
@@ -39,6 +39,7 @@ class SideEffectTests : BaseTest() {
         every { pushState = captureNullable(capturedPushState) } returns Unit
         every { getAsProfile(withAttributes = any()) } returns profile
         every { resetAttributes() } returns Unit
+        every { pushToken } returns null
     }
 
     @Test

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/state/SideEffectTests.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/state/SideEffectTests.kt
@@ -15,8 +15,10 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import org.junit.After
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Before
 import org.junit.Test
 
 class SideEffectTests : BaseTest() {
@@ -27,7 +29,6 @@ class SideEffectTests : BaseTest() {
     private val capturedStateObserver = slot<StateObserver>()
     private val capturedPushState = slot<String?>()
     private val apiClientMock: ApiClient = mockk<ApiClient>().apply {
-        Registry.register<ApiClient>(this)
         every { onApiRequest(any(), capture(capturedApiObserver)) } returns Unit
         every { enqueueProfile(capture(capturedProfile)) } returns Unit
         every { enqueueEvent(any(), any()) } returns Unit
@@ -40,6 +41,18 @@ class SideEffectTests : BaseTest() {
         every { getAsProfile(withAttributes = any()) } returns profile
         every { resetAttributes() } returns Unit
         every { pushToken } returns null
+    }
+
+    @Before
+    override fun setup() {
+        super.setup()
+        Registry.register<ApiClient>(apiClientMock)
+    }
+
+    @After
+    override fun cleanup() {
+        Registry.unregister<ApiClient>()
+        super.cleanup()
     }
 
     @Test


### PR DESCRIPTION
# Description

Previously we used Klaviyo's `client/profiles` endpoint for all profile related updates and the `client/push-tokens` endpoint for just setting the push token when it was passed to the SDK. This works fine for most cases but in the case a profile changes, we would require developers to call our SDK's `setPushToken` method to reset the push token when seemed unnecessary since push token doesn't change with the changing profile.  

To address this, we are now using the token endpoint for even the profile updates so that when a profile or any profile identifier changes the token is automatically moved over to the new profile w/o the developer needing to do this. This should not only lower the number of calls to our endpoint but also improve network bandwidth consumption of host apps.

One thing to note is if a push token is not set then we will always call the profiles endpoint.

Below is a table reflecting the change in more detail - 

Token Set? | SDK method | Tokens API | Profiles API
-- | -- | -- | -- |
⛔️ | set(profile: Profile) |   | ✅
⛔️ | set(email: String) |   | ✅
⛔️ | set(phoneNumber: String) |   | ✅
⛔️ | set(externalId: String) |   | ✅
⛔️ | set(profileAttribute: Profile.ProfileKey, value: Any) |   | ✅
✅ | set(profile: Profile) | ✅ |  
✅ | set(email: String) | ✅ |  
✅ | set(phoneNumber: String) | ✅ |  
✅ | set(externalId: String) | ✅ |  
✅ | set(profileAttribute: Profile.ProfileKey, value: Any) | ✅ |  

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you tested this change on real device?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all Android versions the SDK currently supports?


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->


## Test Plan

Installed a proxy and made sure that all profile related calls like set profile, set email, set external id were routed through the profiles endpoint when a push token wasn't set. When a push token was set in the SDK state verified that all profiles related called including then profile attributes were made to the token endpoint.


## Related Issues/Tickets
<!-- Link to relevant issues or discussion -->

