### PR TITLE
Require an opt-in to override the current activity. 

### DIFF
--- a/sdk/core/src/main/java/com/klaviyo/core/lifecycle/KlaviyoLifecycleMonitor.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/lifecycle/KlaviyoLifecycleMonitor.kt
@@ -6,6 +6,7 @@ import android.content.ComponentCallbacks
 import android.content.res.Configuration
 import android.os.Bundle
 import com.klaviyo.core.Registry
+import com.klaviyo.core.utils.AdvancedAPI
 import com.klaviyo.core.utils.WeakReferenceDelegate
 import java.util.Collections
 
@@ -21,6 +22,11 @@ internal object KlaviyoLifecycleMonitor : LifecycleMonitor, Application.Activity
     )
 
     override var currentActivity: Activity? by WeakReferenceDelegate()
+
+    @AdvancedAPI
+    override fun assignCurrentActivity(activity: Activity) {
+        currentActivity = activity
+    }
 
     override fun onActivityEvent(observer: ActivityObserver) {
         activityObservers += observer

--- a/sdk/core/src/main/java/com/klaviyo/core/lifecycle/LifecycleMonitor.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/lifecycle/LifecycleMonitor.kt
@@ -1,8 +1,10 @@
 package com.klaviyo.core.lifecycle
 
 import android.app.Activity
+import android.app.Application
 import android.content.res.Configuration
 import android.os.Bundle
+import com.klaviyo.core.utils.AdvancedAPI
 
 typealias ActivityObserver = (activity: ActivityEvent) -> Unit
 
@@ -34,11 +36,8 @@ interface LifecycleMonitor {
 
     /**
      * Tracks the current activity of the host application.
-     *
-     * It is best to allow the lifecycle monitor to track activity internally,
-     * but exposing this as a var allows for an override e.g. in case of timing issues capturing the first Activity
      */
-    var currentActivity: Activity?
+    val currentActivity: Activity?
 
     /**
      * Register an observer to be notified when all application activities stopped
@@ -53,4 +52,16 @@ interface LifecycleMonitor {
      * @param observer
      */
     fun offActivityEvent(observer: ActivityObserver)
+
+    /**
+     * Explicitly sets the current activity.
+     *
+     * It is best to allow the SDK to track activities internally via [Application.ActivityLifecycleCallbacks].
+     * However, this explicit override allows us to work around timing issues such as
+     * when [LifecycleMonitor] can't be attached in time to capture the first Activity.
+     *
+     * @param activity
+     */
+    @AdvancedAPI
+    fun assignCurrentActivity(activity: Activity)
 }

--- a/sdk/core/src/main/java/com/klaviyo/core/utils/AdvancedAPI.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/utils/AdvancedAPI.kt
@@ -1,0 +1,14 @@
+package com.klaviyo.core.utils
+
+@RequiresOptIn(
+    message = "This is an advanced API requiring explicit opt-in. See documentation comments for more information.",
+    level = RequiresOptIn.Level.ERROR
+)
+@Retention(AnnotationRetention.BINARY)
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.PROPERTY,
+    AnnotationTarget.CONSTRUCTOR
+)
+annotation class AdvancedAPI


### PR DESCRIPTION
# Description
Building on earlier PR, this protects the ability to override current activity with an explicit opt-in. 
Side note, this annotation will definitely be used more...

When you try to use it, you'll get a compilation error message like this in the IDE
![Screenshot 2025-03-26 at 16 22 12](https://github.com/user-attachments/assets/354998b2-a21a-4469-acc1-4b1c9bf153d0)
For which the IDE will suggest an auto-fix like this:
`@OptIn(AdvancedAPI::class)`

And I made sure that `AdvancedAPI` is a public class so you can access it to opt in.

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you tested this change on real device?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all Android versions the SDK currently supports?


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->


## Test Plan
<!-- How was this code tested / How should reviewers test it? -->


## Related Issues/Tickets
<!-- Link to relevant issues or discussion -->

