### PR TITLE
Pre-init queue for events

### DIFF
--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -233,7 +233,7 @@ object Klaviyo {
      * @param event A map-like object representing the event attributes
      * @return Returns [Klaviyo] for call chaining
      */
-    fun createEvent(event: Event): Klaviyo = safeApply {
+    fun createEvent(event: Event): Klaviyo = safeApply(preInitQueue) {
         Registry.get<ApiClient>().enqueueEvent(event, Registry.get<State>().getAsProfile())
     }
 

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -3,6 +3,8 @@ package com.klaviyo.analytics
 import android.app.Application
 import android.content.Context
 import android.content.Intent
+import com.klaviyo.analytics.Klaviyo.initialize
+import com.klaviyo.analytics.Klaviyo.resetProfile
 import com.klaviyo.analytics.model.Event
 import com.klaviyo.analytics.model.EventKey
 import com.klaviyo.analytics.model.EventMetric
@@ -20,8 +22,7 @@ import com.klaviyo.core.config.LifecycleException
 import com.klaviyo.core.safeApply
 import com.klaviyo.core.safeCall
 import java.io.Serializable
-import java.util.LinkedList
-import java.util.Queue
+import java.util.*
 
 /**
  * Public API for the core Klaviyo SDK.
@@ -229,7 +230,7 @@ object Klaviyo {
      * @param event A map-like object representing the event attributes
      * @return Returns [Klaviyo] for call chaining
      */
-    fun createEvent(event: Event): Klaviyo = safeApply(preInitQueue) {
+    fun createEvent(event: Event): Klaviyo = safeApply {
         Registry.get<ApiClient>().enqueueEvent(event, Registry.get<State>().getAsProfile())
     }
 

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -3,8 +3,6 @@ package com.klaviyo.analytics
 import android.app.Application
 import android.content.Context
 import android.content.Intent
-import com.klaviyo.analytics.Klaviyo.initialize
-import com.klaviyo.analytics.Klaviyo.resetProfile
 import com.klaviyo.analytics.model.Event
 import com.klaviyo.analytics.model.EventKey
 import com.klaviyo.analytics.model.EventMetric
@@ -22,7 +20,8 @@ import com.klaviyo.core.config.LifecycleException
 import com.klaviyo.core.safeApply
 import com.klaviyo.core.safeCall
 import java.io.Serializable
-import java.util.*
+import java.util.LinkedList
+import java.util.Queue
 
 /**
  * Public API for the core Klaviyo SDK.

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -226,10 +226,6 @@ object Klaviyo {
     /**
      * Creates an [Event] associated with the currently tracked profile
      *
-     * While it is preferable to [initialize] before interacting with the Klaviyo SDK,
-     * due to timing issues on some platforms, events are stored in an in-memory buffer prior to initialization,
-     * and will be replayed once you initialize with your public API key.
-     *
      * @param event A map-like object representing the event attributes
      * @return Returns [Klaviyo] for call chaining
      */
@@ -253,9 +249,9 @@ object Klaviyo {
      * From an opened push Intent, creates an [EventMetric.OPENED_PUSH] [Event]
      * containing appropriate tracking parameters
      *
-     * While it is preferable to [initialize] before interacting with the Klaviyo SDK,
-     * due to timing issues on some platforms, events are stored in an in-memory buffer prior to initialization,
-     * and will be replayed once you initialize with your public API key.
+     * While it is generally required to [initialize] before interacting with the Klaviyo SDK,
+     * due to potential timing issues push open events are stored in an in-memory buffer prior to initializing,
+     * and will be ingested once you initialize with your public API key.
      *
      * @param intent the [Intent] from opening a notification
      */


### PR DESCRIPTION
We have this pre-init queue specifically for push opened events, but we had the same comment on there for the standard `createEvent` method. I'm not sure whether the mistake is having the comment, or missing the preInitQueue. Given react native timing issues, i'm inclined to add the flexibility for any event creation though.