### PR TITLE
Introduce a de-dupe mechanism for push notifications

### DIFF
--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoNotification.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoNotification.kt
@@ -29,6 +29,7 @@ import com.klaviyo.pushFcm.KlaviyoRemoteMessage.imageUrl
 import com.klaviyo.pushFcm.KlaviyoRemoteMessage.isKlaviyoNotification
 import com.klaviyo.pushFcm.KlaviyoRemoteMessage.notificationCount
 import com.klaviyo.pushFcm.KlaviyoRemoteMessage.notificationPriority
+import com.klaviyo.pushFcm.KlaviyoRemoteMessage.notificationTag
 import com.klaviyo.pushFcm.KlaviyoRemoteMessage.sound
 import com.klaviyo.pushFcm.KlaviyoRemoteMessage.title
 import java.net.URL
@@ -62,6 +63,7 @@ class KlaviyoNotification(private val message: RemoteMessage) {
         internal const val COLOR_KEY = "color"
         internal const val NOTIFICATION_COUNT_KEY = "notification_count"
         internal const val NOTIFICATION_PRIORITY = "notification_priority"
+        internal const val NOTIFICATION_TAG = "notification_tag"
         private const val DOWNLOAD_TIMEOUT_MS = 5_000
 
         /**
@@ -104,7 +106,7 @@ class KlaviyoNotification(private val message: RemoteMessage) {
 
         NotificationManagerCompat
             .from(context)
-            .notify(generateId(), notification.build())
+            .notify(message.notificationTag, generateId(), notification.build())
 
         return true
     }

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoNotification.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoNotification.kt
@@ -68,8 +68,8 @@ class KlaviyoNotification(private val message: RemoteMessage) {
 
         /**
          * Get an integer ID to associate with a notification or its pending intent
-         * The notification system service will de-dupe on this ID alone,
-         * and I don't think we want our notifications to be de-duped
+         * The notification system service will de-dupe on this if we get a null
+         * notification tag from the payload
          *
          * NOTE: The FCM SDK also uses a timestamp to construct its integer IDs
          */
@@ -106,7 +106,7 @@ class KlaviyoNotification(private val message: RemoteMessage) {
 
         NotificationManagerCompat
             .from(context)
-            .notify(message.notificationTag, generateId(), notification.build())
+            .notify(message.notificationTag ?: generateId().toString(), 0, notification.build())
 
         return true
     }

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoRemoteMessage.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoRemoteMessage.kt
@@ -75,6 +75,11 @@ object KlaviyoRemoteMessage {
             ?: NotificationCompat.PRIORITY_DEFAULT
 
     /**
+     * Parse out notification tag, used as a de-duping mechanism
+     */
+    val RemoteMessage.notificationTag: String? get() = this.data[KlaviyoNotification.NOTIFICATION_TAG]
+
+    /**
      * Determine if the message originated from Klaviyo from the tracking params
      */
     val RemoteMessage.isKlaviyoMessage: Boolean get() = this.data.containsKey("_k")


### PR DESCRIPTION
# Description
Similar to `apns-collapse-id` this would allow us to collapse duplicate push notifications on the device itself. In general, we assumed in the past that we'd manage de-duping this purely from the backend, but this would give us extra options, never a bad thing!

# Check List

- [x] Are you changing anything with the public API? NO
- [x] Are your changes backwards compatible with previous SDK Versions? YES - tag is a nullable arg
- [ ] Have you tested this change on real device? NOPE
- [ ] Have you added unit test coverage for your changes? NOPE
- [x] Have you verified that your changes are compatible with all Android versions the SDK currently supports? SHOULD!


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->
- Add extension to parse `"notification_tag"` out of the remote data message payload 
- Use that as the tag for notifications (just like stock FCM)

## Test Plan
<!-- How was this code tested / How should reviewers test it? -->
- [ ] Test this with the sample / test app. Can easily do it with a dummy payload, don't need to update server code to be able to test. 

## Related Issues/Tickets
<!-- Link to relevant issues or discussion -->
CHNL-9595
