### PR TITLE
Update android-master.yml to address deprecated action

### DIFF
--- a/.github/workflows/android-master.yml
+++ b/.github/workflows/android-master.yml
@@ -77,8 +77,9 @@ jobs:
 
       # Stores the generated AAR to an outputs folder
       - name: Store AAR
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: sdk
           path: app/build/outputs/aar/debug/aar-debug.aar
+          overwrite: true
 


### PR DESCRIPTION
# Description
<!-- Briefly describe the feature or bug that your pull request addresses -->
The `upload-artifact@v2` action is deprecated. Its been deprecated since June and Github quickly deprecated the V3 as well. The V4 is available and we should adopt that to avoid downtime on out Github action for master builds.

Moving from V2/V3 -> V4 I followed [this migration guide](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md). Since artifacts are no longer mutable I reckon we could get away with marking the artifact as an overwrite so it deletes the old and creates new. Seemed more straightforward to me than building a unique name for each build.
Note: I read some things about `overwrite` causing issues when running parallel jobs but felt this wouldn't likely be an issue for us yet.



Starting Jan 9th, `upload-artifact` will experience brownouts with full disablement by end of month so that's why I thought I'd cut this now.



_Note: I haven't tested this in any way yet. It's just a suggestion for now._


# Check List

- [ ] Are you changing anything with the public API?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you tested this change on real device?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all Android versions the SDK currently supports?


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->


## Test Plan
<!-- How was this code tested / How should reviewers test it? -->


## Related Issues/Tickets
<!-- Link to relevant issues or discussion -->

