### PR TITLE
Flush network queue immediately after opened push is enqueued

### DIFF
--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/KlaviyoApiClient.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/KlaviyoApiClient.kt
@@ -4,6 +4,7 @@ import android.os.Handler
 import android.os.HandlerThread
 import android.os.Looper
 import com.klaviyo.analytics.model.Event
+import com.klaviyo.analytics.model.EventMetric
 import com.klaviyo.analytics.model.Profile
 import com.klaviyo.analytics.networking.requests.EventApiRequest
 import com.klaviyo.analytics.networking.requests.KlaviyoApiRequest
@@ -92,6 +93,10 @@ internal object KlaviyoApiClient : ApiClient {
 
     override fun enqueueEvent(event: Event, profile: Profile) {
         enqueueRequest(EventApiRequest(event, profile))
+
+        if (event.metric == EventMetric.OPENED_PUSH) {
+            flushQueue()
+        }
     }
 
     override fun onApiRequest(withHistory: Boolean, observer: ApiObserver) {


### PR DESCRIPTION
# Description
<!-- Briefly describe the feature or bug that your pull request addresses -->
In the interest of improving push open rates, this would trigger the events API call to create an opened push event right away, instead of waiting on the typical network flush interval. Caveats:
- This force-flushes the whole queue, so if there's other things in the queue it will send those too. I don't see this as a problem generally, except that if there happens to be a big backlog queue, that would delay the opened push event from getting to the backend. Probably not a common scenario though. 
- Force-flush will override any pending retries due to rate limiting. Again probably rare, between the relatively low frequency of rate limit hits, and the fact that an opened push event is typically logged on app launch, so the network queue hasn't attempted to send yet. 

# Check List

- [x] Are you changing anything with the public API? 
- [x] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you tested this change on real device? 
- [x] Have you added unit test coverage for your changes?
- [x] Have you verified that your changes are compatible with all Android versions the SDK currently supports?


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->
For `opened push` events only, trigger the network queue to flush immediately. 

## Test Plan
<!-- How was this code tested / How should reviewers test it? -->
- [x] Unit Tests
- [ ] Test app

## Related Issues/Tickets
<!-- Link to relevant issues or discussion -->
CHNL-9273
