### PR TITLE
Concurrent network observer fix

### DIFF
--- a/sdk/analytics/build.gradle
+++ b/sdk/analytics/build.gradle
@@ -19,6 +19,7 @@ android {
 dependencies {
     implementation project(":sdk:core")
     testImplementation project(":sdk:fixtures")
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.0"
 }
 
 afterEvaluate {

--- a/sdk/analytics/build.gradle
+++ b/sdk/analytics/build.gradle
@@ -19,7 +19,7 @@ android {
 dependencies {
     implementation project(":sdk:core")
     testImplementation project(":sdk:fixtures")
-    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.0"
+    testImplementation KotlinX.coroutines.test
 }
 
 afterEvaluate {

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/KlaviyoApiClient.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/KlaviyoApiClient.kt
@@ -15,6 +15,7 @@ import com.klaviyo.analytics.networking.requests.PushTokenApiRequest
 import com.klaviyo.analytics.networking.requests.UnregisterPushTokenApiRequest
 import com.klaviyo.core.Registry
 import com.klaviyo.core.lifecycle.ActivityEvent
+import java.util.Collections
 import java.util.concurrent.ConcurrentLinkedDeque
 import org.json.JSONArray
 import org.json.JSONException
@@ -34,7 +35,9 @@ internal object KlaviyoApiClient : ApiClient {
     /**
      * List of registered API observers
      */
-    private var apiObservers = mutableListOf<ApiObserver>()
+    private val apiObservers = Collections.synchronizedList(
+        mutableListOf<ApiObserver>()
+    )
 
     /**
      * Initialize logic including lifecycle observers and reviving the queue from persistent store
@@ -141,7 +144,9 @@ internal object KlaviyoApiClient : ApiClient {
             Registry.log.verbose("${request.responseCode} $response")
         }
 
-        apiObservers.forEach { it(request) }
+        synchronized(apiObservers) {
+            apiObservers.forEach { it(request) }
+        }
     }
 
     /**

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/state/KlaviyoState.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/state/KlaviyoState.kt
@@ -14,6 +14,7 @@ import com.klaviyo.analytics.model.ProfileKey.PUSH_TOKEN
 import com.klaviyo.analytics.networking.requests.PushTokenApiRequest
 import com.klaviyo.core.Registry
 import java.io.Serializable
+import java.util.Collections
 import java.util.UUID
 
 /**
@@ -58,7 +59,9 @@ internal class KlaviyoState : State {
     /**
      * List of registered state change observers
      */
-    private var stateObservers = mutableListOf<StateObserver>()
+    private val stateObservers = Collections.synchronizedList(
+        mutableListOf<StateObserver>()
+    )
 
     /**
      * Register an observer to be notified when state changes
@@ -162,6 +165,9 @@ internal class KlaviyoState : State {
     private fun <T> broadcastChange(property: PersistentObservableProperty<T>?, oldValue: T?) =
         broadcastChange(property?.key, oldValue)
 
-    private fun broadcastChange(key: Keyword? = null, oldValue: Any? = null) =
-        stateObservers.forEach { it(key, oldValue) }
+    private fun broadcastChange(key: Keyword? = null, oldValue: Any? = null) {
+        synchronized(stateObservers) {
+            stateObservers.forEach { it(key, oldValue) }
+        }
+    }
 }

--- a/sdk/core/build.gradle
+++ b/sdk/core/build.gradle
@@ -2,6 +2,8 @@ import static de.fayard.refreshVersions.core.Versions.versionFor
 
 dependencies {
     testImplementation project(":sdk:fixtures")
+    // coroutine testing
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.0"
 }
 description = "Core featureset of the Klaviyo SDK including SDK configuration, session tracking and analytics"
 evaluationDependsOn(":sdk")

--- a/sdk/core/build.gradle
+++ b/sdk/core/build.gradle
@@ -3,7 +3,7 @@ import static de.fayard.refreshVersions.core.Versions.versionFor
 dependencies {
     testImplementation project(":sdk:fixtures")
     // coroutine testing
-    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.0"
+    testImplementation KotlinX.coroutines.test
 }
 description = "Core featureset of the Klaviyo SDK including SDK configuration, session tracking and analytics"
 evaluationDependsOn(":sdk")

--- a/sdk/core/src/main/java/com/klaviyo/core/lifecycle/KlaviyoLifecycleMonitor.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/lifecycle/KlaviyoLifecycleMonitor.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.app.Application
 import android.os.Bundle
 import com.klaviyo.core.Registry
+import java.util.Collections
 
 /**
  * Service for monitoring the application lifecycle and network connectivity
@@ -12,7 +13,9 @@ internal object KlaviyoLifecycleMonitor : LifecycleMonitor, Application.Activity
 
     private var activeActivities = 0
 
-    private var activityObservers = mutableListOf<ActivityObserver>()
+    private val activityObservers = Collections.synchronizedList(
+        mutableListOf<ActivityObserver>()
+    )
 
     init {
         onActivityEvent { Registry.log.verbose(it.type) }
@@ -26,7 +29,11 @@ internal object KlaviyoLifecycleMonitor : LifecycleMonitor, Application.Activity
         activityObservers -= observer
     }
 
-    private fun broadcastEvent(event: ActivityEvent) = activityObservers.forEach { it(event) }
+    private fun broadcastEvent(event: ActivityEvent) {
+        synchronized(activityObservers) {
+            activityObservers.forEach { it(event) }
+        }
+    }
 
     //region ActivityLifecycleCallbacks
 

--- a/sdk/core/src/main/java/com/klaviyo/core/model/SharedPreferencesDataStore.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/model/SharedPreferencesDataStore.kt
@@ -3,6 +3,7 @@ package com.klaviyo.core.model
 import android.content.Context
 import android.content.SharedPreferences
 import com.klaviyo.core.Registry
+import java.util.Collections
 
 /**
  * Simple DataStore implementation using SharedPreferences for persistence
@@ -18,7 +19,9 @@ internal object SharedPreferencesDataStore : DataStore {
     /**
      * List of registered observers
      */
-    private var storeObservers = mutableListOf<StoreObserver>()
+    private val storeObservers = Collections.synchronizedList(
+        mutableListOf<StoreObserver>()
+    )
 
     init {
         onStoreChange { key, value -> Registry.log.verbose("$key=$value") }
@@ -33,7 +36,9 @@ internal object SharedPreferencesDataStore : DataStore {
     }
 
     private fun broadcastStoreChange(key: String, value: String?) {
-        storeObservers.forEach { it(key, value) }
+        synchronized(storeObservers) {
+            storeObservers.forEach { it(key, value) }
+        }
     }
 
     /**

--- a/sdk/core/src/main/java/com/klaviyo/core/networking/KlaviyoNetworkMonitor.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/networking/KlaviyoNetworkMonitor.kt
@@ -24,7 +24,7 @@ internal object KlaviyoNetworkMonitor : NetworkMonitor {
     /**
      * List of registered network change observers
      */
-    private val networkChangeObserversConcurrent = Collections.synchronizedList(
+    private val networkChangeObservers = Collections.synchronizedList(
         mutableListOf<NetworkObserver>()
     )
 
@@ -63,7 +63,7 @@ internal object KlaviyoNetworkMonitor : NetworkMonitor {
      */
     override fun onNetworkChange(observer: NetworkObserver) {
         initializeNetworkListener()
-        networkChangeObserversConcurrent += observer
+        networkChangeObservers += observer
     }
 
     /**
@@ -72,7 +72,7 @@ internal object KlaviyoNetworkMonitor : NetworkMonitor {
      * @param observer
      */
     override fun offNetworkChange(observer: NetworkObserver) {
-        networkChangeObserversConcurrent -= observer
+        networkChangeObservers -= observer
     }
 
     /**
@@ -80,8 +80,8 @@ internal object KlaviyoNetworkMonitor : NetworkMonitor {
      */
     private fun broadcastNetworkChange() {
         val isConnected = isNetworkConnected()
-        synchronized(networkChangeObserversConcurrent) {
-            networkChangeObserversConcurrent.forEach { it(isConnected) }
+        synchronized(networkChangeObservers) {
+            networkChangeObservers.forEach { it(isConnected) }
         }
     }
 

--- a/sdk/core/src/test/java/com/klaviyo/core/networking/KlaviyoNetworkMonitorTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/networking/KlaviyoNetworkMonitorTest.kt
@@ -107,11 +107,11 @@ internal class KlaviyoNetworkMonitorTest : BaseTest() {
     fun `Network change observer is invoked with current network status when network changes`() {
         var expectedNetworkConnection = true
         var callCount = 0
-
-        KlaviyoNetworkMonitor.onNetworkChange {
+        val observer: NetworkObserver = {
             assert(it == expectedNetworkConnection)
             callCount++
         }
+        KlaviyoNetworkMonitor.onNetworkChange(observer)
 
         assert(netCallbackSlot.isCaptured) // attaching a listener should have initialized the network callback
 
@@ -134,7 +134,7 @@ internal class KlaviyoNetworkMonitorTest : BaseTest() {
         netCallbackSlot.captured.onLost(mockk())
 
         assertEquals(6, callCount)
-        expectedNetworkConnection = true
+        KlaviyoNetworkMonitor.offNetworkChange(observer)
     }
 
     @Test

--- a/sdk/core/src/test/java/com/klaviyo/core/networking/KlaviyoNetworkMonitorTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/networking/KlaviyoNetworkMonitorTest.kt
@@ -13,6 +13,10 @@ import io.mockk.mockkConstructor
 import io.mockk.slot
 import io.mockk.unmockkObject
 import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -130,6 +134,7 @@ internal class KlaviyoNetworkMonitorTest : BaseTest() {
         netCallbackSlot.captured.onLost(mockk())
 
         assertEquals(6, callCount)
+        expectedNetworkConnection = true
     }
 
     @Test
@@ -166,5 +171,26 @@ internal class KlaviyoNetworkMonitorTest : BaseTest() {
         KlaviyoNetworkMonitor.onNetworkChange(observer) // it can be re-added
         netCallbackSlot.captured.onAvailable(mockk())
         assertEquals(5, callCount)
+    }
+
+    @Test()
+    fun `Concurrent modification exception doesn't get thrown on concurrent observer access`() = runTest {
+        val observer: NetworkObserver = { Thread.sleep(6) }
+
+        KlaviyoNetworkMonitor.onNetworkChange(observer)
+
+        val job = launch(Dispatchers.IO) {
+            netCallbackSlot.captured.onAvailable(mockk())
+        }
+
+        val job2 = launch(Dispatchers.Default) {
+            withContext(Dispatchers.IO) {
+                Thread.sleep(5)
+            }
+            KlaviyoNetworkMonitor.offNetworkChange(observer)
+        }
+
+        job.start()
+        job2.start()
     }
 }


### PR DESCRIPTION
# Description
The observers in `KlaviyoNetworkMonitor` were not stored in a thread-safe structure, so when broadcasting a change we sometimes get a `ConcurrentModificationException` if the list is being modified.

# Check List

- [ ] Are you changing anything with the public API?
- [x] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you tested this change on real device?
- [x] Have you added unit test coverage for your changes?
- [x] Have you verified that your changes are compatible with all Android versions the SDK currently supports?


## Changelog / Code Overview
- updating the `networkChangeObservers` type from a list to a Collections.synchronizedList
- adding a kotlinx coroutine test dependency on the core module

## Test Plan
Created a unit test for this scenario

## Related Issues/Tickets
CHNL-11317

