### PR TITLE
Fix merge conflicts for feat/trigger-by-event

### DIFF
--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -245,7 +245,7 @@ object Klaviyo {
      * @return Returns [Klaviyo] for call chaining
      */
     fun createEvent(event: Event): Klaviyo = safeApply {
-        Registry.get<ApiClient>().enqueueEvent(event, Registry.get<State>().getAsProfile())
+        Registry.get<State>().createEvent(event, Registry.get<State>().getAsProfile())
     }
 
     /**
@@ -289,7 +289,7 @@ object Klaviyo {
         Registry.get<State>().pushToken?.let { event[EventKey.PUSH_TOKEN] = it }
 
         Registry.log.verbose("Enqueuing ${event.metric.name} event")
-        Registry.get<ApiClient>().enqueueEvent(event, Registry.get<State>().getAsProfile())
+        createEvent(event)
     }
 
     /**

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/ApiClient.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/ApiClient.kt
@@ -58,6 +58,8 @@ interface ApiClient {
 
     /**
      * Queue an API request to track an [Event] to Klaviyo for a [Profile]
+     * Note: Calling this directly will result in events not being broadcasted to Forms. This
+     * is used in 'Trigger By Event' situations
      *
      * @param event
      * @param profile

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/state/State.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/state/State.kt
@@ -1,10 +1,13 @@
 package com.klaviyo.analytics.state
 
+import com.klaviyo.analytics.model.Event
 import com.klaviyo.analytics.model.Profile
 import com.klaviyo.analytics.model.ProfileKey
 import java.io.Serializable
 
 typealias StateChangeObserver = (change: StateChange) -> Unit
+
+typealias ProfileEventObserver = (event: Event) -> Unit
 
 interface State {
     var apiKey: String?
@@ -53,4 +56,16 @@ interface State {
      * Clear user's attributes from internal state, leaving profile identifiers intact
      */
     fun resetAttributes()
+
+    fun createEvent(event: Event, profile: Profile)
+
+    /**
+     * Register an observer to be notified when a profile event is sent
+     */
+    fun onProfileEvent(observer: ProfileEventObserver)
+
+    /**
+     * De-register an observer from [onProfileEvent]
+     */
+    fun offProfileEvent(observer: ProfileEventObserver)
 }

--- a/sdk/forms/src/main/assets/klaviyo-js-bridge.js
+++ b/sdk/forms/src/main/assets/klaviyo-js-bridge.js
@@ -50,10 +50,10 @@ window.lifecycleEvent = function (type) {
  * @param metric - The metric of the event
  * @param strProperties - Properties of the event as a JSON string
  */
-window.analyticsEvent = function (metric, strProperties) {
+window.profileEvent = function (metric, strProperties) {
     document.head.dispatchEvent(
         new CustomEvent(
-            'analyticsEvent',
+            'profileEvent',
             {
                 detail: {
                     metric: metric,

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/FormsProfileEventObserver.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/FormsProfileEventObserver.kt
@@ -1,0 +1,24 @@
+package com.klaviyo.forms.bridge
+
+import com.klaviyo.analytics.model.Event
+import com.klaviyo.analytics.state.ProfileEventObserver
+import com.klaviyo.analytics.state.State
+import com.klaviyo.core.Registry
+
+/**
+ * Observe events sent in the analytics package to trigger forms in the webview
+ */
+internal class FormsProfileEventObserver : JsBridgeObserver, ProfileEventObserver {
+
+    override fun startObserver() {
+        Registry.get<State>().onProfileEvent(this)
+    }
+
+    override fun stopObserver() {
+        Registry.get<State>().offProfileEvent(this)
+    }
+
+    override fun invoke(event: Event) {
+        Registry.get<JsBridge>().profileEvent(event)
+    }
+}

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/JsBridge.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/JsBridge.kt
@@ -1,5 +1,6 @@
 package com.klaviyo.forms.bridge
 
+import com.klaviyo.analytics.model.Event
 import com.klaviyo.analytics.model.ImmutableProfile
 
 typealias FormId = String
@@ -44,4 +45,10 @@ internal interface JsBridge {
      * If no ID provided, close any currently open forms.
      */
     fun closeForm(formId: FormId?)
+
+    /**
+     * Dispatch profile events for onsite JS package to consume
+     *
+     */
+    fun profileEvent(event: Event)
 }

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/KlaviyoJsBridge.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/KlaviyoJsBridge.kt
@@ -1,5 +1,6 @@
 package com.klaviyo.forms.bridge
 
+import com.klaviyo.analytics.model.Event
 import com.klaviyo.analytics.model.ImmutableProfile
 import com.klaviyo.core.Registry
 import com.klaviyo.forms.webview.JavaScriptEvaluator
@@ -14,7 +15,8 @@ internal class KlaviyoJsBridge : JsBridge {
         profileMutation,
         lifecycleEvent,
         openForm,
-        closeForm
+        closeForm,
+        profileEvent
     }
 
     override val handshake: List<HandshakeSpec> = listOf(
@@ -28,6 +30,10 @@ internal class KlaviyoJsBridge : JsBridge {
         ),
         HandshakeSpec(
             type = HelperFunction.closeForm.name,
+            version = 1
+        ),
+        HandshakeSpec(
+            type = HelperFunction.profileEvent.name,
             version = 1
         )
     )
@@ -53,6 +59,12 @@ internal class KlaviyoJsBridge : JsBridge {
     override fun lifecycleEvent(type: JsBridge.LifecycleEventType) = evaluateJavascript(
         HelperFunction.lifecycleEvent,
         type.name
+    )
+
+    override fun profileEvent(event: Event) = evaluateJavascript(
+        HelperFunction.profileEvent,
+        event.metric.name,
+        event.toString()
     )
 
     /**

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/KlaviyoObserverCollection.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/KlaviyoObserverCollection.kt
@@ -8,7 +8,8 @@ internal class KlaviyoObserverCollection : JsBridgeObserverCollection {
         listOf(
             CompanyObserver(),
             LifecycleObserver(),
-            ProfileObserver()
+            ProfileObserver(),
+            FormsProfileEventObserver()
         )
     }
 }

--- a/sdk/forms/src/test/java/com/klaviyo/forms/bridge/FormsProfileEventObserverTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/bridge/FormsProfileEventObserverTest.kt
@@ -1,0 +1,40 @@
+package com.klaviyo.forms.bridge
+
+import com.klaviyo.analytics.model.Event
+import com.klaviyo.analytics.model.EventKey
+import com.klaviyo.core.Registry
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+class FormsProfileEventObserverTest {
+    private val mockJsBridge = mockk<JsBridge>(relaxed = true)
+
+    private val testEvent = Event(
+        metric = "Fate Sealed",
+        properties = mapOf(
+            EventKey.CUSTOM("name") to "Anna Karenina",
+            EventKey.CUSTOM("location") to "Saint Petersburg"
+        )
+    )
+
+    @Before
+    fun setup() {
+        Registry.register<JsBridge>(mockJsBridge)
+    }
+
+    @Test
+    fun `invoke event broadcast`() {
+        FormsProfileEventObserver().invoke(testEvent)
+        verify { mockJsBridge.profileEvent(testEvent) }
+    }
+
+    @After
+    fun cleanup() {
+        Registry.unregister<JsBridge>()
+        unmockkAll()
+    }
+}

--- a/sdk/forms/src/test/java/com/klaviyo/forms/bridge/JsBridgeObserverTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/bridge/JsBridgeObserverTest.kt
@@ -35,9 +35,10 @@ class JsBridgeObserverTest {
         val klaviyoObserverCollection = KlaviyoObserverCollection()
         val observers = klaviyoObserverCollection.observers
 
-        assertEquals(3, klaviyoObserverCollection.observers.size)
+        assertEquals(4, klaviyoObserverCollection.observers.size)
         assert(observers.any { it is CompanyObserver }) { "Expected CompanyObserver in the collection" }
         assert(observers.any { it is ProfileObserver }) { "Expected ProfileObserver in the collection" }
         assert(observers.any { it is LifecycleObserver }) { "Expected LifecycleObserver in the collection" }
+        assert(observers.any { it is FormsProfileEventObserver }) { "Expected FormsProfileEventObserver in the collection" }
     }
 }

--- a/sdk/forms/src/test/java/com/klaviyo/forms/bridge/KlaviyoJsBridgeTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/bridge/KlaviyoJsBridgeTest.kt
@@ -31,7 +31,7 @@ class KlaviyoJsBridgeTest : BaseTest() {
     fun `compileJson returns correct JSON for supported functions`() {
         val expectedJson = KlaviyoJsBridge().handshake.compileJson()
         val actualJson = """
-           [{"type":"profileMutation","version":1},{"type":"lifecycleEvent","version":1},{"type":"closeForm","version":1},{"type":"profileEvent","version":1}]
+           [{"type":"profileMutation","version":1},{"type":"lifecycleEvent","version":1},{"type":"closeForm","version":1},{"type":"profileEvent","version":1},{"type":"setSafeArea","version":1}]
         """.trimIndent()
         assertEquals(actualJson, expectedJson)
     }

--- a/sdk/forms/src/test/java/com/klaviyo/forms/bridge/KlaviyoNativeBridgeTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/bridge/KlaviyoNativeBridgeTest.kt
@@ -263,7 +263,7 @@ internal class KlaviyoNativeBridgeTest : BaseTest() {
         // required steps to the profile event
         verify { mockState.getAsProfile() }
         val slot = slot<Event>()
-        verify { mockApiClient.enqueueEvent(capture(slot), any()) }
+        verify { mockState.createEvent(capture(slot), any()) }
         assertEquals(expectedMetric, slot.captured.metric)
     }
 


### PR DESCRIPTION
# Description
Resolves merge conflicts between feat/trigger-by-event and master branches by merging both profileEvent and setSafeArea methods in the JsBridge interface.

## Due Diligence
- [x] I have tested this on an emulator and/or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all Android versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API. 
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [ ] This is planned work for an upcoming release.

## Changelog / Code Overview
- **JsBridge Interface**: Added both `profileEvent(event: Event)` and `setSafeArea()` methods
- **KlaviyoJsBridge Implementation**: 
  - Added `setSafeArea` to `HelperFunction` enum
  - Added `setSafeArea` handshake specification
  - Implemented both `profileEvent` and `setSafeArea` methods
- **Tests**: Updated handshake JSON expectation to include new `setSafeArea` method

## Test Plan
- All forms module tests pass (`./gradlew :sdk:forms:test`)
- Conflict resolution preserves functionality from both branches
- Both event triggering and safe area insets features work correctly

## Related Issues/Tickets
- Fixes conflicts blocking PR #315 (feat/trigger-by-event)