### PR TITLE
CHNL-13255 Add wrapper view for hosting form webview

### DIFF
--- a/sdk/messaging/src/main/java/com/klaviyo/messaging/InAppMessaging.kt
+++ b/sdk/messaging/src/main/java/com/klaviyo/messaging/InAppMessaging.kt
@@ -1,15 +1,15 @@
 package com.klaviyo.messaging
 
 import android.app.Activity
-import android.view.ViewGroup
+import android.webkit.JavascriptInterface
 import com.klaviyo.core.Registry
 import java.io.BufferedReader
 
 object InAppMessaging {
 
+    @JavascriptInterface
     fun triggerInAppMessage(activity: Activity) {
-        val rootView = activity.getRootViewGroup()
-        val webView = KlaviyoWebView()
+        val webView = KlaviyoWebView(activity)
         val html = Registry.config.applicationContext
             .assets
             .open("IAMTest.html")
@@ -18,9 +18,5 @@ object InAppMessaging {
             .replace("KLAVIYO_PUBLIC_KEY_PLACEHOLDER", Registry.config.apiKey)
 
         webView.loadHtml(html)
-        webView.addTo(rootView)
     }
-
-    private fun Activity.getRootViewGroup(): ViewGroup =
-        window.decorView.findViewById(android.R.id.content)
 }

--- a/sdk/messaging/src/main/java/com/klaviyo/messaging/KlaviyoWebView.kt
+++ b/sdk/messaging/src/main/java/com/klaviyo/messaging/KlaviyoWebView.kt
@@ -1,19 +1,10 @@
 package com.klaviyo.messaging
 
 import android.annotation.SuppressLint
-import android.content.Intent
-import android.graphics.Bitmap
+import android.app.Activity
+import android.app.Dialog
 import android.graphics.Color
-import android.net.Uri
-import android.view.View
-import android.view.ViewGroup
-import android.webkit.WebResourceRequest
-import android.webkit.WebResourceResponse
 import android.webkit.WebView
-import android.webkit.WebViewClient
-import androidx.core.content.ContextCompat.startActivity
-import androidx.webkit.JavaScriptReplyProxy
-import androidx.webkit.WebMessageCompat
 import androidx.webkit.WebViewCompat
 import androidx.webkit.WebViewFeature.DOCUMENT_START_SCRIPT
 import androidx.webkit.WebViewFeature.WEB_MESSAGE_LISTENER
@@ -21,108 +12,60 @@ import androidx.webkit.WebViewFeature.isFeatureSupported
 import com.klaviyo.analytics.DeviceProperties
 import com.klaviyo.core.BuildConfig
 import com.klaviyo.core.Registry
-import java.io.BufferedReader
-import org.json.JSONException
-import org.json.JSONObject
+import com.klaviyo.messaging.KlaviyoWebViewClient.Companion.JS_BRIDGE_NAME
+import com.klaviyo.messaging.KlaviyoWebViewClient.Companion.MIME_TYPE
+import com.klaviyo.messaging.KlaviyoWebViewClient.Companion.USE_NEW_FEATURES
+import com.klaviyo.messaging.KlaviyoWebViewClient.Companion.getBridgeJs
 
-class KlaviyoWebView : WebViewClient(), WebViewCompat.WebMessageListener {
-    companion object {
-        private const val MIME_TYPE = "text/html"
-        private const val JS_BRIDGE_NAME = "Klaviyo"
-        private const val USE_NEW_FEATURES = true
+@SuppressLint("SetJavaScriptEnabled", "JavascriptInterface")
+class KlaviyoWebView(activity: Activity) : Dialog(activity) {
 
-        fun getBridgeJs(): String = Registry.config.applicationContext
-            .assets
-            .open("bridge.js")
-            .bufferedReader()
-            .use(BufferedReader::readText)
-            .apply {
-                val opts = JSONObject()
-                    .put("bridgeName", JS_BRIDGE_NAME)
-                    .toString()
-
-                return "$this('$opts');"
-            }
+    private val webViewClient: KlaviyoWebViewClient by lazy {
+        KlaviyoWebViewClient(
+            onShow = { show() },
+            onClose = { dismiss() },
+            evaluateJs = { script, result -> webView.evaluateJavascript(script, result) },
+            launchWebViewUrl = { intent -> activity.startActivity(intent) }
+        )
     }
+
+    private var webView: WebView
 
     init {
         WebView.setWebContentsDebuggingEnabled(BuildConfig.DEBUG)
-    }
+        setContentView(R.layout.klaviyo_web_view)
+        webView = findViewById(R.id.webview)
+        webView.also {
+            it.setBackgroundColor(Color.TRANSPARENT)
+            it.webViewClient = webViewClient
+            it.settings.userAgentString = DeviceProperties.userAgent
+            setCanceledOnTouchOutside(true)
+            it.settings.javaScriptEnabled = true
 
-    @SuppressLint("SetJavaScriptEnabled")
-    private val webView = WebView(Registry.config.applicationContext).also {
-        it.setBackgroundColor(Color.TRANSPARENT)
-        it.webViewClient = this
-        it.settings.userAgentString = DeviceProperties.userAgent
-        it.settings.javaScriptEnabled = true
-
-        if (USE_NEW_FEATURES && isFeatureSupported(WEB_MESSAGE_LISTENER)) {
-            Registry.log.verbose("$WEB_MESSAGE_LISTENER Supported")
-            WebViewCompat.addWebMessageListener(
-                it,
-                JS_BRIDGE_NAME,
-                setOf(Registry.config.baseUrl),
-                this
-            )
-        } else {
-            Registry.log.verbose("$WEB_MESSAGE_LISTENER Unsupported")
-            it.addJavascriptInterface(this, JS_BRIDGE_NAME)
-        }
-
-        if (USE_NEW_FEATURES && isFeatureSupported(DOCUMENT_START_SCRIPT)) {
-            Registry.log.verbose("$DOCUMENT_START_SCRIPT Supported")
-            WebViewCompat.addDocumentStartJavaScript(
-                it,
-                getBridgeJs(),
-                setOf(Registry.config.baseUrl)
-            )
-        } else {
-            Registry.log.verbose("$DOCUMENT_START_SCRIPT Unsupported")
-        }
-    }
-
-    override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
-        super.onPageStarted(view, url, favicon)
-
-        if (!USE_NEW_FEATURES || isFeatureSupported(DOCUMENT_START_SCRIPT)) {
-            // When addDocumentStartJavaScript is not supported, we have to inject our JS onPageStarted
-            webView.evaluateJavascript(getBridgeJs(), null)
-        }
-    }
-
-    override fun onReceivedHttpError(
-        view: WebView?,
-        request: WebResourceRequest?,
-        errorResponse: WebResourceResponse?
-    ) {
-        Registry.log.error("HTTP Error: ${errorResponse?.statusCode} - ${request?.url}")
-        super.onReceivedHttpError(view, request, errorResponse)
-    }
-
-    override fun shouldInterceptRequest(
-        view: WebView?,
-        request: WebResourceRequest?
-    ): WebResourceResponse? {
-        Registry.log.debug("Request: ${request?.url}")
-        return super.shouldInterceptRequest(view, request)
-    }
-
-    override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
-        if (request?.isForMainFrame == true) {
-            Registry.log.debug("Overriding external URL to browser: ${request.url}")
-            val intent = Intent(Intent.ACTION_VIEW).apply {
-                data = request.url
-                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            if (USE_NEW_FEATURES && isFeatureSupported(WEB_MESSAGE_LISTENER)) {
+                Registry.log.verbose("$WEB_MESSAGE_LISTENER Supported")
+                WebViewCompat.addWebMessageListener(
+                    it,
+                    JS_BRIDGE_NAME,
+                    setOf(Registry.config.baseUrl),
+                    webViewClient
+                )
+            } else {
+                Registry.log.verbose("$WEB_MESSAGE_LISTENER Unsupported")
+                it.addJavascriptInterface(this, JS_BRIDGE_NAME)
             }
-            startActivity(webView.context, intent, null)
-            return true
-        }
-        return super.shouldOverrideUrlLoading(view, request)
-    }
 
-    fun addTo(view: ViewGroup) {
-        webView.visibility = View.INVISIBLE
-        view.addView(webView)
+            if (USE_NEW_FEATURES && isFeatureSupported(DOCUMENT_START_SCRIPT)) {
+                Registry.log.verbose("$DOCUMENT_START_SCRIPT Supported")
+                WebViewCompat.addDocumentStartJavaScript(
+                    it,
+                    getBridgeJs(),
+                    setOf(Registry.config.baseUrl)
+                )
+            } else {
+                Registry.log.verbose("$DOCUMENT_START_SCRIPT Unsupported")
+            }
+        }
     }
 
     fun loadHtml(html: String) = webView.loadDataWithBaseURL(
@@ -132,53 +75,4 @@ class KlaviyoWebView : WebViewClient(), WebViewCompat.WebMessageListener {
         null,
         null
     )
-
-    fun show() = webView.post { webView.visibility = View.VISIBLE }
-
-    fun close() = webView.post {
-        webView.visibility = View.GONE
-        webView.parent?.let {
-            (it as ViewGroup).removeView(webView)
-            webView.destroy()
-        }
-    }
-
-    override fun onPostMessage(
-        view: WebView,
-        message: WebMessageCompat,
-        sourceOrigin: Uri,
-        isMainFrame: Boolean,
-        replyProxy: JavaScriptReplyProxy
-    ) {
-        message.data?.let { data -> postMessage(data) }
-    }
-
-    @android.webkit.JavascriptInterface
-    fun postMessage(message: String) {
-        Registry.log.debug("JS interface postMessage $message")
-        try {
-            val jsonMessage = JSONObject(message)
-            val jsonData = jsonMessage.optJSONObject("data") ?: JSONObject()
-
-            when (jsonMessage.optString("type")) {
-                "documentReady" -> show()
-                "imagesLoaded" -> show()
-                "close" -> close()
-                "console" -> console(jsonData)
-                else -> console(jsonData)
-            }
-        } catch (exception: JSONException) {
-            Registry.log.warning("JS interface error", exception)
-        }
-    }
-
-    private fun console(jsonData: JSONObject) {
-        val message = jsonData.optJSONObject("message") ?: ""
-
-        when (jsonData.optString("level")) {
-            "log" -> Registry.log.info(message.toString())
-            "warning" -> Registry.log.warning(message.toString())
-            "error" -> Registry.log.error(message.toString())
-        }
-    }
 }

--- a/sdk/messaging/src/main/java/com/klaviyo/messaging/KlaviyoWebViewClient.kt
+++ b/sdk/messaging/src/main/java/com/klaviyo/messaging/KlaviyoWebViewClient.kt
@@ -1,0 +1,123 @@
+package com.klaviyo.messaging
+
+import android.content.Intent
+import android.graphics.Bitmap
+import android.net.Uri
+import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.webkit.JavaScriptReplyProxy
+import androidx.webkit.WebMessageCompat
+import androidx.webkit.WebViewCompat
+import androidx.webkit.WebViewFeature.DOCUMENT_START_SCRIPT
+import androidx.webkit.WebViewFeature.isFeatureSupported
+import com.klaviyo.core.Registry
+import java.io.BufferedReader
+import org.json.JSONException
+import org.json.JSONObject
+
+class KlaviyoWebViewClient(
+    private val onShow: () -> Unit,
+    private val onClose: () -> Unit,
+    private val evaluateJs: (String, (String) -> Unit) -> Unit,
+    private val launchWebViewUrl: (Intent) -> Unit
+) : WebViewClient(), WebViewCompat.WebMessageListener {
+
+    companion object {
+        internal const val MIME_TYPE = "text/html"
+        internal const val JS_BRIDGE_NAME = "Klaviyo"
+        internal const val USE_NEW_FEATURES = true
+
+        fun getBridgeJs(): String = Registry.config.applicationContext
+            .assets
+            .open("bridge.js")
+            .bufferedReader()
+            .use(BufferedReader::readText)
+            .apply {
+                val opts = JSONObject()
+                    .put("bridgeName", JS_BRIDGE_NAME)
+                    .toString()
+
+                return "$this('$opts');"
+            }
+    }
+
+    override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
+        super.onPageStarted(view, url, favicon)
+
+        if (!USE_NEW_FEATURES || isFeatureSupported(DOCUMENT_START_SCRIPT)) {
+            // When addDocumentStartJavaScript is not supported, we have to inject our JS onPageStarted
+            evaluateJs(getBridgeJs()) {}
+        }
+    }
+
+    override fun onReceivedHttpError(
+        view: WebView?,
+        request: WebResourceRequest?,
+        errorResponse: WebResourceResponse?
+    ) {
+        Registry.log.error("HTTP Error: ${errorResponse?.statusCode} - ${request?.url}")
+        super.onReceivedHttpError(view, request, errorResponse)
+    }
+
+    override fun shouldInterceptRequest(
+        view: WebView?,
+        request: WebResourceRequest?
+    ): WebResourceResponse? {
+        Registry.log.debug("Request: ${request?.url}")
+        return super.shouldInterceptRequest(view, request)
+    }
+
+    override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
+        if (request?.isForMainFrame == true) {
+            Registry.log.debug("Overriding external URL to browser: ${request.url}")
+            val intent = Intent(Intent.ACTION_VIEW).apply {
+                data = request.url
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+            launchWebViewUrl(intent)
+            return true
+        }
+        return super.shouldOverrideUrlLoading(view, request)
+    }
+
+    override fun onPostMessage(
+        view: WebView,
+        message: WebMessageCompat,
+        sourceOrigin: Uri,
+        isMainFrame: Boolean,
+        replyProxy: JavaScriptReplyProxy
+    ) {
+        message.data?.let { data -> postMessage(data) }
+    }
+
+    @android.webkit.JavascriptInterface
+    fun postMessage(message: String) {
+        Registry.log.debug("JS interface postMessage $message")
+        try {
+            val jsonMessage = JSONObject(message)
+            val jsonData = jsonMessage.optJSONObject("data") ?: JSONObject()
+            Registry.log.debug("JS interface postMessage $jsonData")
+
+            when (jsonMessage.optString("type")) {
+                "documentReady" -> onShow() // todo get a more accurate way to tell if webview loaded
+                "close" -> onClose() // todo get a more accurate way to tell if close was pressed
+                "console" -> console(jsonData)
+                else -> console(jsonData)
+            }
+        } catch (exception: JSONException) {
+            Registry.log.warning("JS interface error", exception)
+        }
+    }
+
+    private fun console(jsonData: JSONObject) {
+        val message = jsonData.optString("message") ?: ""
+
+        when (jsonData.optString("level")) {
+            "log" -> Registry.log.info(message)
+            "warning" -> Registry.log.warning(message)
+            "error" -> Registry.log.error(message)
+        }
+    }
+}

--- a/sdk/messaging/src/main/res/layout/klaviyo_web_view.xml
+++ b/sdk/messaging/src/main/res/layout/klaviyo_web_view.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <WebView
+        android:layout_width="match_parent"
+        android:layout_height="500dp"
+        android:id="@+id/webview"/>
+    <!-- this height for testing, how we want to handle this comes further down the line-->
+
+</FrameLayout>

--- a/sdk/messaging/src/test/kotlin/com/klaviyo/messaging/KlaviyoWebViewClientTest.kt
+++ b/sdk/messaging/src/test/kotlin/com/klaviyo/messaging/KlaviyoWebViewClientTest.kt
@@ -1,0 +1,63 @@
+package com.klaviyo.messaging
+
+import android.content.Intent
+import com.klaviyo.core.Registry
+import com.klaviyo.fixtures.LogFixture
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.spyk
+import io.mockk.verify
+import org.json.JSONObject
+import org.junit.Before
+import org.junit.Test
+
+class KlaviyoWebViewClientTest {
+
+    private lateinit var client: KlaviyoWebViewClient
+    private val mockOnShow = mockk<() -> Unit>(relaxed = true)
+    private val mockOnClose = mockk<() -> Unit>(relaxed = true)
+    private val mockEvaluateJs = mockk<(String, (String) -> Unit) -> Unit>(relaxed = true)
+    private val mockLaunchWebViewUrl = mockk<(Intent) -> Unit>(relaxed = true)
+    private val spyLog = spyk(LogFixture())
+
+    @Before
+    fun setUp() {
+        client = KlaviyoWebViewClient(
+            onShow = mockOnShow,
+            onClose = mockOnClose,
+            evaluateJs = mockEvaluateJs,
+            launchWebViewUrl = mockLaunchWebViewUrl
+        )
+        mockkObject(Registry)
+        every { Registry.log } returns spyLog
+    }
+
+    @Test
+    fun `postMessage with documentReady type calls onShow`() {
+        val message = JSONObject().put("type", "documentReady").toString()
+
+        client.postMessage(message)
+
+        verify { mockOnShow.invoke() }
+    }
+
+    @Test
+    fun `postMessage with close type calls onClose`() {
+        val message = JSONObject().put("type", "close").toString()
+
+        client.postMessage(message)
+
+        verify { mockOnClose.invoke() }
+    }
+
+    @Test
+    fun `postMessage with console type logs to console`() {
+        val jsonData = JSONObject().put("level", "log").put("message", "web is for clowns")
+        val message = JSONObject().put("type", "console").put("data", jsonData).toString()
+
+        client.postMessage(message)
+
+        verify { spyLog.info(eq("web is for clowns")) }
+    }
+}


### PR DESCRIPTION
# Description
Creates a dialog we can wrap the webview we'll interact with around. I have a video showing the functionality below, but note this PR does *not* address the following open issues. 
- How do we determine if the content has fully loaded? Onsite team knows about this and are coming up with a way to communicate that, for now we're using the documentReady method which klaviyo.js does not respect.
- How do we communicate a button press closing the dialog? Our current bridge functionality looks for the view to be removed from the tree, which explains why the dialog closes _after_ the webview has already been collapsed. We need a way of hooking into the button press action rather than the removal of the button id from the tree.

[webview-as-dialog.webm](https://github.com/user-attachments/assets/3077491e-68d5-4d42-aca6-ba24831ae6c3)

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [x] Have you tested this change on real device?
- [x] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all Android versions the SDK currently supports?
^ we might have an issue supporting devices below Android API 17 but our SDK does not support those anyway. 

## Changelog / Code Overview
- making a dialog for the webview, and extrapolating the webview client code into its own class for better separation of intents


## Test Plan

## Related Issues/Tickets
<!-- Link to relevant issues or discussion -->

