### PR TITLE
Automatically update push permission state on app resume

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -2,6 +2,19 @@
 This document provides guidance on how to migrate from the old version of the SDK to a newer version. 
 It will be updated as new versions are released including deprecations or breaking changes.
 
+# 3.0.0
+
+### Improvements
+- The Klaviyo Android SDK now automatically tracks changes to the
+  user's notification permission whenever the app is opened or resumed.
+- Additionally, the SDK will now hold the push token internally after you `resetProfile`
+  and automatically attach the token to the next profile. This is a change from past behavior where the token
+  would need to be explicitly set again after resetting.   
+
+### Removals
+- The `ProfileKey` options deprecated in `2.3.0` have been removed
+- `Klaviyo.lifecycleCallbacks`, deprecated in `2.1.0` has been removed
+
 ## 2.3.0 Deprecations
 #### Deprecated `ProfileKey` objects pertaining to identifiers
 The following `ProfileKey` objects have been deprecated in favor of using the explicit 

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ In order to send push notifications to your users, you must collect their push t
 This is done via the `Klaviyo.setPushToken` method, which registers push token and current authorization state
 via the [Create Client Push Token API](https://developers.klaviyo.com/en/reference/create_client_push_token).
 Once registered in your manifest, `KlaviyoPushService` will receive *new* push tokens via the `onNewToken` method.
-We also recommend retrieving the current token on app startup and registering it with Klaviyo SDK.
+We also recommend retrieving the latest token value on app startup and registering it with Klaviyo SDK.
 Add the following to your `Application.onCreate` method. 
 
 ```kotlin
@@ -248,6 +248,9 @@ override fun onCreate(savedInstanceState: Bundle?) {
     }
 }
 ```
+
+*As of version 3.0.0*: After setting a push token, the Klaviyo SDK will automatically track changes to
+the user's notification permission whenever the application is opened or resumed from the background.
 
 **Reminder**: `Klaviyo.initialize` is required before using any other Klaviyo SDK functionality, even 
 if you are only using the SDK for push notifications and not analytics.

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -69,6 +69,7 @@ object Klaviyo {
         Registry.get<ApiClient>().startService()
 
         Registry.register<State>(KlaviyoState())
+        Registry.getOrNull<StateSideEffects>()?.detach()
         Registry.register<StateSideEffects>(StateSideEffects())
 
         Registry.get<State>().apiKey = apiKey

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/state/KlaviyoState.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/state/KlaviyoState.kt
@@ -49,12 +49,10 @@ internal class KlaviyoState : State {
     override var pushToken: String?
         set(value) {
             // Set token should also update entire push state value
-            _pushToken.setValue(this, ::pushToken, value)
-
-            // TODO use a better representation of push state to decouple from PushTokenApiRequest
+            _pushToken.setValue(this, ::_pushToken, value)
             pushState = value?.let { PushTokenApiRequest(it, getAsProfile()).requestBody } ?: ""
         }
-        get() = _pushToken.getValue(this, ::pushToken)
+        get() = _pushToken.getValue(this, ::_pushToken)
 
     /**
      * List of registered state change observers

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/state/StateSideEffects.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/state/StateSideEffects.kt
@@ -119,15 +119,19 @@ internal class StateSideEffects(
                 ?.let { inputError ->
                     when (inputError.source?.pointer) {
                         KlaviyoErrorSource.EMAIL_PATH -> {
-                            (Registry.get<State>() as? KlaviyoState)?.resetEmail()
-                            Registry.log.warning("Invalid email - resetting email state to null")
+                            (Registry.get<State>() as? KlaviyoState)?.resetEmail().also {
+                                Registry.log.warning(
+                                    "Invalid email - resetting email state to null"
+                                )
+                            }
                         }
 
                         KlaviyoErrorSource.PHONE_NUMBER_PATH -> {
-                            (Registry.get<State>() as? KlaviyoState)?.resetPhoneNumber()
-                            Registry.log.warning(
-                                "Invalid phone number - resetting phone number state to null"
-                            )
+                            (Registry.get<State>() as? KlaviyoState)?.resetPhoneNumber().also {
+                                Registry.log.warning(
+                                    "Invalid phone number - resetting phone number state to null"
+                                )
+                            }
                         }
 
                         else -> {

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoPreInitializeTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoPreInitializeTest.kt
@@ -42,6 +42,7 @@ internal class KlaviyoPreInitializeTest : BaseTest() {
     private val mockApiClient: ApiClient = mockk<ApiClient>().apply {
         every { startService() } returns Unit
         every { onApiRequest(any(), any()) } returns Unit
+        every { offApiRequest(any()) } returns Unit
         every { enqueueProfile(any()) } returns Unit
         every { enqueueEvent(any(), any()) } returns Unit
         every { enqueuePushToken(any(), any()) } returns Unit

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/state/SideEffectTests.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/state/SideEffectTests.kt
@@ -71,10 +71,12 @@ class SideEffectTests : BaseTest() {
         val sideEffects = StateSideEffects(stateMock, apiClientMock)
         verify { stateMock.onStateChange(any()) }
         verify { apiClientMock.onApiRequest(any(), any()) }
+        verify { mockLifecycleMonitor.onActivityEvent(any()) }
 
         sideEffects.detach()
         verify { stateMock.offStateChange(any()) }
         verify { apiClientMock.offApiRequest(any()) }
+        verify { mockLifecycleMonitor.offActivityEvent(any()) }
     }
 
     @Test

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/state/StateSideEffectsTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/state/StateSideEffectsTest.kt
@@ -24,7 +24,7 @@ import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 
-class SideEffectTests : BaseTest() {
+class StateSideEffectsTest : BaseTest() {
 
     private val profile = Profile(email = EMAIL)
     private val capturedProfile = slot<Profile>()

--- a/sdk/core/src/main/java/com/klaviyo/core/Registry.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/Registry.kt
@@ -120,6 +120,19 @@ object Registry {
     }
 
     /**
+     * Get a registered service by type, else null
+     *
+     * @param T - Type of service, usually an interface
+     * @return The instance of the service
+     */
+    inline fun <reified T : Any> getOrNull(): T? {
+        val type = typeOf<T>()
+        val service: Any? = services[type]
+
+        return if (service is T) service else null
+    }
+
+    /**
      * Get a registered service by type
      *
      * @param T - Type of service, usually an interface

--- a/sdk/fixtures/src/main/java/com/klaviyo/fixtures/BaseTest.kt
+++ b/sdk/fixtures/src/main/java/com/klaviyo/fixtures/BaseTest.kt
@@ -79,7 +79,10 @@ abstract class BaseTest {
         every { networkJitterRange } returns 0..0
         every { baseUrl } returns "https://test.fake-klaviyo.com"
     }
-    protected val mockLifecycleMonitor = mockk<LifecycleMonitor>()
+    protected val mockLifecycleMonitor = mockk<LifecycleMonitor>().apply {
+        every { onActivityEvent(any()) } returns Unit
+        every { offActivityEvent(any()) } returns Unit
+    }
     protected val mockNetworkMonitor = mockk<NetworkMonitor>()
     protected val spyDataStore = spyk(InMemoryDataStore())
     protected val spyLog = spyk(LogFixture())


### PR DESCRIPTION
# Description
Adds automatic tracking of permission state change, by listening for `resume` events from the host app and re-checking permission state and device metadata against the latest push state data.

TODO:
- [x] Add migration notes and readme updates
- [x] Check with test app
- [x] Compile and test edge cases / extended use cases.
- [x] Check on performance implications

# Check List

- [x] Are you changing anything with the public API?
- [x] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you tested this change on real device?
- [x] Have you added unit test coverage for your changes?
- [x] Have you verified that your changes are compatible with all Android versions the SDK currently supports?


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->
- Attach a state side effect listener to activity lifecycle events
- On resume, if there is a push token in state, refresh overall push state
- Detach listeners on re-initialize to prevent dupes

## Test Plan
<!-- How was this code tested / How should reviewers test it? -->
- [x] Quick test in an emulator
- [x] Unit tests
- [ ] Extended app testing

## Related Issues/Tickets
<!-- Link to relevant issues or discussion -->
#161 - Required for version 3.0.0
CHNL-961