### PR TITLE
Allow currentActivity to be set from outside the service

### DIFF
--- a/sdk/core/src/main/java/com/klaviyo/core/lifecycle/LifecycleMonitor.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/lifecycle/LifecycleMonitor.kt
@@ -32,7 +32,13 @@ sealed class ActivityEvent(val activity: Activity? = null, val bundle: Bundle? =
  */
 interface LifecycleMonitor {
 
-    val currentActivity: Activity?
+    /**
+     * Tracks the current activity of the host application.
+     *
+     * It is best to allow the lifecycle monitor to track activity internally,
+     * but exposing this as a var allows for an override e.g. in case of timing issues capturing the first Activity
+     */
+    var currentActivity: Activity?
 
     /**
      * Register an observer to be notified when all application activities stopped


### PR DESCRIPTION
# Description
This would allow any consumer of the `core` package to override the current activity.

While its best to track currentActivity internally with activity lifecycle listeners, in the RN SDK we are not able to attach lifecycle listeners "in time" to catch the first activity's creation. However, react native's android framework _does_ have a reference to the first activity (via a lifecycle listener that works the same way as ours). So if we can just pass a reference in to that first activity, from that point on we can track activity changes with lifecycle listeners. This way, we don't have to ask RN devs to add any native code for Android, which is a sticking point for RN, especially Expo.

This can be a patch version, I can include the version bump in this PR for expediency. 

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you tested this change on real device?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all Android versions the SDK currently supports?


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->


## Test Plan
<!-- How was this code tested / How should reviewers test it? -->


## Related Issues/Tickets
<!-- Link to relevant issues or discussion -->

