### PR TITLE
[CHNL-16656] Enqueue Aggregate Events from IAF

### DIFF
--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/ApiClient.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/ApiClient.kt
@@ -2,6 +2,7 @@ package com.klaviyo.analytics.networking
 
 import com.klaviyo.analytics.model.Event
 import com.klaviyo.analytics.model.Profile
+import com.klaviyo.analytics.networking.requests.AggregateEventPayload
 import com.klaviyo.analytics.networking.requests.ApiRequest
 
 typealias ApiObserver = (request: ApiRequest) -> Unit
@@ -76,4 +77,9 @@ interface ApiClient {
      * @param observer
      */
     fun offApiRequest(observer: ApiObserver)
+
+    /**
+     * For sending aggregate analytics for IAF - not to be called directly
+     */
+    fun enqueueAggregateEvent(payload: AggregateEventPayload)
 }

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/KlaviyoApiClient.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/KlaviyoApiClient.kt
@@ -6,6 +6,8 @@ import android.os.Looper
 import com.klaviyo.analytics.model.Event
 import com.klaviyo.analytics.model.EventMetric
 import com.klaviyo.analytics.model.Profile
+import com.klaviyo.analytics.networking.requests.AggregateEventApiRequest
+import com.klaviyo.analytics.networking.requests.AggregateEventPayload
 import com.klaviyo.analytics.networking.requests.EventApiRequest
 import com.klaviyo.analytics.networking.requests.KlaviyoApiRequest
 import com.klaviyo.analytics.networking.requests.KlaviyoApiRequest.Status
@@ -64,6 +66,11 @@ internal object KlaviyoApiClient : ApiClient {
     override fun enqueuePushToken(token: String, profile: Profile) {
         Registry.log.verbose("Enqueuing Push Token request")
         enqueueRequest(PushTokenApiRequest(token, profile))
+    }
+
+    override fun enqueueAggregateEvent(payload: AggregateEventPayload) {
+        Registry.log.verbose("Enqueuing Aggregate Event request")
+        enqueueRequest(AggregateEventApiRequest(payload))
     }
 
     override fun enqueueUnregisterPushToken(apiKey: String, token: String, profile: Profile) {

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/KlaviyoApiClient.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/KlaviyoApiClient.kt
@@ -74,6 +74,7 @@ internal object KlaviyoApiClient : ApiClient {
     }
 
     override fun enqueueUnregisterPushToken(apiKey: String, token: String, profile: Profile) {
+        Registry.log.verbose("Enqueuing unregister token request")
         enqueueRequest(UnregisterPushTokenApiRequest(apiKey, token, profile))
     }
 

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/AggregateEventApiRequest.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/AggregateEventApiRequest.kt
@@ -1,0 +1,26 @@
+package com.klaviyo.analytics.networking.requests
+
+import com.klaviyo.core.Registry
+import org.json.JSONObject
+
+typealias AggregateEventPayload = JSONObject
+internal class AggregateEventApiRequest(
+    queuedTime: Long? = null,
+    uuid: String? = null
+) : KlaviyoApiRequest(PATH, RequestMethod.POST, queuedTime, uuid) {
+
+    companion object {
+        private const val PATH = "onsite/track-analytics"
+    }
+
+    override val type: String = "Create Aggregate Event"
+    override var query: Map<String, String> = mapOf(
+        COMPANY_ID to Registry.config.apiKey
+    )
+
+    override val successCodes: IntRange get() = HTTP_ACCEPTED..HTTP_ACCEPTED
+
+    constructor(payload: AggregateEventPayload) : this() {
+        body = payload
+    }
+}

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/BaseApiRequestTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/BaseApiRequestTest.kt
@@ -3,6 +3,7 @@ package com.klaviyo.analytics.networking.requests
 import com.klaviyo.analytics.DevicePropertiesTest
 import com.klaviyo.analytics.model.Profile
 import com.klaviyo.fixtures.BaseTest
+import org.json.JSONObject
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
@@ -29,6 +30,53 @@ internal abstract class BaseApiRequestTest<T> : BaseTest() where T : KlaviyoApiR
         .setAnonymousId(ANON_ID)
         .setEmail(EMAIL)
         .setPhoneNumber(PHONE)
+
+    open val stubAggregateEventPayload = JSONObject(
+        """
+            {
+              "type": "aggregateEventTracked",
+              "data": {
+                "metric_group": "signup-forms",
+                "events": [
+                  {
+                    "metric": "stepSubmit",
+                    "log_to_statsd": true,
+                    "log_to_s3": true,
+                    "log_to_metrics_service": true,
+                    "metric_service_event_name": "submitted_form_step",
+                    "event_details": {
+                      "form_version_c_id": "1",
+                      "is_client": true,
+                      "submitted_fields": {
+                        "source": "Local Form",
+                        "email": "local@local.com",
+                        "consent_method": "Klaviyo Form",
+                        "consent_form_id": "64CjgW",
+                        "consent_form_version": 3,
+                        "sent_identifiers": {},
+                        "sms_consent": true,
+                        "step_name": "Email Opt-In"
+                      },
+                      "step_name": "Email Opt-In",
+                      "step_number": 1,
+                      "action_type": "Submit Step",
+                      "form_id": "64CjgW",
+                      "form_version_id": 3,
+                      "form_type": "POPUP",
+                      "device_type": "DESKTOP",
+                      "hostname": "localhost",
+                      "href": "http://localhost:4001/onsite/js/",
+                      "page_url": "http://localhost:4001/onsite/js/",
+                      "first_referrer": "http://localhost:4001/onsite/js/",
+                      "referrer": "http://localhost:4001/onsite/js/",
+                      "cid": "ODZjYjJmMjUtNjliMC00ZGVlLTllM2YtNDY5YTlmNjcwYmUz"
+                    }
+                  }
+                ]
+              }
+            }
+        """.trimIndent()
+    )
 
     abstract fun makeTestRequest(): T
 

--- a/sdk/messaging/src/main/java/com/klaviyo/messaging/Constants.kt
+++ b/sdk/messaging/src/main/java/com/klaviyo/messaging/Constants.kt
@@ -8,9 +8,10 @@ internal const val IAF_MESSAGE_TYPE_KEY = "type"
 internal const val IAF_MESSAGE_TYPE_SHOW = "formDidAppear"
 internal const val IAF_MESSAGE_TYPE_CLOSE = "formDidClose"
 internal const val IAF_MESSAGE_TYPE_PROFILE_EVENT = "profileEventTracked"
+internal const val IAF_MESSAGE_TYPE_AGGREGATE_EVENT = "aggregateEventTracked"
 
 /**
  * Profile event constants
  */
-internal const val IAF_EVENT_NAME_KEY = "eventName"
+internal const val IAF_METRIC_KEY = "metric"
 internal const val IAF_PROPERTIES_KEY = "properties"

--- a/sdk/messaging/src/main/java/com/klaviyo/messaging/KlaviyoWebFormMessageType.kt
+++ b/sdk/messaging/src/main/java/com/klaviyo/messaging/KlaviyoWebFormMessageType.kt
@@ -1,14 +1,20 @@
 package com.klaviyo.messaging
 
 import com.klaviyo.analytics.model.Event
+import com.klaviyo.analytics.networking.requests.AggregateEventPayload
 
 /**
  * This should be updated with any new message types we add coming from the onsite-in-app-forms
  */
 sealed class KlaviyoWebFormMessageType {
     data object Show : KlaviyoWebFormMessageType()
+
     data object Close : KlaviyoWebFormMessageType()
     data class ProfileEvent(
         val event: Event
+    ) : KlaviyoWebFormMessageType()
+
+    data class AggregateEventTracked(
+        val payload: AggregateEventPayload
     ) : KlaviyoWebFormMessageType()
 }

--- a/sdk/messaging/src/main/java/com/klaviyo/messaging/KlaviyoWebView.kt
+++ b/sdk/messaging/src/main/java/com/klaviyo/messaging/KlaviyoWebView.kt
@@ -126,9 +126,8 @@ class KlaviyoWebView : WebViewClient(), WebViewCompat.WebMessageListener {
                 KlaviyoWebFormMessageType.Close -> close()
                 is KlaviyoWebFormMessageType.ProfileEvent -> Klaviyo.createEvent(messageType.event)
                 KlaviyoWebFormMessageType.Show -> show()
-                is KlaviyoWebFormMessageType.AggregateEventTracked -> {
-                    Registry.get<ApiClient>().enqueueAggregateEvent(messageType.payload)
-                }
+                is KlaviyoWebFormMessageType.AggregateEventTracked -> Registry.get<ApiClient>()
+                    .enqueueAggregateEvent(messageType.payload)
             }
         } catch (e: Exception) {
             Registry.log.error("Failed to decode webview message type", e)

--- a/sdk/messaging/src/main/java/com/klaviyo/messaging/KlaviyoWebView.kt
+++ b/sdk/messaging/src/main/java/com/klaviyo/messaging/KlaviyoWebView.kt
@@ -18,6 +18,7 @@ import androidx.webkit.WebViewFeature.WEB_MESSAGE_LISTENER
 import androidx.webkit.WebViewFeature.isFeatureSupported
 import com.klaviyo.analytics.DeviceProperties
 import com.klaviyo.analytics.Klaviyo
+import com.klaviyo.analytics.networking.ApiClient
 import com.klaviyo.core.BuildConfig
 import com.klaviyo.core.Registry
 
@@ -125,6 +126,9 @@ class KlaviyoWebView : WebViewClient(), WebViewCompat.WebMessageListener {
                 KlaviyoWebFormMessageType.Close -> close()
                 is KlaviyoWebFormMessageType.ProfileEvent -> Klaviyo.createEvent(messageType.event)
                 KlaviyoWebFormMessageType.Show -> show()
+                is KlaviyoWebFormMessageType.AggregateEventTracked -> {
+                    Registry.get<ApiClient>().enqueueAggregateEvent(messageType.payload)
+                }
             }
         } catch (e: Exception) {
             Registry.log.error("Failed to decode webview message type", e)

--- a/sdk/messaging/src/main/java/com/klaviyo/messaging/Utils.kt
+++ b/sdk/messaging/src/main/java/com/klaviyo/messaging/Utils.kt
@@ -29,9 +29,14 @@ internal fun decodeWebviewMessage(webMessage: String): KlaviyoWebFormMessageType
         IAF_MESSAGE_TYPE_CLOSE -> KlaviyoWebFormMessageType.Close
         IAF_MESSAGE_TYPE_PROFILE_EVENT -> {
             KlaviyoWebFormMessageType.ProfileEvent(
-                event = jsonData.optString(IAF_EVENT_NAME_KEY)?.let {
+                event = jsonData.optString(IAF_METRIC_KEY)?.let {
                     Event(it, properties = jsonData.getProperties())
-                } ?: throw IllegalStateException("Missing profile eventName key")
+                } ?: throw IllegalStateException("Missing profile metric key")
+            )
+        }
+        IAF_MESSAGE_TYPE_AGGREGATE_EVENT -> {
+            KlaviyoWebFormMessageType.AggregateEventTracked(
+                payload = jsonData
             )
         }
         else -> throw IllegalStateException("Unrecognized message type $type")

--- a/sdk/messaging/src/test/kotlin/FormsUtilityTest.kt
+++ b/sdk/messaging/src/test/kotlin/FormsUtilityTest.kt
@@ -1,6 +1,7 @@
 package com.klaviyo.messaging
 
 import com.klaviyo.analytics.model.EventKey
+import com.klaviyo.analytics.model.EventMetric
 import com.klaviyo.core.Registry
 import com.klaviyo.fixtures.BaseTest
 import io.mockk.Runs
@@ -102,5 +103,74 @@ class FormsUtilityTest : BaseTest() {
         assertThrows(IllegalStateException::class.java) {
             decodeWebviewMessage(eventMessage)
         }
+    }
+
+    @Test
+    fun `test decodeWebviewMessage success profile event`() {
+        // Setup
+        val eventMessage = "{\"type\": \"profileEventTracked\", \"data\": {\"metric\": \"Form completed by profile\", \"properties\": {}}}"
+        every { Registry.log.error(any(), any<Throwable>()) } just Runs
+
+        val decoded = decodeWebviewMessage(eventMessage) as KlaviyoWebFormMessageType.ProfileEvent
+        val expectedMetric = EventMetric.CUSTOM("Form completed by profile")
+        assertEquals(expectedMetric, decoded.event.metric)
+    }
+
+    @Test
+    fun `test aggregate event`() {
+        // Setup
+        val aggregateMessage = """
+            {
+              "type": "aggregateEventTracked",
+              "data": {
+                "metric_group": "signup-forms",
+                "events": [
+                  {
+                    "metric": "stepSubmit",
+                    "log_to_statsd": true,
+                    "log_to_s3": true,
+                    "log_to_metrics_service": true,
+                    "metric_service_event_name": "submitted_form_step",
+                    "event_details": {
+                      "form_version_c_id": "1",
+                      "is_client": true,
+                      "submitted_fields": {
+                        "source": "Local Form",
+                        "email": "local@local.com",
+                        "consent_method": "Klaviyo Form",
+                        "consent_form_id": "64CjgW",
+                        "consent_form_version": 3,
+                        "sent_identifiers": {},
+                        "sms_consent": true,
+                        "step_name": "Email Opt-In"
+                      },
+                      "step_name": "Email Opt-In",
+                      "step_number": 1,
+                      "action_type": "Submit Step",
+                      "form_id": "64CjgW",
+                      "form_version_id": 3,
+                      "form_type": "POPUP",
+                      "device_type": "DESKTOP",
+                      "hostname": "localhost",
+                      "href": "http://localhost:4001/onsite/js/",
+                      "page_url": "http://localhost:4001/onsite/js/",
+                      "first_referrer": "http://localhost:4001/onsite/js/",
+                      "referrer": "http://localhost:4001/onsite/js/",
+                      "cid": "ODZjYjJmMjUtNjliMC00ZGVlLTllM2YtNDY5YTlmNjcwYmUz"
+                    }
+                  }
+                ]
+              }
+            }
+        """.trimIndent()
+
+        val expectedAggBody =
+            JSONObject("{\"metric_group\":\"signup-forms\",\"events\":[{\"log_to_metrics_service\":true,\"metric\":\"stepSubmit\",\"log_to_statsd\":true,\"event_details\":{\"page_url\":\"http://localhost:4001/onsite/js/\",\"first_referrer\":\"http://localhost:4001/onsite/js/\",\"action_type\":\"Submit Step\",\"form_version_id\":3,\"form_id\":\"64CjgW\",\"device_type\":\"DESKTOP\",\"form_type\":\"POPUP\",\"referrer\":\"http://localhost:4001/onsite/js/\",\"submitted_fields\":{\"sms_consent\":true,\"consent_method\":\"Klaviyo Form\",\"consent_form_version\":3,\"step_name\":\"Email Opt-In\",\"consent_form_id\":\"64CjgW\",\"source\":\"Local Form\",\"email\":\"local@local.com\",\"sent_identifiers\":{}},\"hostname\":\"localhost\",\"step_number\":1,\"form_version_c_id\":\"1\",\"step_name\":\"Email Opt-In\",\"is_client\":true,\"href\":\"http://localhost:4001/onsite/js/\",\"cid\":\"ODZjYjJmMjUtNjliMC00ZGVlLTllM2YtNDY5YTlmNjcwYmUz\"},\"metric_service_event_name\":\"submitted_form_step\",\"log_to_s3\":true}]}")
+        // Act
+        val result =
+            decodeWebviewMessage(aggregateMessage) as KlaviyoWebFormMessageType.AggregateEventTracked
+
+        // Assert
+        assertEquals(expectedAggBody.toString(), result.payload.toString())
     }
 }


### PR DESCRIPTION
# Description
- support for new API request
- support for deserializing new event type
- unit tests for the mapper 

note that we are adding to the interface of the public ApiClient; however, this is only available through the `core` module which is not a recommended import for our users. Currently we tell users to send requests through the `Klaviyo.` object, which I have not included a route for here.


# Check List

- [ish] Are you changing anything with the public API?
- [x] Are your changes backwards compatible with previous SDK Versions?
- [x] Have you tested this change on real device?
- [x] Have you added unit test coverage for your changes?
- [x] Have you verified that your changes are compatible with all Android versions the SDK currently supports?


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->


## Test Plan
- tested on local with mocked responses from the response google doc Evan opened


## Related Issues/Tickets
https://klaviyo.atlassian.net/browse/CHNL-16656
