### PR TITLE
Exposing klaviyo SDK name and version privately

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -26,5 +26,8 @@ android.enableJetifier=true
 # URL to Klaviyo server
 klaviyoServerUrl=https://a.klaviyo.com
 
+# SDK name
+klaviyoAndroidSDKName=android
+
 # Group ID prefix for all our published modules
 klaviyoGroupId=com.klaviyo

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/DeviceProperties.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/DeviceProperties.kt
@@ -50,9 +50,8 @@ internal object DeviceProperties {
     val sdkVersion: String
         get() = KlaviyoConfig.sdkVersion
 
-    val sdkName: String by lazy {
-        KlaviyoConfig.sdkName
-    }
+    val sdkName: String
+        get() = KlaviyoConfig.sdkName
 
     val backgroundDataEnabled: Boolean by lazy {
         !activityManager.isBackgroundRestrictedCompat()

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/DeviceProperties.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/DeviceProperties.kt
@@ -5,8 +5,8 @@ import android.content.pm.ApplicationInfo
 import android.content.pm.PackageInfo
 import android.os.Build
 import androidx.core.app.NotificationManagerCompat
-import com.klaviyo.core.BuildConfig
 import com.klaviyo.core.Registry
+import com.klaviyo.core.config.KlaviyoConfig
 import com.klaviyo.core.config.getPackageInfoCompat
 import com.klaviyo.core.model.fetchOrCreate
 import java.util.UUID
@@ -48,11 +48,11 @@ internal object DeviceProperties {
     }
 
     val sdkVersion: String by lazy {
-        BuildConfig.VERSION
+        KlaviyoConfig.sdkVersion
     }
 
     val sdkName: String by lazy {
-        "android"
+        KlaviyoConfig.sdkName
     }
 
     val backgroundDataEnabled: Boolean by lazy {

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/DeviceProperties.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/DeviceProperties.kt
@@ -48,7 +48,8 @@ internal object DeviceProperties {
     }
 
     val sdkVersion: String by lazy {
-        KlaviyoConfig.sdkVersion
+val sdkVersion: String
+        get() = KlaviyoConfig.sdkVersion
     }
 
     val sdkName: String by lazy {

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/DeviceProperties.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/DeviceProperties.kt
@@ -47,10 +47,8 @@ internal object DeviceProperties {
         packageInfo.getVersionCodeCompat().toString()
     }
 
-    val sdkVersion: String by lazy {
-val sdkVersion: String
+    val sdkVersion: String
         get() = KlaviyoConfig.sdkVersion
-    }
 
     val sdkName: String by lazy {
         KlaviyoConfig.sdkName

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -47,11 +47,13 @@ subprojects {
                 proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
                 buildConfigField "String", "KLAVIYO_SERVER_URL", "\"${serverTarget}\""
                 buildConfigField "String", "VERSION", "\"${versionFor(project, "version.klaviyo.versionName")}\""
+                buildConfigField "String", "NAME", "\"${klaviyoAndroidSDKName}\""
             }
             debug {
                 debuggable = true
                 buildConfigField "String", "KLAVIYO_SERVER_URL", "\"${serverTarget}\""
                 buildConfigField "String", "VERSION", "\"${versionFor(project, "version.klaviyo.versionName")}\""
+                buildConfigField "String", "NAME", "\"${klaviyoAndroidSDKName}\""
             }
         }
 

--- a/sdk/core/src/main/java/com/klaviyo/core/config/Config.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/config/Config.kt
@@ -6,6 +6,8 @@ import com.klaviyo.core.networking.NetworkMonitor
 interface Config {
     val isDebugBuild: Boolean
     val baseUrl: String
+    val sdkName: String
+    val sdkVersion: String
 
     val apiKey: String
     val applicationContext: Context
@@ -25,6 +27,8 @@ interface Config {
         fun apiKey(apiKey: String): Builder
         fun applicationContext(context: Context): Builder
         fun baseUrl(baseUrl: String): Builder
+        fun sdkName(name: String): Builder
+        fun sdkVersion(version: String): Builder
         fun debounceInterval(debounceInterval: Int): Builder
         fun networkTimeout(networkTimeout: Int): Builder
         fun networkFlushInterval(networkFlushInterval: Long, type: NetworkMonitor.NetworkType): Builder

--- a/sdk/core/src/main/java/com/klaviyo/core/config/KlaviyoConfig.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/config/KlaviyoConfig.kt
@@ -94,6 +94,8 @@ object KlaviyoConfig : Config {
 
     override var baseUrl: String = BuildConfig.KLAVIYO_SERVER_URL
         private set
+    override var sdkName: String = BuildConfig.NAME
+    override var sdkVersion: String = BuildConfig.VERSION
     override lateinit var apiKey: String private set
     override lateinit var applicationContext: Context private set
     override var debounceInterval = DEBOUNCE_INTERVAL
@@ -127,6 +129,8 @@ object KlaviyoConfig : Config {
         private var apiKey: String = ""
         private var applicationContext: Context? = null
         private var baseUrl: String? = null
+        private var sdkName: String? = null
+        private var sdkVersion: String? = null
         private var debounceInterval: Int = DEBOUNCE_INTERVAL
         private var networkTimeout: Int = NETWORK_TIMEOUT_DEFAULT
         private var networkFlushIntervals = longArrayOf(
@@ -153,6 +157,14 @@ object KlaviyoConfig : Config {
 
         override fun baseUrl(baseUrl: String): Config.Builder = apply {
             this.baseUrl = baseUrl
+        }
+
+        override fun sdkName(name: String): Config.Builder = apply {
+            this.sdkName = name
+        }
+
+        override fun sdkVersion(version: String): Config.Builder = apply {
+            this.sdkVersion = version
         }
 
         override fun debounceInterval(debounceInterval: Int) = apply {
@@ -232,6 +244,8 @@ object KlaviyoConfig : Config {
             packageInfo.assertRequiredPermissions(requiredPermissions)
 
             baseUrl?.let { KlaviyoConfig.baseUrl = it }
+            sdkName?.let { KlaviyoConfig.sdkName = it }
+            sdkVersion?.let { KlaviyoConfig.sdkVersion = it }
             KlaviyoConfig.apiKey = apiKey
             KlaviyoConfig.applicationContext = context
             KlaviyoConfig.debounceInterval = debounceInterval


### PR DESCRIPTION
# Description
Exposing SDK name and version so that this can be set from react native. This would aid in better debugging on our end and also know the usage of react native. 

## Test Plan
Tested setting these using the android test app like so,
```kotlin
            val config = Registry.configBuilder
                .apiKey(companyId)
                .sdkName("Klaviyo SDK Test App")
                .sdkVersion("2.0.0")
                .applicationContext(context)
                .baseUrl(it)
                .build()
```

and then looking at the events and making sure that the sdk name and version was what was set above. 

