### PR TITLE
[CHNL-13778] Fix network monitor over-broadcasting

### DIFF
--- a/sdk/core/src/main/java/com/klaviyo/core/networking/KlaviyoNetworkMonitor.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/networking/KlaviyoNetworkMonitor.kt
@@ -39,11 +39,6 @@ internal object KlaviyoNetworkMonitor : NetworkMonitor {
 
         override fun onUnavailable() = broadcastNetworkChange()
 
-        override fun onCapabilitiesChanged(
-            network: Network,
-            networkCapabilities: NetworkCapabilities
-        ) = broadcastNetworkChange()
-
         override fun onLinkPropertiesChanged(
             network: Network,
             linkProperties: LinkProperties

--- a/sdk/core/src/test/java/com/klaviyo/core/networking/KlaviyoNetworkMonitorTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/networking/KlaviyoNetworkMonitorTest.kt
@@ -126,14 +126,13 @@ internal class KlaviyoNetworkMonitorTest : BaseTest() {
 
         expectedNetworkConnection = true
         every { capabilitiesMock.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) } returns true
-        netCallbackSlot.captured.onCapabilitiesChanged(mockk(), mockk())
         netCallbackSlot.captured.onLinkPropertiesChanged(mockk(), mockk())
 
         expectedNetworkConnection = false
         every { capabilitiesMock.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) } returns false
         netCallbackSlot.captured.onLost(mockk())
 
-        assertEquals(6, callCount)
+        assertEquals(5, callCount)
         KlaviyoNetworkMonitor.offNetworkChange(observer)
     }
 


### PR DESCRIPTION
# Description

We were seeing an issue manifest in the rate limit retry logic where requests that should have waited `retry-header` amount of time would send off regardless. This was happening because we would retry the top request on the queue when a network change gets broadcasted. In Android land, this capability is quite sensitive and can lead to us sending many requests out that have a 429 and ignoring the retry time value. This PR removes the broadcast on a network capability change. 

# Check List

- [ ] Are you changing anything with the public API?
- [x] Are your changes backwards compatible with previous SDK Versions?
- [x] Have you tested this change on real device?
- [x] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all Android versions the SDK currently supports?


## Changelog / Code Overview
- removing internal network broadcast relaying of the `ConnectivityManager.NetworkCallback.onCapabilityChanged` message. 

## Test Plan
- tested on a physical device to ensure the header retry value was being respected
- tested on an emulator and ensured the same thing

## Related Issues/Tickets
[CHNL-13778]


[CHNL-13778]: https://klaviyo.atlassian.net/browse/CHNL-13778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ