### PR TITLE
Add Base64 encoding to X-Klaviyo-Profile-Info header

### DIFF
--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/UniversalClickTrackRequest.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/UniversalClickTrackRequest.kt
@@ -4,6 +4,7 @@ import android.net.Uri
 import androidx.core.net.toUri
 import com.klaviyo.analytics.model.Profile
 import com.klaviyo.core.Registry
+import java.util.Base64
 import kotlin.time.Duration.Companion.milliseconds
 import org.json.JSONObject
 
@@ -69,7 +70,11 @@ internal class UniversalClickTrackRequest(
      */
     constructor(trackingUrl: String, profile: Profile) : this() {
         this.baseUrl = trackingUrl
-        headers.put(KLAVIYO_PROFILE_INFO_HEADER, profile.identifiers.toString())
+        val profileJson = profile.identifiers.toString()
+        val encodedProfile = Base64.getEncoder().encodeToString(
+            profileJson.toByteArray(Charsets.UTF_8)
+        )
+        headers.put(KLAVIYO_PROFILE_INFO_HEADER, encodedProfile)
     }
 
     /**


### PR DESCRIPTION
## Summary
Implements Base64 encoding for the `X-Klaviyo-Profile-Info` header in Universal Link tracking requests to address potential security vulnerabilities.

## Changes
- **UniversalClickTrackRequest**: Added Base64 encoding of profile identifiers JSON before setting header value
- **UniversalClickTrackRequestTest**: Updated tests to handle Base64 encoded values and decode them for validation
- Uses `java.util.Base64` for unit test compatibility

## Security Benefits
- **Prevents header injection attacks** by eliminating newline characters from user data
- **Standardizes encoding** regardless of special characters in emails, external IDs, etc.
- **Reduces accidental exposure** in server logs (though data remains sensitive)
- **Ensures consistent parsing** on the receiving end

## Test Plan
- [x] All existing `UniversalClickTrackRequestTest` tests pass
- [x] Verified Base64 encoding/decoding works correctly for profile identifiers
- [x] Code style (ktlint) compliance verified
- [x] Manual verification that encoded headers contain valid Base64 strings

🤖 Generated with [Claude Code](https://claude.ai/code)