### PR TITLE
[CHNL-19996] Support Automatic Push Service Manifest Entry

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -2,6 +2,13 @@
 This document provides guidance on how to migrate from the old version of the SDK to a newer version. 
 It will be updated as new versions are released including deprecations or breaking changes.
 
+# 3.3.1
+
+### Improvements
+- The Klaviyo Push Service manifest entry has been added to our PushFcm module. You no longer have to manually
+add this to your AndroidManifest to register our service. This can be easily overridden by declaring your own implementation
+of `KlaviyoPushService` or `FirebaseMessagingService` in the manifest.
+
 # 3.0.0
 
 ### Improvements

--- a/README.md
+++ b/README.md
@@ -203,25 +203,6 @@ Klaviyo.createEvent(event)
 - If you expect to use deep links in your push notifications, see the [deep linking](#deep-linking) section below.
 
 ### Setup
-The Klaviyo Push SDK for Android works as a wrapper around `FirebaseMessagingService`, so the
-setup process is very similar to the Firebase client documentation linked above.  We've added it to the library
-manifest, which will be merged with your app on build. If you'd like to override this implementation with your 
-own push service, consider it will impact SDK functionality.
-
-```xml
-<!-- AndroidManifest.xml -->
-<manifest>
-    <!-- ... -->
-    <application>
-        <!-- ... -->
-        <service android:name="com.your.own.PushService" android:exported="false">
-            <intent-filter>
-                <action android:name="com.google.firebase.MESSAGING_EVENT" />
-            </intent-filter>
-        </service>
-    </application>
-</manifest>
-``` 
 
 To specify an icon and/or color for Klaviyo notifications, add the following optional metadata elements to the
 application component of `AndroidManifest.xml`. Absent these keys, the firebase keys
@@ -337,7 +318,9 @@ processing, logging analytics events, or dynamically updating app content.
 
 ### Advanced Setup
 If you'd prefer to have your own implementation of `FirebaseMessagingService`,
-follow the FCM setup docs including referencing your own service class in the manifest.
+follow the FCM setup docs including referencing your own service class in the manifest. We've included
+the default Klaviyo Push Service in our SDK Manifest (which will be merged into the final APK), but
+if you'd like to override this you can.
 
 ```xml
 <!-- AndroidManifest.xml -->

--- a/README.md
+++ b/README.md
@@ -204,8 +204,9 @@ Klaviyo.createEvent(event)
 
 ### Setup
 The Klaviyo Push SDK for Android works as a wrapper around `FirebaseMessagingService`, so the
-setup process is very similar to the Firebase client documentation linked above.  
-In your `AndroidManifest.xml` file, register `KlaviyoPushService` to receive `MESSAGING_EVENT` intents.
+setup process is very similar to the Firebase client documentation linked above.  We've added it to the library
+manifest, which will be merged with your app on build. If you'd like to override this implementation with your 
+own push service, consider it will impact SDK functionality.
 
 ```xml
 <!-- AndroidManifest.xml -->
@@ -213,7 +214,7 @@ In your `AndroidManifest.xml` file, register `KlaviyoPushService` to receive `ME
     <!-- ... -->
     <application>
         <!-- ... -->
-        <service android:name="com.klaviyo.pushFcm.KlaviyoPushService" android:exported="false">
+        <service android:name="com.your.own.PushService" android:exported="false">
             <intent-filter>
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />
             </intent-filter>
@@ -356,6 +357,8 @@ follow the FCM setup docs including referencing your own service class in the ma
 The `Application` code snippets above for handling push tokens and intents are still required.
 
 You may either subclass `KlaviyoPushService` or invoke the necessary Klaviyo SDK methods in your service.
+`KlaviyoPushService` is automatically added to your manifest by our SDK, if you prefer to use
+your own implementation it will take precedence over our implementation.
 
 1. Subclass `KlaviyoPushService`:
     ```kotlin

--- a/sdk/push-fcm/src/main/AndroidManifest.xml
+++ b/sdk/push-fcm/src/main/AndroidManifest.xml
@@ -1,4 +1,13 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <application>
+        <service
+            android:name="com.klaviyo.pushFcm.KlaviyoPushService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
+    </application>
 </manifest>


### PR DESCRIPTION
# Description
Did some testing, if we add this to our library manifest it will get merged with importing apps. It can be overridden by adding your own push service to the manifest. This will make our Expo plugin a bit simpler, since we won't have to write "dangerous" manifest modifications.

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [x] Have you tested this change on real device?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all Android versions the SDK currently supports?


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->


## Test Plan
<!-- How was this code tested / How should reviewers test it? -->


## Related Issues/Tickets
[ticket](https://klaviyo.atlassian.net/browse/CHNL-19996)
