### PR TITLE
CI | Run tests in parallel

### DIFF
--- a/.github/workflows/android-feature.yml
+++ b/.github/workflows/android-feature.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        module: [ :sdk:core, :sdk:analytics, :sdk:forms, :sdk:push-fcm ]
+        module: [ ':sdk:core', ':sdk:analytics', ':sdk:forms', ':sdk:push-fcm' ]
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so the job can access it

--- a/.github/workflows/android-feature.yml
+++ b/.github/workflows/android-feature.yml
@@ -32,7 +32,7 @@ jobs:
 
       # Call Gradle to run the unit tests
       - name: Unit Tests
-        run: ./gradlew {{ matrix.module }}:test --stacktrace --no-daemon
+        run: ./gradlew ${{ matrix.module }}:test --stacktrace --no-daemon
 
   # Another job for asserting our linting rules
   ktlint:

--- a/.github/workflows/android-feature.yml
+++ b/.github/workflows/android-feature.yml
@@ -14,6 +14,10 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-22.04
 
+    strategy:
+      matrix:
+        module: [ :sdk:core, :sdk:analytics, :sdk:forms, :sdk:push-fcm ]
+
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so the job can access it
       - uses: actions/checkout@v4
@@ -28,7 +32,7 @@ jobs:
 
       # Call Gradle to run the unit tests
       - name: Unit Tests
-        run: ./gradlew test --stacktrace --no-daemon
+        run: ./gradlew {{ matrix.module }}:test --stacktrace --no-daemon
 
   # Another job for asserting our linting rules
   ktlint:

--- a/.github/workflows/android-master.yml
+++ b/.github/workflows/android-master.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        module: [ :sdk:core, :sdk:analytics, :sdk:forms, :sdk:push-fcm ]
+        module: [ ':sdk:core', ':sdk:analytics', ':sdk:forms', ':sdk:push-fcm' ]
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so the job can access it

--- a/.github/workflows/android-master.yml
+++ b/.github/workflows/android-master.yml
@@ -16,6 +16,10 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-22.04
 
+    strategy:
+      matrix:
+        module: [ :sdk:core, :sdk:analytics, :sdk:forms, :sdk:push-fcm ]
+
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so the job can access it
       - uses: actions/checkout@v4
@@ -30,7 +34,8 @@ jobs:
 
       # Call Gradle to run the unit tests
       - name: Unit Tests
-        run: ./gradlew test --stacktrace --no-daemon
+        run: ./gradlew {{ matrix.module }}:test --stacktrace --no-daemon
+
   # Another job for asserting our linting rules
   ktlint:
     name: Run ktlintCheck
@@ -53,6 +58,7 @@ jobs:
       # Call Gradle to run ktlint check
       - name: KtlintCheck
         run: bash ./gradlew ktlintCheck
+
   # Another job for building our SDK's AAR file
   aar:
     name: Generate AAR
@@ -82,4 +88,3 @@ jobs:
           name: sdk
           path: app/build/outputs/aar/debug/aar-debug.aar
           overwrite: true
-

--- a/.github/workflows/android-master.yml
+++ b/.github/workflows/android-master.yml
@@ -34,7 +34,7 @@ jobs:
 
       # Call Gradle to run the unit tests
       - name: Unit Tests
-        run: ./gradlew {{ matrix.module }}:test --stacktrace --no-daemon
+        run: ./gradlew ${{ matrix.module }}:test --stacktrace --no-daemon
 
   # Another job for asserting our linting rules
   ktlint:


### PR DESCRIPTION
Thought I'd try running our tests in parallel to speed up CI a little.

Looks like a minimum of 1.5-2 minutes is just compiling code, which all the parallel tests will have to do anyways. And then 1-2 minutes on the longer test suites. So maybe shaves a minute off. 
Serially:
![Screenshot 2025-06-17 at 12 11 37](https://github.com/user-attachments/assets/b250697b-4b31-4559-8925-0a9b60d3ad14)
![Screenshot 2025-06-17 at 12 11 54](https://github.com/user-attachments/assets/b45a9678-1878-41ab-adad-395c2cfb9ef4)

Parallel:
![Screenshot 2025-06-17 at 12 10 51](https://github.com/user-attachments/assets/bfee7f55-e3d3-497f-bd39-7f836e76ca3d)

I tried front-loading the build/assemble task but it slowed things down because the build jobs still have to run twice, and that is net longer even though the second run does skip a few steps.
