### PR TITLE
[CHNL-16704] Deeplink Support for IAF

### DIFF
--- a/sdk/messaging/src/main/java/com/klaviyo/messaging/Constants.kt
+++ b/sdk/messaging/src/main/java/com/klaviyo/messaging/Constants.kt
@@ -1,6 +1,13 @@
 package com.klaviyo.messaging
 
 /**
+ * Fields to replace in the HTML template
+ */
+internal const val IAF_SDK_NAME_PLACEHOLDER = "SDK_NAME"
+internal const val IAF_SDK_VERSION_PLACEHOLDER = "SDK_VERSION"
+internal const val IAF_PUBLIC_KEY_PLACEHOLDER = "KLAVIYO_PUBLIC_KEY_PLACEHOLDER"
+
+/**
  * Decoding top-level message types
  */
 internal const val IAF_MESSAGE_DATA_KEY = "data"
@@ -9,9 +16,15 @@ internal const val IAF_MESSAGE_TYPE_SHOW = "formDidAppear"
 internal const val IAF_MESSAGE_TYPE_CLOSE = "formDidClose"
 internal const val IAF_MESSAGE_TYPE_PROFILE_EVENT = "profileEventTracked"
 internal const val IAF_MESSAGE_TYPE_AGGREGATE_EVENT = "aggregateEventTracked"
+internal const val IAF_MESSAGE_TYPE_DEEPLINK = "deepLinkShouldOpen"
 
 /**
  * Profile event constants
  */
 internal const val IAF_METRIC_KEY = "metric"
 internal const val IAF_PROPERTIES_KEY = "properties"
+
+/**
+ * Deep Link fields
+ */
+internal const val IAF_DEEPLINK_ANDROID = "android"

--- a/sdk/messaging/src/main/java/com/klaviyo/messaging/InAppMessaging.kt
+++ b/sdk/messaging/src/main/java/com/klaviyo/messaging/InAppMessaging.kt
@@ -9,15 +9,15 @@ object InAppMessaging {
 
     fun triggerInAppMessage(activity: Activity) {
         val rootView = activity.getRootViewGroup()
-        val webView = KlaviyoWebView()
-        val html = Registry.config.applicationContext
+        val webView = KlaviyoWebView(activity)
+        val html = activity
             .assets
             .open("IAMTest.html")
             .bufferedReader()
             .use(BufferedReader::readText)
-            .replace("KLAVIYO_PUBLIC_KEY_PLACEHOLDER", Registry.config.apiKey)
-            .replace("SDK_NAME", Registry.config.sdkName)
-            .replace("SDK_VERSION", Registry.config.sdkVersion)
+            .replace(IAF_PUBLIC_KEY_PLACEHOLDER, Registry.config.apiKey)
+            .replace(IAF_SDK_NAME_PLACEHOLDER, Registry.config.sdkName)
+            .replace(IAF_SDK_VERSION_PLACEHOLDER, Registry.config.sdkVersion)
 
         webView.loadHtml(html)
         webView.addTo(rootView)

--- a/sdk/messaging/src/main/java/com/klaviyo/messaging/KlaviyoWebFormMessageType.kt
+++ b/sdk/messaging/src/main/java/com/klaviyo/messaging/KlaviyoWebFormMessageType.kt
@@ -18,4 +18,8 @@ sealed class KlaviyoWebFormMessageType {
     data class AggregateEventTracked(
         val payload: AggregateEventPayload
     ) : KlaviyoWebFormMessageType()
+
+    data class DeepLink(
+        val route: String
+    ) : KlaviyoWebFormMessageType()
 }

--- a/sdk/messaging/src/main/java/com/klaviyo/messaging/KlaviyoWebFormMessageType.kt
+++ b/sdk/messaging/src/main/java/com/klaviyo/messaging/KlaviyoWebFormMessageType.kt
@@ -10,6 +10,7 @@ sealed class KlaviyoWebFormMessageType {
     data object Show : KlaviyoWebFormMessageType()
 
     data object Close : KlaviyoWebFormMessageType()
+
     data class ProfileEvent(
         val event: Event
     ) : KlaviyoWebFormMessageType()

--- a/sdk/messaging/src/main/java/com/klaviyo/messaging/KlaviyoWebView.kt
+++ b/sdk/messaging/src/main/java/com/klaviyo/messaging/KlaviyoWebView.kt
@@ -134,26 +134,28 @@ class KlaviyoWebView(
                 KlaviyoWebFormMessageType.Show -> show()
                 is KlaviyoWebFormMessageType.AggregateEventTracked -> Registry.get<ApiClient>()
                     .enqueueAggregateEvent(messageType.payload)
-                is KlaviyoWebFormMessageType.DeepLink -> {
-                    val uri = Uri.parse(messageType.route)
-                    activityRef.get()?.let { activity ->
-                        activity.startActivity(
-                            Intent().apply {
-                                data = uri
-                                action = Intent.ACTION_VIEW
-                                setPackage(activity.packageName)
-                                addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
-                            }
-                        )
-                    } ?: run {
-                        Registry.log.error(
-                            "Failed to launch deeplink ${messageType.route}, activity reference null"
-                        )
-                    }
-                }
+                is KlaviyoWebFormMessageType.DeepLink -> deepLink(messageType)
             }
         } catch (e: Exception) {
             Registry.log.error("Failed to relay webview message: $message", e)
+        }
+    }
+
+    private fun deepLink(messageType: KlaviyoWebFormMessageType.DeepLink) {
+        val uri = Uri.parse(messageType.route)
+        activityRef.get()?.let { activity ->
+            activity.startActivity(
+                Intent().apply {
+                    data = uri
+                    action = Intent.ACTION_VIEW
+                    setPackage(activity.packageName)
+                    addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
+                }
+            )
+        } ?: run {
+            Registry.log.error(
+                "Failed to launch deeplink ${messageType.route}, activity reference null"
+            )
         }
     }
 }

--- a/sdk/messaging/src/main/java/com/klaviyo/messaging/Utils.kt
+++ b/sdk/messaging/src/main/java/com/klaviyo/messaging/Utils.kt
@@ -39,6 +39,11 @@ internal fun decodeWebviewMessage(webMessage: String): KlaviyoWebFormMessageType
                 payload = jsonData
             )
         }
+        IAF_MESSAGE_TYPE_AGGREGATE_EVENT -> {
+            KlaviyoWebFormMessageType.AggregateEventTracked(
+                payload = jsonData
+            )
+        }
         else -> throw IllegalStateException("Unrecognized message type $type")
     }
 }

--- a/sdk/messaging/src/main/java/com/klaviyo/messaging/Utils.kt
+++ b/sdk/messaging/src/main/java/com/klaviyo/messaging/Utils.kt
@@ -29,9 +29,10 @@ internal fun decodeWebviewMessage(webMessage: String): KlaviyoWebFormMessageType
         IAF_MESSAGE_TYPE_CLOSE -> KlaviyoWebFormMessageType.Close
         IAF_MESSAGE_TYPE_PROFILE_EVENT -> {
             KlaviyoWebFormMessageType.ProfileEvent(
-                event = jsonData.optString(IAF_METRIC_KEY)?.let {
-                    Event(it, properties = jsonData.getProperties())
-                } ?: throw IllegalStateException("Missing profile metric key")
+                event = Event(
+                    jsonData.getString(IAF_METRIC_KEY),
+                    properties = jsonData.getProperties()
+                )
             )
         }
         IAF_MESSAGE_TYPE_AGGREGATE_EVENT -> {
@@ -39,10 +40,15 @@ internal fun decodeWebviewMessage(webMessage: String): KlaviyoWebFormMessageType
                 payload = jsonData
             )
         }
-        IAF_MESSAGE_TYPE_AGGREGATE_EVENT -> {
-            KlaviyoWebFormMessageType.AggregateEventTracked(
-                payload = jsonData
-            )
+        IAF_MESSAGE_TYPE_DEEPLINK -> {
+            val routeString = jsonData.getString(IAF_DEEPLINK_ANDROID)
+            if (routeString.isNullOrEmpty()) {
+                throw IllegalStateException("No android deeplink found in js payload")
+            } else {
+                KlaviyoWebFormMessageType.DeepLink(
+                    route = routeString
+                )
+            }
         }
         else -> throw IllegalStateException("Unrecognized message type $type")
     }

--- a/sdk/messaging/src/test/kotlin/FormsUtilityTest.kt
+++ b/sdk/messaging/src/test/kotlin/FormsUtilityTest.kt
@@ -8,6 +8,7 @@ import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.verify
+import org.json.JSONException
 import org.json.JSONObject
 import org.junit.After
 import org.junit.Before
@@ -172,5 +173,42 @@ class FormsUtilityTest : BaseTest() {
 
         // Assert
         assertEquals(expectedAggBody.toString(), result.payload.toString())
+    }
+
+    @Test
+    fun `test deeplinks decoding`() {
+        // setup
+        val deeplinkMessage = """
+            {
+              "type": "deepLinkShouldOpen",
+              "data": {
+                "ios": "klaviyotest://settings",
+                "android": "klaviyotest://settings"
+              }
+            }
+        """.trimIndent()
+
+        val result = decodeWebviewMessage(deeplinkMessage) as KlaviyoWebFormMessageType.DeepLink
+
+        assertEquals("klaviyotest://settings", result.route)
+    }
+
+    @Test
+    fun `deeplink does not have android field, throws error`(){
+        val deeplinkMessage = """
+            {
+              "type": "deepLinkShouldOpen",
+              "data": {
+                "ios": "klaviyotest://settings"
+              }
+            }
+        """.trimIndent()
+
+        every { Registry.log.error(any(), any<Throwable>()) } just Runs
+
+        // Act & Assert
+        assertThrows(JSONException::class.java) {
+            decodeWebviewMessage(deeplinkMessage)
+        }
     }
 }


### PR DESCRIPTION
# Description
 
Supporting Deeplinks for IAF messages, according to the contract specc'd out in @evan-masseau s doc. The deeplink logic is very similar to the one we have for adding an intent to deeplinking notifications, but I did have to change around our implementation of the webview to support the `addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)` line. This can only be used when launching an activity from an activity (noticeably _not_ from an application which we were using as our primary context before). We already almost certainly want some sort of Activity reference for the API anyhow, so I'm just forwarding this to the klaviyo webview class we already have. I added some safety around the activity reference, since this is a super common android memory leak I'd like to avoid. Hence, the weak reference which will be garbage collected once the webview is destroyed. 

# Check List

- [x] Are you changing anything with the public API?
- [x] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you tested this change on real device?
- [x] Have you added unit test coverage for your changes?
- [x] Have you verified that your changes are compatible with all Android versions the SDK currently supports?
  
[deeplink-and-aggregate-events.webm](https://github.com/user-attachments/assets/1459abc8-d946-42ee-85b1-12c02054854e)




## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->


## Test Plan
<!-- How was this code tested / How should reviewers test it? -->


## Related Issues/Tickets
https://klaviyo.atlassian.net/browse/CHNL-16704
