### PR TITLE
Add base url as a field on the API request

### DIFF
--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/ApiRequest.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/ApiRequest.kt
@@ -43,7 +43,12 @@ interface ApiRequest {
     val endTime: Long?
 
     /**
-     * URL of the request, omitting query string
+     * Base URL of the request
+     */
+    val baseUrl: String
+
+    /**
+     * Full URL of the request
      */
     val url: URL
 

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/EventApiRequest.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/EventApiRequest.kt
@@ -20,7 +20,7 @@ internal class EventApiRequest(
 ) : KlaviyoApiRequest(PATH, RequestMethod.POST, queuedTime, uuid) {
 
     private companion object {
-        const val PATH = "client/events/"
+        const val PATH = "client/events"
         const val METRIC = "metric"
         const val NAME = "name"
         const val VALUE = "value"

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequest.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequest.kt
@@ -71,6 +71,7 @@ internal open class KlaviyoApiRequest(
         const val METHOD_JSON_KEY = "method"
         const val TIME_JSON_KEY = "time"
         const val UUID_JSON_KEY = "uuid"
+        const val URL_JSON_KEY = "base_url"
         const val HEADERS_JSON_KEY = "headers"
         const val QUERY_JSON_KEY = "query"
         const val BODY_JSON_KEY = "body"
@@ -140,17 +141,18 @@ internal open class KlaviyoApiRequest(
      * Tracks number of attempts to limit retries
      */
     final override var attempts = 0
-        private set(value) {
+        protected set(value) {
             field = value
             headers[HEADER_KLAVIYO_ATTEMPT] = "$value/${Registry.config.networkMaxAttempts}"
         }
+
+    override var baseUrl: String = Registry.config.baseUrl
 
     /**
      * Compiles the base url, path and query data into a [URL] object
      */
     override val url: URL
         get() {
-            val baseUrl = Registry.config.baseUrl
             val queryMap = query.map { (key, value) -> "$key=$value" }
             val queryString = queryMap.joinToString(separator = "&")
 
@@ -262,6 +264,7 @@ internal open class KlaviyoApiRequest(
         .accumulate(METHOD_JSON_KEY, method.name)
         .accumulate(TIME_JSON_KEY, queuedTime)
         .accumulate(UUID_JSON_KEY, uuid)
+        .accumulate(URL_JSON_KEY, baseUrl)
         .accumulate(HEADERS_JSON_KEY, JSONObject(headers as Map<String, String>))
         .accumulate(QUERY_JSON_KEY, JSONObject(query))
         .accumulate(BODY_JSON_KEY, body)

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequestDecoder.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequestDecoder.kt
@@ -1,5 +1,7 @@
 package com.klaviyo.analytics.networking.requests
 
+import com.klaviyo.analytics.networking.requests.KlaviyoApiRequest.Companion.URL_JSON_KEY
+import com.klaviyo.core.Registry
 import org.json.JSONException
 import org.json.JSONObject
 
@@ -31,6 +33,7 @@ internal object KlaviyoApiRequestDecoder {
             AggregateEventApiRequest::class.simpleName -> AggregateEventApiRequest(time, uuid)
             else -> KlaviyoApiRequest(urlPath, method, time, uuid)
         }.apply {
+            baseUrl = json.optString(URL_JSON_KEY, Registry.config.baseUrl)
             headers.replaceAllWith(
                 json.getJSONObject(KlaviyoApiRequest.HEADERS_JSON_KEY).let {
                     it.keys().asSequence().associateWith { k -> it.getString(k) }.toMap()

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/ProfileApiRequest.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/ProfileApiRequest.kt
@@ -18,7 +18,7 @@ internal class ProfileApiRequest(
 ) : KlaviyoApiRequest(PATH, RequestMethod.POST, queuedTime, uuid) {
 
     companion object {
-        private const val PATH = "client/profiles/"
+        private const val PATH = "client/profiles"
         private const val LOCATION = "location"
 
         fun formatBody(profile: Profile): Array<Pair<String, Any>> {

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/EventApiRequestTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/EventApiRequestTest.kt
@@ -15,7 +15,7 @@ import org.junit.Test
 
 internal class EventApiRequestTest : BaseApiRequestTest<EventApiRequest>() {
 
-    override val expectedUrl = "client/events/"
+    override val expectedPath = "client/events"
 
     private val stubEvent: Event = Event(EventMetric.CUSTOM("Test Event"))
 

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequestTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequestTest.kt
@@ -22,13 +22,15 @@ import org.junit.Test
 
 internal class KlaviyoApiRequestTest : BaseApiRequestTest<KlaviyoApiRequest>() {
 
-    override val expectedUrl = "test"
+    override val expectedPath = "test"
+
+    override val expectedUrl: URL = URL("${mockConfig.baseUrl}/$expectedPath")
 
     override val expectedMethod: RequestMethod = RequestMethod.GET
 
     override val expectedQuery: Map<String, String> = emptyMap()
 
-    private val expectedFullUrl = "${mockConfig.baseUrl}/$expectedUrl"
+    private val expectedFullUrl = "${mockConfig.baseUrl}/$expectedPath"
 
     private val bodySlot = slot<String>()
 
@@ -81,13 +83,13 @@ internal class KlaviyoApiRequestTest : BaseApiRequestTest<KlaviyoApiRequest>() {
     }
 
     override fun makeTestRequest(): KlaviyoApiRequest =
-        KlaviyoApiRequest(expectedUrl, RequestMethod.GET)
+        KlaviyoApiRequest(expectedPath, RequestMethod.GET)
 
     @Test
     fun `Treats same UUID as equal requests for deduplication`() {
-        val request1 = KlaviyoApiRequest(expectedUrl, RequestMethod.GET, uuid = "uuid1")
-        val request2 = KlaviyoApiRequest(expectedUrl, RequestMethod.GET, uuid = "uuid2")
-        val request3 = KlaviyoApiRequest(expectedUrl, RequestMethod.GET, uuid = "uuid2")
+        val request1 = KlaviyoApiRequest(expectedPath, RequestMethod.GET, uuid = "uuid1")
+        val request2 = KlaviyoApiRequest(expectedPath, RequestMethod.GET, uuid = "uuid2")
+        val request3 = KlaviyoApiRequest(expectedPath, RequestMethod.GET, uuid = "uuid2")
 
         assertNotEquals(request1, null)
         assertNotEquals(request1, request2)
@@ -292,7 +294,7 @@ internal class KlaviyoApiRequestTest : BaseApiRequestTest<KlaviyoApiRequest>() {
 
         every { connectionMock.responseCode } returns 200
 
-        val request = KlaviyoApiRequest(expectedUrl, RequestMethod.POST).apply {
+        val request = KlaviyoApiRequest(expectedPath, RequestMethod.POST).apply {
             body = expectedBody
         }
         val actualResponse = request.send()
@@ -310,7 +312,7 @@ internal class KlaviyoApiRequestTest : BaseApiRequestTest<KlaviyoApiRequest>() {
 
         every { connectionMock.responseCode } returns 200
 
-        val request = KlaviyoApiRequest(expectedUrl, RequestMethod.POST)
+        val request = KlaviyoApiRequest(expectedPath, RequestMethod.POST)
         val actualResponse = request.send()
 
         assert(!bodySlot.isCaptured)
@@ -322,6 +324,7 @@ internal class KlaviyoApiRequestTest : BaseApiRequestTest<KlaviyoApiRequest>() {
     private val postJson = """
         {
           "request_type": "KlaviyoApiRequest",
+          "base_url": "https://test.fake-klaviyo.com",
           "headers": {
             "headerKey": "headerValue"
           },
@@ -341,6 +344,7 @@ internal class KlaviyoApiRequestTest : BaseApiRequestTest<KlaviyoApiRequest>() {
     private val getJson = """
         {
           "request_type": "KlaviyoApiRequest",
+          "base_url": "https://test.fake-klaviyo.com",
           "headers": {
             "headerKey": "headerValue"
           },

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/ProfileApiRequestTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/ProfileApiRequestTest.kt
@@ -6,7 +6,7 @@ import org.junit.Test
 
 internal class ProfileApiRequestTest : BaseApiRequestTest<ProfileApiRequest>() {
 
-    override val expectedUrl = "client/profiles/"
+    override val expectedPath = "client/profiles"
 
     override fun makeTestRequest(): ProfileApiRequest =
         ProfileApiRequest(stubProfile)

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/PushTokenApiRequestTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/PushTokenApiRequestTest.kt
@@ -8,7 +8,7 @@ import org.junit.Test
 
 internal class PushTokenApiRequestTest : BaseApiRequestTest<PushTokenApiRequest>() {
 
-    override val expectedUrl = "client/push-tokens"
+    override val expectedPath = "client/push-tokens"
 
     override fun makeTestRequest(): PushTokenApiRequest =
         PushTokenApiRequest(PUSH_TOKEN, stubProfile)

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/UnregisterPushTokenApiRequestTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/UnregisterPushTokenApiRequestTest.kt
@@ -7,7 +7,7 @@ import org.junit.Test
 
 internal class UnregisterPushTokenApiRequestTest : BaseApiRequestTest<UnregisterPushTokenApiRequest>() {
 
-    override val expectedUrl = "client/push-token-unregister"
+    override val expectedPath = "client/push-token-unregister"
 
     override fun makeTestRequest(): UnregisterPushTokenApiRequest =
         UnregisterPushTokenApiRequest(API_KEY, PUSH_TOKEN, stubProfile)


### PR DESCRIPTION
# Description
This adds base url as a field on the API request that is persisted / restored from disk for queued requests. 
It will be necessary for universal click tracking links because we need to send those API requests to arbitrary URLs, not just the configured API base url. 
Incidentally, this also fixes an old, trivial bug where switching base URLs in the config can cause queued requests to wind up sending to the wrong server.


## Due Diligence
<!-- Best practices before submitting, add additional notes below -->
<!-- If your changes are particularly affected by different Android version, please note API levels you tested on below  -->
- [x] I have tested this on an emulator and/or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable. -- Not really applicable
- [x] I am confident these changes are compatible with all Android versions the SDK currently supports.


## Release/Versioning Considerations
<!-- Help determine how this should be categorized for release, add additional notes below. -->
<!-- Please add the planned version as a `milestone` label on this PR -->
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API. 
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [x] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->
Adds base url as a field on the API request so it can be overridden. 
De/serializes that field to disk when persisting (deserializing falls back on configured base url for migration purposes)

## Test Plan
<!-- Provide reproducible testing steps. Link any artifacts, recordings, spreadsheets, etc. -->
Use the test app to send some basic event/push/profile event requests.

## Related Issues/Tickets
<!-- Link to relevant Jira issues, Slack discussions, Google Docs --> 
 Relates to universal linking but not explicitly ticketed. 
 