### PR TITLE
API Header Fix

### DIFF
--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequest.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequest.kt
@@ -282,12 +282,12 @@ internal open class KlaviyoApiRequest(
         }
 
         status = Status.Inflight
+        attempts++
 
         return try {
             val connection = buildUrlConnection()
 
             try {
-                attempts++
                 beforeSend.invoke()
                 connection.connect()
                 parseResponse(connection)

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequestTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequestTest.kt
@@ -129,14 +129,14 @@ internal class KlaviyoApiRequestTest : BaseApiRequestTest<KlaviyoApiRequest>() {
     }
 
     @Test
-    fun `Increments attempt counter on send`() {
-        withConnectionMock(URL(expectedFullUrl))
+    fun `Increments attempt counter on send and uses correct attempt number in header`() {
+        val connectionMock = withConnectionMock(URL(expectedFullUrl))
         val request = makeTestRequest()
 
         assertEquals(0, request.attempts)
         request.send()
         assertEquals(1, request.attempts)
-        assertEquals(request.headers["X-Klaviyo-Attempt-Count"], "1/50")
+        verify { connectionMock.setRequestProperty("X-Klaviyo-Attempt-Count", "1/50") }
     }
 
     @Test


### PR DESCRIPTION
 Move attempt count increment to before we write request headers into the url connection.

# Description
Made a silly mistake in the attempt count header. The request header value is updated correctly... but only _after_ the request header has already been written in to the url connection object. Functionally this means our requests still only retry up to 50 times, but the header that the server sees will be `0/50` -> `49/50`

# Check List

- [x] Are you changing anything with the public API? NO
- [x] Are your changes backwards compatible with previous SDK Versions? YES
- [x] Have you tested this change on real device? YES
- [x] Have you added unit test coverage for your changes? YES
- [x] Have you verified that your changes are compatible with all Android versions the SDK currently supports? YES


## Changelog / Code Overview
Fix attempt count header that is actually sent to server


## Test Plan
Fixed the unit test that should have caught this, so it is verifying the actual header value written to url connection. 


## Related Issues/Tickets
CHNL-8887

