### PR TITLE
[CHNL-20122] SDK Plugin User-Agent Field update

### DIFF
--- a/sdk/core/src/main/java/com/klaviyo/core/DeviceProperties.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/DeviceProperties.kt
@@ -57,7 +57,8 @@ object DeviceProperties {
     }
 
     val notificationPermissionGranted: Boolean
-        get() = NotificationManagerCompat.from(Registry.config.applicationContext).areNotificationsEnabled()
+        get() = NotificationManagerCompat.from(Registry.config.applicationContext)
+            .areNotificationsEnabled()
 
     val applicationId: String by lazy {
         Registry.config.applicationContext.packageName
@@ -69,10 +70,25 @@ object DeviceProperties {
         ).toString()
     }
 
-    val userAgent: String by lazy {
-        val sdkAgent = "klaviyo-${sdkName.replace("_", "-")}"
-        "$applicationLabel/$appVersion ($applicationId; build:$appVersionCode; $platform $osVersion) $sdkAgent/$sdkVersion"
+    val pluginSdk: String? by lazy {
+        Registry.config.applicationContext.getString(R.string.klaviyo_sdk_plugin_name_override)
+            .ifBlank { null }
     }
+
+    val pluginSdkVersion: String? by lazy {
+        Registry.config.applicationContext.getString(R.string.klaviyo_sdk_plugin_version_override)
+            .ifBlank { null }
+    }
+
+    val userAgent: String
+        get() {
+            val pluginString = pluginSdk?.let {
+                "($it/$pluginSdkVersion)"
+            }
+            val sdkAgent = "klaviyo-${sdkName.replace("_", "-")}"
+            return "$applicationLabel/$appVersion ($applicationId; build:$appVersionCode; $platform $osVersion)" +
+                " $sdkAgent/$sdkVersion${pluginString?.let { " $it" } ?: ""}"
+        }
 
     val environment: String by lazy {
         if (Registry.config.applicationContext.applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE != 0) {

--- a/sdk/core/src/main/java/com/klaviyo/core/DeviceProperties.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/DeviceProperties.kt
@@ -83,7 +83,7 @@ object DeviceProperties {
     val userAgent: String
         get() {
             val pluginString = pluginSdk?.let {
-                "($it/$pluginSdkVersion)"
+                "($it/${pluginSdkVersion ?: "UNKNOWN"})"
             }
             val sdkAgent = "klaviyo-${sdkName.replace("_", "-")}"
             return "$applicationLabel/$appVersion ($applicationId; build:$appVersionCode; $platform $osVersion)" +

--- a/sdk/core/src/main/res/values/strings.xml
+++ b/sdk/core/src/main/res/values/strings.xml
@@ -3,4 +3,6 @@
     <!-- Please do not modify these values, it will stop SDK functionality-->
     <string name="klaviyo_sdk_name_override">android</string>
     <string name="klaviyo_sdk_version_override">3.3.1</string>
+    <string name="klaviyo_sdk_plugin_name_override"/>
+    <string name="klaviyo_sdk_plugin_version_override"/>
 </resources>

--- a/sdk/core/src/test/java/com/klaviyo/core/DevicePropertiesTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/DevicePropertiesTest.kt
@@ -65,9 +65,33 @@ class DevicePropertiesTest : BaseTest() {
         every { DeviceProperties.osVersion } returns "4"
         every { DeviceProperties.sdkName } returns "cross_platform"
         every { DeviceProperties.userAgent } answers { callOriginal() }
+        every { DeviceProperties.pluginSdk } returns null
+        every { DeviceProperties.pluginSdkVersion } returns null
 
         assertEquals(
             "MockApp/1.0.0 (com.mock.app; build:2; Android 4) klaviyo-cross-platform/3.0.0",
+            DeviceProperties.userAgent
+        )
+    }
+
+    @Test
+    fun `User agent reflects SDK name override and plugin name`() {
+        mockDeviceProperties()
+        // Use some more realistic values for this, so the expected user agent string actually matches our regexes
+        every { DeviceProperties.applicationLabel } returns "MockApp"
+        every { DeviceProperties.appVersion } returns "1.0.0"
+        every { DeviceProperties.appVersionCode } returns "2"
+        every { DeviceProperties.sdkVersion } returns "3.0.0"
+        every { DeviceProperties.applicationId } returns "com.mock.app"
+        every { DeviceProperties.platform } returns "Android"
+        every { DeviceProperties.osVersion } returns "4"
+        every { DeviceProperties.sdkName } returns "cross_platform"
+        every { DeviceProperties.userAgent } answers { callOriginal() }
+        every { DeviceProperties.pluginSdk } returns "klaviyo-expo"
+        every { DeviceProperties.pluginSdkVersion } returns "1.0.0"
+
+        assertEquals(
+            "MockApp/1.0.0 (com.mock.app; build:2; Android 4) klaviyo-cross-platform/3.0.0 (klaviyo-expo/1.0.0)",
             DeviceProperties.userAgent
         )
     }

--- a/sdk/core/src/test/java/com/klaviyo/core/DevicePropertiesTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/DevicePropertiesTest.kt
@@ -95,4 +95,26 @@ class DevicePropertiesTest : BaseTest() {
             DeviceProperties.userAgent
         )
     }
+
+    @Test
+    fun `user agent with no plugin sdk version is not blank`() {
+        mockDeviceProperties()
+        // Use some more realistic values for this, so the expected user agent string actually matches our regexes
+        every { DeviceProperties.applicationLabel } returns "MockApp"
+        every { DeviceProperties.appVersion } returns "1.0.0"
+        every { DeviceProperties.appVersionCode } returns "2"
+        every { DeviceProperties.sdkVersion } returns "3.0.0"
+        every { DeviceProperties.applicationId } returns "com.mock.app"
+        every { DeviceProperties.platform } returns "Android"
+        every { DeviceProperties.osVersion } returns "4"
+        every { DeviceProperties.sdkName } returns "cross_platform"
+        every { DeviceProperties.userAgent } answers { callOriginal() }
+        every { DeviceProperties.pluginSdk } returns "klaviyo-expo"
+        every { DeviceProperties.pluginSdkVersion } returns null
+
+        assertEquals(
+            "MockApp/1.0.0 (com.mock.app; build:2; Android 4) klaviyo-cross-platform/3.0.0 (klaviyo-expo/UNKNOWN)",
+            DeviceProperties.userAgent
+        )
+    }
 }

--- a/sdk/fixtures/src/main/java/com/klaviyo/fixtures/DevicePropertiesFixture.kt
+++ b/sdk/fixtures/src/main/java/com/klaviyo/fixtures/DevicePropertiesFixture.kt
@@ -21,7 +21,7 @@ fun mockDeviceProperties() {
     every { DeviceProperties.deviceId } returns "Mock Device ID"
     every { DeviceProperties.manufacturer } returns "Mock Manufacturer"
     every { DeviceProperties.osVersion } returns "Mock OS Version"
-    every { DeviceProperties.pluginSdk } returns "klaviyo-expo"
+    every { DeviceProperties.pluginSdk } returns "klaviyo-mock-plugin"
     every { DeviceProperties.pluginSdkVersion } returns "1.0.0"
 }
 

--- a/sdk/fixtures/src/main/java/com/klaviyo/fixtures/DevicePropertiesFixture.kt
+++ b/sdk/fixtures/src/main/java/com/klaviyo/fixtures/DevicePropertiesFixture.kt
@@ -21,6 +21,8 @@ fun mockDeviceProperties() {
     every { DeviceProperties.deviceId } returns "Mock Device ID"
     every { DeviceProperties.manufacturer } returns "Mock Manufacturer"
     every { DeviceProperties.osVersion } returns "Mock OS Version"
+    every { DeviceProperties.pluginSdk } returns "klaviyo-expo"
+    every { DeviceProperties.pluginSdkVersion } returns "1.0.0"
 }
 
 fun unmockDeviceProperties() {


### PR DESCRIPTION
# Description

- we want a way to discern if a request is being sent with an app that was built using the expo plugin
- to avoid a backend change, we'll add it to the user agent field
- EXPO apps will add a string resource with the new id, and if the SDK detects those have been set it will add them to the user agent

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [x] Have you tested this change on real device?
- [x] Have you added unit test coverage for your changes?
- [x] Have you verified that your changes are compatible with all Android versions the SDK currently supports?


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->


## Test Plan
Need to release this on both android and react native before we can test with expo, but the same resource overriding logic is what we use for the SDK name and version

## Related Issues/Tickets
https://klaviyo.atlassian.net/browse/CHNL-20122
