### PR TITLE
IAF - Fixes fonts loading cross-origin with a meta referrer tag

### DIFF
--- a/sdk/forms/src/main/assets/InAppFormsTemplate.html
+++ b/sdk/forms/src/main/assets/InAppFormsTemplate.html
@@ -9,7 +9,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0, viewport-fit=cover"/>
     <meta name="referrer" content="same-origin" />
     <title>Klaviyo In-App Form Template</title>
-    <link rel="stylesheet" type="text/css" href="https://static-forms.klaviyo.com/fonts/api/v1/in-app-web-fonts/custom_fonts.css" crossorigin/>
+    <link rel="stylesheet" type="text/css" href="https://static-forms.klaviyo.com/fonts/api/v1/in-app-web-fonts/websafe_fonts.css" crossorigin/>
     <script type="text/javascript" src="KLAVIYO_JS_URL"></script>
 </head>
 <body></body>

--- a/sdk/forms/src/main/assets/InAppFormsTemplate.html
+++ b/sdk/forms/src/main/assets/InAppFormsTemplate.html
@@ -7,7 +7,9 @@
 >
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0, viewport-fit=cover"/>
+    <meta name="referrer" content="same-origin" />
     <title>Klaviyo In-App Form Template</title>
+    <link rel="stylesheet" type="text/css" href="https://static-forms.klaviyo.com/fonts/api/v1/in-app-web-fonts/custom_fonts.css" crossorigin/>
     <script type="text/javascript" src="KLAVIYO_JS_URL"></script>
 </head>
 <body></body>


### PR DESCRIPTION
# Description
After a number of dead ends, I finally tracked down the font loading CORS issue to be a difference between webkit and chromium when loading cross-origin resources. Specifically, for a css import, the referrer header is set to the origin of the CSS file (on webkit it is left empty) this was causing google fonts to return a 403. Conveniently, this was even reproducible in my desktop version of chrome.
If you want to test -- try using proxyman with the "No Caching" tool toggled on -- I found that a combination of browser cache and application cache were confounding some of my test results until I deployed that tool. 

### In the weeds: 
The css file itself loads fine, however the `@import`ed font file from google fonts does _not_, we get a 403 error back 
from the server with a message attributed to CORS. On iOS, the fonts were all loading fine. So we inspected the traffic from within android studio and identified it appeared to be sending a Referrer header that iOS was not. 
The most obvious difference was that iOS was loading from a file path, while android was using `loadDataWithBaseUrl` which loads an HTML string while explicitly setting an origin on the page. Figured that might be the source of the extra security header. In a quick test, this _appeared_ to solve the CORS issue so I converted to loading from file. But then it stopped working again... I think a combination of debugging with chrome remote debugger, and the application cache must have confounded that initial test. The suspicious thing was that the `Referrer` header was not using the base url of my web page, it was using `static-forms.klaviyo` -- the host of the base CSS that does the importing. 
Then I tried to use the webview delegate method `shouldInterceptRequest` to re-make the CSS request with new headers. It was an ugly solution that required creating the HTTP client myself to execute the request, and it wasn't going to be fully backward compatible because some versions of android don't allow you to access the _headers_ of the web request, and ironically since I couldn't access all the headers, I was getting CORS errors straight from the webview instead -- it wouldn't even make the request to the server to get the 403.
Finally searched more into whether it is possible to control the headers used to make `@import` requests. Found this meta tag that can specify `Referrer` behavior for all resource loads, and that is good enough for what we're doing here! 

[MDN Docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy) on this meta tag
[Likely related chromium bug](https://issues.chromium.org/issues/40545188)


# Check List

- [ ] Are you changing anything with the public API?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you tested this change on real device?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all Android versions the SDK currently supports?


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->


## Test Plan
<!-- How was this code tested / How should reviewers test it? -->


## Related Issues/Tickets
<!-- Link to relevant issues or discussion -->

