### PR TITLE
CHNL-6996 Proguard docs and consumer rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,6 +483,17 @@ the following metadata tag to your manifest file.
 </manifest>
 ```
 
+#### Proguard / R8 Issues
+
+If you notice issues in the release build of your apps, you can try to manually add a couple rules
+to your `proguard-rules.pro` to prevent obfuscation:
+```
+-keep class com.klaviyo.analytics.** { *; }
+-keep class com.klaviyo.core.** { *; }
+-keep class com.klaviyo.push-fcm.** { *; }
+```
+
+
 ## Contributing
 See the [contributing guide](.github/CONTRIBUTING.md) to learn how to contribute to the Klaviyo Android SDK.
 We welcome your feedback in the [issues](https://github.com/klaviyo/klaviyo-android-sdk/issues) section of our public GitHub repository.

--- a/sdk/analytics/consumer-rules.pro
+++ b/sdk/analytics/consumer-rules.pro
@@ -1,0 +1,1 @@
+-keep class com.klaviyo.core.** { *; }

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -25,6 +25,7 @@ subprojects {
             testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
             versionCode versionFor(project, "version.klaviyo.versionCode") as Integer
             versionName versionFor(project, "version.klaviyo.versionName") as String
+            consumerProguardFiles("consumer-rules.pro")
         }
 
         buildFeatures {

--- a/sdk/push-fcm/consumer-rules.pro
+++ b/sdk/push-fcm/consumer-rules.pro
@@ -1,0 +1,2 @@
+-keep class com.klaviyo.core.** { *; }
+-keep class com.klaviyo.analytics.** { *; }


### PR DESCRIPTION
# Description
https://github.com/klaviyo/klaviyo-react-native-sdk/issues/138

Related to the above issue - basically we have the ability to add some rules in our SDK to safeguard obfuscation. Adding these rules and additional documentation for troubleshooting.

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you tested this change on real device?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all Android versions the SDK currently supports?


## Changelog / Code Overview
- adding consumer proguard rule for modules that depend on each other


## Test Plan
- test with RN release build


## Related Issues/Tickets
CHNL-6996

