### PR TITLE
IAF Single Webview

### DIFF
--- a/sdk/forms/src/main/java/com/klaviyo/forms/InAppForms.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/InAppForms.kt
@@ -4,15 +4,10 @@ import com.klaviyo.analytics.Klaviyo
 import com.klaviyo.core.Registry
 import com.klaviyo.core.safeApply
 import java.io.BufferedReader
-import java.lang.ref.WeakReference
-
-private var weakDelegateReference: WeakReference<KlaviyoWebViewDelegate>? = null
 
 fun Klaviyo.registerForInAppForms(): Klaviyo = safeApply {
-    var webViewDelegate = weakDelegateReference?.get()
-    if (webViewDelegate == null) {
-        webViewDelegate = KlaviyoWebViewDelegate()
-        weakDelegateReference = WeakReference(webViewDelegate)
+    if (!Registry.isRegistered<KlaviyoWebViewDelegate>()) {
+        Registry.register<KlaviyoWebViewDelegate>(KlaviyoWebViewDelegate())
     }
     val klaviyoJsUrl =
         // todo remove the asset source from url
@@ -27,5 +22,5 @@ fun Klaviyo.registerForInAppForms(): Klaviyo = safeApply {
         .replace(IAF_SDK_VERSION_PLACEHOLDER, Registry.config.sdkVersion)
         .replace(IAF_HANDSHAKE_PLACEHOLDER, IAF_HANDSHAKE)
         .replace(IAF_KLAVIYO_JS_PLACEHOLDER, klaviyoJsUrl)
-    webViewDelegate.loadHtml(html)
+    Registry.get<KlaviyoWebViewDelegate>().loadHtml(html)
 }

--- a/sdk/forms/src/main/java/com/klaviyo/forms/InAppForms.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/InAppForms.kt
@@ -4,9 +4,16 @@ import com.klaviyo.analytics.Klaviyo
 import com.klaviyo.core.Registry
 import com.klaviyo.core.safeApply
 import java.io.BufferedReader
+import java.lang.ref.WeakReference
+
+private var weakDelegateReference: WeakReference<KlaviyoWebViewDelegate>? = null
 
 fun Klaviyo.registerForInAppForms(): Klaviyo = safeApply {
-    val webView = KlaviyoWebViewDelegate()
+    var webViewDelegate = weakDelegateReference?.get()
+    if (webViewDelegate == null) {
+        webViewDelegate = KlaviyoWebViewDelegate()
+        weakDelegateReference = WeakReference(webViewDelegate)
+    }
     val klaviyoJsUrl =
         // todo remove the asset source from url
         "${Registry.config.baseCdnUrl}/onsite/js/klaviyo.js?env=in-app&company_id=${Registry.config.apiKey}&assetSource=pr-38360"
@@ -20,6 +27,5 @@ fun Klaviyo.registerForInAppForms(): Klaviyo = safeApply {
         .replace(IAF_SDK_VERSION_PLACEHOLDER, Registry.config.sdkVersion)
         .replace(IAF_HANDSHAKE_PLACEHOLDER, IAF_HANDSHAKE)
         .replace(IAF_KLAVIYO_JS_PLACEHOLDER, klaviyoJsUrl)
-
-    webView.loadHtml(html)
+    webViewDelegate.loadHtml(html)
 }


### PR DESCRIPTION
# Description
- We want to ensure that a user cannot have multiple webviews maintained in the stack
- we need to then hold a reference to both the delegate (weak reference in the singleton file), and a reference to the webview ui component in the delegate class itself. 


# Check List

- [ ] Are you changing anything with the public API?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you tested this change on real device?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all Android versions the SDK currently supports?


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->


## Test Plan
- try to spam the button and see that webviews are behaving properly
- every time we launch a webview we should see one appear (if it is set to do so)

## Related Issues/Tickets
na

