### PR TITLE
setProfileAttribute should accept any Serializable value not just String

### DIFF
--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -19,6 +19,7 @@ import com.klaviyo.core.config.Config
 import com.klaviyo.core.config.LifecycleException
 import com.klaviyo.core.safeApply
 import com.klaviyo.core.safeCall
+import java.io.Serializable
 import java.util.LinkedList
 import java.util.Queue
 

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -207,7 +207,7 @@ object Klaviyo {
      * @param value
      * @return Returns [Klaviyo] for call chaining
      */
-    fun setProfileAttribute(propertyKey: ProfileKey, value: String): Klaviyo = safeApply {
+    fun setProfileAttribute(propertyKey: ProfileKey, value: Serializable): Klaviyo = safeApply {
         Registry.get<State>().setAttribute(propertyKey, value)
     }
 

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/state/KlaviyoState.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/state/KlaviyoState.kt
@@ -111,10 +111,26 @@ internal class KlaviyoState : State {
      * Set an individual property or attribute
      */
     override fun setAttribute(key: ProfileKey, value: Serializable) = when (key) {
-        EMAIL -> email = (value as? String)
-        EXTERNAL_ID -> externalId = (value as? String)
-        PHONE_NUMBER -> phoneNumber = (value as? String)
+        EMAIL -> (value as? String)?.let { email = it } ?: run { logCastError(EMAIL, value) }
+        EXTERNAL_ID -> (value as? String)?.let { externalId = it } ?: run {
+            logCastError(
+                EXTERNAL_ID,
+                value
+            )
+        }
+        PHONE_NUMBER -> (value as? String)?.let { phoneNumber = it } ?: run {
+            logCastError(
+                PHONE_NUMBER,
+                value
+            )
+        }
         else -> this.attributes = (this.attributes?.copy() ?: Profile()).setProperty(key, value)
+    }
+
+    private fun logCastError(key: ProfileKey, value: Serializable) {
+        Registry.log.error(
+            "Unable to cast value $value of type ${value::class.java} to String attribute ${key.name}"
+        )
     }
 
     /**

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/state/KlaviyoState.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/state/KlaviyoState.kt
@@ -13,6 +13,7 @@ import com.klaviyo.analytics.model.ProfileKey.PUSH_STATE
 import com.klaviyo.analytics.model.ProfileKey.PUSH_TOKEN
 import com.klaviyo.analytics.networking.requests.PushTokenApiRequest
 import com.klaviyo.core.Registry
+import java.io.Serializable
 import java.util.UUID
 
 /**
@@ -109,10 +110,10 @@ internal class KlaviyoState : State {
     /**
      * Set an individual property or attribute
      */
-    override fun setAttribute(key: ProfileKey, value: String) = when (key) {
-        EMAIL -> email = value
-        EXTERNAL_ID -> externalId = value
-        PHONE_NUMBER -> phoneNumber = value
+    override fun setAttribute(key: ProfileKey, value: Serializable) = when (key) {
+        EMAIL -> email = (value as? String)
+        EXTERNAL_ID -> externalId = (value as? String)
+        PHONE_NUMBER -> phoneNumber = (value as? String)
         else -> this.attributes = (this.attributes?.copy() ?: Profile()).setProperty(key, value)
     }
 

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/state/State.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/state/State.kt
@@ -3,6 +3,7 @@ package com.klaviyo.analytics.state
 import com.klaviyo.analytics.model.Keyword
 import com.klaviyo.analytics.model.Profile
 import com.klaviyo.analytics.model.ProfileKey
+import java.io.Serializable
 
 typealias StateObserver = (key: Keyword?, oldValue: Any?) -> Unit
 
@@ -42,7 +43,7 @@ interface State {
     /**
      * Set an individual attribute
      */
-    fun setAttribute(key: ProfileKey, value: String)
+    fun setAttribute(key: ProfileKey, value: Serializable)
 
     /**
      * Remove all user identifiers and attributes from internal state

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
@@ -319,6 +319,27 @@ internal class KlaviyoTest : BaseTest() {
     }
 
     @Test
+    fun `Sets a serializable user property`() {
+        val bestNumber = 4
+        Klaviyo.setProfileAttribute(ProfileKey.FIRST_NAME, bestNumber)
+
+        verifyProfileDebounced()
+        assert(capturedProfile.isCaptured)
+        assertEquals(bestNumber, capturedProfile.captured[ProfileKey.FIRST_NAME])
+    }
+
+    @Test
+    fun `Serialiazable not in identifiers still gets debounced`() {
+        val bestString = ""
+        val key = ProfileKey.CUSTOM("danKey")
+        Klaviyo.setProfileAttribute(key, bestString)
+
+        verifyProfileDebounced()
+        assert(capturedProfile.isCaptured)
+        assertEquals(bestString, capturedProfile.captured[key])
+    }
+
+    @Test
     fun `Resets user info`() {
         val anonId = Registry.get<State>().anonymousId
         Registry.get<State>().email = EMAIL

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/state/KlaviyoStateTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/state/KlaviyoStateTest.kt
@@ -153,6 +153,24 @@ internal class KlaviyoStateTest : BaseTest() {
     }
 
     @Test
+    fun `Set attributes does not set on non-string profile info`() {
+        var broadcastKey: Keyword? = null
+        var broadcastValue: Any? = null
+
+        state.onStateChange { k, v ->
+            broadcastKey = k
+            broadcastValue = v
+        }
+
+        // expecting an string but sending an int, should not be set
+        state.setAttribute(ProfileKey.EMAIL, 29864)
+        state.setAttribute(ProfileKey.LAST_NAME, "Frog")
+
+        assertEquals(PROFILE_ATTRIBUTES, broadcastKey)
+        assertEquals(null, (broadcastValue as? Profile)?.get(ProfileKey.EMAIL))
+    }
+
+    @Test
     fun `Broadcasts on reset attributes`() {
         var broadcastKey: Keyword? = null
         var broadcastValue: Any? = null

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/state/KlaviyoStateTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/state/KlaviyoStateTest.kt
@@ -136,6 +136,7 @@ internal class KlaviyoStateTest : BaseTest() {
     fun `Broadcasts on set attributes`() {
         var broadcastKey: Keyword? = null
         var broadcastValue: Any? = null
+        val customKey = ProfileKey.CUSTOM("color")
 
         state.onStateChange { k, v ->
             broadcastKey = k
@@ -143,10 +144,12 @@ internal class KlaviyoStateTest : BaseTest() {
         }
 
         state.setAttribute(ProfileKey.FIRST_NAME, "Kermit")
+        state.setAttribute(customKey, "Green")
         state.setAttribute(ProfileKey.LAST_NAME, "Frog")
 
         assertEquals(PROFILE_ATTRIBUTES, broadcastKey)
         assertEquals("Kermit", (broadcastValue as? Profile)?.get(ProfileKey.FIRST_NAME))
+        assertEquals("Green", (broadcastValue as? Profile)?.get(customKey))
     }
 
     @Test


### PR DESCRIPTION
# Description
Changing the signature of the setAttribute to accept any Serializable

I currently having this take the form of 'attempt to cast to a String, if that fails add a null value' but I can see an argument against that. Do we want to support being able to add non-string types for our main profile keys (email, external id, phone number, etc) or should we throw an error here if that fails? Looking for input.

# Check List

- [x] Are you changing anything with the public API?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you tested this change on real device?
- [x] Have you added unit test coverage for your changes?
- [x] Have you verified that your changes are compatible with all Android versions the SDK currently supports?


## Changelog / Code Overview
- updating the `setProfileAttribute` to take in any serializable rather than only String
- updating `setAttribute` on the State interface to accept a Serializable (nullable type cast to a string)

## Test Plan
Updated unit tests

## Related Issues/Tickets
CHNL-7939
