### PR TITLE
fix: prevent crash when connection issue product a response without body

### DIFF
--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequest.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequest.kt
@@ -378,7 +378,9 @@ internal open class KlaviyoApiRequest(
             else -> connection.errorStream
         }
 
-        responseBody = BufferedReader(InputStreamReader(stream)).use { it.readText() }
+        if (stream != null) {
+            responseBody = BufferedReader(InputStreamReader(stream)).use { it.readText() }
+        }
 
         return status
     }


### PR DESCRIPTION
# Description
<!-- Briefly describe the feature or bug that your pull request addresses -->

# Check List

- [ ] Are you changing anything with the public API?
- [x] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you tested this change on real device?
- [ ] Have you added unit test coverage for your changes?
- [x] Have you verified that your changes are compatible with all Android versions the SDK currently supports?


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->

- errorStream only handles HTTP error with a body, when there is a connection issue, there is no body, so no stream is returned
- This makes the app crash

<img width="985" alt="image" src="https://github.com/user-attachments/assets/22f16d94-1ce6-4ed4-9a84-ef2d6c018546" />



## Test Plan
<!-- How was this code tested / How should reviewers test it? -->


## Related Issues/Tickets
<!-- Link to relevant issues or discussion -->

