### PR TITLE
[CHNL-14635] Fetch Full Forms

### DIFF
--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/ApiClient.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/ApiClient.kt
@@ -76,4 +76,9 @@ interface ApiClient {
      * @param observer
      */
     fun offApiRequest(observer: ApiObserver)
+
+    /**
+     * Grab the forms from the onsite endpoint
+     */
+    fun getActiveForms()
 }

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/KlaviyoApiClient.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/KlaviyoApiClient.kt
@@ -7,6 +7,7 @@ import com.klaviyo.analytics.model.Event
 import com.klaviyo.analytics.model.EventMetric
 import com.klaviyo.analytics.model.Profile
 import com.klaviyo.analytics.networking.requests.EventApiRequest
+import com.klaviyo.analytics.networking.requests.FormApiRequest
 import com.klaviyo.analytics.networking.requests.KlaviyoApiRequest
 import com.klaviyo.analytics.networking.requests.KlaviyoApiRequest.Status
 import com.klaviyo.analytics.networking.requests.KlaviyoApiRequestDecoder
@@ -115,6 +116,10 @@ internal object KlaviyoApiClient : ApiClient {
 
     override fun offApiRequest(observer: ApiObserver) {
         apiObservers -= observer
+    }
+
+    override fun getActiveForms() {
+        enqueueRequest(FormApiRequest())
     }
 
     private fun broadcastApiRequest(request: KlaviyoApiRequest) {

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/KlaviyoApiClient.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/KlaviyoApiClient.kt
@@ -119,6 +119,7 @@ internal object KlaviyoApiClient : ApiClient {
     }
 
     override fun getActiveForms() {
+        Registry.log.verbose("Enqueuing Full Forms request")
         enqueueRequest(FormApiRequest())
     }
 

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/FormApiRequest.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/FormApiRequest.kt
@@ -1,0 +1,25 @@
+package com.klaviyo.analytics.networking.requests
+
+import com.klaviyo.core.Registry
+
+internal class FormApiRequest(
+    queuedTime: Long? = null,
+    uuid: String? = null
+) : KlaviyoApiRequest(PATH, RequestMethod.GET, queuedTime, uuid) {
+
+    private companion object {
+        const val PATH = "forms/api/v7/full-forms"
+    }
+
+    override val type: String = "Full Forms"
+
+    override var query: Map<String, String> = mapOf(
+        COMPANY_ID to Registry.config.apiKey
+    )
+
+    override val successCodes: IntRange get() = HTTP_OK..HTTP_ACCEPTED
+
+    override fun hashCode(): Int {
+        return body.toString().hashCode()
+    }
+}

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/FullFormsApiResponseDecoder.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/FullFormsApiResponseDecoder.kt
@@ -1,0 +1,26 @@
+package com.klaviyo.analytics.networking.requests
+
+import org.json.JSONObject
+
+object FullFormsApiResponseDecoder {
+
+    /**
+     * We'll be updating the endpoint to only return one form for mobile clients
+     * but for now, this uses the web version and only grabs the top form
+     */
+    fun onlyFirstForm(json: JSONObject): JSONObject =
+        JSONObject().apply {
+            put(
+                FullsFormsResponse.FULL_FORMS,
+                json.getJSONArray(FullsFormsResponse.FULL_FORMS)[0]
+            )
+            put(
+                FullsFormsResponse.FORM_SETTINGS,
+                json.getJSONObject(FullsFormsResponse.FORM_SETTINGS)
+            )
+            put(
+                FullsFormsResponse.DYNAMIC_INFO_CONFIG,
+                json.getJSONObject(FullsFormsResponse.DYNAMIC_INFO_CONFIG)
+            )
+        }
+}

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/FullsFormsResponse.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/FullsFormsResponse.kt
@@ -1,0 +1,13 @@
+package com.klaviyo.analytics.networking.requests
+
+data class FullsFormsResponse(
+    val fullForms: List<String>,
+    val formSettings: String,
+    val dynamicInfoConfig: String
+) {
+    internal companion object {
+        const val FULL_FORMS = "full_forms"
+        const val FORM_SETTINGS = "form_settings"
+        const val DYNAMIC_INFO_CONFIG = "dynamic_info_config"
+    }
+}

--- a/sdk/messaging/src/main/java/com/klaviyo/messaging/InAppMessaging.kt
+++ b/sdk/messaging/src/main/java/com/klaviyo/messaging/InAppMessaging.kt
@@ -19,6 +19,8 @@ object InAppMessaging {
 
         webView.loadHtml(html)
         webView.addTo(rootView)
+        // for testing the full forms endpoint
+        webView.loadFullFormsResponse()
     }
 
     private fun Activity.getRootViewGroup(): ViewGroup =

--- a/sdk/messaging/src/main/java/com/klaviyo/messaging/KlaviyoWebView.kt
+++ b/sdk/messaging/src/main/java/com/klaviyo/messaging/KlaviyoWebView.kt
@@ -19,6 +19,9 @@ import androidx.webkit.WebViewFeature.DOCUMENT_START_SCRIPT
 import androidx.webkit.WebViewFeature.WEB_MESSAGE_LISTENER
 import androidx.webkit.WebViewFeature.isFeatureSupported
 import com.klaviyo.analytics.DeviceProperties
+import com.klaviyo.analytics.networking.ApiClient
+import com.klaviyo.analytics.networking.requests.ApiRequest
+import com.klaviyo.analytics.networking.requests.FullFormsApiResponseDecoder
 import com.klaviyo.core.BuildConfig
 import com.klaviyo.core.Registry
 import java.io.BufferedReader
@@ -132,6 +135,27 @@ class KlaviyoWebView : WebViewClient(), WebViewCompat.WebMessageListener {
         null,
         null
     )
+
+    fun loadFullFormsResponse() {
+        val apiClient: ApiClient = Registry.get<ApiClient>()
+        apiClient.getActiveForms()
+        apiClient.onApiRequest { request: ApiRequest ->
+            if (request.type == "Full Forms") {
+                request.responseBody?.let {
+                    val responseJson = try {
+                        JSONObject(it)
+                    } catch (e: JSONException) {
+                        Registry.log.wtf("Malformed error response body from backend", e)
+                        JSONObject()
+                    }
+                    val onlyFirstForm = FullFormsApiResponseDecoder.onlyFirstForm(responseJson)
+                    Registry.log.debug("Forms serialized response was successful")
+                } ?: run {
+                    Registry.log.debug("Forms received null response body")
+                }
+            }
+        }
+    }
 
     fun show() = webView.post { webView.visibility = View.VISIBLE }
 


### PR DESCRIPTION
# Description
- adding new request for 'full-forms' and logging the response

A few things to consider
 - This response will be going to the `klaviyo.js loadData()` call, so we don't need to serialize more than the top 3 fields here (and probably wouldn't want to given how we don't care about the details)
 - For now we're using the web forms endpoint, so we have to take only the first item on the list of forms
 - We still need to define that function in the klaviyo.js updates, so for now this PR is just creating the request and logging with some basic serialization, I will integrate once klaviyo.js gets updated

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you tested this change on real device?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all Android versions the SDK currently supports?


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->


## Test Plan
<!-- How was this code tested / How should reviewers test it? -->


## Related Issues/Tickets
CHNL-14635

