### PR TITLE
CHNL-3990 Remove identifiers from state if format issues

### DIFF
--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/ApiRequest.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/ApiRequest.kt
@@ -88,4 +88,9 @@ interface ApiRequest {
      * @return
      */
     val responseBody: String?
+
+    /**
+     * Error messaging associated with the response
+     */
+    val errorBody: KlaviyoErrorResponse
 }

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/ErrorResponse.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/ErrorResponse.kt
@@ -1,0 +1,39 @@
+package com.klaviyo.analytics.networking.requests
+
+/**
+ * For parsing Error responses from the backend when an HTTP request fails
+ */
+
+internal data class ErrorResponse(
+    val errors: List<KlaviyoError>
+) {
+    companion object {
+        // Error body constants
+        const val ERRORS = "errors"
+        const val ID = "id"
+        const val STATUS = "status"
+        const val TITLE = "title"
+        const val DETAIL = "detail"
+        const val SOURCE = "source"
+        const val POINTER = "pointer"
+        const val INVALID_INPUT_TITLE = "Invalid input."
+    }
+}
+
+internal data class KlaviyoError(
+    val id: String? = null,
+    val status: Int? = null,
+    val title: String? = null,
+    val detail: String? = null,
+    val source: KlaviyoErrorSource? = null
+)
+
+internal data class KlaviyoErrorSource(
+    val pointer: String? = null
+) {
+    companion object {
+        // current path objects from the backend
+        const val EMAIL_PATH = "/data/attributes/email"
+        const val PHONE_NUMBER_PATH = "/data/attributes/phone_number"
+    }
+}

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/JSONUtil.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/JSONUtil.kt
@@ -4,6 +4,9 @@ import org.json.JSONObject
 
 internal object JSONUtil {
 
+    /**
+     * Using this util since built-in optString gets scared with a null default value
+     */
     fun JSONObject.getStringNullable(key: String): String? =
         if (has(key) && !isNull(key)) getString(key) else null
 }

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/JSONUtil.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/JSONUtil.kt
@@ -1,0 +1,9 @@
+package com.klaviyo.analytics.networking.requests
+
+import org.json.JSONObject
+
+internal object JSONUtil {
+
+    fun JSONObject.getStringNullable(key: String): String? =
+        if (has(key) && !isNull(key)) getString(key) else null
+}

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequest.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequest.kt
@@ -63,6 +63,7 @@ internal open class KlaviyoApiRequest(
         const val HTTP_MULT_CHOICE = HttpURLConnection.HTTP_MULT_CHOICE
         const val HTTP_RETRY = 429 // oddly not a const in HttpURLConnection
         const val HTTP_UNAVAILABLE = HttpURLConnection.HTTP_UNAVAILABLE
+        const val HTTP_BAD_REQUEST = HttpURLConnection.HTTP_BAD_REQUEST
 
         // JSON keys for persistence
         const val TYPE_JSON_KEY = "request_type"

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequest.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequest.kt
@@ -12,6 +12,7 @@ import javax.net.ssl.HttpsURLConnection
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.pow
+import org.json.JSONException
 import org.json.JSONObject
 
 /**
@@ -234,6 +235,22 @@ internal open class KlaviyoApiRequest(
      */
     override var responseBody: String? = null
         protected set
+
+    /**
+     * Parsing the error response or creating an empty one if there is none
+     */
+    override val errorBody: KlaviyoErrorResponse
+        by lazy {
+            responseBody?.let { body ->
+                val responseJson = try {
+                    JSONObject(body)
+                } catch (e: JSONException) {
+                    Registry.log.wtf("Malformed error response body from backend", e)
+                    JSONObject()
+                }
+                KlaviyoErrorResponseDecoder.fromJson(responseJson)
+            } ?: KlaviyoErrorResponse(listOf())
+        }
 
     /**
      * Creates a representation of this [KlaviyoApiRequest] in JSON

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoErrorResponse.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoErrorResponse.kt
@@ -4,10 +4,10 @@ package com.klaviyo.analytics.networking.requests
  * For parsing Error responses from the backend when an HTTP request fails
  */
 
-internal data class ErrorResponse(
+data class KlaviyoErrorResponse(
     val errors: List<KlaviyoError>
 ) {
-    companion object {
+    internal companion object {
         // Error body constants
         const val ERRORS = "errors"
         const val ID = "id"
@@ -20,7 +20,7 @@ internal data class ErrorResponse(
     }
 }
 
-internal data class KlaviyoError(
+data class KlaviyoError(
     val id: String? = null,
     val status: Int? = null,
     val title: String? = null,
@@ -28,10 +28,10 @@ internal data class KlaviyoError(
     val source: KlaviyoErrorSource? = null
 )
 
-internal data class KlaviyoErrorSource(
+data class KlaviyoErrorSource(
     val pointer: String? = null
 ) {
-    companion object {
+    internal companion object {
         // current path objects from the backend
         const val EMAIL_PATH = "/data/attributes/email"
         const val PHONE_NUMBER_PATH = "/data/attributes/phone_number"

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoErrorResponseDecoder.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoErrorResponseDecoder.kt
@@ -1,0 +1,35 @@
+package com.klaviyo.analytics.networking.requests
+
+import com.klaviyo.analytics.networking.requests.JSONUtil.getStringNullable
+import org.json.JSONArray
+import org.json.JSONObject
+
+internal object KlaviyoErrorResponseDecoder {
+
+    /**
+     * Construct an Error Response from a JSON object
+     *
+     * @return ErrorResponse from the JSON
+     */
+    internal fun fromJson(json: JSONObject): ErrorResponse {
+        val errorsJsonArray: JSONArray = json.getJSONArray(ErrorResponse.ERRORS)
+        val errorsList = mutableListOf<KlaviyoError>()
+        for (errorJsonIndex in 0 until errorsJsonArray.length()) {
+            val errorJson = errorsJsonArray.getJSONObject(errorJsonIndex)
+            errorsList.add(
+                KlaviyoError(
+                    id = errorJson.getStringNullable(ErrorResponse.ID),
+                    status = errorJson.getInt(ErrorResponse.STATUS),
+                    title = errorJson.getStringNullable(ErrorResponse.TITLE),
+                    detail = errorJson.getStringNullable(ErrorResponse.DETAIL),
+                    source = errorJson.getJSONObject(ErrorResponse.SOURCE)?.let {
+                        KlaviyoErrorSource(
+                            it.getStringNullable(ErrorResponse.POINTER)
+                        )
+                    }
+                )
+            )
+        }
+        return ErrorResponse(errorsList)
+    }
+}

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoErrorResponseDecoder.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoErrorResponseDecoder.kt
@@ -2,6 +2,7 @@ package com.klaviyo.analytics.networking.requests
 
 import com.klaviyo.analytics.networking.requests.JSONUtil.getStringNullable
 import org.json.JSONArray
+import org.json.JSONException
 import org.json.JSONObject
 
 internal object KlaviyoErrorResponseDecoder {
@@ -11,25 +12,29 @@ internal object KlaviyoErrorResponseDecoder {
      *
      * @return ErrorResponse from the JSON
      */
-    internal fun fromJson(json: JSONObject): ErrorResponse {
-        val errorsJsonArray: JSONArray = json.getJSONArray(ErrorResponse.ERRORS)
+    internal fun fromJson(json: JSONObject): KlaviyoErrorResponse {
+        val errorsJsonArray: JSONArray = try {
+            json.getJSONArray(KlaviyoErrorResponse.ERRORS)
+        } catch (e: JSONException) {
+            JSONArray()
+        }
         val errorsList = mutableListOf<KlaviyoError>()
         for (errorJsonIndex in 0 until errorsJsonArray.length()) {
             val errorJson = errorsJsonArray.getJSONObject(errorJsonIndex)
             errorsList.add(
                 KlaviyoError(
-                    id = errorJson.getStringNullable(ErrorResponse.ID),
-                    status = errorJson.getInt(ErrorResponse.STATUS),
-                    title = errorJson.getStringNullable(ErrorResponse.TITLE),
-                    detail = errorJson.getStringNullable(ErrorResponse.DETAIL),
-                    source = errorJson.getJSONObject(ErrorResponse.SOURCE)?.let {
+                    id = errorJson.getStringNullable(KlaviyoErrorResponse.ID),
+                    status = errorJson.getInt(KlaviyoErrorResponse.STATUS),
+                    title = errorJson.getStringNullable(KlaviyoErrorResponse.TITLE),
+                    detail = errorJson.getStringNullable(KlaviyoErrorResponse.DETAIL),
+                    source = errorJson.getJSONObject(KlaviyoErrorResponse.SOURCE)?.let {
                         KlaviyoErrorSource(
-                            it.getStringNullable(ErrorResponse.POINTER)
+                            it.getStringNullable(KlaviyoErrorResponse.POINTER)
                         )
                     }
                 )
             )
         }
-        return ErrorResponse(errorsList)
+        return KlaviyoErrorResponse(errorsList)
     }
 }

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/state/KlaviyoState.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/state/KlaviyoState.kt
@@ -170,4 +170,18 @@ internal class KlaviyoState : State {
             stateObservers.forEach { it(key, oldValue) }
         }
     }
+
+    /**
+     * For resetting user email field after an invalid input response
+     */
+    internal fun resetEmail() {
+        _email.reset()
+    }
+
+    /**
+     * For resetting user email field after an invalid input response
+     */
+    internal fun resetPhoneNumber() {
+        _phoneNumber.reset()
+    }
 }

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/state/StateSideEffects.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/state/StateSideEffects.kt
@@ -8,15 +8,13 @@ import com.klaviyo.analytics.model.Profile
 import com.klaviyo.analytics.model.ProfileKey
 import com.klaviyo.analytics.networking.ApiClient
 import com.klaviyo.analytics.networking.requests.ApiRequest
-import com.klaviyo.analytics.networking.requests.ErrorResponse
 import com.klaviyo.analytics.networking.requests.KlaviyoApiRequest
 import com.klaviyo.analytics.networking.requests.KlaviyoApiRequest.Companion.HTTP_BAD_REQUEST
-import com.klaviyo.analytics.networking.requests.KlaviyoErrorResponseDecoder
+import com.klaviyo.analytics.networking.requests.KlaviyoErrorResponse
 import com.klaviyo.analytics.networking.requests.KlaviyoErrorSource
 import com.klaviyo.analytics.networking.requests.PushTokenApiRequest
 import com.klaviyo.core.Registry
 import com.klaviyo.core.config.Clock
-import org.json.JSONObject
 
 internal class StateSideEffects(
     private val state: State = Registry.get<State>(),
@@ -117,30 +115,32 @@ internal class StateSideEffects(
 
     private fun afterApiRequest(request: ApiRequest) = when {
         request.responseCode == HTTP_BAD_REQUEST -> {
-            request.responseBody?.let { responseBody ->
-                val error = KlaviyoErrorResponseDecoder.fromJson(JSONObject(responseBody))
-                error.errors.find { it.title == ErrorResponse.INVALID_INPUT_TITLE }?.let { inputError ->
+            request.errorBody.errors.find { it.title == KlaviyoErrorResponse.INVALID_INPUT_TITLE }
+                ?.let { inputError ->
                     when (inputError.source?.pointer) {
                         KlaviyoErrorSource.EMAIL_PATH -> {
                             (Registry.get<State>() as? KlaviyoState)?.resetEmail()
                             Registry.log.warning("Invalid email - resetting email state to null")
                         }
+
                         KlaviyoErrorSource.PHONE_NUMBER_PATH -> {
                             (Registry.get<State>() as? KlaviyoState)?.resetPhoneNumber()
                             Registry.log.warning(
                                 "Invalid phone number - resetting phone number state to null"
                             )
                         }
+
                         else -> {
                             Registry.log.warning("Input error: ${inputError.detail}")
                         }
                     }
                 }
-            }
         }
+
         request is PushTokenApiRequest && request.status == KlaviyoApiRequest.Status.Failed && request.responseCode != HTTP_BAD_REQUEST -> {
             state.pushState = null
         }
+
         else -> Unit
     }
 }

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/KlaviyoErrorResponseDecoderTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/KlaviyoErrorResponseDecoderTest.kt
@@ -139,37 +139,4 @@ class KlaviyoErrorResponseDecoderTest : BaseTest() {
         """.trimIndent()
         assertEquals(errorResponse, KlaviyoErrorResponseDecoder.fromJson(JSONObject(errorJson)))
     }
-
-    @Test
-    fun `Error json except it was written by somebody who does not know what json is`() {
-        val errorResponse = KlaviyoErrorResponse(
-            errors = listOf(
-                KlaviyoError(
-                    id = "",
-                    status = -1,
-                    title = "",
-                    source = KlaviyoErrorSource(null)
-                )
-            )
-        )
-        val errorJson = """
-            {
-              "errors": [
-              {
-                  "id": "",
-                  "status": -1,
-                  "code": null,
-                  "title": "",
-                  "detail": null,
-                  "source": {
-                    "pointer": null
-                  },
-                  "links": {},
-                  "meta": {}
-                }
-              ]
-            }
-        """.trimIndent()
-        assertEquals(errorResponse, KlaviyoErrorResponseDecoder.fromJson(JSONObject(errorJson)))
-    }
 }

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/KlaviyoErrorResponseDecoderTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/KlaviyoErrorResponseDecoderTest.kt
@@ -9,7 +9,7 @@ class KlaviyoErrorResponseDecoderTest : BaseTest() {
 
     @Test
     fun `Builds error response`() {
-        val errorResponse = ErrorResponse(
+        val errorResponse = KlaviyoErrorResponse(
             errors = listOf(
                 KlaviyoError(
                     id = "67ed6dbf-1653-499b-a11d-30310aa01ff7",
@@ -45,7 +45,7 @@ class KlaviyoErrorResponseDecoderTest : BaseTest() {
 
     @Test
     fun `Builds error response with some spooky nulls`() {
-        val errorResponse = ErrorResponse(
+        val errorResponse = KlaviyoErrorResponse(
             errors = listOf(
                 KlaviyoError(
                     id = "67ed6dbf-1653-499b-a11d-30310aa01ff7",
@@ -78,7 +78,7 @@ class KlaviyoErrorResponseDecoderTest : BaseTest() {
 
     @Test
     fun `Build error response with an empty list of errors`() {
-        val errorResponse = ErrorResponse(
+        val errorResponse = KlaviyoErrorResponse(
             errors = listOf()
         )
         val errorJson = """
@@ -91,7 +91,7 @@ class KlaviyoErrorResponseDecoderTest : BaseTest() {
 
     @Test
     fun `Build error response with an multiple errors`() {
-        val errorResponse = ErrorResponse(
+        val errorResponse = KlaviyoErrorResponse(
             errors = listOf(
                 KlaviyoError(
                     id = "67ed6dbf-1653-499b-a11d-30310aa01ff7",
@@ -127,6 +127,39 @@ class KlaviyoErrorResponseDecoderTest : BaseTest() {
                   "status": 800,
                   "code": null,
                   "title": "Invalid input.",
+                  "detail": null,
+                  "source": {
+                    "pointer": null
+                  },
+                  "links": {},
+                  "meta": {}
+                }
+              ]
+            }
+        """.trimIndent()
+        assertEquals(errorResponse, KlaviyoErrorResponseDecoder.fromJson(JSONObject(errorJson)))
+    }
+
+    @Test
+    fun `Error json except it was written by somebody who does not know what json is`() {
+        val errorResponse = KlaviyoErrorResponse(
+            errors = listOf(
+                KlaviyoError(
+                    id = "",
+                    status = -1,
+                    title = "",
+                    source = KlaviyoErrorSource(null)
+                )
+            )
+        )
+        val errorJson = """
+            {
+              "errors": [
+              {
+                  "id": "",
+                  "status": -1,
+                  "code": null,
+                  "title": "",
                   "detail": null,
                   "source": {
                     "pointer": null

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/KlaviyoErrorResponseDecoderTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/KlaviyoErrorResponseDecoderTest.kt
@@ -1,0 +1,142 @@
+package com.klaviyo.analytics.networking.requests
+
+import com.klaviyo.fixtures.BaseTest
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class KlaviyoErrorResponseDecoderTest : BaseTest() {
+
+    @Test
+    fun `Builds error response`() {
+        val errorResponse = ErrorResponse(
+            errors = listOf(
+                KlaviyoError(
+                    id = "67ed6dbf-1653-499b-a11d-30310aa01ff7",
+                    status = 400,
+                    title = "Invalid input.",
+                    detail = "Invalid phone number format (Example of a valid format: +12345678901)",
+                    source = KlaviyoErrorSource(
+                        pointer = "/data/attributes/phone_number"
+                    )
+                )
+            )
+        )
+        val errorJson = """
+            {
+              "errors": [
+                {
+                  "id": "67ed6dbf-1653-499b-a11d-30310aa01ff7",
+                  "status": 400,
+                  "code": "invalid",
+                  "title": "Invalid input.",
+                  "detail": "Invalid phone number format (Example of a valid format: +12345678901)",
+                  "source": {
+                    "pointer": "/data/attributes/phone_number"
+                  },
+                  "links": {},
+                  "meta": {}
+                }
+              ]
+            }
+        """.trimIndent()
+        assertEquals(errorResponse, KlaviyoErrorResponseDecoder.fromJson(JSONObject(errorJson)))
+    }
+
+    @Test
+    fun `Builds error response with some spooky nulls`() {
+        val errorResponse = ErrorResponse(
+            errors = listOf(
+                KlaviyoError(
+                    id = "67ed6dbf-1653-499b-a11d-30310aa01ff7",
+                    status = -1,
+                    title = "Invalid input.",
+                    source = KlaviyoErrorSource()
+                )
+            )
+        )
+        val errorJson = """
+            {
+              "errors": [
+                {
+                  "id": "67ed6dbf-1653-499b-a11d-30310aa01ff7",
+                  "status": -1,
+                  "code": null,
+                  "title": "Invalid input.",
+                  "detail": null,
+                  "source": {
+                    "pointer": null
+                  },
+                  "links": {},
+                  "meta": {}
+                }
+              ]
+            }
+        """.trimIndent()
+        assertEquals(errorResponse, KlaviyoErrorResponseDecoder.fromJson(JSONObject(errorJson)))
+    }
+
+    @Test
+    fun `Build error response with an empty list of errors`() {
+        val errorResponse = ErrorResponse(
+            errors = listOf()
+        )
+        val errorJson = """
+            {
+              "errors": []
+            }
+        """.trimIndent()
+        assertEquals(errorResponse, KlaviyoErrorResponseDecoder.fromJson(JSONObject(errorJson)))
+    }
+
+    @Test
+    fun `Build error response with an multiple errors`() {
+        val errorResponse = ErrorResponse(
+            errors = listOf(
+                KlaviyoError(
+                    id = "67ed6dbf-1653-499b-a11d-30310aa01ff7",
+                    status = -1,
+                    title = "Invalid input.",
+                    source = KlaviyoErrorSource()
+                ),
+                KlaviyoError(
+                    id = "123456",
+                    status = 800,
+                    title = "Invalid input.",
+                    source = KlaviyoErrorSource()
+                )
+            )
+        )
+        val errorJson = """
+            {
+              "errors": [
+              {
+                  "id": "67ed6dbf-1653-499b-a11d-30310aa01ff7",
+                  "status": -1,
+                  "code": null,
+                  "title": "Invalid input.",
+                  "detail": null,
+                  "source": {
+                    "pointer": null
+                  },
+                  "links": {},
+                  "meta": {}
+                },
+                {
+                  "id": "123456",
+                  "status": 800,
+                  "code": null,
+                  "title": "Invalid input.",
+                  "detail": null,
+                  "source": {
+                    "pointer": null
+                  },
+                  "links": {},
+                  "meta": {}
+                }
+              ]
+            }
+        """.trimIndent()
+        assertEquals(errorResponse, KlaviyoErrorResponseDecoder.fromJson(JSONObject(errorJson)))
+    }
+}

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/state/KlaviyoStateTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/state/KlaviyoStateTest.kt
@@ -238,4 +238,16 @@ internal class KlaviyoStateTest : BaseTest() {
         assertEquals("Kermit", broadcastProfile[ProfileKey.FIRST_NAME])
         assertEquals("Frog", broadcastProfile[ProfileKey.LAST_NAME])
     }
+
+    @Test
+    fun `Resetting profile email and phone number values`() {
+        state.email = EMAIL
+        state.phoneNumber = PHONE
+
+        state.resetEmail()
+        state.resetPhoneNumber()
+
+        assertEquals(state.email, null)
+        assertEquals(state.phoneNumber, null)
+    }
 }

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/state/SideEffectTests.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/state/SideEffectTests.kt
@@ -7,6 +7,9 @@ import com.klaviyo.analytics.networking.ApiClient
 import com.klaviyo.analytics.networking.ApiObserver
 import com.klaviyo.analytics.networking.requests.EventApiRequest
 import com.klaviyo.analytics.networking.requests.KlaviyoApiRequest
+import com.klaviyo.analytics.networking.requests.KlaviyoError
+import com.klaviyo.analytics.networking.requests.KlaviyoErrorResponse
+import com.klaviyo.analytics.networking.requests.KlaviyoErrorSource
 import com.klaviyo.analytics.networking.requests.ProfileApiRequest
 import com.klaviyo.analytics.networking.requests.PushTokenApiRequest
 import com.klaviyo.core.Registry
@@ -234,24 +237,19 @@ class SideEffectTests : BaseTest() {
             mockk<ProfileApiRequest>().apply {
                 every { status } returns KlaviyoApiRequest.Status.Failed
                 every { responseCode } returns 400
-                every { responseBody } returns """
-                    {
-                      "errors": [
-                        {
-                          "id": "67ed6dbf-1653-499b-a11d-30310aa01ff7",
-                          "status": 400,
-                          "code": "invalid",
-                          "title": "Invalid input.",
-                          "detail": "Invalid phone number format (Example of a valid format: +12345678901)",
-                          "source": {
-                            "pointer": "/data/attributes/phone_number"
-                          },
-                          "links": {},
-                          "meta": {}
-                        }
-                      ]
-                    }
-                """.trimIndent()
+                every { errorBody } returns KlaviyoErrorResponse(
+                    listOf(
+                        KlaviyoError(
+                            id = "67ed6dbf-1653-499b-a11d-30310aa01ff7",
+                            status = 400,
+                            title = "Invalid input.",
+                            detail = "Invalid phone number format (Example of a valid format: +12345678901)",
+                            source = KlaviyoErrorSource(
+                                pointer = "/data/attributes/phone_number"
+                            )
+                        )
+                    )
+                )
             }
         )
 
@@ -271,28 +269,46 @@ class SideEffectTests : BaseTest() {
             mockk<ProfileApiRequest>().apply {
                 every { status } returns KlaviyoApiRequest.Status.Failed
                 every { responseCode } returns 400
-                every { responseBody } returns """
-                    {
-                      "errors": [
-                        {
-                          "id": "4f739784-390b-4df3-acd8-6eb07d60e6b4",
-                          "status": 400,
-                          "code": "invalid",
-                          "title": "Invalid input.",
-                          "detail": "Invalid email address",
-                          "source": {
-                            "pointer": "/data/attributes/email"
-                          },
-                          "links": {},
-                          "meta": {}
-                        }
-                      ]
-                    }
-                """.trimIndent()
+                every { errorBody } returns KlaviyoErrorResponse(
+                    listOf(
+                        KlaviyoError(
+                            id = "4f739784-390b-4df3-acd8-6eb07d60e6b4",
+                            status = 400,
+                            title = "Invalid input.",
+                            detail = "Invalid email address",
+                            source = KlaviyoErrorSource(
+                                pointer = "/data/attributes/email"
+                            )
+                        )
+                    )
+                )
             }
         )
 
         verify { klaviyoStateMock.resetEmail() }
+        Registry.unregister<State>()
+    }
+
+    @Test
+    fun `Empty error body does not reset fields`() {
+        Registry.register<State>(klaviyoStateMock)
+        StateSideEffects(
+            state = klaviyoStateMock,
+            apiClient = apiClientMock
+        )
+
+        capturedApiObserver.captured(
+            mockk<ProfileApiRequest>().apply {
+                every { status } returns KlaviyoApiRequest.Status.Failed
+                every { responseCode } returns 400
+                every { errorBody } returns KlaviyoErrorResponse(
+                    listOf()
+                )
+            }
+        )
+
+        verify(exactly = 0) { klaviyoStateMock.resetEmail() }
+        verify(exactly = 0) { klaviyoStateMock.resetEmail() }
         Registry.unregister<State>()
     }
 


### PR DESCRIPTION
# Description
- if we get a 400 from the backend due to a bad email / phone number, we need to clear that bad value from the local state
- adding some logic to deserialize the error body of a request
- adding a way to clear email and phone number fields to the State (internal to SDK only)
# Check List

- [ ] Are you changing anything with the public API?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you tested this change on real device?
- [x] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all Android versions the SDK currently supports?


## Changelog / Code Overview


## Test Plan
Tested locally and in production endpoints by using an ill-formatted email and phone number

## Related Issues/Tickets
CHNL-3990

