### PR TITLE
In-memory buffer to allow opened push events to be handled prior to initialize

### DIFF
--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -81,11 +81,8 @@ object Klaviyo {
         Registry.get<ApiClient>().startService()
 
         if (preInitQueue.isNotEmpty()) {
-            val operationCount = preInitQueue.count()
-            val operation = if (operationCount == 1) "operation" else "operations"
-
             Registry.log.info(
-                "Replaying $operationCount $operation that were invoked prior to Klaviyo initialization."
+                "Replaying ${preInitQueue.count()} operation(s) invoked prior to Klaviyo initialization."
             )
 
             while (preInitQueue.isNotEmpty()) {

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/ApiClient.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/ApiClient.kt
@@ -12,6 +12,12 @@ typealias ApiObserver = (request: ApiRequest) -> Unit
 interface ApiClient {
 
     /**
+     * Launch the API client service
+     * Should be idempotent in case of re-initialization
+     */
+    fun startService()
+
+    /**
      * Tell the client to write its queue to the persistent store
      */
     fun persistQueue()

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/KlaviyoApiClient.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/KlaviyoApiClient.kt
@@ -27,6 +27,7 @@ internal object KlaviyoApiClient : ApiClient {
     private var handlerThread = HandlerUtil.getHandlerThread(KlaviyoApiClient::class.simpleName)
     private var handler: Handler? = null
     private var apiQueue = ConcurrentLinkedDeque<KlaviyoApiRequest>()
+    private var queueInitialized = false
 
     /**
      * List of registered API observers
@@ -43,9 +44,10 @@ internal object KlaviyoApiClient : ApiClient {
         Registry.networkMonitor.offNetworkChange(::onNetworkChange)
         Registry.networkMonitor.onNetworkChange(::onNetworkChange)
 
-        if (getQueueSize() == 0) {
+        if (!queueInitialized) {
             // We only need to restore queue from persistent store once
             restoreQueue()
+            queueInitialized = true
         }
     }
 

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/KlaviyoApiClient.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/KlaviyoApiClient.kt
@@ -33,81 +33,35 @@ internal object KlaviyoApiClient : ApiClient {
      */
     private var apiObservers = mutableListOf<ApiObserver>()
 
-    init {
-        onApiRequest { r ->
-            when (r.state) {
-                Status.Unsent.name -> Registry.log.verbose("${r.type} Request enqueued")
-                Status.Inflight.name -> Registry.log.verbose("${r.type} Request inflight")
-                Status.PendingRetry.name -> {
-                    val attemptsRemaining = Registry.config.networkMaxAttempts - r.attempts
-                    Registry.log.warning(
-                        "${r.type} Request failed with code ${r.responseCode}, and will be retried up to $attemptsRemaining more times."
-                    )
-                }
-                Status.Complete.name -> Registry.log.verbose(
-                    "${r.type} Request succeeded with code ${r.responseCode}"
-                )
-                else -> Registry.log.error(
-                    "${r.type} Request failed with code ${r.responseCode}, and will be dropped"
-                )
-            }
+    /**
+     * Initialize logic including lifecycle observers and reviving the queue from persistent store
+     */
+    override fun startService() {
+        Registry.lifecycleMonitor.offActivityEvent(::onLifecycleActivity)
+        Registry.lifecycleMonitor.onActivityEvent(::onLifecycleActivity)
 
-            r.responseBody?.let { response ->
-                val body = r.requestBody?.let { JSONObject(it).toString(2) }
-                Registry.log.verbose("${r.httpMethod}: ${r.url}")
-                Registry.log.verbose("Headers: ${r.headers}")
-                Registry.log.verbose("Query: ${r.query}")
-                Registry.log.verbose("Body: $body")
-                Registry.log.verbose("${r.responseCode} $response")
-            }
+        Registry.networkMonitor.offNetworkChange(::onNetworkChange)
+        Registry.networkMonitor.onNetworkChange(::onNetworkChange)
+
+        if (getQueueSize() == 0) {
+            // We only need to restore queue from persistent store once
+            restoreQueue()
         }
-
-        // Stop our handler thread when all activities stop
-        Registry.lifecycleMonitor.onActivityEvent {
-            when (it) {
-                is ActivityEvent.AllStopped -> startBatch(true)
-                else -> Unit
-            }
-        }
-
-        // Stop the background batching job while offline
-        Registry.networkMonitor.onNetworkChange { isOnline ->
-            if (isOnline) {
-                startBatch(true)
-            } else {
-                stopBatch()
-            }
-        }
-
-        restoreQueue()
     }
 
     override fun enqueueProfile(profile: Profile) {
+        Registry.log.verbose("Enqueuing Profile request")
         enqueueRequest(ProfileApiRequest(profile))
     }
 
     override fun enqueuePushToken(token: String, profile: Profile) {
+        Registry.log.verbose("Enqueuing Push Token request")
         enqueueRequest(PushTokenApiRequest(token, profile))
     }
 
     override fun enqueueEvent(event: Event, profile: Profile) {
+        Registry.log.verbose("Enqueuing ${event.metric.name} event")
         enqueueRequest(EventApiRequest(event, profile))
-    }
-
-    override fun onApiRequest(withHistory: Boolean, observer: ApiObserver) {
-        if (withHistory) {
-            apiQueue.forEach(observer)
-        }
-
-        apiObservers += observer
-    }
-
-    override fun offApiRequest(observer: ApiObserver) {
-        apiObservers -= observer
-    }
-
-    private fun broadcastApiRequest(request: KlaviyoApiRequest) {
-        apiObservers.forEach { it(request) }
     }
 
     /**
@@ -125,8 +79,8 @@ internal object KlaviyoApiClient : ApiClient {
         var addedRequest = false
         requests.forEach { request ->
             if (!apiQueue.contains(request)) {
-                apiQueue.offer(request)
                 Registry.dataStore.store(request.uuid, request.toString())
+                apiQueue.offer(request)
                 broadcastApiRequest(request)
                 addedRequest = true
             }
@@ -134,6 +88,65 @@ internal object KlaviyoApiClient : ApiClient {
         if (addedRequest) {
             persistQueue()
         }
+    }
+
+    override fun onApiRequest(withHistory: Boolean, observer: ApiObserver) {
+        if (withHistory) {
+            apiQueue.forEach(observer)
+        }
+
+        apiObservers += observer
+    }
+
+    override fun offApiRequest(observer: ApiObserver) {
+        apiObservers -= observer
+    }
+
+    private fun broadcastApiRequest(request: KlaviyoApiRequest) {
+        when (request.status) {
+            Status.Unsent -> Registry.log.verbose("${request.type} Request enqueued")
+            Status.Inflight -> Registry.log.verbose("${request.type} Request inflight")
+            Status.PendingRetry -> {
+                val attemptsRemaining = Registry.config.networkMaxAttempts - request.attempts
+                Registry.log.warning(
+                    "${request.type} Request failed with code ${request.responseCode}, and will be retried up to $attemptsRemaining more times."
+                )
+            }
+            Status.Complete -> Registry.log.verbose(
+                "${request.type} Request succeeded with code ${request.responseCode}"
+            )
+            else -> Registry.log.error(
+                "${request.type} Request failed with code ${request.responseCode}, and will be dropped"
+            )
+        }
+
+        request.responseBody?.let { response ->
+            val body = request.requestBody?.let { JSONObject(it).toString(2) }
+            Registry.log.verbose("${request.httpMethod}: ${request.url}")
+            Registry.log.verbose("Headers: ${request.headers}")
+            Registry.log.verbose("Query: ${request.query}")
+            Registry.log.verbose("Body: $body")
+            Registry.log.verbose("${request.responseCode} $response")
+        }
+
+        apiObservers.forEach { it(request) }
+    }
+
+    /**
+     * Stop our handler thread when all activities stop
+     */
+    private fun onLifecycleActivity(activity: ActivityEvent) = when (activity) {
+        is ActivityEvent.AllStopped -> startBatch(true)
+        else -> Unit
+    }
+
+    /**
+     * Stop the background batching job while offline
+     */
+    private fun onNetworkChange(isConnected: Boolean) = if (isConnected) {
+        startBatch(true)
+    } else {
+        stopBatch()
     }
 
     /**

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequest.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequest.kt
@@ -282,12 +282,12 @@ internal open class KlaviyoApiRequest(
         }
 
         status = Status.Inflight
+        attempts++
 
         return try {
             val connection = buildUrlConnection()
 
             try {
-                attempts++
                 beforeSend.invoke()
                 connection.connect()
                 parseResponse(connection)

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoPreInitializeTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoPreInitializeTest.kt
@@ -1,0 +1,92 @@
+package com.klaviyo.analytics
+
+import android.app.Application
+import com.klaviyo.analytics.model.EventMetric
+import com.klaviyo.analytics.networking.ApiClient
+import com.klaviyo.core.MissingConfig
+import com.klaviyo.core.Registry
+import com.klaviyo.core.config.Config
+import com.klaviyo.fixtures.BaseTest
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+internal class KlaviyoPreInitializeTest : BaseTest() {
+
+    private val mockBuilder = mockk<Config.Builder>().apply {
+        every { apiKey(any()) } returns this
+        every { applicationContext(any()) } returns this
+        every { build() } returns configMock
+    }
+
+    private val mockApiClient: ApiClient = mockk<ApiClient>().apply {
+        every { onApiRequest(any(), any()) } returns Unit
+        every { enqueueProfile(any()) } returns Unit
+        every { enqueueEvent(any(), any()) } returns Unit
+        every { enqueuePushToken(any(), any()) } returns Unit
+    }
+
+    @Before
+    override fun setup() {
+        super.setup()
+        every { Registry.configBuilder } returns mockBuilder
+        every { contextMock.applicationContext } returns mockk<Application>().apply {
+            every { unregisterActivityLifecycleCallbacks(any()) } returns Unit
+            every { registerActivityLifecycleCallbacks(any()) } returns Unit
+        }
+        Registry.register<ApiClient>(mockApiClient)
+    }
+
+    @After
+    override fun cleanup() {
+        Registry.unregister<Config>()
+        Registry.unregister<ApiClient>()
+        super.cleanup()
+    }
+
+    private inline fun <reified T> assertCaught() where T : Throwable {
+        verify { logSpy.error(any(), any<T>()) }
+    }
+
+    @Test
+    fun `Opened Push events are replayed upon initializing`() {
+        Klaviyo.handlePush(KlaviyoTest.mockIntent(KlaviyoTest.stubIntentExtras))
+        assertCaught<MissingConfig>()
+
+        Klaviyo.createEvent(EventMetric.OPENED_APP)
+        assertCaught<MissingConfig>()
+
+        verify(inverse = true) { mockApiClient.enqueueEvent(any(), any()) }
+
+        Klaviyo.initialize(
+            apiKey = API_KEY,
+            applicationContext = contextMock
+        )
+
+        Klaviyo.initialize(
+            apiKey = "different-$API_KEY",
+            applicationContext = contextMock
+        )
+
+        verify(inverse = true) {
+            mockApiClient.enqueueEvent(
+                match {
+                    it.metric == EventMetric.OPENED_APP
+                },
+                any()
+            )
+        }
+
+        verify(exactly = 1) {
+            mockApiClient.enqueueEvent(
+                match {
+                    it.metric == EventMetric.OPENED_PUSH
+                },
+                any()
+            )
+        }
+    }
+}

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
@@ -86,6 +86,7 @@ internal class KlaviyoTest : BaseTest() {
         super.setup()
         Registry.register<ApiClient> { apiClientMock }
         every { Registry.clock } returns staticClock
+        every { apiClientMock.startService() } returns Unit
         every { apiClientMock.onApiRequest(any(), any()) } returns Unit
         every { apiClientMock.enqueueProfile(capture(capturedProfile)) } returns Unit
         every { apiClientMock.enqueueEvent(any(), any()) } returns Unit

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
@@ -100,6 +100,7 @@ internal class KlaviyoTest : BaseTest() {
     override fun cleanup() {
         UserInfo.reset()
         super.cleanup()
+        Registry.unregister<Config>()
         DevicePropertiesTest.unmockDeviceProperties()
     }
 

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoUninitializedTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoUninitializedTest.kt
@@ -19,12 +19,7 @@ import org.junit.Test
 
 internal class KlaviyoUninitializedTest {
 
-    private val logger = spyk(LogFixture()).apply {
-        every { error(any(), any<Throwable>()) } answers {
-            println(firstArg<String>())
-            secondArg<Throwable>().printStackTrace()
-        }
-    }
+    private val logger = spyk(LogFixture())
 
     @Before
     fun setup() {

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoUninitializedTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoUninitializedTest.kt
@@ -10,18 +10,19 @@ import com.klaviyo.fixtures.LogFixture
 import io.mockk.every
 import io.mockk.mockkObject
 import io.mockk.spyk
+import io.mockk.unmockkObject
 import io.mockk.verify
+import org.junit.After
 import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 
 internal class KlaviyoUninitializedTest {
-    companion object {
-        private val logger = spyk(LogFixture()).apply {
-            every { error(any(), any<Throwable>()) } answers {
-                println(firstArg<String>())
-                secondArg<Throwable>().printStackTrace()
-            }
+
+    private val logger = spyk(LogFixture()).apply {
+        every { error(any(), any<Throwable>()) } answers {
+            println(firstArg<String>())
+            secondArg<Throwable>().printStackTrace()
         }
     }
 
@@ -29,6 +30,11 @@ internal class KlaviyoUninitializedTest {
     fun setup() {
         mockkObject(Registry)
         every { Registry.log } returns logger
+    }
+
+    @After
+    fun cleanup() {
+        unmockkObject(Registry)
     }
 
     private inline fun <reified T> assertCaught() where T : Throwable {

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoUninitializedTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoUninitializedTest.kt
@@ -3,15 +3,12 @@ package com.klaviyo.analytics
 import com.klaviyo.analytics.model.EventMetric
 import com.klaviyo.analytics.model.Profile
 import com.klaviyo.analytics.model.ProfileKey
-import com.klaviyo.analytics.networking.ApiClient
 import com.klaviyo.core.MissingConfig
 import com.klaviyo.core.Registry
-import com.klaviyo.core.config.Config
-import com.klaviyo.core.config.Log
 import com.klaviyo.fixtures.BaseTest
 import com.klaviyo.fixtures.LogFixture
 import io.mockk.every
-import io.mockk.mockk
+import io.mockk.mockkObject
 import io.mockk.spyk
 import io.mockk.verify
 import org.junit.Assert.assertNull
@@ -26,16 +23,12 @@ internal class KlaviyoUninitializedTest {
                 secondArg<Throwable>().printStackTrace()
             }
         }
-
-        private val mockApiClient = mockk<ApiClient>()
     }
 
     @Before
     fun setup() {
-        Registry.unregister<Config>()
-        Registry.register<Log>(logger)
-        Registry.register<ApiClient>(mockApiClient)
-        every { mockApiClient.onApiRequest(any(), any()) } returns Unit
+        mockkObject(Registry)
+        every { Registry.log } returns logger
     }
 
     private inline fun <reified T> assertCaught() where T : Throwable {

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/KlaviyoApiClientTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/KlaviyoApiClientTest.kt
@@ -71,7 +71,9 @@ internal class KlaviyoApiClientTest : BaseTest() {
         every { networkMonitorMock.isNetworkConnected() } returns false
         every { networkMonitorMock.getNetworkType() } returns NetworkMonitor.NetworkType.Wifi
         every { lifecycleMonitorMock.onActivityEvent(capture(slotOnActivityEvent)) } returns Unit
+        every { lifecycleMonitorMock.offActivityEvent(capture(slotOnActivityEvent)) } returns Unit
         every { networkMonitorMock.onNetworkChange(capture(slotOnNetworkChange)) } returns Unit
+        every { networkMonitorMock.offNetworkChange(capture(slotOnNetworkChange)) } returns Unit
 
         mockkObject(HandlerUtil)
         every { HandlerUtil.getHandler(any()) } returns mockHandler.apply {
@@ -90,6 +92,8 @@ internal class KlaviyoApiClientTest : BaseTest() {
             every { looper } returns mockk()
             every { state } returns Thread.State.NEW
         }
+
+        KlaviyoApiClient.startService()
     }
 
     @After
@@ -108,6 +112,7 @@ internal class KlaviyoApiClientTest : BaseTest() {
         status: KlaviyoApiRequest.Status = KlaviyoApiRequest.Status.Complete
     ): KlaviyoApiRequest =
         spyk(KlaviyoApiRequest("https://mock.com", RequestMethod.GET)).also {
+            every { it.status } returns status
             every { it.state } returns status.name
             val getState = {
                 when (it.state) {
@@ -221,6 +226,25 @@ internal class KlaviyoApiClientTest : BaseTest() {
         )
 
         assertEquals(1, KlaviyoApiClient.getQueueSize())
+    }
+
+    @Test
+    fun `Supports idempotent re-starting`() {
+        KlaviyoApiClient.startService()
+        val priorOnActivityEvent = slotOnActivityEvent.captured
+        val priorOnNetworkChange = slotOnNetworkChange.captured
+
+        KlaviyoApiClient.enqueueRequest(mockRequest("abc123"))
+        assertEquals(1, KlaviyoApiClient.getQueueSize())
+
+        KlaviyoApiClient.startService()
+
+        // Queue should be left as it was
+        assertEquals(1, KlaviyoApiClient.getQueueSize())
+
+        // Listeners should have been removed
+        verify { lifecycleMonitorMock.offActivityEvent(priorOnActivityEvent) }
+        verify { networkMonitorMock.offNetworkChange(priorOnNetworkChange) }
     }
 
     @Test

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequestTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequestTest.kt
@@ -129,14 +129,15 @@ internal class KlaviyoApiRequestTest : BaseApiRequestTest<KlaviyoApiRequest>() {
     }
 
     @Test
-    fun `Increments attempt counter on send`() {
-        withConnectionMock(URL(expectedFullUrl))
+    fun `Increments attempt counter on send and uses correct attempt number in header`() {
+        val connectionMock = withConnectionMock(URL(expectedFullUrl))
         val request = makeTestRequest()
 
         assertEquals(0, request.attempts)
         request.send()
         assertEquals(1, request.attempts)
         assertEquals(request.headers["X-Klaviyo-Attempt-Count"], "1/50")
+        verify { connectionMock.setRequestProperty("X-Klaviyo-Attempt-Count", "1/50") }
     }
 
     @Test

--- a/sdk/core/src/main/java/com/klaviyo/core/Registry.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/Registry.kt
@@ -16,12 +16,8 @@ import kotlin.reflect.KType
 import kotlin.reflect.typeOf
 
 class MissingConfig : KlaviyoException("Klaviyo SDK accessed before initializing")
-class MissingRegistration(type: KType) : KlaviyoException(
-    "No service registered for ${type::class.qualifiedName}"
-)
-class InvalidRegistration(type: KType) : KlaviyoException(
-    "Registered service does not match ${type::class.qualifiedName}"
-)
+class MissingRegistration(type: KType) : KlaviyoException("No service registered for $type")
+class InvalidRegistration(type: KType) : KlaviyoException("Registered service does not match $type")
 
 typealias Registration = () -> Any
 


### PR DESCRIPTION
# Description
<!-- Briefly describe the feature or bug that your pull request addresses -->
Adds a buffer for `handlePush` calls invoked prior to initializing, and replays them during init. 

I condensed the critical parts of #172 and #173 into one PR, branched off master instead, in the interest of getting a hotfix out earlier. 

# Check List

- [x] Are you changing anything with the public API?
- [x] Are your changes backwards compatible with previous SDK Versions?
- [x] Have you tested this change on real device?
- [x] Have you added unit test coverage for your changes?
- [x] Have you verified that your changes are compatible with all Android versions the SDK currently supports?


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->
- Moved init code from the api client object, to avoid unrecoverable initializer  error
- For `handlePush` only, save operations in memory prior to initializing and replay the queue from `initialize` (though it is a generic solution if we need to extend in future) 
- Added/fixed unit tests

## Test Plan
<!-- How was this code tested / How should reviewers test it? -->
- [x] Unit tests
- [ ] Test against RN test app.

## Related Issues/Tickets
<!-- Link to relevant issues or discussion -->
