### PR TITLE
Patch version: 3.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ send them timely push notifications via [FCM (Firebase Cloud Messaging)](https:/
       ```kotlin
       // build.gradle.kts
       dependencies {
-          implementation("com.github.klaviyo.klaviyo-android-sdk:analytics:3.3.0")
-          implementation("com.github.klaviyo.klaviyo-android-sdk:push-fcm:3.3.0")
-          implementation("com.github.klaviyo.klaviyo-android-sdk:forms:3.3.0")
+          implementation("com.github.klaviyo.klaviyo-android-sdk:analytics:3.3.1")
+          implementation("com.github.klaviyo.klaviyo-android-sdk:push-fcm:3.3.1")
+          implementation("com.github.klaviyo.klaviyo-android-sdk:forms:3.3.1")
       }
       ```
    </details>
@@ -68,9 +68,9 @@ send them timely push notifications via [FCM (Firebase Cloud Messaging)](https:/
       ```groovy
        // build.gradle
        dependencies {
-           implementation "com.github.klaviyo.klaviyo-android-sdk:analytics:3.3.0"
-           implementation "com.github.klaviyo.klaviyo-android-sdk:push-fcm:3.3.0"
-           implementation "com.github.klaviyo.klaviyo-android-sdk:forms:3.3.0"
+           implementation "com.github.klaviyo.klaviyo-android-sdk:analytics:3.3.1"
+           implementation "com.github.klaviyo.klaviyo-android-sdk:push-fcm:3.3.1"
+           implementation "com.github.klaviyo.klaviyo-android-sdk:forms:3.3.1"
        }
       ```
    </details>

--- a/build.gradle
+++ b/build.gradle
@@ -109,7 +109,6 @@ public class BumpVersion extends DefaultTask {
     @TaskAction
     public void bumpVersion() {
         def currentVersion = readXmlValue('sdk/core/src/main/res/values/strings.xml','klaviyo_sdk_version_override')
-        println(currentVersion)
         def nextVersion = this.getNextVersion()
         def currentBuild = versionFor(project, "version.klaviyo.versionCode") as Integer
         def nextBuild = currentBuild + 1

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,2 +1,2 @@
 <!-- Redirect to latest version -->
-<meta HTTP-EQUIV="REFRESH" content="0; url=./3.3.0/index.html">
+<meta HTTP-EQUIV="REFRESH" content="0; url=./3.3.1/index.html">

--- a/sdk/core/src/main/res/values/strings.xml
+++ b/sdk/core/src/main/res/values/strings.xml
@@ -2,5 +2,5 @@
 <resources>
     <!-- Please do not modify these values, it will stop SDK functionality-->
     <string name="klaviyo_sdk_name_override">android</string>
-    <string name="klaviyo_sdk_version_override">3.3.0</string>
+    <string name="klaviyo_sdk_version_override">3.3.1</string>
 </resources>

--- a/versions.properties
+++ b/versions.properties
@@ -13,7 +13,7 @@
 #  NOTE: semantic version of the SDK lives in strings.xml
 #  run the following gradle command to update version numbers automatically:
 #  ./gradlew bumpVersion --nextVersion=X.Y.Z
-version.klaviyo.versionCode=30
+version.klaviyo.versionCode=31
 
 # Project gradle plugins
 plugin.android=8.2.1


### PR DESCRIPTION
# Description
3.3.1 adds in the ability to set our ActivityLifecycle monitor's `currentActivity` by importing `core`. This is a blocker to RN release for In App Forms. 
see https://github.com/klaviyo/klaviyo-android-sdk/pull/248
# Check List

- [ ] Are you changing anything with the public API?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you tested this change on real device?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all Android versions the SDK currently supports?


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->


## Test Plan
<!-- How was this code tested / How should reviewers test it? -->


## Related Issues/Tickets
<!-- Link to relevant issues or discussion -->

