### PR TITLE
User agent format update

### DIFF
--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/DeviceProperties.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/DeviceProperties.kt
@@ -71,7 +71,8 @@ internal object DeviceProperties {
     }
 
     val userAgent: String by lazy {
-        "$applicationLabel/$appVersion ($applicationId; build:$appVersionCode; $platform $osVersion) klaviyo-android/$sdkVersion"
+        val sdkAgent = "klaviyo-${sdkName.replace("_","-")}"
+        "$applicationLabel/$appVersion ($applicationId; build:$appVersionCode; $platform $osVersion) $sdkAgent/$sdkVersion"
     }
 
     private val packageInfo: PackageInfo by lazy {


### PR DESCRIPTION
Minor user agent string format update to reflect the recent ability to override the SDK's name. This will allow our API monitoring boards, which depend upon the user agent, to differentiate klaviyo-[ios, android, react-native ... etc)

# Description
<!-- Briefly describe the feature or bug that your pull request addresses -->

# Check List

- [x] Are you changing anything with the public API? - Nah
- [x] Are your changes backwards compatible with previous SDK Versions?
- [x] Have you tested this change on real device?
- [ ] Have you added unit test coverage for your changes? -- Coming
- [x] Have you verified that your changes are compatible with all Android versions the SDK currently supports?


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->
Use the configurable SDK name in the user agent, new format would look like:

Stock Android:
`AndroidApp/1.2.3-beta (com.company.androidapp; build:15; Android 34) klaviyo-android/3.0.1`

React Native Android
`ReactApp/1.2.3-beta (com.cool_company.reactapp; build:15; Android 34) klaviyo-react-native/1.0.1`

## Test Plan
<!-- How was this code tested / How should reviewers test it? -->
- Unit test

## Related Issues/Tickets
<!-- Link to relevant issues or discussion -->
- Monitoring improvements / nice to have
