### PR TITLE
[CHNL-16653] Enqueue Profile Events

### DIFF
--- a/sdk/messaging/src/main/java/com/klaviyo/messaging/Constants.kt
+++ b/sdk/messaging/src/main/java/com/klaviyo/messaging/Constants.kt
@@ -3,15 +3,14 @@ package com.klaviyo.messaging
 /**
  * Decoding top-level message types
  */
-internal const val IAF_MESSAGE_TYPE_DATA = "data"
+internal const val IAF_MESSAGE_DATA_KEY = "data"
 internal const val IAF_MESSAGE_TYPE_KEY = "type"
-internal const val IAF_MESSAGE_TYPE_SHOW = "show"
-internal const val IAF_MESSAGE_TYPE_CLOSE = "close"
-internal const val IAF_MESSAGE_TYPE_CONSOLE = "console"
+internal const val IAF_MESSAGE_TYPE_SHOW = "formDidAppear"
+internal const val IAF_MESSAGE_TYPE_CLOSE = "formDidClose"
 internal const val IAF_MESSAGE_TYPE_PROFILE_EVENT = "profileEventTracked"
 
 /**
  * Profile event constants
  */
-internal const val IAM_EVENT_NAME_KEY = "eventName"
+internal const val IAF_EVENT_NAME_KEY = "eventName"
 internal const val IAF_PROPERTIES_KEY = "properties"

--- a/sdk/messaging/src/main/java/com/klaviyo/messaging/Constants.kt
+++ b/sdk/messaging/src/main/java/com/klaviyo/messaging/Constants.kt
@@ -1,0 +1,17 @@
+package com.klaviyo.messaging
+
+/**
+ * Decoding top-level message types
+ */
+internal const val IAF_MESSAGE_TYPE_DATA = "data"
+internal const val IAF_MESSAGE_TYPE_KEY = "type"
+internal const val IAF_MESSAGE_TYPE_SHOW = "show"
+internal const val IAF_MESSAGE_TYPE_CLOSE = "close"
+internal const val IAF_MESSAGE_TYPE_CONSOLE = "console"
+internal const val IAF_MESSAGE_TYPE_PROFILE_EVENT = "profileEventTracked"
+
+/**
+ * Profile event constants
+ */
+internal const val IAM_EVENT_NAME_KEY = "eventName"
+internal const val IAF_PROPERTIES_KEY = "properties"

--- a/sdk/messaging/src/main/java/com/klaviyo/messaging/KlaviyoWebFormMessageType.kt
+++ b/sdk/messaging/src/main/java/com/klaviyo/messaging/KlaviyoWebFormMessageType.kt
@@ -8,10 +8,6 @@ import com.klaviyo.analytics.model.Event
 sealed class KlaviyoWebFormMessageType {
     data object Show : KlaviyoWebFormMessageType()
     data object Close : KlaviyoWebFormMessageType()
-    data class Console(
-        val consoleLog: String,
-        val level: String? = null
-    ) : KlaviyoWebFormMessageType()
     data class ProfileEvent(
         val event: Event
     ) : KlaviyoWebFormMessageType()

--- a/sdk/messaging/src/main/java/com/klaviyo/messaging/KlaviyoWebFormMessageType.kt
+++ b/sdk/messaging/src/main/java/com/klaviyo/messaging/KlaviyoWebFormMessageType.kt
@@ -1,0 +1,18 @@
+package com.klaviyo.messaging
+
+import com.klaviyo.analytics.model.Event
+
+/**
+ * This should be updated with any new message types we add coming from the onsite-in-app-forms
+ */
+sealed class KlaviyoWebFormMessageType {
+    data object Show : KlaviyoWebFormMessageType()
+    data object Close : KlaviyoWebFormMessageType()
+    data class Console(
+        val consoleLog: String,
+        val level: String? = null
+    ) : KlaviyoWebFormMessageType()
+    data class ProfileEvent(
+        val event: Event
+    ) : KlaviyoWebFormMessageType()
+}

--- a/sdk/messaging/src/main/java/com/klaviyo/messaging/KlaviyoWebView.kt
+++ b/sdk/messaging/src/main/java/com/klaviyo/messaging/KlaviyoWebView.kt
@@ -128,7 +128,7 @@ class KlaviyoWebView : WebViewClient(), WebViewCompat.WebMessageListener {
                 KlaviyoWebFormMessageType.Show -> show()
             }
         } catch (e: Exception) {
-            Registry.log.error("Failed to decode webview message type")
+            Registry.log.error("Failed to decode webview message type", e)
         }
     }
 

--- a/sdk/messaging/src/main/java/com/klaviyo/messaging/KlaviyoWebView.kt
+++ b/sdk/messaging/src/main/java/com/klaviyo/messaging/KlaviyoWebView.kt
@@ -123,21 +123,11 @@ class KlaviyoWebView : WebViewClient(), WebViewCompat.WebMessageListener {
         try {
             when (val messageType = decodeWebviewMessage(message)) {
                 KlaviyoWebFormMessageType.Close -> close()
-                is KlaviyoWebFormMessageType.Console -> console(messageType)
                 is KlaviyoWebFormMessageType.ProfileEvent -> Klaviyo.createEvent(messageType.event)
                 KlaviyoWebFormMessageType.Show -> show()
             }
         } catch (e: Exception) {
             Registry.log.error("Failed to decode webview message type", e)
-        }
-    }
-
-    private fun console(message: KlaviyoWebFormMessageType.Console) {
-        when (message.level) {
-            "log" -> Registry.log.info(message.consoleLog)
-            "warning" -> Registry.log.warning(message.consoleLog)
-            "error" -> Registry.log.error(message.consoleLog)
-            else -> Registry.log.debug(message.consoleLog)
         }
     }
 }

--- a/sdk/messaging/src/main/java/com/klaviyo/messaging/Utils.kt
+++ b/sdk/messaging/src/main/java/com/klaviyo/messaging/Utils.kt
@@ -22,23 +22,14 @@ internal fun JSONObject.getProperties(): Map<EventKey, Serializable> {
 
 internal fun decodeWebviewMessage(webMessage: String): KlaviyoWebFormMessageType {
     val jsonMessage = JSONObject(webMessage)
-    val jsonData = jsonMessage.optJSONObject(IAF_MESSAGE_TYPE_DATA) ?: JSONObject()
+    val jsonData = jsonMessage.optJSONObject(IAF_MESSAGE_DATA_KEY) ?: JSONObject()
 
     return when (val type = jsonMessage.optString(IAF_MESSAGE_TYPE_KEY)) {
         IAF_MESSAGE_TYPE_SHOW -> KlaviyoWebFormMessageType.Show
         IAF_MESSAGE_TYPE_CLOSE -> KlaviyoWebFormMessageType.Close
-        IAF_MESSAGE_TYPE_CONSOLE -> {
-            val message = jsonData.optJSONObject("message")?.toString() ?: ""
-            val level = jsonData.optString("level")
-            KlaviyoWebFormMessageType.Console(
-                message,
-                level
-            )
-        }
-
         IAF_MESSAGE_TYPE_PROFILE_EVENT -> {
             KlaviyoWebFormMessageType.ProfileEvent(
-                event = jsonData.optString(IAM_EVENT_NAME_KEY)?.let {
+                event = jsonData.optString(IAF_EVENT_NAME_KEY)?.let {
                     Event(it, properties = jsonData.getProperties())
                 } ?: throw IllegalStateException("Missing profile eventName key")
             )

--- a/sdk/messaging/src/main/java/com/klaviyo/messaging/Utils.kt
+++ b/sdk/messaging/src/main/java/com/klaviyo/messaging/Utils.kt
@@ -1,0 +1,48 @@
+package com.klaviyo.messaging
+
+import com.klaviyo.analytics.model.Event
+import com.klaviyo.analytics.model.EventKey
+import com.klaviyo.core.Registry
+import java.io.Serializable
+import org.json.JSONObject
+
+internal fun JSONObject.getProperties(): Map<EventKey, Serializable> {
+    val map = mutableMapOf<EventKey, Serializable>()
+    // todo this might change depending on the message bus contract
+    val propertyMap = this.getJSONObject(IAF_PROPERTIES_KEY)
+    propertyMap.keys().forEach {
+        try {
+            map[EventKey.CUSTOM(it)] = propertyMap.getString(it)
+        } catch (e: Exception) {
+            Registry.log.error("Failed to write property $it to profile event payload", e)
+        }
+    }
+    return map
+}
+
+internal fun decodeWebviewMessage(webMessage: String): KlaviyoWebFormMessageType {
+    val jsonMessage = JSONObject(webMessage)
+    val jsonData = jsonMessage.optJSONObject(IAF_MESSAGE_TYPE_DATA) ?: JSONObject()
+
+    return when (val type = jsonMessage.optString(IAF_MESSAGE_TYPE_KEY)) {
+        IAF_MESSAGE_TYPE_SHOW -> KlaviyoWebFormMessageType.Show
+        IAF_MESSAGE_TYPE_CLOSE -> KlaviyoWebFormMessageType.Close
+        IAF_MESSAGE_TYPE_CONSOLE -> {
+            val message = jsonData.optJSONObject("message")?.toString() ?: ""
+            val level = jsonData.optString("level")
+            KlaviyoWebFormMessageType.Console(
+                message,
+                level
+            )
+        }
+
+        IAF_MESSAGE_TYPE_PROFILE_EVENT -> {
+            KlaviyoWebFormMessageType.ProfileEvent(
+                event = jsonData.optString(IAM_EVENT_NAME_KEY)?.let {
+                    Event(it, properties = jsonData.getProperties())
+                } ?: throw IllegalStateException("Missing profile eventName key")
+            )
+        }
+        else -> throw IllegalStateException("Unrecognized message type $type")
+    }
+}

--- a/sdk/messaging/src/test/kotlin/FormsUtilityTest.kt
+++ b/sdk/messaging/src/test/kotlin/FormsUtilityTest.kt
@@ -1,0 +1,124 @@
+package com.klaviyo.messaging
+
+import com.klaviyo.analytics.model.EventKey
+import com.klaviyo.core.Registry
+import com.klaviyo.fixtures.BaseTest
+import io.mockk.*
+import org.json.JSONObject
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+
+class FormsUtilityTest : BaseTest() {
+
+    @Before
+    override fun setup() {
+        super.setup()
+    }
+
+    @After
+    override fun cleanup() {
+        super.cleanup()
+    }
+
+    @Test
+    fun `test getProperties successfully parses properties`() {
+        // Setup
+        val json = JSONObject()
+        val properties = JSONObject()
+        properties.put("key1", "value1")
+        properties.put("key2", "value2")
+        json.put("properties", properties)
+
+        // Act
+        val result = json.getProperties()
+
+        // Assert
+        assertEquals(2, result.size)
+        assertEquals("value1", result[EventKey.CUSTOM("key1")])
+        assertEquals("value2", result[EventKey.CUSTOM("key2")])
+    }
+
+    @Test
+    fun `test getProperties logs error on exception`() {
+        // Setup
+        val json = JSONObject("{\"properties\": {\"key1\": 123}}") // Non-string value
+        every { Registry.log.error(any(), any<Throwable>()) } just Runs
+
+        // Act
+        json.getProperties()
+
+        // Assert
+        verify { Registry.log.error(any(), any<Exception>()) }
+    }
+
+    @Test
+    fun `test decodeWebviewMessage with unrecognized message type throws exception`() {
+        // Setup
+        val unrecognizedMessage = "{\"type\": \"javascript is for clowns\", \"data\": {}}"
+
+        // Act & Assert
+        assertThrows(IllegalStateException::class.java) {
+            decodeWebviewMessage(unrecognizedMessage)
+        }
+    }
+
+    @Test
+    fun `test decodeWebviewMessage properly decodes show type`() {
+        // Setup
+        val showMessage = "{\"type\": \"show\", \"data\": {}}"
+
+        // Act
+        val result = decodeWebviewMessage(showMessage)
+
+        // Assert
+        assertEquals(KlaviyoWebFormMessageType.Show, result)
+    }
+
+    @Test
+    fun `test decodeWebviewMessage properly decodes close type`() {
+        // Setup
+        val closeMessage = "{\"type\": \"close\", \"data\": {}}"
+
+        // Act
+        val result = decodeWebviewMessage(closeMessage)
+
+        // Assert
+        assertEquals(KlaviyoWebFormMessageType.Close, result)
+    }
+
+    @Test
+    fun `test decodeWebviewMessage properly decodes console type`() {
+        // Setup
+        val consoleMessage = """
+            {
+              "type": "console",
+              "data": {
+                "message": {"text": "Test message"},
+                "level": "info"
+              }
+            }
+        """.trimIndent()
+
+        // Act
+        val result = decodeWebviewMessage(consoleMessage) as KlaviyoWebFormMessageType.Console
+
+        // Assert
+        assertEquals("{\"text\":\"Test message\"}", result.consoleLog)
+        assertEquals("info", result.level)
+    }
+
+    @Test
+    fun `test decodeWebviewMessage errors when profile event has no event name`() {
+        // Setup
+        val eventMessage = "{\"type\": \"profileEvent\", \"data\": {\"properties\": {}}}"
+        every { Registry.log.error(any(), any<Throwable>()) } just Runs
+
+        // Act & Assert
+        assertThrows(IllegalStateException::class.java) {
+            decodeWebviewMessage(eventMessage)
+        }
+    }
+}

--- a/sdk/messaging/src/test/kotlin/FormsUtilityTest.kt
+++ b/sdk/messaging/src/test/kotlin/FormsUtilityTest.kt
@@ -3,7 +3,10 @@ package com.klaviyo.messaging
 import com.klaviyo.analytics.model.EventKey
 import com.klaviyo.core.Registry
 import com.klaviyo.fixtures.BaseTest
-import io.mockk.*
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.verify
 import org.json.JSONObject
 import org.junit.After
 import org.junit.Before
@@ -68,7 +71,7 @@ class FormsUtilityTest : BaseTest() {
     @Test
     fun `test decodeWebviewMessage properly decodes show type`() {
         // Setup
-        val showMessage = "{\"type\": \"show\", \"data\": {}}"
+        val showMessage = "{\"type\": \"formDidAppear\", \"data\": {}}"
 
         // Act
         val result = decodeWebviewMessage(showMessage)
@@ -80,34 +83,13 @@ class FormsUtilityTest : BaseTest() {
     @Test
     fun `test decodeWebviewMessage properly decodes close type`() {
         // Setup
-        val closeMessage = "{\"type\": \"close\", \"data\": {}}"
+        val closeMessage = "{\"type\": \"formDidClose\", \"data\": {}}"
 
         // Act
         val result = decodeWebviewMessage(closeMessage)
 
         // Assert
         assertEquals(KlaviyoWebFormMessageType.Close, result)
-    }
-
-    @Test
-    fun `test decodeWebviewMessage properly decodes console type`() {
-        // Setup
-        val consoleMessage = """
-            {
-              "type": "console",
-              "data": {
-                "message": {"text": "Test message"},
-                "level": "info"
-              }
-            }
-        """.trimIndent()
-
-        // Act
-        val result = decodeWebviewMessage(consoleMessage) as KlaviyoWebFormMessageType.Console
-
-        // Assert
-        assertEquals("{\"text\":\"Test message\"}", result.consoleLog)
-        assertEquals("info", result.level)
     }
 
     @Test


### PR DESCRIPTION
# Description
- creating a new utility for mapping message strings (trying to make this more unit testable)
- supporting the new profile events through our existing network queue

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you tested this change on real device?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all Android versions the SDK currently supports?


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->


## Test Plan
<!-- How was this code tested / How should reviewers test it? -->


## Related Issues/Tickets
<!-- Link to relevant issues or discussion -->

