### PR TITLE
Patches related to webview.destroy

### DIFF
--- a/sdk/forms/src/main/java/com/klaviyo/forms/KlaviyoWebViewDelegate.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/KlaviyoWebViewDelegate.kt
@@ -120,6 +120,16 @@ internal class KlaviyoWebViewDelegate : WebViewClient(), WebViewCompat.WebMessag
         super.onReceivedHttpError(view, request, errorResponse)
     }
 
+    override fun onPageFinished(view: WebView?, url: String?) {
+        super.onPageFinished(view, url)
+        // When an assetSource is specified, log whether we actually got it
+        Registry.config.assetSource?.let { expected ->
+            webView?.evaluateJavascript("window.klaviyoModulesObject?.assetSource") { actual ->
+                Registry.log.info("Actual Asset Source: $actual. Expected $expected")
+            }
+        }
+    }
+
     /**
      * Intercept page navigation and redirect to an external browser application
      */
@@ -229,10 +239,8 @@ internal class KlaviyoWebViewDelegate : WebViewClient(), WebViewCompat.WebMessag
                 Registry.log.verbose("Clear IAF WebView reference")
                 this.webView = null
                 webView.visibility = View.GONE
-                webView.parent?.let {
-                    (it as ViewGroup).removeView(webView)
-                    webView.destroy()
-                }
+                webView.parent?.let { it as ViewGroup }?.removeView(webView)
+                webView.destroy()
             }
         } ?: run {
             Registry.log.warning("Unable to close IAF - null activity reference")

--- a/sdk/forms/src/main/java/com/klaviyo/forms/KlaviyoWebViewDelegate.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/KlaviyoWebViewDelegate.kt
@@ -105,7 +105,7 @@ internal class KlaviyoWebViewDelegate : WebViewClient(), WebViewCompat.WebMessag
     }
 
     private fun Uri.Builder.appendAssetSource() = Registry.config.assetSource?.let { assetSource ->
-        Registry.log.info("Appending assetSource=$assetSource to klaviyo.js")
+        Registry.log.debug("Appending assetSource=$assetSource to klaviyo.js")
         appendQueryParameter("assetSource", assetSource)
     } ?: this
 
@@ -126,7 +126,7 @@ internal class KlaviyoWebViewDelegate : WebViewClient(), WebViewCompat.WebMessag
         // When an assetSource is specified, log whether we actually got it
         Registry.config.assetSource?.let { expected ->
             webView?.evaluateJavascript("window.klaviyoModulesObject?.assetSource") { actual ->
-                Registry.log.info("Actual Asset Source: $actual. Expected $expected")
+                Registry.log.debug("Actual Asset Source: $actual. Expected $expected")
             }
         }
     }
@@ -136,7 +136,7 @@ internal class KlaviyoWebViewDelegate : WebViewClient(), WebViewCompat.WebMessag
      * we have to clean up and return true here else the host app will crash
      */
     override fun onRenderProcessGone(view: WebView?, detail: RenderProcessGoneDetail?): Boolean = close().let {
-        Registry.log.info("WebView crashed or deallocated")
+        Registry.log.error("WebView crashed or deallocated")
         return true
     }
 

--- a/sdk/forms/src/main/java/com/klaviyo/forms/KlaviyoWebViewDelegate.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/KlaviyoWebViewDelegate.kt
@@ -242,6 +242,7 @@ internal class KlaviyoWebViewDelegate : WebViewClient(), WebViewCompat.WebMessag
      * Handle a [BridgeMessage.Close] message by detaching and destroying the [KlaviyoWebView]
      */
     private fun close() = webView?.let { webView ->
+        handshakeTimer?.cancel()
         activity?.window?.decorView?.post {
             Registry.log.verbose("Clear IAF WebView reference")
             this.webView = null
@@ -258,8 +259,8 @@ internal class KlaviyoWebViewDelegate : WebViewClient(), WebViewCompat.WebMessag
     /**
      * Handle a [BridgeMessage.Abort] message by logging the reason and destroying the webview
      */
-    private fun abort(reason: String) = Registry.log.info("IAF aborted, reason: $reason").also {
-        close()
+    private fun abort(reason: String) = close().also {
+        Registry.log.info("IAF aborted, reason: $reason")
     }
 
     /**


### PR DESCRIPTION
While testing the new abort condition, I noticed that webviews seemed to be accumulating according to chrome device inspector. LeakCanary didn't detect this as a leak for some reason, but it does appear to be accumulating in memory, and simply moving where we call `destroy` from, to be every time rather than only if the view had been attached, fixes the issue in that chrome devices list. 

And while reading up on `webview.destroy` I came across [this method](https://developer.android.com/develop/ui/views/layout/webapps/managing-webview) that is called if the webview's javascript context crashes or gets GC'd. It seems like a very unlikely situation but we may as well handle it gracefully rather than crash the host app. 