### PR TITLE
Updating readme with min kotlin version

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ send them timely push notifications via [FCM (Firebase Cloud Messaging)](https:/
 > ⚠️ **We support Android API level 23 and above** ⚠️
 
 ## Installation
+
+### Requirements
+
+- Kotlin **1.9.0** or later
+
 1. Include the [JitPack](https://jitpack.io/#klaviyo/klaviyo-android-sdk) repository in your project's build file
    <details>
       <summary>Kotlin DSL</summary>

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ send them timely push notifications via [FCM (Firebase Cloud Messaging)](https:/
 
 ## Requirements
 
-- Kotlin **1.9.0** or later
+- Kotlin **1.8.0** or later
 - Android API level **23** or later
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -14,13 +14,12 @@ The queue is persisted to local storage so that data is not lost if the device i
 Once integrated, your marketing team will be able to better understand your app users' needs and
 send them timely push notifications via [FCM (Firebase Cloud Messaging)](https://firebase.google.com/docs/cloud-messaging).
 
-> ⚠️ **We support Android API level 23 and above** ⚠️
-
-## Installation
-
-### Requirements
+## Requirements
 
 - Kotlin **1.9.0** or later
+- Android API level **23** or later
+
+## Installation
 
 1. Include the [JitPack](https://jitpack.io/#klaviyo/klaviyo-android-sdk) repository in your project's build file
    <details>


### PR DESCRIPTION
# Description
We should specify a min verision that correlates to our SDK kotlin version. I tested it with Kotlin 1.9.0 (note this is a previous version to our internal 1.9.22) and it worked with the SDK.

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [x] Have you tested this change on real device?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all Android versions the SDK currently supports?


## Changelog / Code Overview
- updating documentation

## Test Plan
 - tested with a new app running on Kotlin 1.9.0 and was able to send a push / event / instantiate
 - Evan tested with a new app running Kotlin 1.8.0 and was able to send a push / event / instantiate


## Related Issues/Tickets
https://github.com/klaviyo/klaviyo-android-sdk/issues/182

