### PR TITLE
IAF | Two timing related bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ send them timely push notifications via [FCM (Firebase Cloud Messaging)](https:/
       ```kotlin
       // build.gradle.kts
       dependencies {
-          implementation("com.github.klaviyo.klaviyo-android-sdk:analytics:3.4.0-alpha.1")
-          implementation("com.github.klaviyo.klaviyo-android-sdk:push-fcm:3.4.0-alpha.1")
-          implementation("com.github.klaviyo.klaviyo-android-sdk:forms:3.4.0-alpha.1")
+          implementation("com.github.klaviyo.klaviyo-android-sdk:analytics:3.4.0-alpha.2")
+          implementation("com.github.klaviyo.klaviyo-android-sdk:push-fcm:3.4.0-alpha.2")
+          implementation("com.github.klaviyo.klaviyo-android-sdk:forms:3.4.0-alpha.2")
       }
       ```
    </details>
@@ -68,9 +68,9 @@ send them timely push notifications via [FCM (Firebase Cloud Messaging)](https:/
       ```groovy
        // build.gradle
        dependencies {
-           implementation "com.github.klaviyo.klaviyo-android-sdk:analytics:3.4.0-alpha.1"
-           implementation "com.github.klaviyo.klaviyo-android-sdk:push-fcm:3.4.0-alpha.1"
-           implementation "com.github.klaviyo.klaviyo-android-sdk:forms:3.4.0-alpha.1"
+           implementation "com.github.klaviyo.klaviyo-android-sdk:analytics:3.4.0-alpha.2"
+           implementation "com.github.klaviyo.klaviyo-android-sdk:push-fcm:3.4.0-alpha.2"
+           implementation "com.github.klaviyo.klaviyo-android-sdk:forms:3.4.0-alpha.2"
        }
       ```
    </details>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,2 +1,2 @@
 <!-- Redirect to latest version -->
-<meta HTTP-EQUIV="REFRESH" content="0; url=./3.4.0-alpha.1/index.html">
+<meta HTTP-EQUIV="REFRESH" content="0; url=./3.4.0-alpha.2/index.html">

--- a/sdk/core/src/main/java/com/klaviyo/core/lifecycle/LifecycleMonitor.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/lifecycle/LifecycleMonitor.kt
@@ -11,7 +11,7 @@ typealias ActivityObserver = (activity: ActivityEvent) -> Unit
 /**
  * Represent different events emitted in response to lifecycle triggers from the host application
  */
-sealed class ActivityEvent(val activity: Activity? = null, val bundle: Bundle? = null) {
+sealed class ActivityEvent(open val activity: Activity? = null, val bundle: Bundle? = null) {
 
     /**
      * Get the type of the event as a string (e.g. for logging)
@@ -21,38 +21,44 @@ sealed class ActivityEvent(val activity: Activity? = null, val bundle: Bundle? =
     /**
      * Emitted when [Activity.onCreate] is called from an activity within the host app
      */
-    class Created(activity: Activity, bundle: Bundle?) : ActivityEvent(activity, bundle)
+    class Created(override val activity: Activity, bundle: Bundle?) : ActivityEvent(
+        activity,
+        bundle
+    )
 
     /**
      * Emitted when [Activity.onStart] is called from an activity within the host app
      */
-    class Started(activity: Activity) : ActivityEvent(activity)
+    class Started(override val activity: Activity) : ActivityEvent(activity)
 
     /**
      * Emitted when the host application moves to the foreground
      * i.e. an activity [Started], and the application transitions from 0 to 1 started activity
      */
-    class FirstStarted(activity: Activity) : ActivityEvent(activity)
+    class FirstStarted(override val activity: Activity) : ActivityEvent(activity)
 
     /**
      * Emitted when [Activity.onResume] is called from an activity within the host app
      */
-    class Resumed(activity: Activity) : ActivityEvent(activity)
+    class Resumed(override val activity: Activity) : ActivityEvent(activity)
 
     /**
      * Emitted when [Activity.onSaveInstanceState] is called from an activity within the host app
      */
-    class SaveInstanceState(activity: Activity, bundle: Bundle) : ActivityEvent(activity, bundle)
+    class SaveInstanceState(override val activity: Activity, bundle: Bundle) : ActivityEvent(
+        activity,
+        bundle
+    )
 
     /**
      * Emitted when [Activity.onPause] is called from an activity within the host app
      */
-    class Paused(activity: Activity) : ActivityEvent(activity)
+    class Paused(override val activity: Activity) : ActivityEvent(activity)
 
     /**
      * Emitted when [Activity.onStop] is called from an activity within the host app
      */
-    class Stopped(activity: Activity) : ActivityEvent(activity)
+    class Stopped(override val activity: Activity) : ActivityEvent(activity)
 
     /**
      * Emitted when the host application moves to the background,

--- a/sdk/core/src/main/res/values/strings.xml
+++ b/sdk/core/src/main/res/values/strings.xml
@@ -2,7 +2,7 @@
 <resources>
     <!-- Please do not modify / override these values, they are critical for internal versioning  -->
     <string name="klaviyo_sdk_name_override">android</string>
-    <string name="klaviyo_sdk_version_override">3.4.0-alpha.1</string>
+    <string name="klaviyo_sdk_version_override">3.4.0-alpha.2</string>
     <string name="klaviyo_sdk_plugin_name_override"/>
     <string name="klaviyo_sdk_plugin_version_override"/>
 </resources>

--- a/sdk/core/src/test/java/com/klaviyo/core/config/KlaviyoConfigTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/config/KlaviyoConfigTest.kt
@@ -40,8 +40,6 @@ internal class KlaviyoConfigTest : BaseTest() {
         super.setup()
         mockkStatic(PackageManager.PackageInfoFlags::class)
         every { PackageManager.PackageInfoFlags.of(any()) } returns mockPackageManagerFlags
-        every { mockContext.packageManager } returns mockPackageManager
-        every { mockContext.packageName } returns BuildConfig.LIBRARY_PACKAGE_NAME
         every { mockContext.resources } returns mockk {
             every { getString(R.string.klaviyo_sdk_name_override) } returns "android"
             every { getString(R.string.klaviyo_sdk_version_override) } returns "9.9.9"

--- a/sdk/fixtures/src/main/java/com/klaviyo/fixtures/BaseTest.kt
+++ b/sdk/fixtures/src/main/java/com/klaviyo/fixtures/BaseTest.kt
@@ -7,6 +7,7 @@ import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Handler
 import android.os.HandlerThread
+import com.klaviyo.core.BuildConfig
 import com.klaviyo.core.Registry
 import com.klaviyo.core.config.Config
 import com.klaviyo.core.config.FormEnvironment
@@ -71,6 +72,7 @@ abstract class BaseTest {
     protected val mockContext = mockk<Context>().apply {
         every { applicationInfo } returns mockApplicationInfo
         every { packageManager } returns mockPackageManager
+        every { packageName } returns BuildConfig.LIBRARY_PACKAGE_NAME
     }
 
     protected val debounceTime = 5

--- a/sdk/forms/src/main/java/com/klaviyo/forms/presentation/KlaviyoPresentationManager.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/presentation/KlaviyoPresentationManager.kt
@@ -1,11 +1,15 @@
 package com.klaviyo.forms.presentation
 
+import android.app.Activity
 import com.klaviyo.core.Registry
 import com.klaviyo.core.config.Clock
 import com.klaviyo.core.lifecycle.ActivityEvent
+import com.klaviyo.core.lifecycle.ActivityObserver
+import com.klaviyo.core.lifecycle.LifecycleMonitor
 import com.klaviyo.core.utils.WeakReferenceDelegate
 import com.klaviyo.core.utils.takeIf
 import com.klaviyo.core.utils.takeIfNot
+import com.klaviyo.forms.InAppFormsConfig
 import com.klaviyo.forms.bridge.FormId
 import com.klaviyo.forms.bridge.JsBridge
 import com.klaviyo.forms.presentation.PresentationState.Hidden
@@ -17,7 +21,17 @@ import com.klaviyo.forms.webview.WebViewClient
  * Coordinates preloading klaviyo.js and presentation forms in an overlay activity
  */
 internal class KlaviyoPresentationManager() : PresentationManager {
-    private var pendingClose: Clock.Cancellable? = null
+    /**
+     * If we postpone presenting a form,
+     * this token can be used to cancel that delayed job
+     */
+    private var cancelPostponedPresent: Clock.Cancellable? = null
+
+    /**
+     * If we invoke JS to close a form, this represents a timeout
+     * to dismiss the overlay activity if we don't get a formDisappeared event from JS
+     */
+    private var dismissOnTimeout: Clock.Cancellable? = null
 
     private var overlayActivity by WeakReferenceDelegate<KlaviyoFormsOverlayActivity>(null)
 
@@ -38,19 +52,17 @@ internal class KlaviyoPresentationManager() : PresentationManager {
      * We wait for a change, see if it's different from the current, and close an open webview
      */
     private fun onActivityEvent(event: ActivityEvent) = when (event) {
-        is ActivityEvent.Created -> event.activity.takeIf<KlaviyoFormsOverlayActivity>()
-            ?.let { activity ->
-                presentationState.takeIf<Presenting>()?.let {
-                    overlayActivity = activity
-                    Registry.get<WebViewClient>().attachWebView(activity)
-                    presentationState = Presented(it.formId)
-                    Registry.log.debug("Presentation State: $presentationState")
-                }
+        is ActivityEvent.Created -> event.activity.takeIf<KlaviyoFormsOverlayActivity>()?.let { activity ->
+            presentationState.takeIf<Presenting>()?.let {
+                overlayActivity = activity
+                Registry.get<WebViewClient>().attachWebView(activity)
+                presentationState = Presented(it.formId)
+                Registry.log.debug("Presentation State: $presentationState")
             }
+        }
 
         is ActivityEvent.ConfigurationChanged -> event.newConfig.orientation.takeIf { it != orientation }
-            ?.also { newOrientation -> orientation = newOrientation }
-            ?.let {
+            ?.also { newOrientation -> orientation = newOrientation }?.let {
                 presentationState.takeIfNot<PresentationState, Hidden>()?.let {
                     orientation = event.newConfig.orientation
                     Registry.get<WebViewClient>().detachWebView()
@@ -63,36 +75,58 @@ internal class KlaviyoPresentationManager() : PresentationManager {
     }
 
     /**
-     * Launch the overlay activity
+     * Present the form now if the app is foregrounded,
+     * or else wait till next foregrounded unless session ends
      */
-    override fun present(formId: FormId?) = presentationState.takeIf<Hidden>()?.let {
-        presentationState = Presenting(formId)
-        Registry.log.debug("Presentation State: $presentationState")
-        Registry.config.applicationContext.startActivity(KlaviyoFormsOverlayActivity.launchIntent)
-    } ?: run {
-        Registry.log.debug("Cannot present activity. Current state: $presentationState")
+    override fun present(formId: FormId?) {
+        clearTimers()
+        cancelPostponedPresent = Registry.lifecycleMonitor.runWithCurrentOrNextActivity(
+            timeout = Registry.get<InAppFormsConfig>().getSessionTimeoutDurationInMillis()
+        ) {
+            presentationState.takeIf<Hidden>()?.let {
+                presentationState = Presenting(formId)
+                Registry.log.debug("Presentation State: $presentationState")
+                Registry.config.applicationContext.startActivity(
+                    KlaviyoFormsOverlayActivity.launchIntent
+                )
+            } ?: run {
+                Registry.log.debug("Cannot present activity. Current state: $presentationState")
+            }
+        }
     }
 
     /**
      * Detach the webview from the overlay activity and finish it
      */
     override fun dismiss() = overlayActivity?.let { activity ->
-        pendingClose?.cancel().also { pendingClose = null }
+        clearTimers()
         Registry.get<WebViewClient>().detachWebView()
         activity.finish()
         presentationState = Hidden
         overlayActivity = null
         Registry.log.debug("Presentation State: $presentationState")
-    } ?: pendingClose?.cancel().let {
-        pendingClose = null
+    } ?: clearTimers().also {
         Registry.log.debug("No-op dismiss: overlay activity is not presented")
     }
 
+    /**
+     * Close any open forms and dismiss the overlay activity
+     */
     override fun closeFormAndDismiss() = presentationState.takeIf<Presented>()?.let {
         Registry.get<JsBridge>().closeForm(it.formId)
-        pendingClose = Registry.clock.schedule(CLOSE_TIMEOUT, ::dismiss)
+        dismissOnTimeout = Registry.clock.schedule(CLOSE_TIMEOUT, ::dismiss)
     } ?: dismiss().also {
         Registry.log.debug("Dismissing without closing form. Current state: $presentationState")
+    }
+
+    /**
+     * Clear timers to stop any delayed side effects
+     */
+    private fun clearTimers() {
+        // Run this cancel job now to stop any postponed form presentation
+        cancelPostponedPresent?.runNow().also { cancelPostponedPresent = null }
+        // Cancel the timeout for dismissing the overlay activity
+        dismissOnTimeout?.cancel().also { dismissOnTimeout = null }
     }
 
     private companion object {
@@ -103,4 +137,39 @@ internal class KlaviyoPresentationManager() : PresentationManager {
          */
         private const val CLOSE_TIMEOUT = 400L
     }
+}
+
+/**
+ * Helper function to run a task immediately if there is a current activity,
+ * or wait for the next resumed activity if resumed within the optional timeout.
+ * Returns a token that can be used to cancel the pending task if needed.
+ */
+internal fun LifecycleMonitor.runWithCurrentOrNextActivity(
+    timeout: Long? = null,
+    job: (activity: Activity) -> Unit
+): Clock.Cancellable? {
+    currentActivity?.let { activity ->
+        job(activity)
+        return null
+    }
+
+    var observer: ActivityObserver? = null
+    val token: Clock.Cancellable? = timeout?.let { delay ->
+        Registry.log.wtf("Cancel task scheduled for $delay ms")
+        Registry.clock.schedule(delay) {
+            Registry.log.verbose("Removing postponed observer after timeout")
+            observer?.let { offActivityEvent(it) }
+        }
+    }
+    observer = { event ->
+        event.takeIf<ActivityEvent.Resumed>()?.let { event ->
+            Registry.log.verbose("Invoking postponed observer on resume")
+            job(event.activity)
+            observer?.let { offActivityEvent(it) }
+            token?.cancel()
+        }
+    }
+    onActivityEvent(observer)
+
+    return token
 }

--- a/sdk/forms/src/main/java/com/klaviyo/forms/presentation/KlaviyoPresentationManager.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/presentation/KlaviyoPresentationManager.kt
@@ -155,7 +155,6 @@ internal fun LifecycleMonitor.runWithCurrentOrNextActivity(
 
     var observer: ActivityObserver? = null
     val token: Clock.Cancellable? = timeout?.let { delay ->
-        Registry.log.wtf("Cancel task scheduled for $delay ms")
         Registry.clock.schedule(delay) {
             Registry.log.verbose("Removing postponed observer after timeout")
             observer?.let { offActivityEvent(it) }

--- a/sdk/forms/src/test/java/com/klaviyo/forms/presentation/KlaviyoFormsOverlayActivityTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/presentation/KlaviyoFormsOverlayActivityTest.kt
@@ -14,7 +14,6 @@ import org.junit.Test
 class KlaviyoFormsOverlayActivityTest : BaseTest() {
     @Test
     fun `launchIntent creates intent to open the overlay activity`() {
-        every { mockContext.packageName } returns BuildConfig.LIBRARY_PACKAGE_NAME
         val packageSlot = slot<String>()
         val classSlot = slot<String>()
         val flagsSlot = slot<Int>()

--- a/versions.properties
+++ b/versions.properties
@@ -13,7 +13,7 @@
 #  NOTE: Semantic version of the SDK lives in strings.xml
 #  Use this shell script to update the version numbers automatically:
 #  ./bumpVersion.sh
-version.klaviyo.versionCode=32
+version.klaviyo.versionCode=33
 
 # Project gradle plugins
 plugin.android=8.8.0


### PR DESCRIPTION
# Description
<!-- Briefly describe the feature or bug that your pull request addresses, 1-2 sentences. -->
Squashed two bugs with one stone. Added this `runWithCurrentOrNextActivity` utility for operations that are sensitive to the current activity. 

## Due Diligence
<!-- Best practices before submitting, add additional notes below -->
<!-- If your changes are particularly affected by different Android version, please note API levels you tested on below  -->
- [x] I have tested this on an emulator and/or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all Android versions the SDK currently supports.


## Release/Versioning Considerations
<!-- Help determine how this should be categorized for release, add additional notes below. -->
<!-- Please add the planned version as a `milestone` label on this PR -->
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API. 
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [x] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->
Fixes two bugs both related to being sensitive to activity transitions: 
- Deep links: fixed an unreliable timing issue where current activity can be null when deep link is received during the brief transition from our overlay back to the host app's activity. 
- Time delayed forms: if a time delayed form is evaluated to display after the app has been backgrounded, the webview could force the app to reopen when it presented our form overlay activity. Fixed by postponing presentation till the app is next resumed

## Test Plan
<!-- Provide reproducible testing steps. Link any artifacts, recordings, spreadsheets, etc. -->
- Deep links: 
  - Open a form with a deep link and tap the deep linked button.
  - On the play store build `3.4.0-alpha.1` we saw intermittent issue where the form would close without navigating to the deep link. (I was able to isolate the issue because of a debug log, when the deep link didn't work, we were logging "Current activity is null)")
  - With this fix, deep link should work 100% of the time. 
- Form while app is backgrounded: 
  - Configure a form to display on a 10 second delay
  - Open the app to trigger the form, but background the app before it appears
  - On prior to this branch: the app would re-open to display the form!
  - After this fix, the form will only appear once you open the app (before your the inactivity timeout)
  - Additional check: If you wait for your form session to timeout, the form should not appear on next launch (it should wait the 15s timer as expected)

## Related Issues/Tickets
<!-- Link to relevant Jira issues, Slack discussions, Google Docs --> 
 https://klaviyo.atlassian.net/browse/CHNL-22081
https://klaviyo.atlassian.net/browse/CHNL-22082
 