### PR TITLE
[CHNL-12435] Adding new lifecycle listener function

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,10 @@ persist data. Upon initialize, the SDK registers listeners for your application'
 to gracefully manage background processes.
 
 `Klaviyo.initialize()` **must** be called before any other SDK methods can be invoked. We recommend initializing from 
-the earliest point in your application code, such as the `Application.onCreate()` method.
+the earliest point in your application code, such as the `Application.onCreate()` method If you are
+unable to provide your Klaviyo API Key in the `Application.onCreate()` method, please call
+`Klaviyo.registerForLifecycleCallbacks()` in the `onCreate()`. You will still need to provide the API
+key eventually for full functionality.
 
 ```kotlin
 // Application subclass 
@@ -98,6 +101,11 @@ class YourApplication : Application() {
         /* ... */
         
         // Initialize is required before invoking any other Klaviyo SDK functionality 
+        Klaviyo.initialize("KLAVIYO_PUBLIC_API_KEY", applicationContext)
+        
+        // If you don't have the API key at Application creation, call this before
+        Klaviyo.registerForLifecycleCallbacks(applicationContext)
+        // and this after
         Klaviyo.initialize("KLAVIYO_PUBLIC_API_KEY", applicationContext)
     }
 }

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -46,6 +46,23 @@ object Klaviyo {
     }
 
     /**
+     * Use this method to register Klaviyo for lifecycle functions. This is necessary for
+     * apps that are not able to initialize Klaviyo immediately on app launch, but would like to
+     * utilize Klaviyo Forms
+     *
+     * @param applicationContext
+     */
+    fun registerForLifecycleCallbacks(applicationContext: Context) = safeApply {
+        val application = applicationContext.applicationContext as? Application
+        application?.apply {
+            unregisterActivityLifecycleCallbacks(Registry.lifecycleCallbacks)
+            unregisterComponentCallbacks(Registry.componentCallbacks)
+            registerActivityLifecycleCallbacks(Registry.lifecycleCallbacks)
+            registerComponentCallbacks(Registry.componentCallbacks)
+        } ?: throw LifecycleException()
+    }
+
+    /**
      * Configure Klaviyo SDK with your account's public API Key and application context.
      * This must be called to before using any other SDK functionality
      *
@@ -60,13 +77,7 @@ object Klaviyo {
                 .build()
         )
 
-        val application = applicationContext.applicationContext as? Application
-        application?.apply {
-            unregisterActivityLifecycleCallbacks(Registry.lifecycleCallbacks)
-            unregisterComponentCallbacks(Registry.componentCallbacks)
-            registerActivityLifecycleCallbacks(Registry.lifecycleCallbacks)
-            registerComponentCallbacks(Registry.componentCallbacks)
-        } ?: throw LifecycleException()
+        registerForLifecycleCallbacks(applicationContext)
 
         Registry.get<ApiClient>().startService()
 

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoRegisterForLifecycleCallbacksTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoRegisterForLifecycleCallbacksTest.kt
@@ -1,0 +1,61 @@
+package com.klaviyo.analytics
+
+import android.app.Application
+import com.klaviyo.core.Registry
+import com.klaviyo.core.config.Config
+import com.klaviyo.fixtures.BaseTest
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.mockk.verifyAll
+import org.junit.Test
+
+internal class KlaviyoRegisterForLifecycleCallbacksTest : BaseTest() {
+
+    private val mockBuilder = mockk<Config.Builder>().apply {
+        every { apiKey(any()) } returns this
+        every { applicationContext(any()) } returns this
+        every { build() } returns mockConfig
+    }
+
+    private val mockApplicationContext = mockk<Application> {
+        every { applicationContext } returns mockk()
+        every { unregisterActivityLifecycleCallbacks(any()) } returns Unit
+        every { unregisterComponentCallbacks(any()) } returns Unit
+        every { registerActivityLifecycleCallbacks(any()) } returns Unit
+        every { registerComponentCallbacks(any()) } returns Unit
+    }
+
+    private val mockApplication = mockk<Application>().apply {
+        every { applicationContext } returns mockApplicationContext
+    }
+
+    @Test
+    fun `check that lifecycle register function does not touch api key dependent functions`() {
+        val expectedListener = Registry.lifecycleCallbacks
+        val expectedConfigListener = Registry.componentCallbacks
+
+        Klaviyo.registerForLifecycleCallbacks(mockApplication)
+
+        verifyAll {
+            mockApplicationContext.unregisterActivityLifecycleCallbacks(
+                match { it == expectedListener }
+            )
+            mockApplicationContext.registerActivityLifecycleCallbacks(
+                match { it == expectedListener }
+            )
+            mockApplicationContext.unregisterComponentCallbacks(
+                match { it == expectedConfigListener }
+            )
+            mockApplicationContext.registerComponentCallbacks(
+                match { it == expectedConfigListener }
+            )
+        }
+
+        verify(exactly = 0) {
+            mockBuilder.apiKey(any())
+            mockBuilder.applicationContext(any())
+            mockBuilder.build()
+        }
+    }
+}


### PR DESCRIPTION
# Description
- while porting forms to react native, we found that if the Klaviyo SDK is initialized after the first activity is started, our internal lifecycle listener has no way to access the current activity. This means that we cannot show the in app web form. To protect against this, I'm adding back the lifecycle listener function. In the case of react native, this means that we need to update that documentation to tell users 'hey add this to your Android built application onCreate'. 
- 
# Check List

- [x] Are you changing anything with the public API?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [x] Have you tested this change on real device?
- [x] Have you added unit test coverage for your changes?
- [x] Have you verified that your changes are compatible with all Android versions the SDK currently supports?


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->


## Test Plan
Tested on an Android device with the test app, on the react native example app, and the react native test app.

## Related Issues/Tickets
https://klaviyo.atlassian.net/browse/CHNL-18547