### PR TITLE
[CHNL-15530] Message Bus Support

### DIFF
--- a/sdk/messaging/src/main/assets/IAMTest.html
+++ b/sdk/messaging/src/main/assets/IAMTest.html
@@ -33,6 +33,9 @@
             });
         }
     </script>
+    <!-- uncomment this if you want to listen to a locally running instance -->
+    <!--<script type="text/javascript"
+            src="http://localhost:8080/onsite/js/klaviyo.js?company_id=9BX3wh"></script>-->
     <script type="text/javascript"
             src="https://static.klaviyo.com/onsite/js/klaviyo.js?company_id=KLAVIYO_PUBLIC_KEY_PLACEHOLDER"></script>
 </head>

--- a/sdk/messaging/src/main/assets/bridge.js
+++ b/sdk/messaging/src/main/assets/bridge.js
@@ -46,6 +46,27 @@
                         WebViewBridge.postMessageToNative("close", {});
                     });
                 });
+
+                // add a listener to the message bridge init function, so we only listen to the bus if it's ready
+                window.addEventListener('inAppFormsInitMessage', function(event) {
+                    const supportedEventTypes = event.detail.eventTypes;
+                    console.log('Supporting message types:', supportedEventTypes);
+
+                    const messageBus = window['inAppFormsMessageBus']?.messageBus;
+                    if (!messageBus) {
+                        console.error('Message bus not found');
+                        return;
+                    } else {
+                        console.log('Found the message bus!');
+                    }
+
+                    supportedEventTypes.forEach(eventType => {
+                        console.log('Registering listener for eventType: ', eventType);
+                        messageBus.addEventListener(eventType.toString(), function(subEvent) {
+                            WebViewBridge.postMessageToNative(subEvent.type, subEvent.detail);
+                        });
+                    });
+                }, false);
             },
 
             /**


### PR DESCRIPTION
# Description
Mostly logic added to the bridge.js (which I am certainly in support of making a different repo so we can import the same file for every native client we have) to support listening for the bus to be created, and then listening for each of the messages and relaying to the kotlin webview client.

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [x] Have you tested this change on real device?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all Android versions the SDK currently supports?


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->


## Test Plan
Testing this requires some decent setup:
1 - get app running with onsite modules

2 - get fender running [(using this branch)](https://github.com/klaviyo/fender/pull/36364) with onsite dependencies as well - should be able to publish a form in the webapp and then make it live

3 - change the HTML code to point to a local `:8080` onsite instead of production, and make sure to run the following adb commands if you're running a network proxy
`adb reverse tcp:8080 tcp:8080`
`adb reverse tcp:4001 tcp:4001`

You should now be able to see the locally created form from the android test app in the 'messaging' menu. Check the logs after loading and ensure that a `inAppFormsDataLoaded` has come through.

## Related Issues/Tickets
https://klaviyo.atlassian.net/browse/CHNL-15530
