### PR TITLE
IAF | Lifecycle observers to support foreground/backgrounding tracking

### DIFF
--- a/sdk/core/src/main/java/com/klaviyo/core/lifecycle/KlaviyoLifecycleMonitor.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/lifecycle/KlaviyoLifecycleMonitor.kt
@@ -22,9 +22,15 @@ internal object KlaviyoLifecycleMonitor : LifecycleMonitor, Application.Activity
     )
 
     override var currentActivity: Activity? by WeakReferenceDelegate()
+        private set
 
     @AdvancedAPI
     override fun assignCurrentActivity(activity: Activity) {
+        if (activity != currentActivity) {
+            // If we missed this activity's creation, then we need to increment the count now
+            activeActivities++
+        }
+
         currentActivity = activity
     }
 
@@ -50,6 +56,10 @@ internal object KlaviyoLifecycleMonitor : LifecycleMonitor, Application.Activity
     }
 
     override fun onActivityStarted(activity: Activity) {
+        if (activeActivities == 0) {
+            broadcastEvent(ActivityEvent.FirstStarted(activity))
+        }
+
         activeActivities++
         broadcastEvent(ActivityEvent.Started(activity))
     }

--- a/sdk/core/src/main/java/com/klaviyo/core/lifecycle/KlaviyoLifecycleMonitor.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/lifecycle/KlaviyoLifecycleMonitor.kt
@@ -29,9 +29,8 @@ internal object KlaviyoLifecycleMonitor : LifecycleMonitor, Application.Activity
         if (activity != currentActivity) {
             // If we missed this activity's creation, then we need to increment the count now
             activeActivities++
+            currentActivity = activity
         }
-
-        currentActivity = activity
     }
 
     override fun onActivityEvent(observer: ActivityObserver) {

--- a/sdk/core/src/main/java/com/klaviyo/core/lifecycle/LifecycleMonitor.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/lifecycle/LifecycleMonitor.kt
@@ -12,7 +12,15 @@ sealed class ActivityEvent(val activity: Activity? = null, val bundle: Bundle? =
 
     val type: String get() = this.javaClass.simpleName
 
+    /**
+     * An activity was created
+     */
     class Created(activity: Activity, bundle: Bundle?) : ActivityEvent(activity, bundle)
+
+    /**
+     * Application moved to the foreground, i.e. went from 0 to 1 active activities
+     */
+    class FirstStarted(activity: Activity) : ActivityEvent(activity)
 
     class Started(activity: Activity) : ActivityEvent(activity)
 
@@ -24,6 +32,9 @@ sealed class ActivityEvent(val activity: Activity? = null, val bundle: Bundle? =
 
     class Stopped(activity: Activity) : ActivityEvent(activity)
 
+    /**
+     * Application moved to the background, called after the last application activity is stopped
+     */
     class AllStopped : ActivityEvent()
 
     class ConfigurationChanged(val newConfig: Configuration) : ActivityEvent()

--- a/sdk/core/src/main/java/com/klaviyo/core/lifecycle/LifecycleMonitor.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/lifecycle/LifecycleMonitor.kt
@@ -8,35 +8,61 @@ import com.klaviyo.core.utils.AdvancedAPI
 
 typealias ActivityObserver = (activity: ActivityEvent) -> Unit
 
+/**
+ * Represent different events emitted in response to lifecycle triggers from the host application
+ */
 sealed class ActivityEvent(val activity: Activity? = null, val bundle: Bundle? = null) {
 
+    /**
+     * Get the type of the event as a string (e.g. for logging)
+     */
     val type: String get() = this.javaClass.simpleName
 
     /**
-     * An activity was created
+     * Emitted when [Activity.onCreate] is called from an activity within the host app
      */
     class Created(activity: Activity, bundle: Bundle?) : ActivityEvent(activity, bundle)
 
     /**
-     * Application moved to the foreground, i.e. went from 0 to 1 active activities
+     * Emitted when [Activity.onStart] is called from an activity within the host app
+     */
+    class Started(activity: Activity) : ActivityEvent(activity)
+
+    /**
+     * Emitted when the host application moves to the foreground
+     * i.e. an activity [Started], and the application transitions from 0 to 1 started activity
      */
     class FirstStarted(activity: Activity) : ActivityEvent(activity)
 
-    class Started(activity: Activity) : ActivityEvent(activity)
-
+    /**
+     * Emitted when [Activity.onResume] is called from an activity within the host app
+     */
     class Resumed(activity: Activity) : ActivityEvent(activity)
 
+    /**
+     * Emitted when [Activity.onSaveInstanceState] is called from an activity within the host app
+     */
     class SaveInstanceState(activity: Activity, bundle: Bundle) : ActivityEvent(activity, bundle)
 
+    /**
+     * Emitted when [Activity.onPause] is called from an activity within the host app
+     */
     class Paused(activity: Activity) : ActivityEvent(activity)
 
+    /**
+     * Emitted when [Activity.onStop] is called from an activity within the host app
+     */
     class Stopped(activity: Activity) : ActivityEvent(activity)
 
     /**
-     * Application moved to the background, called after the last application activity is stopped
+     * Emitted when the host application moves to the background,
+     * i.e. the last active activity [Stopped]
      */
     class AllStopped : ActivityEvent()
 
+    /**
+     * Emitted when [Activity.onConfigurationChanged] is called from an activity within the host app
+     */
     class ConfigurationChanged(val newConfig: Configuration) : ActivityEvent()
 }
 
@@ -66,10 +92,14 @@ interface LifecycleMonitor {
 
     /**
      * Explicitly sets the current activity.
+     * Intended for use in advanced scenarios where [LifecycleMonitor] cannot capture
+     * an activity's [com.klaviyo.core.lifecycle.ActivityEvent.Started] event.
      *
-     * It is best to allow the SDK to track activities internally via [Application.ActivityLifecycleCallbacks].
-     * However, this explicit override allows us to work around timing issues such as
-     * when [LifecycleMonitor] can't be attached in time to capture the first Activity.
+     * Note: It is best to allow the SDK to track activities internally via [Application.ActivityLifecycleCallbacks].
+     * However, this explicit override allows us to work around launch timing issues on certain platforms.
+     *
+     * See also: Klaviyo.registerForLifecycleCallbacks which allows for registering callbacks prior to initializing
+     * which is typically a better workaround for launch timing issues.
      *
      * @param activity
      */

--- a/sdk/forms/src/main/assets/onsite-bridge.js
+++ b/sdk/forms/src/main/assets/onsite-bridge.js
@@ -26,16 +26,14 @@ window.setProfile = function (external_id, email, phone_number, anonymous_id) {
  * Dispatches a lifecycle event to be detected by klaviyo.js
  *
  * @param type - The type of lifecycle event to dispatch: "foreground" | "background"
- * @param session - Session behavior: "persist" | "restore" | "purge"
  */
-window.dispatchLifecycleEvent = function (type, session) {
+window.dispatchLifecycleEvent = function (type) {
     document.head.dispatchEvent(
         new CustomEvent(
             'lifecycleEvent',
             {
                 detail: {
-                    type: type,
-                    session: session
+                    type: type
                 }
             }
         )

--- a/sdk/forms/src/main/java/com/klaviyo/forms/InAppForms.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/InAppForms.kt
@@ -26,10 +26,11 @@ fun Klaviyo.registerForInAppForms(
 ): Klaviyo = safeApply {
     // Register IAF services
     Registry.apply {
+        register<InAppFormsConfig>(config)
         registerOnce<PresentationManager> { KlaviyoPresentationManager() }
         registerOnce<BridgeMessageHandler> { KlaviyoBridgeMessageHandler() }
         registerOnce<WebViewClient> {
-            KlaviyoWebViewClient(config).also {
+            KlaviyoWebViewClient().also {
                 register<JavaScriptEvaluator>(it)
             }
         }

--- a/sdk/forms/src/main/java/com/klaviyo/forms/InAppFormsConfig.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/InAppFormsConfig.kt
@@ -1,7 +1,7 @@
 package com.klaviyo.forms
 
 /**
- * Configuration for in app forms
+ * Configuration for in-app forms
  *
  * @param sessionTimeoutDuration Duration (in seconds) of the period of user inactivity after which the user's app session is terminated. Defaults to 1 Hour.
  */

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/KlaviyoObserverCollection.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/KlaviyoObserverCollection.kt
@@ -1,12 +1,10 @@
 package com.klaviyo.forms.bridge
 
 /**
- * TODO Manage all observers that inject data into the webview, to include
- *  - Profile identifiers
- *  - Lifecycle events
- *  - Analytics events
- *  - Host App navigation events
+ * Manages the collection of observers that inject data into the webview
  */
 internal class KlaviyoObserverCollection : ObserverCollection {
-    override val observers: List<Observer> = emptyList()
+    override val observers: List<Observer> = listOf(
+        LifecycleObserver()
+    )
 }

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/KlaviyoOnsiteBridge.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/KlaviyoOnsiteBridge.kt
@@ -3,7 +3,6 @@ package com.klaviyo.forms.bridge
 import com.klaviyo.analytics.model.ImmutableProfile
 import com.klaviyo.core.Registry
 import com.klaviyo.forms.webview.JavaScriptEvaluator
-import com.klaviyo.forms.webview.JsCallback
 
 /**
  * API for communicating data and events from native to the onsite-in-app JS module
@@ -24,31 +23,19 @@ internal class KlaviyoOnsiteBridge : OnsiteBridge {
         profile.anonymousId ?: ""
     )
 
-    override fun dispatchLifecycleEvent(
-        type: OnsiteBridge.LifecycleEventType,
-        session: OnsiteBridge.LifecycleSessionBehavior,
-        callback: JsCallback
-    ) = evaluateJavascript(
+    override fun dispatchLifecycleEvent(type: OnsiteBridge.LifecycleEventType) = evaluateJavascript(
         HelperFunction.dispatchLifecycleEvent,
-        type.name,
-        session.name,
-        callback = callback
+        type.name
     )
 
     /**
      * Evaluates a JS function in the webview with the given arguments
      */
-    private fun evaluateJavascript(
-        function: HelperFunction,
-        vararg arguments: String,
-        callback: JsCallback = {}
-    ) {
+    private fun evaluateJavascript(function: HelperFunction, vararg arguments: String) {
         val args = arguments.joinToString(",") { "\"$it\"" }
         val javaScript = "window.$function($args)"
 
         Registry.get<JavaScriptEvaluator>().evaluateJavascript(javaScript) { result ->
-            callback(result)
-
             if (result) {
                 Registry.log.verbose("JS $function evaluation succeeded")
             } else {

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/KlaviyoOnsiteBridge.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/KlaviyoOnsiteBridge.kt
@@ -3,6 +3,7 @@ package com.klaviyo.forms.bridge
 import com.klaviyo.analytics.model.ImmutableProfile
 import com.klaviyo.core.Registry
 import com.klaviyo.forms.webview.JavaScriptEvaluator
+import com.klaviyo.forms.webview.JsCallback
 
 /**
  * API for communicating data and events from native to the onsite-in-app JS module
@@ -15,28 +16,39 @@ internal class KlaviyoOnsiteBridge : OnsiteBridge {
         dispatchLifecycleEvent
     }
 
-    override fun setProfile(profile: ImmutableProfile) =
-        evaluateJavascript(
-            HelperFunction.setProfile,
-            profile.externalId ?: "",
-            profile.email ?: "",
-            profile.phoneNumber ?: "",
-            profile.anonymousId ?: ""
-        )
+    override fun setProfile(profile: ImmutableProfile) = evaluateJavascript(
+        HelperFunction.setProfile,
+        profile.externalId ?: "",
+        profile.email ?: "",
+        profile.phoneNumber ?: "",
+        profile.anonymousId ?: ""
+    )
 
     override fun dispatchLifecycleEvent(
         type: OnsiteBridge.LifecycleEventType,
-        session: OnsiteBridge.LifecycleSessionBehavior
-    ) = evaluateJavascript(HelperFunction.dispatchLifecycleEvent, type.name, session.name)
+        session: OnsiteBridge.LifecycleSessionBehavior,
+        callback: JsCallback
+    ) = evaluateJavascript(
+        HelperFunction.dispatchLifecycleEvent,
+        type.name,
+        session.name,
+        callback = callback
+    )
 
     /**
      * Evaluates a JS function in the webview with the given arguments
      */
-    private fun evaluateJavascript(function: HelperFunction, vararg arguments: String) {
+    private fun evaluateJavascript(
+        function: HelperFunction,
+        vararg arguments: String,
+        callback: JsCallback = {}
+    ) {
         val args = arguments.joinToString(",") { "\"$it\"" }
         val javaScript = "window.$function($args)"
 
         Registry.get<JavaScriptEvaluator>().evaluateJavascript(javaScript) { result ->
+            callback(result)
+
             if (result) {
                 Registry.log.verbose("JS $function evaluation succeeded")
             } else {

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/LifecycleObserver.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/LifecycleObserver.kt
@@ -1,0 +1,64 @@
+package com.klaviyo.forms.bridge
+
+import com.klaviyo.core.Registry
+import com.klaviyo.core.lifecycle.ActivityEvent
+import com.klaviyo.forms.InAppFormsConfig
+import com.klaviyo.forms.bridge.OnsiteBridge.LifecycleEventType
+import com.klaviyo.forms.bridge.OnsiteBridge.LifecycleSessionBehavior
+import com.klaviyo.forms.webview.WebViewClient
+
+internal class LifecycleObserver : Observer {
+    private var lastBackgrounded: Long? = null
+
+    private val sessionTimeoutMs: Long
+        get() = Registry.get<InAppFormsConfig>().sessionTimeoutDuration * 1_000
+
+    override val handshake: HandshakeSpec = HandshakeSpec(
+        type = "lifecycleEvent",
+        version = 1
+    )
+
+    override fun startObserver() = Registry.lifecycleMonitor.onActivityEvent(::onLifecycleEvent)
+
+    override fun stopObserver() = Registry.lifecycleMonitor.offActivityEvent(::onLifecycleEvent)
+
+    private fun onLifecycleEvent(activity: ActivityEvent): Unit = when (activity) {
+        // App foregrounded
+        is ActivityEvent.FirstStarted -> {
+            val behavior = getForegroundedBehavior()
+
+            Registry.get<OnsiteBridge>().dispatchLifecycleEvent(
+                LifecycleEventType.foreground,
+                behavior
+            ) {
+                if (behavior == LifecycleSessionBehavior.purge) {
+                    // Re-initialize the webview if session times out
+                    Registry.get<WebViewClient>()
+                        .destroyWebView()
+                        .initializeWebView()
+                }
+            }
+        }
+
+        // App backgrounded
+        is ActivityEvent.AllStopped -> {
+            Registry.get<OnsiteBridge>().dispatchLifecycleEvent(
+                LifecycleEventType.background,
+                LifecycleSessionBehavior.persist
+            ) {
+                lastBackgrounded = Registry.clock.currentTimeMillis()
+            }
+        }
+
+        else -> Unit
+    }
+
+    /**
+     * If the app was last backgrounded within the session timeout, we can restore, else purge.
+     */
+    private fun getForegroundedBehavior(): LifecycleSessionBehavior = lastBackgrounded
+        ?.let { Registry.clock.currentTimeMillis() - it }
+        ?.takeIf { elapsedMs -> elapsedMs < sessionTimeoutMs }
+        ?.let { LifecycleSessionBehavior.restore }
+        ?: LifecycleSessionBehavior.purge
+}

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/OnsiteBridge.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/OnsiteBridge.kt
@@ -1,7 +1,6 @@
 package com.klaviyo.forms.bridge
 
 import com.klaviyo.analytics.model.ImmutableProfile
-import com.klaviyo.forms.webview.JsCallback
 
 /**
  * API for communicating data and events from native to the onsite-in-app JS module
@@ -14,12 +13,6 @@ internal interface OnsiteBridge {
         foreground
     }
 
-    enum class LifecycleSessionBehavior {
-        persist,
-        restore,
-        purge
-    }
-
     /**
      * Inject profile data into the webview as data attributes
      */
@@ -28,9 +21,5 @@ internal interface OnsiteBridge {
     /**
      * Dispatch lifecycle events for onsite JS package to consume
      */
-    fun dispatchLifecycleEvent(
-        type: LifecycleEventType,
-        session: LifecycleSessionBehavior,
-        callback: JsCallback = {}
-    )
+    fun dispatchLifecycleEvent(type: LifecycleEventType)
 }

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/OnsiteBridge.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/OnsiteBridge.kt
@@ -1,6 +1,7 @@
 package com.klaviyo.forms.bridge
 
 import com.klaviyo.analytics.model.ImmutableProfile
+import com.klaviyo.forms.webview.JsCallback
 
 /**
  * API for communicating data and events from native to the onsite-in-app JS module
@@ -27,5 +28,9 @@ internal interface OnsiteBridge {
     /**
      * Dispatch lifecycle events for onsite JS package to consume
      */
-    fun dispatchLifecycleEvent(type: LifecycleEventType, session: LifecycleSessionBehavior)
+    fun dispatchLifecycleEvent(
+        type: LifecycleEventType,
+        session: LifecycleSessionBehavior,
+        callback: JsCallback = {}
+    )
 }

--- a/sdk/forms/src/main/java/com/klaviyo/forms/webview/JavaScriptEvaluator.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/webview/JavaScriptEvaluator.kt
@@ -1,14 +1,16 @@
 package com.klaviyo.forms.webview
 
+internal typealias JsCallback = (success: Boolean) -> Unit
+
 /**
  * Interface for evaluating any JavaScript string, decoupled from direct access to the WebView instance itself
  */
-interface JavaScriptEvaluator {
+internal interface JavaScriptEvaluator {
     /**
      * Evaluates a JavaScript string and invokes callback on success or failure
      */
     fun evaluateJavascript(
         javascript: String,
-        callback: (success: Boolean) -> Unit = {}
+        callback: JsCallback = {}
     )
 }

--- a/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
@@ -14,7 +14,6 @@ import androidx.core.net.toUri
 import com.klaviyo.core.Registry
 import com.klaviyo.core.config.Clock
 import com.klaviyo.core.utils.WeakReferenceDelegate
-import com.klaviyo.forms.InAppFormsConfig
 import com.klaviyo.forms.bridge.BridgeMessageHandler
 import com.klaviyo.forms.bridge.HandshakeSpec
 import com.klaviyo.forms.bridge.ObserverCollection
@@ -26,9 +25,7 @@ import java.io.BufferedReader
  * Manages the [KlaviyoWebView] instance that powers in-app forms behavior, triggering, rendering and display,
  * and handles all its [android.webkit.WebViewClient] delegate methods, and loading of klaviyo.js
  */
-internal class KlaviyoWebViewClient(
-    val config: InAppFormsConfig = InAppFormsConfig()
-) : AndroidWebViewClient(), WebViewClient, JavaScriptEvaluator {
+internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, JavaScriptEvaluator {
 
     /**
      * For timeout on awaiting the native bridge [com.klaviyo.forms.bridge.BridgeMessage.HandShook] event

--- a/sdk/forms/src/test/java/com/klaviyo/forms/bridge/KlaviyoOnsiteBridgeTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/bridge/KlaviyoOnsiteBridgeTest.kt
@@ -7,7 +7,6 @@ import com.klaviyo.forms.webview.JavaScriptEvaluator
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class KlaviyoOnsiteBridgeTest : BaseTest() {
@@ -82,35 +81,17 @@ class KlaviyoOnsiteBridgeTest : BaseTest() {
     @Test
     fun `dispatchLifecycleEvent calls JS evaluator with correct JS`() {
         val type = OnsiteBridge.LifecycleEventType.background
-        val session = OnsiteBridge.LifecycleSessionBehavior.persist
         every { jsEvaluator.evaluateJavascript(any(), any()) } answers {
             secondArg<(Boolean) -> Unit>().invoke(true)
         }
 
-        bridge.dispatchLifecycleEvent(type, session)
+        bridge.dispatchLifecycleEvent(type)
 
         verify {
             jsEvaluator.evaluateJavascript(
-                eq("window.dispatchLifecycleEvent(\"background\",\"persist\")"),
+                eq("window.dispatchLifecycleEvent(\"background\")"),
                 any()
             )
         }
-    }
-
-    @Test
-    fun `dispatchLifecycleEvent invokes callback after JS is evaluated`() {
-        val type = OnsiteBridge.LifecycleEventType.background
-        val session = OnsiteBridge.LifecycleSessionBehavior.persist
-        every { jsEvaluator.evaluateJavascript(any(), any()) } answers {
-            secondArg<(Boolean) -> Unit>().invoke(false)
-        }
-
-        var callbackCalled = false
-        bridge.dispatchLifecycleEvent(type, session) { result ->
-            assertEquals(false, result)
-            callbackCalled = true
-        }
-
-        assert(callbackCalled) { "Callback was not called" }
     }
 }

--- a/sdk/forms/src/test/java/com/klaviyo/forms/bridge/KlaviyoOnsiteBridgeTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/bridge/KlaviyoOnsiteBridgeTest.kt
@@ -7,6 +7,7 @@ import com.klaviyo.forms.webview.JavaScriptEvaluator
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class KlaviyoOnsiteBridgeTest : BaseTest() {
@@ -94,5 +95,22 @@ class KlaviyoOnsiteBridgeTest : BaseTest() {
                 any()
             )
         }
+    }
+
+    @Test
+    fun `dispatchLifecycleEvent invokes callback after JS is evaluated`() {
+        val type = OnsiteBridge.LifecycleEventType.background
+        val session = OnsiteBridge.LifecycleSessionBehavior.persist
+        every { jsEvaluator.evaluateJavascript(any(), any()) } answers {
+            secondArg<(Boolean) -> Unit>().invoke(false)
+        }
+
+        var callbackCalled = false
+        bridge.dispatchLifecycleEvent(type, session) { result ->
+            assertEquals(false, result)
+            callbackCalled = true
+        }
+
+        assert(callbackCalled) { "Callback was not called" }
     }
 }

--- a/sdk/forms/src/test/java/com/klaviyo/forms/bridge/LifecycleObserverTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/bridge/LifecycleObserverTest.kt
@@ -1,0 +1,149 @@
+package com.klaviyo.forms.bridge
+
+import com.klaviyo.core.Registry
+import com.klaviyo.core.lifecycle.ActivityEvent
+import com.klaviyo.core.lifecycle.ActivityObserver
+import com.klaviyo.fixtures.BaseTest
+import com.klaviyo.forms.InAppFormsConfig
+import com.klaviyo.forms.webview.WebViewClient
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class LifecycleObserverTest : BaseTest() {
+    private val observerSlot = slot<ActivityObserver>()
+    private val mockWebViewClient = mockk<WebViewClient>(relaxed = true).apply {
+        every { destroyWebView() } returns this
+    }
+
+    @Before
+    override fun setup() {
+        super.setup()
+        every { mockLifecycleMonitor.onActivityEvent(capture(observerSlot)) } returns Unit
+        Registry.register<WebViewClient>(mockWebViewClient)
+        Registry.register<InAppFormsConfig>(InAppFormsConfig(10))
+    }
+
+    @After
+    override fun cleanup() {
+        super.cleanup()
+        Registry.unregister<WebViewClient>()
+        Registry.unregister<InAppFormsConfig>()
+    }
+
+    private fun withBridge(): OnsiteBridge {
+        val mockBridge = mockk<OnsiteBridge>(relaxed = true).apply {
+            every { dispatchLifecycleEvent(any(), any(), any()) } answers {
+                thirdArg<(Boolean) -> Unit>().invoke(true)
+            }
+        }
+        Registry.register<OnsiteBridge>(mockBridge)
+        LifecycleObserver().startObserver()
+        return mockBridge
+    }
+
+    @Test
+    fun `handshake is correct`() = assertEquals(
+        HandshakeSpec(
+            type = "lifecycleEvent",
+            version = 1
+        ),
+        LifecycleObserver().handshake
+    )
+
+    @Test
+    fun `startObserver attaches and detaches from lifecycle monitor`() {
+        val observer = LifecycleObserver()
+        observer.startObserver()
+        observer.stopObserver()
+        verify(exactly = 1) { mockLifecycleMonitor.offActivityEvent(observerSlot.captured) }
+    }
+
+    @Test
+    fun `other lifecycle events are ignored`() {
+        val mockBridge = withBridge()
+
+        observerSlot.captured(ActivityEvent.Resumed(mockActivity))
+
+        verify(inverse = true) {
+            mockBridge.dispatchLifecycleEvent(any(), any(), any())
+        }
+        verify(inverse = true) {
+            mockWebViewClient.destroyWebView()
+        }
+    }
+
+    @Test
+    fun `app launch injects foreground lifecycle event with purge behavior`() {
+        val mockBridge = withBridge()
+
+        observerSlot.captured(ActivityEvent.FirstStarted(mockActivity))
+
+        verify {
+            mockBridge.dispatchLifecycleEvent(
+                OnsiteBridge.LifecycleEventType.foreground,
+                OnsiteBridge.LifecycleSessionBehavior.purge,
+                any()
+            )
+        }
+        verify { mockWebViewClient.destroyWebView() }
+        verify { mockWebViewClient.initializeWebView() }
+    }
+
+    @Test
+    fun `app backgrounded injects background lifecycle event with persist behavior`() {
+        val mockBridge = withBridge()
+
+        observerSlot.captured(ActivityEvent.AllStopped())
+
+        verify {
+            mockBridge.dispatchLifecycleEvent(
+                OnsiteBridge.LifecycleEventType.background,
+                OnsiteBridge.LifecycleSessionBehavior.persist,
+                any()
+            )
+        }
+    }
+
+    @Test
+    fun `app foregrounded within session timeout injects foreground lifecycle event with persist behavior`() {
+        val mockBridge = withBridge()
+
+        observerSlot.captured(ActivityEvent.AllStopped())
+        staticClock.execute(1_000)
+        observerSlot.captured(ActivityEvent.FirstStarted(mockActivity))
+
+        verify {
+            mockBridge.dispatchLifecycleEvent(
+                OnsiteBridge.LifecycleEventType.foreground,
+                OnsiteBridge.LifecycleSessionBehavior.restore,
+                any()
+            )
+        }
+        verify(inverse = true) { mockWebViewClient.destroyWebView() }
+    }
+
+    @Test
+    fun `app foregrounded after session timeout injects foreground lifecycle event with purge behavior and resets webview`() {
+        val mockBridge = withBridge()
+
+        observerSlot.captured(ActivityEvent.AllStopped())
+        staticClock.execute(10_000)
+        observerSlot.captured(ActivityEvent.FirstStarted(mockActivity))
+
+        verify {
+            mockBridge.dispatchLifecycleEvent(
+                OnsiteBridge.LifecycleEventType.foreground,
+                OnsiteBridge.LifecycleSessionBehavior.purge,
+                any()
+            )
+        }
+        verify() { mockWebViewClient.destroyWebView() }
+        verify { mockWebViewClient.initializeWebView() }
+    }
+}


### PR DESCRIPTION
# Description
<!-- Briefly describe the feature or bug that your pull request addresses, 1-2 sentences. -->
Builds on #265 to add specific implementation of lifecycle observers for tracking foregrounding/backgrounding of the host app. Partially implements app session tracking, the rest of that implementation will be in another PR to keep things more reviewable. 

## Due Diligence
<!-- Best practices before submitting, add additional notes below -->
<!-- If your changes are particularly affected by different Android version, please note API levels you tested on below  -->
- [ ] I have tested this on an emulator and/or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all Android versions the SDK currently supports.


## Release/Versioning Considerations
<!-- Help determine how this should be categorized for release, add additional notes below. -->
<!-- Please add the planned version as a `milestone` label on this PR -->
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API. 
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [x] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->
- Updated the lifecycle monitor in core to also track when an app is foregrounded, based on activity tracking
- Added forms observer for foreground/background events to pass those into the webview
- Partial session tracking implementation, to refresh the webview on session timeout

## Test Plan
<!-- Provide reproducible testing steps. Link any artifacts, recordings, spreadsheets, etc. -->
Not much to test yet because app session isn't fully implemented and fender isn't doing anything with lifecycle event yet. 
But we can test against this [fender branch](https://github.com/klaviyo/fender/pull/42121) just to confirm that the lifecycle event is detected and doesn't console.log a validation error!

## Related Issues/Tickets
<!-- Link to relevant Jira issues, Slack discussions, Google Docs --> 
[CHNL-19932](https://klaviyo.atlassian.net/browse/CHNL-19932) 
 

[CHNL-19932]: https://klaviyo.atlassian.net/browse/CHNL-19932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ