### PR TITLE
Fix some setup/teardown in tests to take care of isolation issues.

### DIFF
--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
@@ -10,6 +10,7 @@ import com.klaviyo.analytics.model.Profile
 import com.klaviyo.analytics.model.ProfileKey
 import com.klaviyo.analytics.networking.ApiClient
 import com.klaviyo.analytics.state.State
+import com.klaviyo.analytics.state.StateSideEffects
 import com.klaviyo.core.Registry
 import com.klaviyo.core.config.Config
 import com.klaviyo.fixtures.BaseTest
@@ -61,7 +62,6 @@ internal class KlaviyoTest : BaseTest() {
 
     private val capturedProfile = slot<Profile>()
     private val apiClientMock: ApiClient = mockk<ApiClient>().apply {
-        Registry.register<ApiClient>(this)
         every { onApiRequest(any(), any()) } returns Unit
         every { enqueueProfile(capture(capturedProfile)) } returns Unit
         every { enqueueEvent(any(), any()) } returns Unit
@@ -84,6 +84,7 @@ internal class KlaviyoTest : BaseTest() {
     override fun setup() {
         super.setup()
         every { Registry.configBuilder } returns builderMock
+        Registry.register<ApiClient>(apiClientMock)
         DevicePropertiesTest.mockDeviceProperties()
         Klaviyo.initialize(
             apiKey = API_KEY,
@@ -94,6 +95,10 @@ internal class KlaviyoTest : BaseTest() {
     @After
     override fun cleanup() {
         Registry.get<State>().reset()
+        Registry.unregister<Config>()
+        Registry.unregister<State>()
+        Registry.unregister<StateSideEffects>()
+        Registry.unregister<ApiClient>()
         super.cleanup()
         DevicePropertiesTest.unmockDeviceProperties()
     }

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoUninitializedTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoUninitializedTest.kt
@@ -6,7 +6,6 @@ import com.klaviyo.analytics.model.ProfileKey
 import com.klaviyo.analytics.networking.ApiClient
 import com.klaviyo.core.MissingConfig
 import com.klaviyo.core.Registry
-import com.klaviyo.core.config.Config
 import com.klaviyo.core.config.Log
 import com.klaviyo.fixtures.BaseTest
 import com.klaviyo.fixtures.LogFixture
@@ -14,28 +13,34 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
+import org.junit.After
 import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 
 internal class KlaviyoUninitializedTest {
-    companion object {
-        private val logger = spyk(LogFixture()).apply {
-            every { error(any(), any<Throwable>()) } answers {
-                println(firstArg<String>())
-                secondArg<Throwable>().printStackTrace()
-            }
-        }
 
-        private val mockApiClient = mockk<ApiClient>()
+    private val logger = spyk(LogFixture()).apply {
+        every { error(any(), any<Throwable>()) } answers {
+            println(firstArg<String>())
+            secondArg<Throwable>().printStackTrace()
+        }
+    }
+
+    private val mockApiClient = mockk<ApiClient>().apply {
+        every { onApiRequest(any(), any()) } returns Unit
     }
 
     @Before
     fun setup() {
-        Registry.unregister<Config>()
         Registry.register<Log>(logger)
         Registry.register<ApiClient>(mockApiClient)
-        every { mockApiClient.onApiRequest(any(), any()) } returns Unit
+    }
+
+    @After
+    fun cleanup() {
+        Registry.unregister<Log>()
+        Registry.unregister<ApiClient>()
     }
 
     private inline fun <reified T> assertCaught() where T : Throwable {

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/state/SideEffectTests.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/state/SideEffectTests.kt
@@ -15,8 +15,10 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import org.junit.After
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Before
 import org.junit.Test
 
 class SideEffectTests : BaseTest() {
@@ -27,7 +29,6 @@ class SideEffectTests : BaseTest() {
     private val capturedStateObserver = slot<StateObserver>()
     private val capturedPushState = slot<String?>()
     private val apiClientMock: ApiClient = mockk<ApiClient>().apply {
-        Registry.register<ApiClient>(this)
         every { onApiRequest(any(), capture(capturedApiObserver)) } returns Unit
         every { enqueueProfile(capture(capturedProfile)) } returns Unit
         every { enqueueEvent(any(), any()) } returns Unit
@@ -40,6 +41,18 @@ class SideEffectTests : BaseTest() {
         every { getAsProfile(withAttributes = any()) } returns profile
         every { resetAttributes() } returns Unit
         every { pushToken } returns null
+    }
+
+    @Before
+    override fun setup() {
+        super.setup()
+        Registry.register<ApiClient>(apiClientMock)
+    }
+
+    @After
+    override fun cleanup() {
+        Registry.unregister<ApiClient>()
+        super.cleanup()
     }
 
     @Test


### PR DESCRIPTION
To fix an issue introduced when I made state into a registered service: `KlaviyoTest` is leaking some registered services.

I have an idea for a better long-term fix that'd change `Registry` a little bit to make it easier to isolate tests. 