### PR TITLE
Avoid crashing on unsupported links

### DIFF
--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/linking/DeepLinking.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/linking/DeepLinking.kt
@@ -11,6 +11,7 @@ import com.klaviyo.analytics.networking.requests.ResolveDestinationResult
 import com.klaviyo.analytics.state.State
 import com.klaviyo.core.Registry
 import com.klaviyo.core.lifecycle.LifecycleMonitor.Companion.ACTIVITY_TRANSITION_GRACE_PERIOD
+import com.klaviyo.core.utils.startActivityIfResolved
 
 /**
  * Callback type for handling a deep link. When registered, this callback is invoked with any
@@ -91,7 +92,7 @@ object DeepLinking {
      * @param extras Optional bundle of extras to be added to the launch intent
      */
     fun sendLaunchIntent(context: Context, extras: Bundle? = null) {
-        makeLaunchIntent(context, extras)?.let { context.startActivity(it) }
+        makeLaunchIntent(context, extras)?.startActivityIfResolved(context)
     }
 
     /**
@@ -102,8 +103,8 @@ object DeepLinking {
     private fun sendDeepLinkIntent(uri: Uri) {
         Registry.lifecycleMonitor.runWithCurrentOrNextActivity(
             ACTIVITY_TRANSITION_GRACE_PERIOD
-        ) { activity ->
-            activity.startActivity(makeDeepLinkIntent(uri, activity))
+        ) { context ->
+            makeDeepLinkIntent(uri, context).startActivityIfResolved(context)
         }
     }
 

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/linking/DeepLinkingTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/linking/DeepLinkingTest.kt
@@ -92,6 +92,22 @@ internal class DeepLinkingTest : BaseTest() {
     }
 
     @Test
+    fun `handleDeepLink sends no intent if link is unsupported`() {
+        every { anyConstructed<Intent>().resolveActivity(any()) } returns null
+
+        every { testActivity.startActivity(any()) } returns Unit
+        every { Registry.lifecycleMonitor.runWithCurrentOrNextActivity(any(), any()) } answers {
+            val callback = secondArg<(Activity) -> Unit>()
+            callback(testActivity)
+            null
+        }
+
+        DeepLinking.handleDeepLink(mockUri)
+
+        verify(inverse = true) { testActivity.startActivity(any()) }
+    }
+
+    @Test
     fun `sendLaunchIntent does nothing when no launch intent available`() {
         every { testPackageManager.getLaunchIntentForPackage("com.test.app") } returns null
 

--- a/sdk/core/src/main/AndroidManifest.xml
+++ b/sdk/core/src/main/AndroidManifest.xml
@@ -2,4 +2,17 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
+
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.BROWSABLE" />
+            <data android:scheme="https" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.BROWSABLE" />
+            <data android:scheme="http" />
+        </intent>
+    </queries>
 </manifest>

--- a/sdk/core/src/main/java/com/klaviyo/core/utils/IntentExtension.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/utils/IntentExtension.kt
@@ -10,9 +10,9 @@ import com.klaviyo.core.Registry
  */
 fun Intent.startActivityIfResolved(context: Context) {
     if (activityResolved(context)) {
-        Registry.log.error("No activity found to handle intent: $this")
-    } else {
         context.startActivity(this)
+    } else {
+        Registry.log.error("No activity found to handle intent: $this")
     }
 }
 

--- a/sdk/core/src/main/java/com/klaviyo/core/utils/IntentExtension.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/utils/IntentExtension.kt
@@ -1,0 +1,17 @@
+package com.klaviyo.core.utils
+
+import android.content.Context
+import android.content.Intent
+import com.klaviyo.core.Registry
+
+/**
+ * Start an activity with this intent if it can be resolved by the package manager.
+ * Logs an error if no activity is found to handle the intent.
+ */
+fun Intent.startActivityIfResolved(context: Context) {
+    if (resolveActivity(context.packageManager) == null) {
+        Registry.log.error("No activity found to handle intent: $this")
+    } else {
+        context.startActivity(this)
+    }
+}

--- a/sdk/core/src/main/java/com/klaviyo/core/utils/IntentExtension.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/utils/IntentExtension.kt
@@ -9,9 +9,16 @@ import com.klaviyo.core.Registry
  * Logs an error if no activity is found to handle the intent.
  */
 fun Intent.startActivityIfResolved(context: Context) {
-    if (resolveActivity(context.packageManager) == null) {
+    if (activityResolved(context)) {
         Registry.log.error("No activity found to handle intent: $this")
     } else {
         context.startActivity(this)
     }
+}
+
+/**
+ * Check if this intent can be resolved to an activity by the package manager.
+ */
+fun Intent.activityResolved(context: Context): Boolean {
+    return resolveActivity(context.packageManager) != null
 }

--- a/sdk/fixtures/src/main/java/com/klaviyo/fixtures/MockIntent.kt
+++ b/sdk/fixtures/src/main/java/com/klaviyo/fixtures/MockIntent.kt
@@ -30,7 +30,7 @@ data class MockIntent(
          *
          * @return IntentMock containing the mocked Intent and capturing slots
          */
-        @SuppressLint("WrongConstant")
+        @SuppressLint("WrongConstant", "QueryPermissionsNeeded")
         fun setupIntentMocking(): MockIntent {
             val mockIntent = MockIntent(mockk<Intent>(relaxed = true)).apply {
                 every { intent.addFlags(any()) } returns intent
@@ -48,6 +48,7 @@ data class MockIntent(
             every { anyConstructed<Intent>().putExtras(any<Bundle>()) } returns intent
             every { anyConstructed<Intent>().addFlags(any()) } returns intent
             every { anyConstructed<Intent>().extras } returns bundle
+            every { anyConstructed<Intent>().resolveActivity(any()) } returns mockk()
 
             // Mock getter methods to return captured values
             every { anyConstructed<Intent>().action } answers {

--- a/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
@@ -14,6 +14,7 @@ import androidx.core.net.toUri
 import com.klaviyo.core.Registry
 import com.klaviyo.core.config.Clock
 import com.klaviyo.core.utils.WeakReferenceDelegate
+import com.klaviyo.core.utils.startActivityIfResolved
 import com.klaviyo.forms.bridge.HandshakeSpec
 import com.klaviyo.forms.bridge.JsBridge
 import com.klaviyo.forms.bridge.JsBridgeObserverCollection
@@ -185,7 +186,7 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
                 action = Intent.ACTION_VIEW
                 flags = Intent.FLAG_ACTIVITY_NEW_TASK
             }
-            Registry.config.applicationContext.startActivity(intent, null)
+            intent.startActivityIfResolved(Registry.config.applicationContext)
             return true
         }
         return false

--- a/sdk/forms/src/test/java/com/klaviyo/forms/webview/KlaviyoWebViewClientTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/webview/KlaviyoWebViewClientTest.kt
@@ -354,7 +354,7 @@ class KlaviyoWebViewClientTest : BaseTest() {
             every { url } returns mockUrl
         }
 
-        every { mockContext.startActivity(any(), null) } just runs
+        every { mockContext.startActivity(any()) } just runs
 
         val mockIntent = MockIntent.setupIntentMocking()
         val result = client.shouldOverrideUrlLoading(null, mockRequest)

--- a/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoNotificationTest.kt
+++ b/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoNotificationTest.kt
@@ -1,0 +1,359 @@
+package com.klaviyo.pushFcm
+
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.core.app.NotificationChannelCompat
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import com.google.firebase.messaging.RemoteMessage
+import com.klaviyo.analytics.linking.DeepLinking
+import com.klaviyo.fixtures.BaseTest
+import com.klaviyo.pushFcm.KlaviyoNotification.Companion.BODY_KEY
+import com.klaviyo.pushFcm.KlaviyoNotification.Companion.TITLE_KEY
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkConstructor
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.spyk
+import io.mockk.verify
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class KlaviyoNotificationTest : BaseTest() {
+    private val stubMessage = mutableMapOf(
+        "_k" to "test_tracking_id",
+        TITLE_KEY to "Test Title",
+        BODY_KEY to "Test Body"
+    )
+
+    private var mockRemoteMessage = mockk<RemoteMessage>(relaxed = true).apply {
+        every { data } returns stubMessage
+
+        mockkObject(KlaviyoRemoteMessage)
+        with(KlaviyoRemoteMessage) {
+            every { isKlaviyoNotification } returns true
+            every { channel_id } returns "test_channel"
+            every { channel_name } returns "Test Channel"
+            every { channel_description } returns "Test Description"
+            every { channel_importance } returns NotificationManagerCompat.IMPORTANCE_DEFAULT
+            every { title } returns "Test Title"
+            every { body } returns "Test Body"
+            every { deepLink } returns null
+            every { imageUrl } returns null
+            every { sound } returns null
+            every { notificationCount } returns 0
+            every { notificationPriority } returns NotificationCompat.PRIORITY_DEFAULT
+            every { notificationTag } returns null
+            every { getSmallIcon(any()) } returns android.R.drawable.ic_dialog_info
+            every { getColor(any()) } returns null
+        }
+    }
+
+    private var notification = spyk(KlaviyoNotification(mockRemoteMessage)).apply {
+        every { hasNotificationPermission(any()) } returns true
+    }
+
+    private var mockNotificationManager = mockk<NotificationManagerCompat>(relaxed = true).apply {
+        mockkStatic(NotificationManagerCompat::class)
+        every { NotificationManagerCompat.from(any()) } returns this
+    }
+
+    @Before
+    override fun setup() {
+        super.setup()
+
+        // Mock NotificationCompat.Builder constructor to return our mock builder
+        mockkConstructor(NotificationCompat.Builder::class)
+        every { anyConstructed<NotificationCompat.Builder>().setContentIntent(any()) } answers { self as NotificationCompat.Builder }
+        every { anyConstructed<NotificationCompat.Builder>().setSmallIcon(any<Int>()) } answers { self as NotificationCompat.Builder }
+        every { anyConstructed<NotificationCompat.Builder>().setColor(any()) } answers { self as NotificationCompat.Builder }
+        every { anyConstructed<NotificationCompat.Builder>().setContentTitle(any()) } answers { self as NotificationCompat.Builder }
+        every { anyConstructed<NotificationCompat.Builder>().setContentText(any()) } answers { self as NotificationCompat.Builder }
+        every { anyConstructed<NotificationCompat.Builder>().setStyle(any()) } answers { self as NotificationCompat.Builder }
+        every { anyConstructed<NotificationCompat.Builder>().setSound(any()) } answers { self as NotificationCompat.Builder }
+        every { anyConstructed<NotificationCompat.Builder>().setNumber(any()) } answers { self as NotificationCompat.Builder }
+        every { anyConstructed<NotificationCompat.Builder>().setPriority(any()) } answers { self as NotificationCompat.Builder }
+        every { anyConstructed<NotificationCompat.Builder>().setAutoCancel(any()) } answers { self as NotificationCompat.Builder }
+        every { anyConstructed<NotificationCompat.Builder>().build() } returns mockk(relaxed = true)
+
+        mockkStatic(PendingIntent::class)
+        every {
+            PendingIntent.getActivity(
+                any(),
+                any(),
+                any(),
+                any()
+            )
+        } returns mockk(relaxed = true)
+
+        with(DeepLinking) {
+            mockkObject(DeepLinking)
+            every { makeLaunchIntent(any()) } returns mockk(relaxed = true)
+            every { makeDeepLinkIntent(any(), any()) } returns mockk(relaxed = true)
+        }
+    }
+
+    @Test
+    fun `displayNotification returns false when not a Klaviyo notification`() {
+        with(KlaviyoRemoteMessage) {
+            every { mockRemoteMessage.isKlaviyoNotification } returns false
+        }
+
+        val result = notification.displayNotification(mockContext)
+
+        assertFalse(result)
+        verify(exactly = 0) { mockNotificationManager.notify(any<String>(), any(), any()) }
+    }
+
+    @Test
+    fun `displayNotification returns false when notification permission not granted`() {
+        every { notification.hasNotificationPermission(any()) } returns false
+
+        val result = notification.displayNotification(mockContext)
+
+        assertFalse(result)
+        verify(exactly = 0) { mockNotificationManager.notify(any<String>(), any(), any()) }
+    }
+
+    @Test
+    fun `displayNotification creates notification channel`() {
+        notification.displayNotification(mockContext)
+        verify { mockNotificationManager.createNotificationChannel(any<NotificationChannelCompat>()) }
+    }
+
+    @Test
+    fun `displayNotification calls buildNotification with context`() {
+        notification.displayNotification(mockContext)
+
+        verify { notification.buildNotification(mockContext) }
+    }
+
+    @Test
+    fun `displayNotification builds and displays notification`() {
+        val result = notification.displayNotification(mockContext)
+
+        assertTrue(result)
+        verify { notification.buildNotification(mockContext) }
+        verify { mockNotificationManager.notify(any<String>(), eq(0), any()) }
+    }
+
+    @Test
+    fun `displayNotification uses custom notification tag when provided`() {
+        with(KlaviyoRemoteMessage) {
+            every { mockRemoteMessage.notificationTag } returns "custom_tag"
+        }
+
+        notification.displayNotification(mockContext)
+
+        verify { mockNotificationManager.notify(eq("custom_tag"), eq(0), any()) }
+    }
+
+    @Test
+    fun `displayNotification generates tag when not provided`() {
+        with(KlaviyoRemoteMessage) {
+            every { mockRemoteMessage.notificationTag } returns null
+        }
+
+        notification.displayNotification(mockContext)
+
+        // Should still call notify with some string tag (generated from timestamp)
+        verify { mockNotificationManager.notify(any<String>(), eq(0), any()) }
+    }
+
+    @Test
+    fun `buildNotification sets title and body from message`() {
+        notification.displayNotification(mockContext)
+
+        verify { anyConstructed<NotificationCompat.Builder>().setContentTitle("Test Title") }
+        verify { anyConstructed<NotificationCompat.Builder>().setContentText("Test Body") }
+    }
+
+    @Test
+    fun `buildNotification sets small icon from message`() {
+        notification.displayNotification(mockContext)
+
+        verify {
+            anyConstructed<NotificationCompat.Builder>().setSmallIcon(
+                android.R.drawable.ic_dialog_info
+            )
+        }
+    }
+
+    @Test
+    fun `buildNotification sets color when provided`() {
+        with(KlaviyoRemoteMessage) {
+            every { mockRemoteMessage.getColor(any()) } returns 0xFF0000
+        }
+
+        notification.displayNotification(mockContext)
+
+        verify { anyConstructed<NotificationCompat.Builder>().setColor(0xFF0000) }
+    }
+
+    @Test
+    fun `buildNotification does not set color when null`() {
+        with(KlaviyoRemoteMessage) {
+            every { mockRemoteMessage.getColor(any()) } returns null
+        }
+
+        notification.displayNotification(mockContext)
+
+        verify(exactly = 0) { anyConstructed<NotificationCompat.Builder>().setColor(any()) }
+    }
+
+    @Test
+    fun `buildNotification sets notification count`() {
+        with(KlaviyoRemoteMessage) {
+            every { mockRemoteMessage.notificationCount } returns 5
+        }
+
+        notification.displayNotification(mockContext)
+
+        verify { anyConstructed<NotificationCompat.Builder>().setNumber(5) }
+    }
+
+    @Test
+    fun `buildNotification sets priority from message`() {
+        with(KlaviyoRemoteMessage) {
+            every { mockRemoteMessage.notificationPriority } returns NotificationCompat.PRIORITY_HIGH
+        }
+
+        notification.displayNotification(mockContext)
+
+        verify {
+            anyConstructed<NotificationCompat.Builder>().setPriority(
+                NotificationCompat.PRIORITY_HIGH
+            )
+        }
+    }
+
+    @Test
+    fun `buildNotification sets autoCancel to true`() {
+        notification.displayNotification(mockContext)
+
+        verify { anyConstructed<NotificationCompat.Builder>().setAutoCancel(true) }
+    }
+
+    @Test
+    fun `buildNotification sets BigTextStyle with body`() {
+        notification.displayNotification(mockContext)
+
+        verify { anyConstructed<NotificationCompat.Builder>().setStyle(any()) }
+    }
+
+    @Test
+    fun `notification with deep link creates ACTION_VIEW intent`() {
+        val mockDeepLinkUri = mockk<Uri>(relaxed = true)
+        val mockDeepLinkIntent = mockk<Intent>(relaxed = true)
+        val intentSlot = slot<Intent>()
+
+        with(KlaviyoRemoteMessage) {
+            every { mockRemoteMessage.deepLink } returns mockDeepLinkUri
+        }
+
+        every { DeepLinking.makeDeepLinkIntent(mockDeepLinkUri, any()) } returns mockDeepLinkIntent
+        every { mockDeepLinkIntent.resolveActivity(any()) } returns mockk() // Intent is supported
+
+        every {
+            PendingIntent.getActivity(any(), any(), capture(intentSlot), any())
+        } returns mockk(relaxed = true)
+
+        notification.displayNotification(mockContext)
+
+        verify { DeepLinking.makeDeepLinkIntent(mockDeepLinkUri, mockContext) }
+        verify(exactly = 0) { DeepLinking.makeLaunchIntent(any()) }
+        assertEquals(intentSlot.captured, mockDeepLinkIntent)
+    }
+
+    @Test
+    fun `notification with unsupported deep link falls back to launch intent`() {
+        val mockDeepLinkUri = mockk<Uri>(relaxed = true)
+        val mockDeepLinkIntent = mockk<Intent>(relaxed = true)
+        val mockLaunchIntent = mockk<Intent>(relaxed = true)
+        val intentSlot = slot<Intent>()
+
+        with(KlaviyoRemoteMessage) {
+            every { mockRemoteMessage.deepLink } returns mockDeepLinkUri
+        }
+
+        every { DeepLinking.makeDeepLinkIntent(mockDeepLinkUri, any()) } returns mockDeepLinkIntent
+        every { mockDeepLinkIntent.resolveActivity(any()) } returns null // Intent is NOT supported
+        every { DeepLinking.makeLaunchIntent(any()) } returns mockLaunchIntent
+
+        every {
+            PendingIntent.getActivity(any(), any(), capture(intentSlot), any())
+        } returns mockk(relaxed = true)
+
+        notification.displayNotification(mockContext)
+
+        verify { DeepLinking.makeDeepLinkIntent(mockDeepLinkUri, mockContext) }
+        verify { DeepLinking.makeLaunchIntent(mockContext) }
+        assertEquals(intentSlot.captured, mockLaunchIntent)
+    }
+
+    @Test
+    fun `notification without deep link creates launch intent`() {
+        val mockLaunchIntent = mockk<Intent>(relaxed = true)
+        val intentSlot = slot<Intent>()
+
+        with(KlaviyoRemoteMessage) {
+            every { mockRemoteMessage.deepLink } returns null
+        }
+
+        every { DeepLinking.makeLaunchIntent(any()) } returns mockLaunchIntent
+
+        every {
+            PendingIntent.getActivity(any(), any(), capture(intentSlot), any())
+        } returns mockk(relaxed = true)
+
+        notification.displayNotification(mockContext)
+
+        verify { DeepLinking.makeLaunchIntent(mockContext) }
+        verify(exactly = 0) { DeepLinking.makeDeepLinkIntent(any(), any()) }
+        assertEquals(intentSlot.captured, mockLaunchIntent)
+    }
+
+    @Test
+    fun `pending intent created with correct flags`() {
+        val flagsSlot = slot<Int>()
+
+        every {
+            PendingIntent.getActivity(any(), any(), any(), capture(flagsSlot))
+        } returns mockk(relaxed = true)
+
+        notification.displayNotification(mockContext)
+
+        val expectedFlags = PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_ONE_SHOT
+        assertEquals(expectedFlags, flagsSlot.captured)
+    }
+
+    @Test
+    fun `pending intent includes context and intent`() {
+        val contextSlot = slot<Context>()
+        val intentSlot = slot<Intent>()
+        val mockPendingIntent = mockk<PendingIntent>(relaxed = true)
+
+        every {
+            PendingIntent.getActivity(
+                capture(contextSlot),
+                any(),
+                capture(intentSlot),
+                any()
+            )
+        } returns mockPendingIntent
+
+        notification.displayNotification(mockContext)
+
+        assertEquals(mockContext, contextSlot.captured)
+        verify { anyConstructed<NotificationCompat.Builder>().setContentIntent(mockPendingIntent) }
+        verify { intentSlot.captured.putExtra("com.klaviyo._k", "test_tracking_id") }
+        verify { intentSlot.captured.putExtra("com.klaviyo.title", "Test Title") }
+    }
+}


### PR DESCRIPTION
# Description
<!-- Briefly describe the feature or bug that your pull request addresses, 1-2 sentences. -->
Fixes an issue discovered in testing universal links where a universal tracking link that resolves to a destination url that the app's intent filters don't support, the app would crash. 
Relatedly, a push notification containing a link that doesn't belong to the host app would simply not open anything. This fixes that by verifying the intent first, and if the link is unsupported, log an error and fallback to using the app's launch intent (like we didn't have a deep link at all).

## Due Diligence
<!-- Best practices before submitting, add additional notes below -->
<!-- If your changes are particularly affected by different Android version, please note API levels you tested on below  -->
- [x] I have tested this on an emulator and/or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [x] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all Android versions the SDK currently supports.


## Release/Versioning Considerations
<!-- Help determine how this should be categorized for release, add additional notes below. -->
<!-- Please add the planned version as a `milestone` label on this PR -->
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API. 
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [ ] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->
Added helper method for starting an activity from an intent only if that intent resolves to an activity
Added required queries permission for that intent filter resolution
Updated uses of `startActivity` where there's chance of ambiguity -- universal tracking links and external links from IAF webviews.

## Test Plan
<!-- Provide reproducible testing steps. Link any artifacts, recordings, spreadsheets, etc. -->
Send yourself a universal tracking link whose destination url is not supported by the app (easiest way is to use the universal="true" attribute). When you open that link, the app should just open to the home page and not redirect (nor crash)

Same goes for including an unsupported link as a deep link on an in-app form. 

Send yourself a notification with a url the app doesn't support. When you tap on it without this fix, it'll just do nothing. After this fix, it'll open the app. 

## Related Issues/Tickets
<!-- Link to relevant Jira issues, Slack discussions, Google Docs --> 
 https://klaviyo.atlassian.net/browse/CHNL-26487
 