### PR TITLE
[CHNL-20017] Web Forms Environment Switching Support

### DIFF
--- a/sdk/core/src/main/java/com/klaviyo/core/config/Config.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/config/Config.kt
@@ -11,6 +11,7 @@ interface Config {
     val assetSource: String?
     val sdkName: String
     val sdkVersion: String
+    val formEnvironment: FormEnvironment
 
     val apiKey: String
     val applicationContext: Context
@@ -34,6 +35,7 @@ interface Config {
         fun assetSource(assetSource: String?): Builder
         fun apiRevision(apiRevision: String): Builder
         fun debounceInterval(debounceInterval: Int): Builder
+        fun formEnvironment(formEnvironment: FormEnvironment): Builder
         fun networkTimeout(networkTimeout: Int): Builder
         fun networkFlushInterval(networkFlushInterval: Long, type: NetworkMonitor.NetworkType): Builder
         fun networkFlushDepth(networkFlushDepth: Int): Builder

--- a/sdk/core/src/main/java/com/klaviyo/core/config/FormEnvironment.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/config/FormEnvironment.kt
@@ -1,0 +1,14 @@
+package com.klaviyo.core.config
+
+enum class FormEnvironment(val templateName: String) {
+    IN_APP("in-app"),
+    WEB("web");
+
+    companion object {
+        fun fromString(value: String): FormEnvironment =
+            when (value) {
+                WEB.templateName -> WEB
+                else -> IN_APP
+            }
+    }
+}

--- a/sdk/core/src/main/java/com/klaviyo/core/config/KlaviyoConfig.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/config/KlaviyoConfig.kt
@@ -104,6 +104,8 @@ object KlaviyoConfig : Config {
     override lateinit var sdkName: String private set
     override lateinit var sdkVersion: String private set
     override lateinit var apiKey: String private set
+    override lateinit var formEnvironment: FormEnvironment
+        private set
     override lateinit var applicationContext: Context private set
     override var debounceInterval = DEBOUNCE_INTERVAL
         private set
@@ -140,6 +142,7 @@ object KlaviyoConfig : Config {
         private var apiRevision: String? = null
         private var baseCdnUrl: String? = null
         private var assetSource: String? = null
+        private var formEnvironment: FormEnvironment = FormEnvironment.IN_APP
         private var sdkName: String? = null
         private var sdkVersion: String? = null
         private var debounceInterval: Int = DEBOUNCE_INTERVAL
@@ -190,6 +193,10 @@ object KlaviyoConfig : Config {
                     "${KlaviyoConfig::debounceInterval.name} must be greater or equal to 0"
                 )
             }
+        }
+
+        override fun formEnvironment(formEnvironment: FormEnvironment) = apply {
+            this.formEnvironment = formEnvironment
         }
 
         override fun networkTimeout(networkTimeout: Int) = apply {
@@ -261,6 +268,7 @@ object KlaviyoConfig : Config {
             apiRevision?.let { KlaviyoConfig.apiRevision = it }
             baseCdnUrl?.let { KlaviyoConfig.baseCdnUrl = it }
             assetSource?.let { KlaviyoConfig.assetSource = it }
+            formEnvironment.let { KlaviyoConfig.formEnvironment = it }
 
             KlaviyoConfig.sdkName = this.sdkName ?: context.resources.getString(
                 R.string.klaviyo_sdk_name_override

--- a/sdk/fixtures/src/main/java/com/klaviyo/fixtures/BaseTest.kt
+++ b/sdk/fixtures/src/main/java/com/klaviyo/fixtures/BaseTest.kt
@@ -6,6 +6,7 @@ import android.content.pm.PackageManager
 import android.os.Build
 import com.klaviyo.core.Registry
 import com.klaviyo.core.config.Config
+import com.klaviyo.core.config.FormEnvironment
 import com.klaviyo.core.lifecycle.LifecycleMonitor
 import com.klaviyo.core.networking.NetworkMonitor
 import io.mockk.every
@@ -84,6 +85,7 @@ abstract class BaseTest {
         every { assetSource } returns null
         every { sdkName } returns "klaviyo-android-sdk"
         every { sdkVersion } returns "4.20.69"
+        every { formEnvironment } returns FormEnvironment.IN_APP
     }
 
     protected val mockLifecycleMonitor = mockk<LifecycleMonitor>().apply {

--- a/sdk/forms/src/main/assets/InAppFormsTemplate.html
+++ b/sdk/forms/src/main/assets/InAppFormsTemplate.html
@@ -4,6 +4,7 @@
       data-sdk-version="SDK_VERSION"
       data-native-bridge-name="BRIDGE_NAME"
       data-native-bridge-handshake='BRIDGE_HANDSHAKE'
+      data-forms-data-environment='FORMS_ENVIRONMENT'
 >
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0, viewport-fit=cover"/>

--- a/sdk/forms/src/main/java/com/klaviyo/forms/KlaviyoWebViewDelegate.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/KlaviyoWebViewDelegate.kt
@@ -93,6 +93,7 @@ internal class KlaviyoWebViewDelegate : WebViewClient(), WebViewCompat.WebMessag
             .replace("BRIDGE_NAME", this.bridgeName)
             .replace("BRIDGE_HANDSHAKE", handShakeData)
             .replace("KLAVIYO_JS_URL", klaviyoJsUrl.toString())
+            .replace("FORMS_ENVIRONMENT", Registry.config.formEnvironment.templateName)
             .also { html ->
                 webView.loadTemplate(html, this)
             }


### PR DESCRIPTION
# Description
- new core config for setting up web forms environment
- new enum! to support this (in case we ever do add more forms environments) (also bc booleans can be tricky to interpret sometimes)

Test App PR - https://github.com/klaviyo/klaviyo-android-test-app/pull/89
# Check List

- [ ] Are you changing anything with the public API?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you tested this change on real device?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all Android versions the SDK currently supports?
[form-env-switching.webm](https://github.com/user-attachments/assets/561c8933-fa42-4a4b-b13b-768cf807a88c)


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->


## Test Plan
<!-- How was this code tested / How should reviewers test it? -->


## Related Issues/Tickets
https://github.com/klaviyo/klaviyo-android-test-app/pull/89

