### PR TITLE
Testing the release verification action

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - 'rel/*'
-      - 'ecm/*'
     tags:
       - '*'
 


### PR DESCRIPTION
When this one is _merged_, it should send an alert in slack bc this branch hasn't actually been updated to 4.1.0 in code yet.