### PR TITLE
IAF | Close all forms on back button

### DIFF
--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/JsBridge.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/JsBridge.kt
@@ -43,5 +43,5 @@ internal interface JsBridge {
      * Close a form in the webview by [FormId]
      * If no ID provided, close any currently open forms.
      */
-    fun closeForm(formId: FormId?)
+    fun closeForm(formId: FormId? = null)
 }

--- a/sdk/forms/src/main/java/com/klaviyo/forms/presentation/KlaviyoPresentationManager.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/presentation/KlaviyoPresentationManager.kt
@@ -89,7 +89,7 @@ internal class KlaviyoPresentationManager() : PresentationManager {
     }
 
     override fun closeFormAndDismiss() = presentationState.takeIf<Presented>()?.let {
-        Registry.get<JsBridge>().closeForm(it.formId)
+        Registry.get<JsBridge>().closeForm()
         pendingClose = Registry.clock.schedule(CLOSE_TIMEOUT, ::dismiss)
     } ?: dismiss().also {
         Registry.log.debug("Dismissing without closing form. Current state: $presentationState")

--- a/sdk/forms/src/test/java/com/klaviyo/forms/presentation/KlaviyoPresentationManagerTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/presentation/KlaviyoPresentationManagerTest.kt
@@ -198,7 +198,7 @@ class KlaviyoPresentationManagerTest : BaseTest() {
 
         manager.closeFormAndDismiss()
 
-        verify(exactly = 1) { mockBridge.closeForm(any()) }
+        verify(exactly = 1) { mockBridge.closeForm(null) }
         verify(exactly = 1) { mockWebViewClient.detachWebView() }
         verify(exactly = 1) { mockOverlayActivity.finish() }
         assertEquals(
@@ -217,7 +217,7 @@ class KlaviyoPresentationManagerTest : BaseTest() {
 
         manager.closeFormAndDismiss()
 
-        verify(exactly = 1) { mockBridge.closeForm(any()) }
+        verify(exactly = 1) { mockBridge.closeForm(null) }
         verify(exactly = 0) { mockWebViewClient.detachWebView() }
         verify(exactly = 0) { mockOverlayActivity.finish() }
 


### PR DESCRIPTION
# Description
<!-- Briefly describe the feature or bug that your pull request addresses, 1-2 sentences. -->
Testing with multiple colliding forms revealed that it would look better to just tell the JS code to close all open forms when you press the back button. Otherwise, if there are two colliding forms open, the first will animate away, the second will just disappear abruptly when the overlay activity is dismissed.

## Due Diligence
<!-- Best practices before submitting, add additional notes below -->
<!-- If your changes are particularly affected by different Android version, please note API levels you tested on below  -->
- [x] I have tested this on an emulator and/or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [x] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all Android versions the SDK currently supports.


## Release/Versioning Considerations
<!-- Help determine how this should be categorized for release, add additional notes below. -->
<!-- Please add the planned version as a `milestone` label on this PR -->
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API. 
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [ ] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->
Close all forms on back button, rather than close form by ID. 

## Test Plan
<!-- Provide reproducible testing steps. Link any artifacts, recordings, spreadsheets, etc. -->
Configure colliding IAFs, trigger them both, press back button: they should both animate closed.

## Related Issues/Tickets
<!-- Link to relevant Jira issues, Slack discussions, Google Docs --> 
None