### PR TITLE
Close on orientation change

### DIFF
--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -63,7 +63,9 @@ object Klaviyo {
         val application = applicationContext.applicationContext as? Application
         application?.apply {
             unregisterActivityLifecycleCallbacks(Registry.lifecycleCallbacks)
+            unregisterComponentCallbacks(Registry.componentCallbacks)
             registerActivityLifecycleCallbacks(Registry.lifecycleCallbacks)
+            registerComponentCallbacks(Registry.componentCallbacks)
         } ?: throw LifecycleException()
 
         Registry.get<ApiClient>().startService()

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoPreInitializeTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoPreInitializeTest.kt
@@ -55,7 +55,9 @@ internal class KlaviyoPreInitializeTest : BaseTest() {
         every { Registry.configBuilder } returns mockBuilder
         every { mockContext.applicationContext } returns mockk<Application>().apply {
             every { unregisterActivityLifecycleCallbacks(any()) } returns Unit
+            every { unregisterComponentCallbacks(any()) } returns Unit
             every { registerActivityLifecycleCallbacks(any()) } returns Unit
+            every { registerComponentCallbacks(any()) } returns Unit
         }
         Registry.register<ApiClient>(mockApiClient)
     }

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
@@ -84,7 +84,9 @@ internal class KlaviyoTest : BaseTest() {
     private val mockApplication = mockk<Application>().apply {
         every { mockContext.applicationContext } returns this
         every { unregisterActivityLifecycleCallbacks(any()) } returns Unit
+        every { unregisterComponentCallbacks(any()) } returns Unit
         every { registerActivityLifecycleCallbacks(any()) } returns Unit
+        every { registerComponentCallbacks(any()) } returns Unit
     }
 
     @Before
@@ -129,12 +131,15 @@ internal class KlaviyoTest : BaseTest() {
     @Test
     fun `Initialize properly creates new config service and attaches lifecycle listeners`() {
         val expectedListener = Registry.lifecycleCallbacks
+        val expectedConfigListener = Registry.componentCallbacks
         verifyAll {
             mockBuilder.apiKey(API_KEY)
             mockBuilder.applicationContext(mockContext)
             mockBuilder.build()
             mockApplication.unregisterActivityLifecycleCallbacks(match { it == expectedListener })
             mockApplication.registerActivityLifecycleCallbacks(match { it == expectedListener })
+            mockApplication.unregisterComponentCallbacks(match { it == expectedConfigListener })
+            mockApplication.registerComponentCallbacks(match { it == expectedConfigListener })
         }
     }
 

--- a/sdk/core/src/main/java/com/klaviyo/core/Registry.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/Registry.kt
@@ -1,6 +1,7 @@
 package com.klaviyo.core
 
 import android.app.Application
+import android.content.ComponentCallbacks
 import com.klaviyo.core.config.Clock
 import com.klaviyo.core.config.Config
 import com.klaviyo.core.config.KlaviyoConfig
@@ -56,6 +57,8 @@ object Registry {
     val lifecycleMonitor: LifecycleMonitor get() = KlaviyoLifecycleMonitor
 
     val lifecycleCallbacks: Application.ActivityLifecycleCallbacks get() = KlaviyoLifecycleMonitor
+
+    val componentCallbacks: ComponentCallbacks get() = KlaviyoLifecycleMonitor
 
     val networkMonitor: NetworkMonitor get() = KlaviyoNetworkMonitor
 

--- a/sdk/core/src/main/java/com/klaviyo/core/lifecycle/KlaviyoLifecycleMonitor.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/lifecycle/KlaviyoLifecycleMonitor.kt
@@ -2,6 +2,8 @@ package com.klaviyo.core.lifecycle
 
 import android.app.Activity
 import android.app.Application
+import android.content.ComponentCallbacks
+import android.content.res.Configuration
 import android.os.Bundle
 import com.klaviyo.core.Registry
 import com.klaviyo.core.utils.WeakReferenceDelegate
@@ -10,7 +12,7 @@ import java.util.Collections
 /**
  * Service for monitoring the application lifecycle and network connectivity
  */
-internal object KlaviyoLifecycleMonitor : LifecycleMonitor, Application.ActivityLifecycleCallbacks {
+internal object KlaviyoLifecycleMonitor : LifecycleMonitor, Application.ActivityLifecycleCallbacks, ComponentCallbacks {
 
     private var activeActivities = 0
 
@@ -80,6 +82,14 @@ internal object KlaviyoLifecycleMonitor : LifecycleMonitor, Application.Activity
 
     override fun onActivityDestroyed(activity: Activity) {
         // Warning: onActivityDestroyed is unreliable, I'm not even going to try to broadcast it
+    }
+
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        broadcastEvent(ActivityEvent.ConfigurationChanged(newConfig))
+    }
+
+    override fun onLowMemory() {
+        // currently not needed
     }
 
     //endregion

--- a/sdk/core/src/main/java/com/klaviyo/core/lifecycle/LifecycleMonitor.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/lifecycle/LifecycleMonitor.kt
@@ -1,6 +1,7 @@
 package com.klaviyo.core.lifecycle
 
 import android.app.Activity
+import android.content.res.Configuration
 import android.os.Bundle
 
 typealias ActivityObserver = (activity: ActivityEvent) -> Unit
@@ -22,6 +23,8 @@ sealed class ActivityEvent(val activity: Activity? = null, val bundle: Bundle? =
     class Stopped(activity: Activity) : ActivityEvent(activity)
 
     class AllStopped : ActivityEvent()
+
+    class ConfigurationChanged(val newConfig: Configuration) : ActivityEvent()
 }
 
 /**

--- a/sdk/core/src/test/java/com/klaviyo/core/lifecycle/KlaviyoLifecycleMonitorTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/lifecycle/KlaviyoLifecycleMonitorTest.kt
@@ -67,6 +67,7 @@ class KlaviyoLifecycleMonitorTest : BaseTest() {
         var pausedCount = 0
         var stoppedCount = 0
         var allStoppedCount = 0
+        var configChangeCount = 0
 
         KlaviyoLifecycleMonitor.onActivityEvent {
             when (it) {
@@ -77,6 +78,7 @@ class KlaviyoLifecycleMonitorTest : BaseTest() {
                 is ActivityEvent.Paused -> pausedCount++
                 is ActivityEvent.Stopped -> stoppedCount++
                 is ActivityEvent.AllStopped -> allStoppedCount++
+                is ActivityEvent.ConfigurationChanged -> configChangeCount++
             }
         }
 
@@ -86,6 +88,7 @@ class KlaviyoLifecycleMonitorTest : BaseTest() {
         KlaviyoLifecycleMonitor.onActivitySaveInstanceState(mockk(), mockk())
         KlaviyoLifecycleMonitor.onActivityPaused(mockk())
         KlaviyoLifecycleMonitor.onActivityStopped(mockk())
+        KlaviyoLifecycleMonitor.onConfigurationChanged(mockk())
 
         assertEquals(1, createdCount)
         assertEquals(1, startedCount)
@@ -94,6 +97,7 @@ class KlaviyoLifecycleMonitorTest : BaseTest() {
         assertEquals(1, pausedCount)
         assertEquals(1, stoppedCount)
         assertEquals(1, allStoppedCount)
+        assertEquals(1, configChangeCount)
     }
 
     @Test

--- a/sdk/forms/src/main/java/com/klaviyo/forms/KlaviyoWebViewDelegate.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/KlaviyoWebViewDelegate.kt
@@ -12,7 +12,6 @@ import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.core.content.ContextCompat.startActivity
-import androidx.core.view.isVisible
 import androidx.webkit.JavaScriptReplyProxy
 import androidx.webkit.WebMessageCompat
 import androidx.webkit.WebViewCompat
@@ -51,15 +50,11 @@ internal class KlaviyoWebViewDelegate : WebViewClient(), WebViewCompat.WebMessag
         Registry.lifecycleMonitor.onActivityEvent {
             if (it is ActivityEvent.ConfigurationChanged) {
                 val newOrientation = it.newConfig.orientation
-                orientation?.let { oldOrientation ->
-                    if (oldOrientation != newOrientation && webView?.isVisible == true) {
-                        Registry.log.debug("New screen rotation, closing form")
-                        close()
-                        orientation = newOrientation
-                    }
-                } ?: run {
-                    orientation = newOrientation
+                if (orientation != newOrientation) {
+                    Registry.log.debug("New screen orientation, closing form")
+                    close()
                 }
+                orientation = newOrientation
             }
         }
     }


### PR DESCRIPTION
# Description
- we attach the webview to the current screen on the show message, but if a new activity is launched (like on a config change) that screen is lost in the ether
- we need to change on not just a config change, but specifically when the orientation is updated
- because that callback gets emitted when the app first started, we locally store the orientation and only close the form if the new orientation is different and the forms is already visible to the user


# Check List

- [ ] Are you changing anything with the public API?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you tested this change on real device?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all Android versions the SDK currently supports?


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->


## Test Plan
<!-- How was this code tested / How should reviewers test it? -->


## Related Issues/Tickets
<!-- Link to relevant issues or discussion -->

