### PR TITLE
Retry on 503

### DIFF
--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequest.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequest.kt
@@ -6,6 +6,7 @@ import java.io.BufferedReader
 import java.io.IOException
 import java.io.InputStreamReader
 import java.net.HttpURLConnection
+import java.net.HttpURLConnection.HTTP_UNAVAILABLE
 import java.net.URL
 import java.util.UUID
 import javax.net.ssl.HttpsURLConnection
@@ -62,6 +63,7 @@ internal open class KlaviyoApiRequest(
         const val HTTP_ACCEPTED = HttpURLConnection.HTTP_ACCEPTED
         const val HTTP_MULT_CHOICE = HttpURLConnection.HTTP_MULT_CHOICE
         const val HTTP_RETRY = 429 // oddly not a const in HttpURLConnection
+        const val HTTP_UNAVAILABLE = HttpURLConnection.HTTP_UNAVAILABLE
 
         // JSON keys for persistence
         const val TYPE_JSON_KEY = "request_type"
@@ -343,7 +345,7 @@ internal open class KlaviyoApiRequest(
 
         status = when (responseCode) {
             in successCodes -> Status.Complete
-            HTTP_RETRY -> {
+            HTTP_RETRY, HTTP_UNAVAILABLE -> {
                 if (attempts < Registry.config.networkMaxAttempts) {
                     Status.PendingRetry
                 } else {
@@ -351,7 +353,7 @@ internal open class KlaviyoApiRequest(
                 }
             }
             // TODO - Special handling of unauthorized i.e. 401 and 403?
-            // TODO - Special handling of server errors 500 and 503?
+            // TODO - Special handling of server error 500?
             else -> Status.Failed
         }
 

--- a/versions.properties
+++ b/versions.properties
@@ -27,6 +27,10 @@ version.android.buildTools=34.0.0
 
 # Project dependencies
 
+version.kotlinx.coroutines=1.8.1
+##             # available=1.9.0-RC
+##             # available=1.9.0-RC.2
+
 version.org.jetbrains.dokka..versioning-plugin=1.9.10
 ##                                 # available=1.9.20
 


### PR DESCRIPTION
# Description
We are now returning 503 from push-tokens endpoint. These can be retried. We should add support for this within the Android SDK.

Since our SDK does not handle this error response accordingly, we’re potentially throwing out retriable requests and losing data. In case of a webserver unavailability this would prevent customers from losing out on data from their mobile apps.

# Check List

- [ ] Are you changing anything with the public API?
- [x] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you tested this change on real device?
- [x] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all Android versions the SDK currently supports?


## Changelog / Code Overview
- sending 503 error codes through the retry flow
- we already have logic for the exponential backoff in the case of no `retry-after` header
- creating a unit test for a 503 response with no header being retried

## Test Plan
We should test this by mocking a 503 response and checking that we retry with exponential backoff


## Related Issues/Tickets
CHNL-8144

