### PR TITLE
[CHNL-12521] Looking for react-native strings to determine sdk name and version for config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,10 +39,7 @@ tasks.register("clean", Delete) {
 }
 
 static def readXmlValue(String filePath, String tagName, Project project) {
-    println "Current directory: ${project.projectDir}"
-    println "Files in sdk/core/src/main/res/values/:"
     def xmlFile = new File(project.projectDir, filePath)
-    println("looking for file in ${project} directory ${project.projectDir} with the path: $filePath")
     // Check if the file exists
     if (!xmlFile.exists()) {
         throw new FileNotFoundException("The XML file does not exist: ${xmlFile.absolutePath}")
@@ -111,7 +108,7 @@ public class BumpVersion extends DefaultTask {
 
     @TaskAction
     public void bumpVersion() {
-        def currentVersion = readXmlValue('sdk/core/src/main/res/values/strings.xml','klaviyo_sdk_version_override',project)
+        def currentVersion = readXmlValue('sdk/core/src/main/res/values/strings.xml','klaviyo_sdk_version_override')
         println(currentVersion)
         def nextVersion = this.getNextVersion()
         def currentBuild = versionFor(project, "version.klaviyo.versionCode") as Integer

--- a/build.gradle
+++ b/build.gradle
@@ -38,16 +38,36 @@ tasks.register("clean", Delete) {
     delete rootProject.layout.buildDirectory
 }
 
-static def readXmlValue(String filePath, String tagName) {
-    def xmlFile = new File(filePath)
-    def xmlContent = new XmlSlurper().parse(xmlFile)
+static def readXmlValue(String filePath, String tagName, Project project) {
+    println "Current directory: ${project.projectDir}"
+    println "Files in sdk/core/src/main/res/values/:"
+    def xmlFile = new File(project.projectDir, filePath)
+    println("looking for file in ${project} directory ${project.projectDir} with the path: $filePath")
+    // Check if the file exists
+    if (!xmlFile.exists()) {
+        throw new FileNotFoundException("The XML file does not exist: ${xmlFile.absolutePath}")
+    }
+
+    // Parse the XML file
+    def xmlContent
+    try {
+        xmlContent = new XmlSlurper().parse(xmlFile)
+    } catch (Exception e) {
+        throw new RuntimeException("Failed to parse XML file: ${xmlFile.absolutePath}. Error: ${e.message}", e)
+    }
+
     // Look for the string with the specific name attribute
     def result = xmlContent.'string'.find { it.@name == tagName }
-    return result?.text() ?: ""
+
+    if (result == null) {
+        throw new IllegalArgumentException("No string found with the name '${tagName}' in the file: ${xmlFile.absolutePath}")
+    }
+
+    return result.text()
 }
 
 dokkaHtmlMultiModule {
-    def versionName = readXmlValue('sdk/core/src/main/res/values/strings.xml','klaviyo_sdk_version_override')
+    def versionName = readXmlValue('sdk/core/src/main/res/values/strings.xml','klaviyo_sdk_version_override', project)
     def oldVersionsDir = layout.buildDirectory.dir("../docs/")
     outputDirectory = layout.buildDirectory.dir("../docs/${versionName}")
     includes.from("README.md")
@@ -91,7 +111,7 @@ public class BumpVersion extends DefaultTask {
 
     @TaskAction
     public void bumpVersion() {
-        def currentVersion = readXmlValue('sdk/core/src/main/res/values/strings.xml','klaviyo_sdk_version_override')
+        def currentVersion = readXmlValue('sdk/core/src/main/res/values/strings.xml','klaviyo_sdk_version_override',project)
         println(currentVersion)
         def nextVersion = this.getNextVersion()
         def currentBuild = versionFor(project, "version.klaviyo.versionCode") as Integer

--- a/build.gradle
+++ b/build.gradle
@@ -38,8 +38,16 @@ tasks.register("clean", Delete) {
     delete rootProject.layout.buildDirectory
 }
 
+static def readXmlValue(String filePath, String tagName) {
+    def xmlFile = new File(filePath)
+    def xmlContent = new XmlSlurper().parse(xmlFile)
+    // Look for the string with the specific name attribute
+    def result = xmlContent.'string'.find { it.@name == tagName }
+    return result?.text() ?: ""
+}
+
 dokkaHtmlMultiModule {
-    def versionName = versionFor(project, "version.klaviyo.versionName") as String
+    def versionName = readXmlValue('sdk/core/src/main/res/values/strings.xml','klaviyo_sdk_version_override')
     def oldVersionsDir = layout.buildDirectory.dir("../docs/")
     outputDirectory = layout.buildDirectory.dir("../docs/${versionName}")
     includes.from("README.md")
@@ -73,9 +81,18 @@ public class BumpVersion extends DefaultTask {
         return nextVersion;
     }
 
+    static String readXmlValue(String filePath, String tagName) {
+        def xmlFile = new File(filePath)
+        def xmlContent = new XmlSlurper().parse(xmlFile)
+        // Look for the string with the specific name attribute
+        def result = xmlContent.'string'.find { it.@name == tagName }
+        return result?.text() ?: ""
+    }
+
     @TaskAction
     public void bumpVersion() {
-        def currentVersion = versionFor(project, "version.klaviyo.versionName") as String
+        def currentVersion = readXmlValue('sdk/core/src/main/res/values/strings.xml','klaviyo_sdk_version_override')
+        println(currentVersion)
         def nextVersion = this.getNextVersion()
         def currentBuild = versionFor(project, "version.klaviyo.versionCode") as Integer
         def nextBuild = currentBuild + 1
@@ -83,7 +100,9 @@ public class BumpVersion extends DefaultTask {
         print("Auto-incrementing version code from $currentBuild to $nextBuild\n")
 
         ant.replace(file:"versions.properties", token:"versionCode=$currentBuild", value:"versionCode=$nextBuild")
-        ant.replace(file:"versions.properties", token:"versionName=$currentVersion", value:"versionName=$nextVersion")
+        def file = new File('sdk/core/src/main/res/values/strings.xml')
+        def newName = file.text.replace(currentVersion,nextVersion)
+        file.text = newName
         ant.replace(file:"README.md", token:"analytics:$currentVersion", value:"analytics:$nextVersion")
         ant.replace(file:"README.md", token:"push-fcm:$currentVersion", value:"push-fcm:$nextVersion")
         ant.replace(file:"docs/index.html", token:"$currentVersion", value:"$nextVersion")

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,8 +29,5 @@ klaviyoServerUrl=https://a.klaviyo.com
 # Klaviyo API Revision
 klaviyoApiRevision=2023-07-15
 
-# SDK name
-klaviyoAndroidSDKName=android
-
 # Group ID prefix for all our published modules
 klaviyoGroupId=com.klaviyo

--- a/sdk/analytics/build.gradle
+++ b/sdk/analytics/build.gradle
@@ -1,4 +1,3 @@
-import static de.fayard.refreshVersions.core.Versions.versionFor
 
 project.description = "Public analytics API functionality for the Klaviyo SDK suite"
 evaluationDependsOn(":sdk")

--- a/sdk/analytics/build.gradle
+++ b/sdk/analytics/build.gradle
@@ -30,7 +30,7 @@ afterEvaluate {
                 from components[ext.publishBuildVariant]
                 groupId = klaviyoGroupId
                 artifactId = "analytics"
-                version = versionFor(project, "version.klaviyo.versionName")
+                version = readXmlValue('sdk/core/src/main/res/values/strings.xml','klaviyo_sdk_version_override')
             }
         }
     }

--- a/sdk/analytics/build.gradle
+++ b/sdk/analytics/build.gradle
@@ -30,7 +30,7 @@ afterEvaluate {
                 from components[ext.publishBuildVariant]
                 groupId = klaviyoGroupId
                 artifactId = "analytics"
-                version = readXmlValue('sdk/core/src/main/res/values/strings.xml','klaviyo_sdk_version_override')
+                version = readXmlValue('src/main/res/values/strings.xml','klaviyo_sdk_version_override', project(":sdk:core"))
             }
         }
     }

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -48,15 +48,11 @@ subprojects {
                 proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
                 buildConfigField "String", "KLAVIYO_SERVER_URL", "\"${serverTarget}\""
                 buildConfigField "String", "KLAVIYO_API_REVISION", "\"${apiRevision}\""
-                buildConfigField "String", "VERSION", "\"${readXmlValue('src/main/res/values/strings.xml','klaviyo_sdk_version_override', project(':sdk:core'))}\""
-                buildConfigField "String", "NAME", "\"${readXmlValue('src/main/res/values/strings.xml','klaviyo_sdk_name_override', project(':sdk:core'))}\""
             }
             debug {
                 debuggable = true
                 buildConfigField "String", "KLAVIYO_SERVER_URL", "\"${serverTarget}\""
                 buildConfigField "String", "KLAVIYO_API_REVISION", "\"${apiRevision}\""
-                buildConfigField "String", "VERSION", "\"${readXmlValue('src/main/res/values/strings.xml','klaviyo_sdk_version_override', project(':sdk:core'))}\""
-                buildConfigField "String", "NAME", "\"${readXmlValue('src/main/res/values/strings.xml','klaviyo_sdk_name_override', project(':sdk:core'))}\""
             }
         }
 

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -25,7 +25,7 @@ subprojects {
             targetSdkVersion versionFor(project, "version.android.targetSdk") as Integer
             testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
             versionCode versionFor(project, "version.klaviyo.versionCode") as Integer
-            versionName getVersionName()
+            versionName readXmlValue('src/main/res/values/strings.xml','klaviyo_sdk_version_override', project(':sdk:core'))
             consumerProguardFiles("consumer-rules.pro")
         }
 

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -25,7 +25,7 @@ subprojects {
             targetSdkVersion versionFor(project, "version.android.targetSdk") as Integer
             testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
             versionCode versionFor(project, "version.klaviyo.versionCode") as Integer
-            versionName versionFor(project, "version.klaviyo.versionName") as String
+            versionName getVersionName()
             consumerProguardFiles("consumer-rules.pro")
         }
 
@@ -48,15 +48,15 @@ subprojects {
                 proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
                 buildConfigField "String", "KLAVIYO_SERVER_URL", "\"${serverTarget}\""
                 buildConfigField "String", "KLAVIYO_API_REVISION", "\"${apiRevision}\""
-                buildConfigField "String", "VERSION", "\"${versionFor(project, "version.klaviyo.versionName")}\""
-                buildConfigField "String", "NAME", "\"${klaviyoAndroidSDKName}\""
+                buildConfigField "String", "VERSION", "\"${readXmlValue('sdk/core/src/main/res/values/strings.xml','klaviyo_sdk_version_override')}\""
+                buildConfigField "String", "NAME", "\"${readXmlValue('sdk/core/src/main/res/values/strings.xml','klaviyo_sdk_name_override')}\""
             }
             debug {
                 debuggable = true
                 buildConfigField "String", "KLAVIYO_SERVER_URL", "\"${serverTarget}\""
                 buildConfigField "String", "KLAVIYO_API_REVISION", "\"${apiRevision}\""
-                buildConfigField "String", "VERSION", "\"${versionFor(project, "version.klaviyo.versionName")}\""
-                buildConfigField "String", "NAME", "\"${klaviyoAndroidSDKName}\""
+                buildConfigField "String", "VERSION", "\"${readXmlValue('sdk/core/src/main/res/values/strings.xml','klaviyo_sdk_version_override')}\""
+                buildConfigField "String", "NAME", "\"${readXmlValue('sdk/core/src/main/res/values/strings.xml','klaviyo_sdk_name_override')}\""
             }
         }
 

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -48,15 +48,15 @@ subprojects {
                 proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
                 buildConfigField "String", "KLAVIYO_SERVER_URL", "\"${serverTarget}\""
                 buildConfigField "String", "KLAVIYO_API_REVISION", "\"${apiRevision}\""
-                buildConfigField "String", "VERSION", "\"${readXmlValue('sdk/core/src/main/res/values/strings.xml','klaviyo_sdk_version_override')}\""
-                buildConfigField "String", "NAME", "\"${readXmlValue('sdk/core/src/main/res/values/strings.xml','klaviyo_sdk_name_override')}\""
+                buildConfigField "String", "VERSION", "\"${readXmlValue('src/main/res/values/strings.xml','klaviyo_sdk_version_override', project(':sdk:core'))}\""
+                buildConfigField "String", "NAME", "\"${readXmlValue('src/main/res/values/strings.xml','klaviyo_sdk_name_override', project(':sdk:core'))}\""
             }
             debug {
                 debuggable = true
                 buildConfigField "String", "KLAVIYO_SERVER_URL", "\"${serverTarget}\""
                 buildConfigField "String", "KLAVIYO_API_REVISION", "\"${apiRevision}\""
-                buildConfigField "String", "VERSION", "\"${readXmlValue('sdk/core/src/main/res/values/strings.xml','klaviyo_sdk_version_override')}\""
-                buildConfigField "String", "NAME", "\"${readXmlValue('sdk/core/src/main/res/values/strings.xml','klaviyo_sdk_name_override')}\""
+                buildConfigField "String", "VERSION", "\"${readXmlValue('src/main/res/values/strings.xml','klaviyo_sdk_version_override', project(':sdk:core'))}\""
+                buildConfigField "String", "NAME", "\"${readXmlValue('src/main/res/values/strings.xml','klaviyo_sdk_name_override', project(':sdk:core'))}\""
             }
         }
 

--- a/sdk/core/build.gradle
+++ b/sdk/core/build.gradle
@@ -30,7 +30,7 @@ afterEvaluate {
                 from components[ext.publishBuildVariant]
                 groupId = klaviyoGroupId
                 artifactId = "core"
-                version = readXmlValue('sdk/core/src/main/res/values/strings.xml','klaviyo_sdk_version_override')
+                version = readXmlValue('src/main/res/values/strings.xml','klaviyo_sdk_version_override', project)
             }
         }
     }

--- a/sdk/core/build.gradle
+++ b/sdk/core/build.gradle
@@ -30,7 +30,7 @@ afterEvaluate {
                 from components[ext.publishBuildVariant]
                 groupId = klaviyoGroupId
                 artifactId = "core"
-                version = versionFor(project, "version.klaviyo.versionName")
+                version = readXmlValue('sdk/core/src/main/res/values/strings.xml','klaviyo_sdk_version_override')
             }
         }
     }

--- a/sdk/core/build.gradle
+++ b/sdk/core/build.gradle
@@ -1,4 +1,3 @@
-import static de.fayard.refreshVersions.core.Versions.versionFor
 
 dependencies {
     testImplementation project(":sdk:fixtures")

--- a/sdk/core/src/main/java/com/klaviyo/core/config/Config.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/config/Config.kt
@@ -29,8 +29,6 @@ interface Config {
         fun applicationContext(context: Context): Builder
         fun baseUrl(baseUrl: String): Builder
         fun apiRevision(apiRevision: String): Builder
-        fun sdkName(name: String): Builder
-        fun sdkVersion(version: String): Builder
         fun debounceInterval(debounceInterval: Int): Builder
         fun networkTimeout(networkTimeout: Int): Builder
         fun networkFlushInterval(networkFlushInterval: Long, type: NetworkMonitor.NetworkType): Builder

--- a/sdk/core/src/main/java/com/klaviyo/core/config/KlaviyoConfig.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/config/KlaviyoConfig.kt
@@ -126,6 +126,25 @@ object KlaviyoConfig : Config {
         } else {
             applicationContext.getManifestInt(key, defaultValue)
         }
+    private fun getReactNativeSdkProperty(key: String): String? =
+        if (!this::applicationContext.isInitialized) {
+            null
+        } else {
+            // check to see if react-native string is in app resources
+            val sdkNameResId =
+                applicationContext.resources.getIdentifier(
+                    key,
+                    "string",
+                    applicationContext.packageName
+                )
+            if (sdkNameResId != 0) {
+                applicationContext.resources.getString(sdkNameResId).also {
+                    Registry.log.debug("Using react-native SDK $key : $it")
+                }
+            } else {
+                null
+            }
+        }
 
     /**
      * Nested class to enable the builder pattern for easy declaration of custom configurations
@@ -246,37 +265,6 @@ object KlaviyoConfig : Config {
             }
 
             val context = applicationContext ?: throw MissingContext()
-            // attempt to grab resources from the manifest
-            val sdkNameResId =
-                context.resources.getIdentifier(
-                    "sdk_version",
-                    "string",
-                    context.packageName
-                )
-            Registry.log.error(
-                "DANO res id $sdkNameResId from sdk_version" +
-                    " in string in package ${context.packageName}"
-            )
-            val sdkNameResId2 =
-                context.resources.getIdentifier(
-                    "sdK_version",
-                    null,
-                    "com.klaviyoreactnativesdk"
-                )
-            Registry.log.error(
-                "DANO res id $sdkNameResId2 from " +
-                    "sdk_version in string in package com.klaviyoreactnativesdk"
-            )
-            if (sdkNameResId != 0) {
-                Registry.log.error("DANO res id not zero, getting string")
-                val str = context.resources.getString(sdkNameResId)
-                Registry.log.error("DANO $str")
-            }
-            if (sdkNameResId2 != 0) {
-                Registry.log.error("DANO res id 2 not zero, getting string")
-                val str = context.resources.getString(sdkNameResId2)
-                Registry.log.error("DANO $str")
-            }
             val packageInfo = context.packageManager.getPackageInfoCompat(
                 context.packageName,
                 PackageManager.GET_PERMISSIONS

--- a/sdk/core/src/main/java/com/klaviyo/core/config/KlaviyoConfig.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/config/KlaviyoConfig.kt
@@ -120,11 +120,12 @@ object KlaviyoConfig : Config {
         private set
     override val networkJitterRange = 0..10
 
-    override fun getManifestInt(key: String, defaultValue: Int): Int = if (!this::applicationContext.isInitialized) {
-        defaultValue
-    } else {
-        applicationContext.getManifestInt(key, defaultValue)
-    }
+    override fun getManifestInt(key: String, defaultValue: Int): Int =
+        if (!this::applicationContext.isInitialized) {
+            defaultValue
+        } else {
+            applicationContext.getManifestInt(key, defaultValue)
+        }
 
     /**
      * Nested class to enable the builder pattern for easy declaration of custom configurations
@@ -245,7 +246,37 @@ object KlaviyoConfig : Config {
             }
 
             val context = applicationContext ?: throw MissingContext()
-
+            // attempt to grab resources from the manifest
+            val sdkNameResId =
+                context.resources.getIdentifier(
+                    "sdk_version",
+                    "string",
+                    context.packageName
+                )
+            Registry.log.error(
+                "DANO res id $sdkNameResId from sdk_version" +
+                    " in string in package ${context.packageName}"
+            )
+            val sdkNameResId2 =
+                context.resources.getIdentifier(
+                    "sdK_version",
+                    null,
+                    "com.klaviyoreactnativesdk"
+                )
+            Registry.log.error(
+                "DANO res id $sdkNameResId2 from " +
+                    "sdk_version in string in package com.klaviyoreactnativesdk"
+            )
+            if (sdkNameResId != 0) {
+                Registry.log.error("DANO res id not zero, getting string")
+                val str = context.resources.getString(sdkNameResId)
+                Registry.log.error("DANO $str")
+            }
+            if (sdkNameResId2 != 0) {
+                Registry.log.error("DANO res id 2 not zero, getting string")
+                val str = context.resources.getString(sdkNameResId2)
+                Registry.log.error("DANO $str")
+            }
             val packageInfo = context.packageManager.getPackageInfoCompat(
                 context.packageName,
                 PackageManager.GET_PERMISSIONS

--- a/sdk/core/src/main/java/com/klaviyo/core/config/KlaviyoConfig.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/config/KlaviyoConfig.kt
@@ -139,7 +139,7 @@ object KlaviyoConfig : Config {
                 )
             if (sdkNameResId != 0) {
                 applicationContext.resources.getString(sdkNameResId).also {
-                    Registry.log.debug("Using react-native SDK $key : $it")
+                    Registry.log.error("Using react-native SDK $key : $it")
                 }
             } else {
                 null

--- a/sdk/core/src/main/res/values/strings.xml
+++ b/sdk/core/src/main/res/values/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Please do not modify these values, it will stop SDK functionality-->
+    <string name="klaviyo_sdk_name_override">android</string>
+    <string name="klaviyo_sdk_version_override">3.0.0-alpha.1</string>
+</resources>

--- a/sdk/core/src/test/java/com/klaviyo/core/config/KlaviyoConfigTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/config/KlaviyoConfigTest.kt
@@ -5,6 +5,7 @@ import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import android.os.Build
 import com.klaviyo.core.BuildConfig
+import com.klaviyo.core.R
 import com.klaviyo.core.Registry
 import com.klaviyo.core.networking.NetworkMonitor
 import com.klaviyo.fixtures.BaseTest
@@ -41,6 +42,10 @@ internal class KlaviyoConfigTest : BaseTest() {
         every { PackageManager.PackageInfoFlags.of(any()) } returns mockPackageManagerFlags
         every { mockContext.packageManager } returns mockPackageManager
         every { mockContext.packageName } returns BuildConfig.LIBRARY_PACKAGE_NAME
+        every { mockContext.resources } returns mockk {
+            every { getString(R.string.klaviyo_sdk_name_override) } returns "android"
+            every { getString(R.string.klaviyo_sdk_version_override) } returns "9.9.9"
+        }
         every {
             mockPackageManager.getPackageInfo(
                 BuildConfig.LIBRARY_PACKAGE_NAME,
@@ -90,6 +95,8 @@ internal class KlaviyoConfigTest : BaseTest() {
         assertEquals(4, KlaviyoConfig.networkFlushDepth)
         assertEquals(5, KlaviyoConfig.networkMaxAttempts)
         assertEquals(7, KlaviyoConfig.networkMaxRetryInterval)
+        assertEquals("android", KlaviyoConfig.sdkName)
+        assertEquals("9.9.9", KlaviyoConfig.sdkVersion)
     }
 
     @Test
@@ -117,6 +124,8 @@ internal class KlaviyoConfigTest : BaseTest() {
         assertEquals(25, KlaviyoConfig.networkFlushDepth)
         assertEquals(50, KlaviyoConfig.networkMaxAttempts)
         assertEquals(180_000L, KlaviyoConfig.networkMaxRetryInterval)
+        assertEquals("android", KlaviyoConfig.sdkName)
+        assertEquals("9.9.9", KlaviyoConfig.sdkVersion)
     }
 
     @Test
@@ -151,9 +160,10 @@ internal class KlaviyoConfigTest : BaseTest() {
         assertEquals(25, KlaviyoConfig.networkFlushDepth)
         assertEquals(50, KlaviyoConfig.networkMaxAttempts)
         assertEquals(180_000, KlaviyoConfig.networkMaxRetryInterval)
-
+        assertEquals("android", KlaviyoConfig.sdkName)
+        assertEquals("9.9.9", KlaviyoConfig.sdkVersion)
         // Each bad call should have generated an error log
-        verify(exactly = 10) { spyLog.error(any(), null) }
+        verify(exactly = 8) { spyLog.error(any(), null) }
     }
 
     @Test(expected = MissingAPIKey::class)

--- a/sdk/core/src/test/java/com/klaviyo/core/config/KlaviyoConfigTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/config/KlaviyoConfigTest.kt
@@ -14,8 +14,10 @@ import io.mockk.mockkStatic
 import io.mockk.verify
 import org.junit.Assert.assertEquals
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 
+@Ignore
 internal class KlaviyoConfigTest : BaseTest() {
 
     private val mockPackageManagerFlags = mockk<PackageManager.PackageInfoFlags>()

--- a/sdk/core/src/test/java/com/klaviyo/core/config/KlaviyoConfigTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/config/KlaviyoConfigTest.kt
@@ -14,10 +14,8 @@ import io.mockk.mockkStatic
 import io.mockk.verify
 import org.junit.Assert.assertEquals
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
 
-@Ignore
 internal class KlaviyoConfigTest : BaseTest() {
 
     private val mockPackageManagerFlags = mockk<PackageManager.PackageInfoFlags>()
@@ -155,7 +153,7 @@ internal class KlaviyoConfigTest : BaseTest() {
         assertEquals(180_000, KlaviyoConfig.networkMaxRetryInterval)
 
         // Each bad call should have generated an error log
-        verify(exactly = 8) { spyLog.error(any(), null) }
+        verify(exactly = 10) { spyLog.error(any(), null) }
     }
 
     @Test(expected = MissingAPIKey::class)

--- a/sdk/push-fcm/build.gradle
+++ b/sdk/push-fcm/build.gradle
@@ -32,7 +32,7 @@ afterEvaluate {
                 from components[ext.publishBuildVariant]
                 groupId = klaviyoGroupId
                 artifactId = "push-fcm"
-                version = versionFor(project, "version.klaviyo.versionName")
+                version = readXmlValue('sdk/core/src/main/res/values/strings.xml','klaviyo_sdk_version_override')
             }
         }
     }

--- a/sdk/push-fcm/build.gradle
+++ b/sdk/push-fcm/build.gradle
@@ -1,4 +1,3 @@
-import static de.fayard.refreshVersions.core.Versions.versionFor
 
 project.description = "Push functionality for the Klaviyo SDK suite"
 evaluationDependsOn(":sdk")

--- a/sdk/push-fcm/build.gradle
+++ b/sdk/push-fcm/build.gradle
@@ -32,7 +32,7 @@ afterEvaluate {
                 from components[ext.publishBuildVariant]
                 groupId = klaviyoGroupId
                 artifactId = "push-fcm"
-                version = readXmlValue('sdk/core/src/main/res/values/strings.xml','klaviyo_sdk_version_override')
+                version = readXmlValue('src/main/res/values/strings.xml','klaviyo_sdk_version_override', project(":sdk:core"))
             }
         }
     }

--- a/versions.properties
+++ b/versions.properties
@@ -9,11 +9,11 @@
 ####
 #### NOTE: Some versions are filtered by the rejectVersionIf predicate. See the settings.gradle.kts file.
 
+version.androidx.compose.compiler=1.5.15
+
 # Project versioning, run the following gradle command to update version numbers automatically:
 # ./gradlew bumpVersion --nextVersion=X.Y.Z
-version.klaviyo.versionCode=20
-
-version.klaviyo.versionName=3.0.0-alpha.1
+version.klaviyo.versionCode=21
 
 # Android versioning
 

--- a/versions.properties
+++ b/versions.properties
@@ -9,8 +9,6 @@
 ####
 #### NOTE: Some versions are filtered by the rejectVersionIf predicate. See the settings.gradle.kts file.
 
-version.androidx.compose.compiler=1.5.15
-
 # Project versioning, run the following gradle command to update version numbers automatically:
 # ./gradlew bumpVersion --nextVersion=X.Y.Z
 version.klaviyo.versionCode=21


### PR DESCRIPTION
# Description
Adding some logic to the Config so we can see if the SDK is being used in the react-native SDK or if it's being implemented natively. Will need to be merged along with [this](https://github.com/klaviyo/klaviyo-react-native-sdk/pull/180) to get the full functionality. tl;dr, this is the android version of [this](https://github.com/klaviyo/klaviyo-swift-sdk/pull/204/files)

# Check List

- [ ] Are you changing anything with the public API?
- [x] Are your changes backwards compatible with previous SDK Versions?
- [x] Have you tested this change on real device?
- [x] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all Android versions the SDK currently supports?


## Changelog / Code Overview

I removed Ajay's code that allows for these to be publicly exposed in the core config builder, since we wouldn't want someone manually building the Klaviyo object to change the thing we're trying to differentiate. There's also some error logging if we fail to use reflection. While reflection is never an ideal option, we need to get the id for the res item. Since this changes depending on how the app is built we need to search for the key name I've declared in the react-native SDK.


## Test Plan
Tested this on both android and react native test apps, and both sent up the proper config value as part of our requests. An interesting note on android was that I was unable to override the string resource, which is a good thing for design integrity. 


## Related Issues/Tickets
CHNL-12052
CHNL-12521

