### PR TITLE
Fix crash in release builds

### DIFF
--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/linking/DeepLinking.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/linking/DeepLinking.kt
@@ -16,7 +16,9 @@ import com.klaviyo.core.lifecycle.LifecycleMonitor.Companion.ACTIVITY_TRANSITION
  * Callback type for handling a deep link. When registered, this callback is invoked with any
  * deep links originating from Klaviyo services, instead of broadcasting an [Intent].
  */
-typealias DeepLinkHandler = (uri: Uri) -> Unit
+fun interface DeepLinkHandler {
+    operator fun invoke(uri: Uri)
+}
 
 /**
  * Utility for handling any deep links into the host application originating from Klaviyo

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/model/Event.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/model/Event.kt
@@ -23,7 +23,7 @@ class Event(val metric: EventMetric, properties: Map<EventKey, Serializable>?) :
         get() = when (val value = this[EventKey.VALUE]) {
             is Double -> value
             else -> try {
-                value.toString().toDouble()
+                value?.toString()?.toDouble()
             } catch (e: NumberFormatException) {
                 Registry.log.error("Event value is not a number: $value", e)
                 null


### PR DESCRIPTION
# Description
<!-- Briefly describe the feature or bug that your pull request addresses, 1-2 sentences. -->
Discovered an error message and a crash in logcat while testing latest 4.1.0 release. The crash seems to be caused by using a typealias as a generic type with Registry functions. I'm not totally sure the exact mechanism, this is the error I saw: 
`java.lang.IllegalArgumentException: Class declares 0 type parameters, but 2 were provided`

I figured converting it to an `interface` would allow it to survive shrinkers, and that was borne out in testing. 

## Due Diligence
<!-- Best practices before submitting, add additional notes below -->
<!-- If your changes are particularly affected by different Android version, please note API levels you tested on below  -->
- [x] I have tested this on an emulator and/or a physical device.
- [ ] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all Android versions the SDK currently supports.

Can't really cover this with unit tests to my knowledge

## Release/Versioning Considerations
<!-- Help determine how this should be categorized for release, add additional notes below. -->
<!-- Please add the planned version as a `milestone` label on this PR -->
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API. 
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [x] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->


## Test Plan
<!-- Provide reproducible testing steps. Link any artifacts, recordings, spreadsheets, etc. -->
Tested by creating local signed release builds, with and without this change. Without, the app crashes as soon as code that interacts with the `DeepLinkHandler` type (registering one, or attempting to invoke it) is executed. With this change, the handler works fine in a release build. 

## Related Issues/Tickets
<!-- Link to relevant Jira issues, Slack discussions, Google Docs --> 
 
 