### PR TITLE
Exposing kv pairs properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,7 +475,7 @@ handled via `onMessageReceived` regardless of the app being in the background or
 If you are working with multiple remote sources, you can check whether a message originated
 from Klaviyo with the extension method `RemoteMessage.isKlaviyoMessage`.
 
-### Custom Notification Handling
+#### Custom Notification Handling
 In addition to the standard notification processing, the Klaviyo Android SDK provides two overridable methods for advanced push handling:
 - `onKlaviyoNotificationMessageReceived(RemoteMessage message)`: Invoked when a standard Klaviyo push notification is received. Override this method to customize how notifications are displayed or processed.
 - `onKlaviyoCustomDataMessageReceived(Map<String, String> customData, RemoteMessage message)`: Invoked when a Klaviyo message contains custom key-value pairs. Override this method to handle additional custom data (e.g., triggering background tasks or logging analytics) that may accompany your push notifications.

--- a/README.md
+++ b/README.md
@@ -372,13 +372,13 @@ deep links in your app.
 
     To perform integration testing, you can send a
     [preview push notification](https://help.klaviyo.com/hc/en-us/articles/18011985278875) 
-    containing a deep link from the Klaviyo push editor. 
+    containing a deep link from the Klaviyo push editor.
+
+For additional resources on deep linking, refer to
+[Android developer documentation](https://developer.android.com/training/app-links/deep-linking).
 
 #### Custom Data
-Klaviyo messages can also include custom key-value pairs (custom data) for both standard and silent push notifications. You can access these key-value pairs using the extension property `RemoteMessage.keyValuePairs` and check for their presence with the boolean extension property `RemoteMessage.hasKlaviyoKeyValuePairs`. This enables you to extract additional information from the push payload and handle it appropriately - for instance, but triggering background processing, logging analytical events, or dynamically updating app content.
-
-For additional resources on deep linking, refer to 
-[Android developer documentation](https://developer.android.com/training/app-links/deep-linking).
+Klaviyo messages can also include custom key-value pairs (custom data) for both standard and silent push notifications. You can access these key-value pairs using the extension property `RemoteMessage.keyValuePairs` and check for their presence with the boolean extension property `RemoteMessage.hasKlaviyoKeyValuePairs`. This enables you to extract additional information from the push payload and handle it appropriately.
 
 ### Advanced Setup
 If you'd prefer to have your own implementation of `FirebaseMessagingService`,

--- a/README.md
+++ b/README.md
@@ -378,7 +378,11 @@ For additional resources on deep linking, refer to
 [Android developer documentation](https://developer.android.com/training/app-links/deep-linking).
 
 #### Custom Data
-Klaviyo messages can also include custom key-value pairs (custom data) for both standard and silent push notifications. You can access these key-value pairs using the extension property `RemoteMessage.keyValuePairs` and check for their presence with the boolean extension property `RemoteMessage.hasKlaviyoKeyValuePairs`. This enables you to extract additional information from the push payload and handle it appropriately.
+Klaviyo messages can also include custom key-value pairs (custom data) for both standard and silent push notifications. 
+You can access these key-value pairs using the extension property `RemoteMessage.keyValuePairs` and check for their 
+presence with the boolean extension property `RemoteMessage.hasKlaviyoKeyValuePairs`. This enables you to extract 
+additional information from the push payload and handle it appropriately - for instance, by triggering background 
+processing, logging analytics events, or dynamically updating app content.
 
 ### Advanced Setup
 If you'd prefer to have your own implementation of `FirebaseMessagingService`,
@@ -435,39 +439,39 @@ You may either subclass `KlaviyoPushService` or invoke the necessary Klaviyo SDK
     }
     ```
 
-   2. Subclass `FirebaseMessagingService` and invoke Klaviyo SDK methods directly
-       ```kotlin
-       import com.google.firebase.messaging.FirebaseMessagingService
-       import com.google.firebase.messaging.RemoteMessage
-       import com.klaviyo.analytics.Klaviyo
-       import com.klaviyo.pushFcm.KlaviyoNotification
-       import com.klaviyo.pushFcm.KlaviyoRemoteMessage.isKlaviyoNotification
+2. Subclass `FirebaseMessagingService` and invoke Klaviyo SDK methods directly
+    ```kotlin
+    import com.google.firebase.messaging.FirebaseMessagingService
+    import com.google.firebase.messaging.RemoteMessage
+    import com.klaviyo.analytics.Klaviyo
+    import com.klaviyo.pushFcm.KlaviyoNotification
+    import com.klaviyo.pushFcm.KlaviyoRemoteMessage.isKlaviyoNotification
 
-       class YourPushService : FirebaseMessagingService() {
+    class YourPushService : FirebaseMessagingService() {
 
-           override fun onNewToken(newToken: String) {
-               super.onNewToken(newToken)
-               Klaviyo.setPushToken(newToken)
-           }
+        override fun onNewToken(newToken: String) {
+            super.onNewToken(newToken)
+            Klaviyo.setPushToken(newToken)
+        }
 
-           override fun onMessageReceived(message: RemoteMessage) {
-               super.onMessageReceived(message)
+        override fun onMessageReceived(message: RemoteMessage) {
+            super.onMessageReceived(message)
 
-               // This extension method allows you to distinguish Klaviyo from other sources
-               if (message.isKlaviyoMessage) {
-                    if (message.isKlaviyoNotification) {
-                       // Handle displaying a notification from Klaviyo
-                       KlaviyoNotification(message).displayNotification(this)
-                    }
-                    if (message.hasKlaviyoKeyValuePairs) {
-                       TODO("Handle custom data in Klaviyo messages")
-                    }
-               } else {
-                    TODO("Handle non-Klaviyo messages")
-               }
-           }
-       }
-       ```
+            // This extension method allows you to distinguish Klaviyo from other sources
+            if (message.isKlaviyoMessage) {
+                 if (message.isKlaviyoNotification) {
+                    // Handle displaying a notification from Klaviyo
+                    KlaviyoNotification(message).displayNotification(this)
+                 }
+                 if (message.hasKlaviyoKeyValuePairs) {
+                    TODO("Handle custom data in Klaviyo messages")
+                 }
+            } else {
+                 TODO("Handle non-Klaviyo messages")
+            }
+        }
+    }
+    ```
 
 **Note:** Klaviyo uses [data messages](https://firebase.google.com/docs/cloud-messaging/android/receive)
 to provide consistent notification formatting. As a result, all Klaviyo notifications are
@@ -476,9 +480,13 @@ If you are working with multiple remote sources, you can check whether a message
 from Klaviyo with the extension method `RemoteMessage.isKlaviyoMessage`.
 
 #### Custom Notification Handling
-In addition to the standard notification processing, the Klaviyo Android SDK provides two overridable methods for advanced push handling:
-- `onKlaviyoNotificationMessageReceived(RemoteMessage message)`: Invoked when a standard Klaviyo push notification is received. Override this method to customize how notifications are displayed or processed.
-- `onKlaviyoCustomDataMessageReceived(Map<String, String> customData, RemoteMessage message)`: Invoked when a Klaviyo message contains custom key-value pairs. Override this method to handle additional custom data (e.g., triggering background tasks or logging analytics) that may accompany your push notifications.
+In addition to the standard notification processing, the Klaviyo Android SDK provides two overridable methods for 
+advanced push handling:
+- `onKlaviyoNotificationMessageReceived(RemoteMessage message)`: Invoked when a standard Klaviyo push notification is 
+received. Override this method to customize how notifications are displayed or processed.
+- `onKlaviyoCustomDataMessageReceived(Map<String, String> customData, RemoteMessage message)`: Invoked when a Klaviyo 
+message contains custom key-value pairs. Override this method to handle additional custom data (e.g., triggering 
+background tasks or logging analytics) that may accompany your push notifications.
 
 #### Custom Notification Display
 If you wish to fully customize the display of notifications, we provide a set of `RemoteMessage` 

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoNotification.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoNotification.kt
@@ -64,6 +64,7 @@ class KlaviyoNotification(private val message: RemoteMessage) {
         internal const val NOTIFICATION_COUNT_KEY = "notification_count"
         internal const val NOTIFICATION_PRIORITY = "notification_priority"
         internal const val NOTIFICATION_TAG = "notification_tag"
+        internal const val KEY_VALUE_PAIRS_KEY = "key_value_pairs"
         private const val DOWNLOAD_TIMEOUT_MS = 5_000
 
         /**

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoPushService.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoPushService.kt
@@ -44,7 +44,7 @@ open class KlaviyoPushService : FirebaseMessagingService() {
     override fun onMessageReceived(message: RemoteMessage) {
         super.onMessageReceived(message)
 
-        if (message.isKlaviyoMessage){
+        if (message.isKlaviyoMessage) {
             if (message.isKlaviyoNotification) {
                 KlaviyoNotification(message).displayNotification(this)
             } else {

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoPushService.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoPushService.kt
@@ -4,6 +4,7 @@ import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import com.klaviyo.analytics.Klaviyo
 import com.klaviyo.core.Registry
+import com.klaviyo.pushFcm.KlaviyoRemoteMessage.isKlaviyoMessage
 import com.klaviyo.pushFcm.KlaviyoRemoteMessage.isKlaviyoNotification
 
 /**
@@ -43,10 +44,33 @@ open class KlaviyoPushService : FirebaseMessagingService() {
     override fun onMessageReceived(message: RemoteMessage) {
         super.onMessageReceived(message)
 
-        if (message.isKlaviyoNotification) {
-            KlaviyoNotification(message).displayNotification(this)
+        if (message.isKlaviyoMessage){
+            if (message.isKlaviyoNotification) {
+                KlaviyoNotification(message).displayNotification(this)
+            } else {
+                // Handle silent push notifications
+                onSilentPushMessageReceived(message)
+            }
         } else {
             Registry.log.info("Ignoring non-Klaviyo RemoteMessage")
         }
+    }
+
+    /**
+     * Called when a silent push notification is received.
+     *
+     * This method is designed to be overridden by subclasses to provide custom handling for silent
+     * push notifications. By default, it simply logs the received [RemoteMessage]. Subclasses can
+     * override this method to extract key-value pairs, perform background processing, or implement
+     * any other custom behavior without requiring a user-visible notification.
+     *
+     * The default implementation is invoked from the default [onMessageReceived] logic. If you
+     * require different behavior for silent pushes, simply override this method in your subclass of
+     * [KlaviyoPushService] and implement your own handling logic.
+     *
+     * @param message The [RemoteMessage] object representing the silent push notification.
+     */
+    open fun onSilentPushMessageReceived(message: RemoteMessage) {
+        Registry.log.info("Received silent push notification RemoteMessage: $message")
     }
 }

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoRemoteMessage.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoRemoteMessage.kt
@@ -19,8 +19,8 @@ import com.klaviyo.core.KlaviyoException
 import com.klaviyo.core.Registry
 import com.klaviyo.core.config.getApplicationInfoCompat
 import com.klaviyo.core.config.getManifestInt
-import org.json.JSONObject
 import java.net.URL
+import org.json.JSONObject
 
 /**
  * Extension functions for RemoteMessage
@@ -145,7 +145,7 @@ object KlaviyoRemoteMessage {
     /**
      * Parse out the key-value pairs into a string:string map
      */
-    val RemoteMessage.keyValuePairs: Map<String,String>?
+    val RemoteMessage.keyValuePairs: Map<String, String>?
         get() = this.data[KlaviyoNotification.KEY_VALUE_PAIRS_KEY]?.let { jsonString ->
             try {
                 val jsonObject = JSONObject(jsonString)
@@ -156,7 +156,8 @@ object KlaviyoRemoteMessage {
                 map
             } catch (e: Exception) {
                 Registry.log.warning(
-                    "Klaviyo SDK failed to parse key-value pairs JSON: $jsonString", e
+                    "Klaviyo SDK failed to parse key-value pairs JSON: $jsonString",
+                    e
                 )
                 null
             }

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoRemoteMessage.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoRemoteMessage.kt
@@ -140,7 +140,7 @@ object KlaviyoRemoteMessage {
      * Determine if the message is bearing key-value pairs
      */
     val RemoteMessage.hasKlaviyoKeyValuePairs: Boolean
-        get() = this.isKlaviyoMessage && (this.data[KlaviyoNotification.KEY_VALUE_PAIRS_KEY]?.let { true } ?: false)
+        get() = this.data.containsKey(KlaviyoNotification.KEY_VALUE_PAIRS_KEY)
 
     /**
      * Parse out the key-value pairs into a string:string map

--- a/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoPushServiceTest.kt
+++ b/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoPushServiceTest.kt
@@ -7,13 +7,14 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkConstructor
 import io.mockk.mockkObject
+import io.mockk.spyk
 import io.mockk.verify
 import org.junit.Before
 import org.junit.Test
 
 class KlaviyoPushServiceTest : BaseTest() {
     private val stubPushToken = "stub_token"
-    private val pushService = KlaviyoPushService()
+    private val pushService = spyk(KlaviyoPushService())
     private val stubMessage = mutableMapOf(
         "_k" to "",
         "title" to "",
@@ -71,6 +72,18 @@ class KlaviyoPushServiceTest : BaseTest() {
         pushService.onMessageReceived(msg)
 
         verify(inverse = true) { anyConstructed<KlaviyoNotification>().displayNotification(any()) }
+    }
+
+    @Test
+    fun `Silent push handler is called`() {
+        val msg = mockk<RemoteMessage>()
+        stubMessage.remove("title")
+        stubMessage.remove("body")
+        every { msg.data } returns stubMessage
+
+        pushService.onMessageReceived(msg)
+
+        verify { pushService.onSilentPushMessageReceived(msg) }
     }
 
     @Test

--- a/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoPushServiceTest.kt
+++ b/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoPushServiceTest.kt
@@ -3,22 +3,32 @@ package com.klaviyo.pushFcm
 import com.google.firebase.messaging.RemoteMessage
 import com.klaviyo.analytics.Klaviyo
 import com.klaviyo.fixtures.BaseTest
+import com.klaviyo.pushFcm.KlaviyoNotification.Companion.BODY_KEY
+import com.klaviyo.pushFcm.KlaviyoNotification.Companion.KEY_VALUE_PAIRS_KEY
+import com.klaviyo.pushFcm.KlaviyoNotification.Companion.TITLE_KEY
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkConstructor
 import io.mockk.mockkObject
 import io.mockk.spyk
 import io.mockk.verify
+import org.json.JSONObject
 import org.junit.Before
 import org.junit.Test
 
 class KlaviyoPushServiceTest : BaseTest() {
     private val stubPushToken = "stub_token"
     private val pushService = spyk(KlaviyoPushService())
+    private val stubKeyValuePairs = mapOf(
+        "test_key_1" to "test_value_1",
+        "test_key_2" to "test_value_2",
+        "test_key_3" to "test_value_3"
+    )
     private val stubMessage = mutableMapOf(
         "_k" to "",
-        "title" to "",
-        "body" to ""
+        TITLE_KEY to "",
+        BODY_KEY to "",
+        KEY_VALUE_PAIRS_KEY to JSONObject(stubKeyValuePairs).toString()
     )
 
     @Before
@@ -75,15 +85,13 @@ class KlaviyoPushServiceTest : BaseTest() {
     }
 
     @Test
-    fun `Silent push handler is called`() {
+    fun `Custom data handler is called`() {
         val msg = mockk<RemoteMessage>()
-        stubMessage.remove("title")
-        stubMessage.remove("body")
         every { msg.data } returns stubMessage
 
         pushService.onMessageReceived(msg)
 
-        verify { pushService.onSilentPushMessageReceived(msg) }
+        verify { pushService.onKlaviyoCustomDataMessageReceived(stubKeyValuePairs, msg) }
     }
 
     @Test

--- a/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoRemoteMessageTest.kt
+++ b/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoRemoteMessageTest.kt
@@ -11,8 +11,8 @@ import com.klaviyo.pushFcm.KlaviyoRemoteMessage.isKlaviyoNotification
 import com.klaviyo.pushFcm.KlaviyoRemoteMessage.keyValuePairs
 import io.mockk.every
 import io.mockk.mockk
-import org.junit.Test
 import org.json.JSONObject
+import org.junit.Test
 
 class KlaviyoRemoteMessageTest : BaseTest() {
     private val stubKeyValuePairs = mapOf(

--- a/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoRemoteMessageTest.kt
+++ b/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoRemoteMessageTest.kt
@@ -44,6 +44,17 @@ class KlaviyoRemoteMessageTest : BaseTest() {
     }
 
     @Test
+    fun `Test message is silent push`() {
+        val msg = mockk<RemoteMessage>()
+
+        stubMessage.remove("title")
+        stubMessage.remove("body")
+        every { msg.data } returns stubMessage
+
+        assert(!msg.isKlaviyoNotification)
+    }
+
+    @Test
     fun `Test Key-Value Pairs Deserialization`() {
         val msg = mockk<RemoteMessage>()
         every { msg.data } returns stubMessage

--- a/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoRemoteMessageTest.kt
+++ b/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoRemoteMessageTest.kt
@@ -1,0 +1,54 @@
+package com.klaviyo.pushFcm
+
+import com.google.firebase.messaging.RemoteMessage
+import com.klaviyo.fixtures.BaseTest
+import com.klaviyo.pushFcm.KlaviyoNotification.Companion.BODY_KEY
+import com.klaviyo.pushFcm.KlaviyoNotification.Companion.KEY_VALUE_PAIRS_KEY
+import com.klaviyo.pushFcm.KlaviyoNotification.Companion.TITLE_KEY
+import com.klaviyo.pushFcm.KlaviyoRemoteMessage.hasKlaviyoKeyValuePairs
+import com.klaviyo.pushFcm.KlaviyoRemoteMessage.isKlaviyoMessage
+import com.klaviyo.pushFcm.KlaviyoRemoteMessage.isKlaviyoNotification
+import com.klaviyo.pushFcm.KlaviyoRemoteMessage.keyValuePairs
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Test
+import org.json.JSONObject
+
+class KlaviyoRemoteMessageTest : BaseTest() {
+    private val stubKeyValuePairs = mapOf(
+        "test_key_1" to "test_value_1",
+        "test_key_2" to "test_value_2",
+        "test_key_3" to "test_value_3"
+    )
+    private val stubMessage = mutableMapOf(
+        "_k" to "",
+        TITLE_KEY to "test title",
+        BODY_KEY to "test body",
+        KEY_VALUE_PAIRS_KEY to JSONObject(stubKeyValuePairs).toString()
+    )
+
+    @Test
+    fun `Test isKlaviyoMessage`() {
+        val msg = mockk<RemoteMessage>()
+        every { msg.data } returns stubMessage
+
+        assert(msg.isKlaviyoMessage)
+    }
+
+    @Test
+    fun `Test isKlaviyoNotification`() {
+        val msg = mockk<RemoteMessage>()
+        every { msg.data } returns stubMessage
+
+        assert(msg.isKlaviyoNotification)
+    }
+
+    @Test
+    fun `Test Key-Value Pairs Deserialization`() {
+        val msg = mockk<RemoteMessage>()
+        every { msg.data } returns stubMessage
+
+        assert(msg.hasKlaviyoKeyValuePairs)
+        assert(msg.keyValuePairs == stubKeyValuePairs)
+    }
+}


### PR DESCRIPTION
# Description
<!-- Briefly describe the feature or bug that your pull request addresses -->

Added two new extension properties to `RemoteMessage`s:

1. `hasKlaviyoKeyValuePairs` which is a boolean (`true` if message payloads contain kv-pairs, `false` otherwise)
2. `keyValuePairs` optional `Map<String,String>` which is the dictionary of kv-pairs itself (deserialized from json)

Also updated the README to reflect these changes.

# Check List

- [ ] Are you changing anything with the public API?
No.
- [X] Are your changes backwards compatible with previous SDK Versions?
- [X] Have you tested this change on real device?
- [X] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all Android versions the SDK currently supports?
How can I do this?

## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->

- Added extension properties for key-value pairs
- Added new branching logic for silent pushes, and an overridable handler method

## Test Plan
<!-- How was this code tested / How should reviewers test it? -->

- Tested on the test app - made standard and silent pushes to it, with and without key-value pairs, and then would use extension properties to access the data.
- Also ensured that the log was being made (for the new conditional logic using the new `onSilentPushMessageReceived` method)

## Related Issues/Tickets
<!-- Link to relevant issues or discussion -->

