### PR TITLE
Support limited pre-initialize operations by registering context only

### DIFF
--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -226,9 +226,7 @@ object Klaviyo {
      *
      * @param pushToken The push token provided by the device push service
      */
-    fun setPushToken(pushToken: String) = safeApply(preInitQueue) {
-        Registry.get<State>().pushToken = pushToken
-    }
+    fun setPushToken(pushToken: String) = safeApply { Registry.get<State>().pushToken = pushToken }
 
     /**
      * @return The device push token, if one has been assigned to currently tracked profile

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -63,7 +63,7 @@ object Klaviyo {
         Registry.registerOnce<ApiClient> { KlaviyoApiClient }
 
         // Register lifecycle callbacks to monitor app foreground/background state
-        Registry.config.applicationContext.applicationContext.takeIf<Application>()?.apply {
+        applicationContext.applicationContext.takeIf<Application>()?.apply {
             unregisterActivityLifecycleCallbacks(Registry.lifecycleCallbacks)
             unregisterComponentCallbacks(Registry.componentCallbacks)
             registerActivityLifecycleCallbacks(Registry.lifecycleCallbacks)
@@ -332,7 +332,7 @@ object Klaviyo {
         try {
             DeepLinking.handleUniversalTrackingLink(url.toUri())
         } catch (e: Exception) {
-            Registry.log.warning("Failed handling universal link: $url", e)
+            Registry.log.error("Failed handling universal link: $url", e)
             false
         }
     } ?: false

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -334,6 +334,9 @@ object Klaviyo {
     /**
      * Handles a universal link [Intent], by resolving the destination [Uri] asynchronously
      * and invoking the registered [DeepLinkHandler] or sending the host application an [Intent]
+     *
+     * @return [Boolean] Indicating whether the url is a Klaviyo tracking link,
+     *         and the destination url is being resolved asynchronously
      */
     fun handleUniversalTrackingLink(url: String): Boolean = safeCall {
         try {
@@ -347,6 +350,9 @@ object Klaviyo {
     /**
      * Handles a universal link [Intent], by resolving the destination [Uri] asynchronously
      * and invoking the registered [DeepLinkHandler] or sending the host application an [Intent]
+     *
+     * @return [Boolean] Indicating whether the url is a Klaviyo tracking link,
+     *         and the destination url is being resolved asynchronously
      */
     fun handleUniversalTrackingLink(intent: Intent?): Boolean = safeCall {
         intent?.data?.let { uri ->

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -332,7 +332,7 @@ object Klaviyo {
         try {
             DeepLinking.handleUniversalTrackingLink(url.toUri())
         } catch (e: Exception) {
-            Registry.log.warning("Invalid universal link: $url", e)
+            Registry.log.warning("Failed handling universal link: $url", e)
             false
         }
     } ?: false

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/linking/DeepLinking.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/linking/DeepLinking.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import com.klaviyo.analytics.linking.DeepLinking.handleDeepLink
 import com.klaviyo.analytics.networking.ApiClient
 import com.klaviyo.analytics.networking.requests.ResolveDestinationResult
 import com.klaviyo.analytics.state.State
@@ -19,7 +20,7 @@ typealias DeepLinkHandler = (uri: Uri) -> Unit
 /**
  * Utility for handling any deep links into the host application originating from Klaviyo
  */
-internal object DeepLinking {
+object DeepLinking {
 
     /**
      * Shortcut to check if the developer has registered a [DeepLinkHandler].

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/linking/DeepLinking.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/linking/DeepLinking.kt
@@ -68,7 +68,6 @@ object DeepLinking {
                     Registry.log.verbose("Resolved destination URL: ${result.destinationUrl}")
                 }
 
-                // TODO on failure, we need to launch the app if no handler is registered
                 is ResolveDestinationResult.Unavailable -> Registry.log.warning(
                     "Destination URL unavailable for ${result.trackingUrl}."
                 )

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/linking/DeepLinking.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/linking/DeepLinking.kt
@@ -4,6 +4,9 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import com.klaviyo.analytics.networking.ApiClient
+import com.klaviyo.analytics.networking.requests.ResolveDestinationResult
+import com.klaviyo.analytics.state.State
 import com.klaviyo.core.Registry
 import com.klaviyo.core.lifecycle.LifecycleMonitor.Companion.ACTIVITY_TRANSITION_GRACE_PERIOD
 
@@ -16,12 +19,18 @@ typealias DeepLinkHandler = (uri: Uri) -> Unit
 /**
  * Utility for handling any deep links into the host application originating from Klaviyo
  */
-object DeepLinking {
+internal object DeepLinking {
 
     /**
      * Shortcut to check if the developer has registered a [DeepLinkHandler].
      */
     val isHandlerRegistered: Boolean get() = Registry.getOrNull<DeepLinkHandler>() != null
+
+    /**
+     * Check if a URI is a Klaviyo universal tracking link based on its scheme and path
+     */
+    fun isUniversalTrackingUri(uri: Uri): Boolean =
+        uri.scheme in listOf("https", "http") && uri.path?.startsWith("/u/") ?: false
 
     /**
      * Handle a deep link by invoking a registered [DeepLinkHandler] if available,
@@ -33,6 +42,43 @@ object DeepLinking {
         Registry.getOrNull<DeepLinkHandler>()?.invoke(uri) ?: run {
             sendDeepLinkIntent(uri)
         }
+    }
+
+    /**
+     * Handle a Klaviyo universal tracking link by resolving it to a destination URL asynchronously,
+     * and then passing that URL to [handleDeepLink].
+     *
+     * @return Boolean - whether the URI is a Klaviyo universal tracking link to be resolved
+     */
+    fun handleUniversalTrackingLink(uri: Uri): Boolean {
+        if (!isUniversalTrackingUri(uri)) {
+            Registry.log.error("Not a Klaviyo universal tracking URI: $uri")
+            return false
+        }
+
+        val profile = Registry.get<State>().getAsProfile()
+
+        // Resolve destination URL via async API call
+        Registry.get<ApiClient>().resolveDestinationUrl(uri.toString(), profile) { result ->
+            when (result) {
+                is ResolveDestinationResult.Success -> handleDeepLink(
+                    result.destinationUrl
+                ).also {
+                    Registry.log.verbose("Resolved destination URL: ${result.destinationUrl}")
+                }
+
+                // TODO on failure, we need to launch the app if no handler is registered
+                is ResolveDestinationResult.Unavailable -> Registry.log.warning(
+                    "Destination URL unavailable for ${result.trackingUrl}."
+                )
+
+                is ResolveDestinationResult.Failure -> Registry.log.error(
+                    "Failed to resolve destination URL for ${result.trackingUrl}."
+                )
+            }
+        }
+
+        return true
     }
 
     /**

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/linking/DeepLinking.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/linking/DeepLinking.kt
@@ -54,7 +54,7 @@ object DeepLinking {
      */
     fun handleUniversalTrackingLink(uri: Uri): Boolean {
         if (!isUniversalTrackingUri(uri)) {
-            Registry.log.error("Not a Klaviyo universal tracking URI: $uri")
+            Registry.log.info("Not a Klaviyo universal tracking URI: $uri")
             return false
         }
 

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/linking/DeepLinking.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/linking/DeepLinking.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import com.klaviyo.analytics.linking.DeepLinking.handleDeepLink
+import com.klaviyo.analytics.model.Profile
 import com.klaviyo.analytics.networking.ApiClient
 import com.klaviyo.analytics.networking.requests.ResolveDestinationResult
 import com.klaviyo.analytics.state.State
@@ -57,7 +58,7 @@ object DeepLinking {
             return false
         }
 
-        val profile = Registry.get<State>().getAsProfile()
+        val profile = Registry.getOrNull<State>()?.getAsProfile() ?: Profile()
 
         // Resolve destination URL via async API call
         Registry.get<ApiClient>().resolveDestinationUrl(uri.toString(), profile) { result ->

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/state/StateSideEffects.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/state/StateSideEffects.kt
@@ -1,5 +1,6 @@
 package com.klaviyo.analytics.state
 
+import com.klaviyo.analytics.Klaviyo
 import com.klaviyo.analytics.model.ImmutableProfile
 import com.klaviyo.analytics.model.Profile
 import com.klaviyo.analytics.model.ProfileKey
@@ -15,6 +16,7 @@ import com.klaviyo.core.Registry
 import com.klaviyo.core.config.Clock
 import com.klaviyo.core.lifecycle.ActivityEvent
 import com.klaviyo.core.lifecycle.LifecycleMonitor
+import com.klaviyo.core.utils.takeIf
 
 internal class StateSideEffects(
     private val state: State = Registry.get<State>(),
@@ -169,12 +171,12 @@ internal class StateSideEffects(
         }
     }
 
-    private fun onLifecycleEvent(activity: ActivityEvent): Unit = when {
-        activity is ActivityEvent.Resumed -> Registry.get<State>().pushToken?.let {
-            // This should trigger the token in state to refresh overall push state
-            Registry.get<State>().pushToken = it
-        } ?: Unit
-
-        else -> Unit
+    private fun onLifecycleEvent(activity: ActivityEvent) {
+        activity.takeIf<ActivityEvent.Resumed>()?.run {
+            Registry.get<State>().pushToken?.let {
+                // Trigger the token in state to refresh overall push state, if changed
+                Klaviyo.setPushToken(it)
+            }
+        }
     }
 }

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoPreInitializeTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoPreInitializeTest.kt
@@ -72,17 +72,13 @@ internal class KlaviyoPreInitializeTest : BaseTest() {
         super.cleanup()
     }
 
-    private inline fun <reified T> assertCaught() where T : Throwable {
-        verify { spyLog.error(any(), any<T>()) }
-    }
-
     @Test
     fun `Opened Push events are replayed upon initializing`() {
         Klaviyo.handlePush(KlaviyoTest.mockIntent(KlaviyoTest.stubIntentExtras))
-        assertCaught<MissingConfig>()
+        verify { spyLog.warning(any(), any<MissingConfig>()) } // Warning bc it will be replayed
 
         Klaviyo.createEvent(EventMetric.OPENED_APP)
-        assertCaught<MissingConfig>()
+        verify { spyLog.error(any(), any<MissingConfig>()) } // Error bc this is a fully invalid call
 
         verify(inverse = true) { mockApiClient.enqueueEvent(any(), any()) }
 

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoRegisterForLifecycleCallbacksTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoRegisterForLifecycleCallbacksTest.kt
@@ -10,7 +10,6 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.unmockkAll
 import io.mockk.verify
-import io.mockk.verifyAll
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -54,20 +53,10 @@ internal class KlaviyoRegisterForLifecycleCallbacksTest : BaseTest() {
 
         Klaviyo.registerForLifecycleCallbacks(mockApplicationContext)
 
-        verifyAll {
-            mockApplicationContext.unregisterActivityLifecycleCallbacks(
-                match { it == expectedListener }
-            )
-            mockApplicationContext.registerActivityLifecycleCallbacks(
-                match { it == expectedListener }
-            )
-            mockApplicationContext.unregisterComponentCallbacks(
-                match { it == expectedConfigListener }
-            )
-            mockApplicationContext.registerComponentCallbacks(
-                match { it == expectedConfigListener }
-            )
-        }
+        verify { mockApplicationContext.unregisterActivityLifecycleCallbacks(expectedListener) }
+        verify { mockApplicationContext.registerActivityLifecycleCallbacks(expectedListener) }
+        verify { mockApplicationContext.unregisterComponentCallbacks(expectedConfigListener) }
+        verify { mockApplicationContext.registerComponentCallbacks(expectedConfigListener) }
 
         verify(exactly = 0) {
             mockBuilder.apiKey(any())

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoRegisterForLifecycleCallbacksTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoRegisterForLifecycleCallbacksTest.kt
@@ -1,13 +1,18 @@
 package com.klaviyo.analytics
 
 import android.app.Application
+import com.klaviyo.analytics.networking.ApiClient
+import com.klaviyo.analytics.state.State
 import com.klaviyo.core.Registry
 import com.klaviyo.core.config.Config
 import com.klaviyo.fixtures.BaseTest
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.unmockkAll
 import io.mockk.verify
 import io.mockk.verifyAll
+import org.junit.After
+import org.junit.Before
 import org.junit.Test
 
 internal class KlaviyoRegisterForLifecycleCallbacksTest : BaseTest() {
@@ -19,15 +24,27 @@ internal class KlaviyoRegisterForLifecycleCallbacksTest : BaseTest() {
     }
 
     private val mockApplicationContext = mockk<Application> {
-        every { applicationContext } returns mockk()
+        every { applicationContext } returns this
         every { unregisterActivityLifecycleCallbacks(any()) } returns Unit
         every { unregisterComponentCallbacks(any()) } returns Unit
         every { registerActivityLifecycleCallbacks(any()) } returns Unit
         every { registerComponentCallbacks(any()) } returns Unit
     }
 
-    private val mockApplication = mockk<Application>().apply {
-        every { applicationContext } returns mockApplicationContext
+    @Before
+    override fun setup() {
+        super.setup()
+        every { Registry.configBuilder } returns mockBuilder
+        every { mockContext.applicationContext } returns mockApplicationContext
+    }
+
+    @After
+    override fun cleanup() {
+        super.cleanup()
+        Registry.unregister<Config>()
+        Registry.unregister<State>()
+        Registry.unregister<ApiClient>()
+        unmockkAll()
     }
 
     @Test
@@ -35,7 +52,7 @@ internal class KlaviyoRegisterForLifecycleCallbacksTest : BaseTest() {
         val expectedListener = Registry.lifecycleCallbacks
         val expectedConfigListener = Registry.componentCallbacks
 
-        Klaviyo.registerForLifecycleCallbacks(mockApplication)
+        Klaviyo.registerForLifecycleCallbacks(mockApplicationContext)
 
         verifyAll {
             mockApplicationContext.unregisterActivityLifecycleCallbacks(
@@ -54,8 +71,6 @@ internal class KlaviyoRegisterForLifecycleCallbacksTest : BaseTest() {
 
         verify(exactly = 0) {
             mockBuilder.apiKey(any())
-            mockBuilder.applicationContext(any())
-            mockBuilder.build()
         }
     }
 }

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoUninitializedTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoUninitializedTest.kt
@@ -32,85 +32,89 @@ internal class KlaviyoUninitializedTest {
         unmockkObject(Registry)
     }
 
-    private inline fun <reified T> assertCaught() where T : Throwable {
+    private inline fun <reified T> assertLoggedError() where T : Throwable {
+        verify { spyLog.error(any(), any<T>()) }
+    }
+
+    private inline fun <reified T> assertLoggedWarning() where T : Throwable {
         verify { spyLog.error(any(), any<T>()) }
     }
 
     @Test
     fun `Profile setter is protected`() {
         Klaviyo.setProfile(Profile())
-        assertCaught<MissingConfig>()
+        assertLoggedError<MissingConfig>()
     }
 
     @Test
     fun `Email setter is protected`() {
         Klaviyo.setEmail(BaseTest.EMAIL)
-        assertCaught<MissingConfig>()
+        assertLoggedError<MissingConfig>()
     }
 
     @Test
     fun `Email getter is protected`() {
         assertNull(Klaviyo.getEmail())
-        assertCaught<MissingConfig>()
+        assertLoggedError<MissingConfig>()
     }
 
     @Test
     fun `Phone setter is protected`() {
         Klaviyo.setPhoneNumber(BaseTest.PHONE)
-        assertCaught<MissingConfig>()
+        assertLoggedError<MissingConfig>()
     }
 
     @Test
     fun `Phone getter is protected`() {
         assertNull(Klaviyo.getPhoneNumber())
-        assertCaught<MissingConfig>()
+        assertLoggedError<MissingConfig>()
     }
 
     @Test
     fun `External ID setter is protected`() {
         Klaviyo.setExternalId(BaseTest.EXTERNAL_ID)
-        assertCaught<MissingConfig>()
+        assertLoggedError<MissingConfig>()
     }
 
     @Test
     fun `External ID getter is protected`() {
         assertNull(Klaviyo.getExternalId())
-        assertCaught<MissingConfig>()
+        assertLoggedError<MissingConfig>()
     }
 
     @Test
     fun `Push token setter is protected`() {
         Klaviyo.setPushToken(BaseTest.PUSH_TOKEN)
-        assertCaught<MissingConfig>()
+        assertLoggedWarning<MissingConfig>()
     }
 
     @Test
     fun `Push token getter is protected`() {
         Klaviyo.getPushToken()
-        assertCaught<MissingConfig>()
+        assertLoggedError<MissingConfig>()
     }
 
     @Test
     fun `Profile Attributes setter is protected`() {
         Klaviyo.setProfileAttribute(ProfileKey.FIRST_NAME, "John")
-        assertCaught<MissingConfig>()
+        assertLoggedError<MissingConfig>()
     }
 
     @Test
     fun `ResetProfile is protected`() {
         Klaviyo.resetProfile()
-        assertCaught<MissingConfig>()
+        assertLoggedError<MissingConfig>()
     }
 
     @Test
     fun `CreateEvent is protected`() {
         Klaviyo.createEvent(EventMetric.VIEWED_PRODUCT, 1.0)
-        assertCaught<MissingConfig>()
+        assertLoggedError<MissingConfig>()
     }
 
     @Test
     fun `HandlePushToken is protected`() {
         Klaviyo.handlePush(KlaviyoTest.mockIntent(KlaviyoTest.stubIntentExtras))
-        assertCaught<MissingConfig>()
+        assertLoggedWarning<MissingConfig>()
     }
 }

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoUninitializedTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoUninitializedTest.kt
@@ -36,10 +36,6 @@ internal class KlaviyoUninitializedTest {
         verify { spyLog.error(any(), any<T>()) }
     }
 
-    private inline fun <reified T> assertLoggedWarning() where T : Throwable {
-        verify { spyLog.error(any(), any<T>()) }
-    }
-
     @Test
     fun `Profile setter is protected`() {
         Klaviyo.setProfile(Profile())
@@ -85,7 +81,7 @@ internal class KlaviyoUninitializedTest {
     @Test
     fun `Push token setter is protected`() {
         Klaviyo.setPushToken(BaseTest.PUSH_TOKEN)
-        assertLoggedWarning<MissingConfig>()
+        assertLoggedError<MissingConfig>()
     }
 
     @Test
@@ -115,6 +111,6 @@ internal class KlaviyoUninitializedTest {
     @Test
     fun `HandlePushToken is protected`() {
         Klaviyo.handlePush(KlaviyoTest.mockIntent(KlaviyoTest.stubIntentExtras))
-        assertLoggedWarning<MissingConfig>()
+        verify { spyLog.warning(any(), any<MissingConfig>()) }
     }
 }

--- a/sdk/core/src/main/java/com/klaviyo/core/KlaviyoException.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/KlaviyoException.kt
@@ -22,8 +22,12 @@ fun <ReturnType> safeCall(
 ): ReturnType? = try {
     block()
 } catch (e: KlaviyoException) {
-    Registry.log.error(e.message, e)
-    errorQueue?.add(block)
+    errorQueue?.apply {
+        Registry.log.warning("The operation will be retried.", e)
+        add(block)
+    } ?: run {
+        Registry.log.error(e.message, e)
+    }
     null
 }
 

--- a/sdk/core/src/main/java/com/klaviyo/core/Registry.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/Registry.kt
@@ -20,7 +20,9 @@ import kotlin.reflect.typeOf
 import kotlinx.coroutines.Dispatchers
 
 class MissingConfig : KlaviyoException("Klaviyo SDK accessed before initializing")
-class MissingRegistration(type: KType) : KlaviyoException("No service registered for $type")
+class MissingRegistration(type: KType) : KlaviyoException(
+    "No service registered for $type. Typically caused by accessing SDK before initializing or providing app lifecycle/context."
+)
 class InvalidRegistration(type: KType) : KlaviyoException("Registered service does not match $type")
 
 typealias Registration = () -> Any

--- a/sdk/core/src/main/java/com/klaviyo/core/config/KlaviyoConfig.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/config/KlaviyoConfig.kt
@@ -108,7 +108,14 @@ object KlaviyoConfig : Config {
         private set
     override lateinit var sdkName: String private set
     override lateinit var sdkVersion: String private set
-    override lateinit var apiKey: String private set
+    private var _apiKey: String = ""
+    override var apiKey: String
+        get() = _apiKey.ifEmpty {
+            throw MissingAPIKey()
+        }
+        set(value) {
+            _apiKey = value
+        }
     override lateinit var formEnvironment: FormEnvironment
         private set
     override lateinit var applicationContext: Context private set
@@ -271,10 +278,6 @@ object KlaviyoConfig : Config {
         }
 
         override fun build(): Config {
-            if (apiKey.isEmpty()) {
-                throw MissingAPIKey()
-            }
-
             val context = applicationContext ?: throw MissingContext()
             val packageInfo = context.packageManager.getPackageInfoCompat(
                 context.packageName,

--- a/sdk/core/src/main/java/com/klaviyo/core/config/KlaviyoConfig.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/config/KlaviyoConfig.kt
@@ -177,7 +177,7 @@ object KlaviyoConfig : Config {
         )
 
         override fun apiKey(apiKey: String) = apply {
-            this.apiKey = apiKey
+            this.apiKey = apiKey.takeIf { it.isNotEmpty() } ?: throw MissingAPIKey()
         }
 
         override fun applicationContext(context: Context) = apply {

--- a/sdk/core/src/test/java/com/klaviyo/core/config/KlaviyoConfigTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/config/KlaviyoConfigTest.kt
@@ -14,6 +14,7 @@ import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.verify
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
 import org.junit.Before
 import org.junit.Test
 
@@ -173,11 +174,14 @@ internal class KlaviyoConfigTest : BaseTest() {
         verify(exactly = 9) { spyLog.error(any(), null) }
     }
 
-    @Test(expected = MissingAPIKey::class)
+    @Test
     fun `KlaviyoConfig Builder missing API key throws expected exception`() {
-        KlaviyoConfig.Builder()
-            .applicationContext(mockContext)
-            .build()
+        assertThrows(MissingAPIKey::class.java) {
+            KlaviyoConfig.Builder()
+                .applicationContext(mockContext)
+                .build()
+                .apiKey
+        }
     }
 
     @Test(expected = MissingContext::class)


### PR DESCRIPTION
# Description
<!-- Briefly describe the feature or bug that your pull request addresses, 1-2 sentences. -->
**Problem**: some companies use the same app with multiple public API keys. They are not able to provide company ID on initial launch because it must be determined via some app logic first. However, our `initialize` method and internal config setup tightly couples the collection of `Context` to the API key. 

**Goal**: decouple Context and API Key such that we can enable more operations that don't require API key, including universal link handling. At the same time, we still need to fail gracefully in the same manner for an pre-initialize operations that do require company ID. We do  buffer some operations in memory (push-related operations that are constrained by system API timing constraints)

## Due Diligence
<!-- Best practices before submitting, add additional notes below -->
<!-- If your changes are particularly affected by different Android version, please note API levels you tested on below  -->
- [x] I have tested this on an emulator and/or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all Android versions the SDK currently supports.


## Release/Versioning Considerations
<!-- Help determine how this should be categorized for release, add additional notes below. -->
<!-- Please add the planned version as a `milestone` label on this PR -->
- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [x] `Minor` Contains changes to the public API. 
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [x] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->
I'm updating `registerForLifecycleCallbacks`, since this is already intended to be our required method for devs who can't initialize with API key immediately. It now captures the provided context in the config and registers API and State services which can partially function without an API key. 
To decouple API key and Context, I moved the validation for API key from the config builder, to the API key accessor. That way the same exception type is thrown, handled the same way by `safeCall` / `safeApply`, but more targeted. 

## Test Plan
<!-- Provide reproducible testing steps. Link any artifacts, recordings, spreadsheets, etc. -->
1. All the existing tests should pass with minimal modification (did have to fix some incorrect mocks). We already had substantial unit testing of pre-init state. 
2. I've done some manual tests with the internal test app, where I just called sdk methods operations before `initialize` to verify they don't crash the app, as expected. Did this with all the public setters, getters, creating an event, handling push, registering for forms, etc. 
4. I [updated the internal test app](https://github.com/klaviyo/klaviyo-android-test-app/pull/103/files) to wait to call initialize till the user hits the "start" button. So that we can consistently test the "late initialize" flow used by some of our customers. Using that new "late initialize" mode, I tested the following (none should crash the app, but they'll fail in different ways)
- [x] Call `registerForLifecycleListeners` to provide partial context to the SDK
- [x] Profile setters/getters -- Must be called after `initialize` (as before)
- [x] `registerForInAppForms` -- Must be called after `initialize` (as before)
- [x] `createEvent` -- Must be called after `initialize` (as before)
- [x] `handlePush` -- API call fails, but retries when API key is provided (as before)
- [x] `registerDeepLinkHander` -- Must call `initialize` or `registerForLifecycleListeners`

## Related Issues/Tickets
<!-- Link to relevant Jira issues, Slack discussions, Google Docs --> 
 https://klaviyo.atlassian.net/browse/CHNL-25429
 