### PR TITLE
Version 2.4.0 Minor Release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ local.properties
 IntelliJ files
 .idea/
 *.iml
+google-services.json
 
 # Mac OS files
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -298,8 +298,8 @@ override fun onNewIntent(intent: Intent?) {
 
 **Note:** Intent handling may differ depending on your app's architecture. Typically, the intent will be received in 
 your main `Activity`. If you have multiple activities, you need to call `handlePush` from any activity that could
-be the receiver of this intent. Adjust this example to your use-case, ensuring that `Klaviyo.handlePush(intent)` 
-is called when your app is opened from a notification.
+receive this intent. Adjust this example to your use-case, ensuring that `Klaviyo.handlePush(intent)` is called 
+whenever your app is opened from a notification.
 
 #### Deep Linking 
 [Deep Links](https://help.klaviyo.com/hc/en-us/articles/14750403974043) allow you to navigate to a particular

--- a/README.md
+++ b/README.md
@@ -280,6 +280,8 @@ This method will check if the app was opened from a notification originating fro
 `Opened Push` event with required message tracking parameters. For example:
 
 ```kotlin
+// Main Activity
+
 override fun onCreate(savedInstanceState: Bundle?) {
     /* ... */
 
@@ -294,8 +296,10 @@ override fun onNewIntent(intent: Intent?) {
 }
 ```
 
-**Note:** Intent handling may differ depending on your app's architecture. Adjust this example to your use-case, 
-ensuring that `Klaviyo.handlePush(intent)` is called when your app is opened from a notification.
+**Note:** Intent handling may differ depending on your app's architecture. Typically, the intent will be received in 
+your main `Activity`. If you have multiple activities, you need to call `handlePush` from any activity that could
+be the receiver of this intent. Adjust this example to your use-case, ensuring that `Klaviyo.handlePush(intent)` 
+is called when your app is opened from a notification.
 
 #### Deep Linking 
 [Deep Links](https://help.klaviyo.com/hc/en-us/articles/14750403974043) allow you to navigate to a particular

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ send them timely push notifications via [FCM (Firebase Cloud Messaging)](https:/
       ```kotlin
       // build.gradle.kts
       dependencies {
-          implementation("com.github.klaviyo.klaviyo-android-sdk:analytics:2.3.0")
-          implementation("com.github.klaviyo.klaviyo-android-sdk:push-fcm:2.3.0")
+          implementation("com.github.klaviyo.klaviyo-android-sdk:analytics:2.4.0")
+          implementation("com.github.klaviyo.klaviyo-android-sdk:push-fcm:2.4.0")
       }
       ```
    </details>
@@ -63,8 +63,8 @@ send them timely push notifications via [FCM (Firebase Cloud Messaging)](https:/
       ```groovy
        // build.gradle
        dependencies {
-           implementation "com.github.klaviyo.klaviyo-android-sdk:analytics:2.3.0"
-           implementation "com.github.klaviyo.klaviyo-android-sdk:push-fcm:2.3.0"
+           implementation "com.github.klaviyo.klaviyo-android-sdk:analytics:2.4.0"
+           implementation "com.github.klaviyo.klaviyo-android-sdk:push-fcm:2.4.0"
        }
       ```
    </details>

--- a/README.md
+++ b/README.md
@@ -296,10 +296,9 @@ override fun onNewIntent(intent: Intent?) {
 }
 ```
 
-**Note:** Intent handling may differ depending on your app's architecture. Typically, the intent will be received in 
-your main `Activity`. If you have multiple activities, you need to call `handlePush` from any activity that could
-receive this intent. Adjust this example to your use-case, ensuring that `Klaviyo.handlePush(intent)` is called 
-whenever your app is opened from a notification.
+**Note:** Intent handling may differ depending on your app's architecture. By default, the Klaviyo SDK will use your
+app's launch intent for a tapped notification. Adjust this example to your use-case, ensuring that 
+`Klaviyo.handlePush(intent)` is called whenever your app is opened from a notification.
 
 #### Deep Linking 
 [Deep Links](https://help.klaviyo.com/hc/en-us/articles/14750403974043) allow you to navigate to a particular

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,2 +1,2 @@
 <!-- Redirect to latest version -->
-<meta HTTP-EQUIV="REFRESH" content="0; url=./2.3.0/index.html">
+<meta HTTP-EQUIV="REFRESH" content="0; url=./2.4.0/index.html">

--- a/versions.properties
+++ b/versions.properties
@@ -9,11 +9,13 @@
 ####
 #### NOTE: Some versions are filtered by the rejectVersionIf predicate. See the settings.gradle.kts file.
 
+version.androidx.compose.compiler=1.5.10
+
 # Project versioning, run the following gradle command to update version numbers automatically:
 # ./gradlew bumpVersion --nextVersion=X.Y.Z
-version.klaviyo.versionCode=17
+version.klaviyo.versionCode=18
 
-version.klaviyo.versionName=2.3.0
+version.klaviyo.versionName=2.4.0
 
 # Android versioning
 

--- a/versions.properties
+++ b/versions.properties
@@ -9,8 +9,6 @@
 ####
 #### NOTE: Some versions are filtered by the rejectVersionIf predicate. See the settings.gradle.kts file.
 
-version.androidx.compose.compiler=1.5.10
-
 # Project versioning, run the following gradle command to update version numbers automatically:
 # ./gradlew bumpVersion --nextVersion=X.Y.Z
 version.klaviyo.versionCode=18


### PR DESCRIPTION
2.4.0 will contain two improvements related to opened push event handling
- Opened Push events will trigger queued API requests to send immediately -- should improve timeliness of reporting
- If Opened Push is triggered prior to `initialize`, we'll hold that request in memory until initialized. Allowing for this special case because of the rigid timing for handling the `intent`. All other SDK methods still require initialization. 