### PR TITLE
Buffer failed operations that were attempted pre-initialize

### DIFF
--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -13,11 +13,13 @@ import com.klaviyo.analytics.networking.KlaviyoApiClient
 import com.klaviyo.analytics.state.KlaviyoState
 import com.klaviyo.analytics.state.State
 import com.klaviyo.analytics.state.StateSideEffects
+import com.klaviyo.core.Operation
 import com.klaviyo.core.Registry
 import com.klaviyo.core.config.Config
 import com.klaviyo.core.config.LifecycleException
 import com.klaviyo.core.safeApply
 import com.klaviyo.core.safeCall
+import java.util.*
 
 /**
  * Public API for the core Klaviyo SDK.
@@ -25,6 +27,11 @@ import com.klaviyo.core.safeCall
  * to be processed and sent to the Klaviyo backend
  */
 object Klaviyo {
+
+    /**
+     * Queue of failed operations attempted prior to [initialize]
+     */
+    private val preInitQueue: Queue<Operation<Unit>> = LinkedList()
 
     init {
         /**
@@ -63,6 +70,10 @@ object Klaviyo {
         Registry.register<StateSideEffects>(StateSideEffects())
 
         Registry.get<State>().apiKey = apiKey
+
+        while (preInitQueue.isNotEmpty()) {
+            preInitQueue.poll()?.let { it() }
+        }
     }
 
     /**
@@ -207,7 +218,7 @@ object Klaviyo {
      * @param event A map-like object representing the event attributes
      * @return Returns [Klaviyo] for call chaining
      */
-    fun createEvent(event: Event): Klaviyo = safeApply {
+    fun createEvent(event: Event): Klaviyo = safeApply(preInitQueue) {
         Registry.get<ApiClient>().enqueueEvent(event, Registry.get<State>().getAsProfile())
     }
 
@@ -229,10 +240,10 @@ object Klaviyo {
      *
      * @param intent the [Intent] from opening a notification
      */
-    fun handlePush(intent: Intent?) = apply {
+    fun handlePush(intent: Intent?) = safeApply(preInitQueue) {
         if (intent?.isKlaviyoIntent != true) {
             Registry.log.verbose("Non-Klaviyo intent ignored")
-            return this
+            return@safeApply
         }
 
         val event = Event(EventMetric.OPENED_PUSH)
@@ -245,9 +256,9 @@ object Klaviyo {
             }
         }
 
-        getPushToken()?.let { event[EventKey.PUSH_TOKEN] = it }
+        Registry.get<State>().pushToken?.let { event[EventKey.PUSH_TOKEN] = it }
 
-        createEvent(event)
+        Registry.get<ApiClient>().enqueueEvent(event, Registry.get<State>().getAsProfile())
     }
 
     /**

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -230,7 +230,7 @@ object Klaviyo {
      * @param event A map-like object representing the event attributes
      * @return Returns [Klaviyo] for call chaining
      */
-    fun createEvent(event: Event): Klaviyo = safeApply(preInitQueue) {
+    fun createEvent(event: Event): Klaviyo = safeApply {
         Registry.get<ApiClient>().enqueueEvent(event, Registry.get<State>().getAsProfile())
     }
 

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -19,7 +19,8 @@ import com.klaviyo.core.config.Config
 import com.klaviyo.core.config.LifecycleException
 import com.klaviyo.core.safeApply
 import com.klaviyo.core.safeCall
-import java.util.*
+import java.util.LinkedList
+import java.util.Queue
 
 /**
  * Public API for the core Klaviyo SDK.

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoPreInitializeTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoPreInitializeTest.kt
@@ -1,0 +1,96 @@
+package com.klaviyo.analytics
+
+import android.app.Application
+import com.klaviyo.analytics.model.EventMetric
+import com.klaviyo.analytics.networking.ApiClient
+import com.klaviyo.analytics.state.State
+import com.klaviyo.analytics.state.StateSideEffects
+import com.klaviyo.core.MissingConfig
+import com.klaviyo.core.Registry
+import com.klaviyo.core.config.Config
+import com.klaviyo.fixtures.BaseTest
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+internal class KlaviyoPreInitializeTest : BaseTest() {
+
+    private val mockBuilder = mockk<Config.Builder>().apply {
+        every { apiKey(any()) } returns this
+        every { applicationContext(any()) } returns this
+        every { build() } returns mockConfig
+    }
+
+    private val mockApiClient: ApiClient = mockk<ApiClient>().apply {
+        every { startService() } returns Unit
+        every { onApiRequest(any(), any()) } returns Unit
+        every { enqueueProfile(any()) } returns Unit
+        every { enqueueEvent(any(), any()) } returns Unit
+        every { enqueuePushToken(any(), any()) } returns Unit
+    }
+
+    @Before
+    override fun setup() {
+        super.setup()
+        every { Registry.configBuilder } returns mockBuilder
+        every { mockContext.applicationContext } returns mockk<Application>().apply {
+            every { unregisterActivityLifecycleCallbacks(any()) } returns Unit
+            every { registerActivityLifecycleCallbacks(any()) } returns Unit
+        }
+        Registry.register<ApiClient>(mockApiClient)
+    }
+
+    @After
+    override fun cleanup() {
+        Registry.get<State>().reset()
+        Registry.unregister<Config>()
+        Registry.unregister<State>()
+        Registry.unregister<StateSideEffects>()
+        Registry.unregister<ApiClient>()
+        super.cleanup()
+    }
+
+    private inline fun <reified T> assertCaught() where T : Throwable {
+        verify { spyLog.error(any(), any<T>()) }
+    }
+
+    @Test
+    fun `HandlePushToken and createEvent are protected and re-invoked upon initializing`() {
+        Klaviyo.createEvent(EventMetric.OPENED_APP)
+        Klaviyo.handlePush(KlaviyoTest.mockIntent(KlaviyoTest.stubIntentExtras))
+        assertCaught<MissingConfig>()
+
+        verify(inverse = true) { mockApiClient.enqueueEvent(any(), any()) }
+
+        Klaviyo.initialize(
+            apiKey = "different-$API_KEY",
+            applicationContext = mockContext
+        )
+
+        Klaviyo.initialize(
+            apiKey = API_KEY,
+            applicationContext = mockContext
+        )
+
+        verify(exactly = 1) {
+            mockApiClient.enqueueEvent(
+                match {
+                    it.metric == EventMetric.OPENED_APP
+                },
+                any()
+            )
+        }
+
+        verify(exactly = 1) {
+            mockApiClient.enqueueEvent(
+                match {
+                    it.metric == EventMetric.OPENED_PUSH
+                },
+                any()
+            )
+        }
+    }
+}

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoPreInitializeTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoPreInitializeTest.kt
@@ -58,7 +58,7 @@ internal class KlaviyoPreInitializeTest : BaseTest() {
     }
 
     @Test
-    fun `HandlePushToken and createEvent are protected and re-invoked upon initializing`() {
+    fun `Events APIs are replayed upon initializing`() {
         Klaviyo.createEvent(EventMetric.OPENED_APP)
         Klaviyo.handlePush(KlaviyoTest.mockIntent(KlaviyoTest.stubIntentExtras))
         assertCaught<MissingConfig>()

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoPreInitializeTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoPreInitializeTest.kt
@@ -58,24 +58,26 @@ internal class KlaviyoPreInitializeTest : BaseTest() {
     }
 
     @Test
-    fun `Events APIs are replayed upon initializing`() {
-        Klaviyo.createEvent(EventMetric.OPENED_APP)
+    fun `Opened Push events are replayed upon initializing`() {
         Klaviyo.handlePush(KlaviyoTest.mockIntent(KlaviyoTest.stubIntentExtras))
         assertCaught<MissingConfig>()
 
-        verify(inverse = true) { mockApiClient.enqueueEvent(any(), any()) }
+        Klaviyo.createEvent(EventMetric.OPENED_APP)
+        assertCaught<MissingConfig>()
 
-        Klaviyo.initialize(
-            apiKey = "different-$API_KEY",
-            applicationContext = mockContext
-        )
+        verify(inverse = true) { mockApiClient.enqueueEvent(any(), any()) }
 
         Klaviyo.initialize(
             apiKey = API_KEY,
             applicationContext = mockContext
         )
 
-        verify(exactly = 1) {
+        Klaviyo.initialize(
+            apiKey = "different-$API_KEY",
+            applicationContext = mockContext
+        )
+
+        verify(inverse = true) {
             mockApiClient.enqueueEvent(
                 match {
                     it.metric == EventMetric.OPENED_APP

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoUninitializedTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoUninitializedTest.kt
@@ -118,4 +118,10 @@ internal class KlaviyoUninitializedTest {
         Klaviyo.handlePush(KlaviyoTest.mockIntent(KlaviyoTest.stubIntentExtras))
         assertCaught<MissingConfig>()
     }
+
+    @Test
+    fun `HandlePushToken gets reinvoked once initialized`() {
+        Klaviyo.handlePush(KlaviyoTest.mockIntent(KlaviyoTest.stubIntentExtras))
+        assertCaught<MissingConfig>()
+    }
 }

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoUninitializedTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoUninitializedTest.kt
@@ -19,7 +19,7 @@ import org.junit.Test
 
 internal class KlaviyoUninitializedTest {
 
-    private val logger = spyk(LogFixture()).apply {
+    private val spyLog = spyk(LogFixture()).apply {
         every { error(any(), any<Throwable>()) } answers {
             println(firstArg<String>())
             secondArg<Throwable>().printStackTrace()
@@ -29,7 +29,7 @@ internal class KlaviyoUninitializedTest {
     @Before
     fun setup() {
         mockkObject(Registry)
-        every { Registry.log } returns logger
+        every { Registry.log } returns spyLog
     }
 
     @After
@@ -38,7 +38,7 @@ internal class KlaviyoUninitializedTest {
     }
 
     private inline fun <reified T> assertCaught() where T : Throwable {
-        verify { logger.error(any(), any<T>()) }
+        verify { spyLog.error(any(), any<T>()) }
     }
 
     @Test

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoUninitializedTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoUninitializedTest.kt
@@ -118,10 +118,4 @@ internal class KlaviyoUninitializedTest {
         Klaviyo.handlePush(KlaviyoTest.mockIntent(KlaviyoTest.stubIntentExtras))
         assertCaught<MissingConfig>()
     }
-
-    @Test
-    fun `HandlePushToken gets reinvoked once initialized`() {
-        Klaviyo.handlePush(KlaviyoTest.mockIntent(KlaviyoTest.stubIntentExtras))
-        assertCaught<MissingConfig>()
-    }
 }


### PR DESCRIPTION
# Description
<!-- Briefly describe the feature or bug that your pull request addresses -->
Allow event operations to be retried if the event was logged prior to initialize. Critical to a timing issue on react native related to opened push events. This is branched off initial work in `ecm/services-refactor` so PR currently targets that branch. 

# Check List

- [x] Are you changing anything with the public API? - Nothing breaking, but this does change the behavior of `createEvent` and `handlePush` when uninitialized.
- [x] Are your changes backwards compatible with previous SDK Versions? - Yes
- [ ] Have you tested this change on real device? 
- [x] Have you added unit test coverage for your changes? YES
- [x] Have you verified that your changes are compatible with all Android versions the SDK currently supports?


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->
- Added an in-memory buffer of operations that were attempted prior to `Klaviyo.initialize` 
- Retry the buffer when initialization happens
- Applied this buffer to event creation since those are subject to potential timing/race condition problems.

## Test Plan
<!-- How was this code tested / How should reviewers test it? -->
- New unit tests
- [ ] TODO Verify this fixes the react native timing issue for users who handle push from native code but initialize from typescript/js code.

## Related Issues/Tickets
<!-- Link to relevant issues or discussion -->
CHNL-8569
