### PR TITLE
Organized the versions.properties file for better readability 

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -9,56 +9,50 @@
 ####
 #### NOTE: Some versions are filtered by the rejectVersionIf predicate. See the settings.gradle.kts file.
 
-# Project versioning, run the following gradle command to update version numbers automatically:
-# ./gradlew bumpVersion --nextVersion=X.Y.Z
+# Project versioning
+#  NOTE: semantic version of the SDK lives in strings.xml
+#  run the following gradle command to update version numbers automatically:
+#  ./gradlew bumpVersion --nextVersion=X.Y.Z
 version.klaviyo.versionCode=22
 
-# Android versioning
+# Project gradle plugins
+plugin.android=8.2.1
+plugin.org.jetbrains.dokka=1.9.10
+plugin.org.jlleitschuh.gradle.ktlint=version.org.jlleitschuh.gradle..ktlint-gradle
 
+# Android support
+version.android.buildTools=34.0.0
+version.android.compileSdk=34
 version.android.minSdk=23
-
 version.android.targetSdk=34
 
-version.android.compileSdk=34
-
-version.android.buildTools=34.0.0
-
 # Project dependencies
+version.androidx.activity=1.6.1
+version.androidx.appcompat=1.6.1
+version.androidx.compose.compiler=1.5.10
+version.androidx.core=1.12.0
+version.androidx.webkit=1.9.0
 
-version.kotlinx.coroutines=1.9.0
-
-version.org.jetbrains.dokka..versioning-plugin=1.9.10
+version.androidx.test.espresso=3.5.1
+version.androidx.test.rules=1.5.0
+version.androidx.test.runner=1.5.2
 
 version.firebase-bom=32.7.0
 
-version.org.json..json=20231013
-
-# Note: updating past 11 will introduce new rules requiring some big formatting changes
-version.org.jlleitschuh.gradle..ktlint-gradle=11.6.1
-##                                # available=12.0.2
-##                                # available=12.0.3
-##                                # available=12.1.0
-
-version.org.jetbrains.dokka..dokka-gradle-plugin=1.9.10
-
-version.mockk=1.13.9
-
-version.kotlin=1.9.22
+version.google.accompanist=0.32.0
 
 version.junit.junit=4.13.2
 
-version.androidx.test.runner=1.5.2
+version.kotlin=1.9.22
 
-version.androidx.test.rules=1.5.0
+version.kotlinx.coroutines=1.9.0
 
-version.androidx.test.espresso=3.5.1
+version.mockk=1.13.9
 
-version.androidx.core=1.12.0
+version.org.jetbrains.dokka..dokka-gradle-plugin=1.9.10
+version.org.jetbrains.dokka..versioning-plugin=1.9.10
 
-# Project Plugins
+# Note: updating past 11 will introduce new rules requiring some big formatting changes
+version.org.jlleitschuh.gradle..ktlint-gradle=11.6.1
 
-plugin.org.jlleitschuh.gradle.ktlint=version.org.jlleitschuh.gradle..ktlint-gradle
-
-plugin.org.jetbrains.dokka=1.9.10
-
-plugin.android=8.2.1
+version.org.json..json=20231013


### PR DESCRIPTION
and added a compose.compiler version (not dependency) to alleviate local dev headaches.

# Description
I organized and alphabetized the versions, and I added the version property for `version.androidx.compose.compiler=1.5.10` that's always causing annoyance in composite test app builds.

There's no version updates in here. I did take out the commented future versions tho, I find those make it harder to read and don't need to be committed (they're useful when you're working on upgrading packages, but as a general rule I prefer to delete them before committing)

I would like to merge this prior to rebasing the IAF feature branch onto master to catch up (something I intend to do soon)

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you tested this change on real device?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all Android versions the SDK currently supports?


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->


## Test Plan
<!-- How was this code tested / How should reviewers test it? -->


## Related Issues/Tickets
<!-- Link to relevant issues or discussion -->

