### PR TITLE
IAF | Inject safe area inset values to work around buggy webview implementation

### DIFF
--- a/sdk/forms/src/main/assets/klaviyo-js-bridge.js
+++ b/sdk/forms/src/main/assets/klaviyo-js-bridge.js
@@ -105,6 +105,14 @@ window.closeForm = function (formId) {
     return true
 }
 
+window.setSafeArea = function(left, top, right, bottom) {
+    document.documentElement.style.setProperty('--safe-area-inset-left', left + 'px');
+    document.documentElement.style.setProperty('--safe-area-inset-top', top + 'px');
+    document.documentElement.style.setProperty('--safe-area-inset-right', right + 'px');
+    document.documentElement.style.setProperty('--safe-area-inset-bottom', bottom + 'px');
+    return true;
+ }
+
 // Notify the SDK over the native bridge that these local JS scripts are initialized
 var bridgeName = document.head.getAttribute("data-native-bridge-name") || ""
 

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/JsBridge.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/JsBridge.kt
@@ -44,4 +44,9 @@ internal interface JsBridge {
      * If no ID provided, close any currently open forms.
      */
     fun closeForm(formId: FormId?)
+
+    /**
+     * Injects safe area insets into the webview
+     */
+    fun setSafeArea(left: Float, top: Float, right: Float, bottom: Float)
 }

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/KlaviyoJsBridge.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/KlaviyoJsBridge.kt
@@ -14,7 +14,8 @@ internal class KlaviyoJsBridge : JsBridge {
         profileMutation,
         lifecycleEvent,
         openForm,
-        closeForm
+        closeForm,
+        setSafeArea
     }
 
     override val handshake: List<HandshakeSpec> = listOf(
@@ -54,6 +55,15 @@ internal class KlaviyoJsBridge : JsBridge {
         HelperFunction.lifecycleEvent,
         type.name
     )
+
+    override fun setSafeArea(left: Float, top: Float, right: Float, bottom: Float) =
+        evaluateJavascript(
+            HelperFunction.setSafeArea,
+            left.toString(),
+            top.toString(),
+            right.toString(),
+            bottom.toString()
+        )
 
     /**
      * Evaluates a JS function in the webview with the given arguments

--- a/sdk/forms/src/test/java/com/klaviyo/forms/bridge/KlaviyoJsBridgeTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/bridge/KlaviyoJsBridgeTest.kt
@@ -138,4 +138,20 @@ class KlaviyoJsBridgeTest : BaseTest() {
             )
         }
     }
+
+    @Test
+    fun `setSafeArea calls JS evaluator with correct JS`() {
+        every { jsEvaluator.evaluateJavascript(any(), any()) } answers {
+            secondArg<(Boolean) -> Unit>().invoke(true)
+        }
+
+        bridge.setSafeArea(10f, 20f, 30f, 40f)
+
+        verify {
+            jsEvaluator.evaluateJavascript(
+                eq("""window.setSafeArea("10.0","20.0","30.0","40.0")"""),
+                any()
+            )
+        }
+    }
 }


### PR DESCRIPTION
# Description
Android webview has a buggy implementation of safe area insets. Support was only even introduced in May, and they have an extant issue where loading the content before attaching to the view hierarchy causes all safe area insets to compute as 0, with no way to re-compute other than reloading the page 🙄 

With this work around we will compute the safe area ourselves and inject them as css variables. In our JS/CSS package we will check for this variable first, and fall back on the env value if these values are not present.

## Due Diligence
<!-- Best practices before submitting, add additional notes below -->
<!-- If your changes are particularly affected by different Android version, please note API levels you tested on below  -->
- [x] I have tested this on an emulator and/or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all Android versions the SDK currently supports.


## Release/Versioning Considerations
<!-- Help determine how this should be categorized for release, add additional notes below. -->
<!-- Please add the planned version as a `milestone` label on this PR -->
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API. 
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [ ] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->
Compute safe area on the native side
Inject that as a CSS var

## Test Plan
<!-- Provide reproducible testing steps. Link any artifacts, recordings, spreadsheets, etc. -->
- [ ] Asset source the corresponding fender PR and test that a full screen form properly pads the form content (namely the X icon)

## Related Issues/Tickets
<!-- Link to relevant Jira issues, Slack discussions, Google Docs --> 
 https://klaviyo.atlassian.net/browse/CHNL-23925
 