### PR TITLE
Geofencing: Boot receiver to restore monitored geofences from disk

### DIFF
--- a/sdk/location/src/main/AndroidManifest.xml
+++ b/sdk/location/src/main/AndroidManifest.xml
@@ -2,11 +2,21 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <application>
         <!-- Register Klaviyo service for receiving geofence broadcasts -->
         <receiver
             android:name="com.klaviyo.location.KlaviyoGeofenceReceiver"
             android:exported="false" />
+
+        <!-- Register Klaviyo service for receiving boot events to restore geofences -->
+        <receiver
+            android:name="com.klaviyo.location.KlaviyoLocationBootReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
     </application>
 </manifest>

--- a/sdk/location/src/main/java/com/klaviyo/location/KlaviyoLocationBootReceiver.kt
+++ b/sdk/location/src/main/java/com/klaviyo/location/KlaviyoLocationBootReceiver.kt
@@ -1,0 +1,23 @@
+package com.klaviyo.location
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import com.klaviyo.core.Registry
+
+/**
+ * BroadcastReceiver that handles device boot events to re-register geofences
+ * when the device reboots. System geofences are cleared on reboot, so we need
+ * to restore them from persistent storage.
+ */
+class KlaviyoLocationBootReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action == Intent.ACTION_BOOT_COMPLETED) {
+            try {
+                Registry.locationManager.restoreGeofencesOnBoot(context)
+            } catch (e: Exception) {
+                Registry.log.error("Uncaught exception restoring Klaviyo Geofences on boot", e)
+            }
+        }
+    }
+}

--- a/sdk/location/src/main/java/com/klaviyo/location/LocationManager.kt
+++ b/sdk/location/src/main/java/com/klaviyo/location/LocationManager.kt
@@ -48,4 +48,9 @@ interface LocationManager {
         intent: Intent,
         pendingResult: BroadcastReceiver.PendingResult
     )
+
+    /**
+     * Handle device boot event to re-register geofences
+     */
+    fun restoreGeofencesOnBoot(context: Context)
 }

--- a/sdk/location/src/test/java/com/klaviyo/location/KlaviyoBootReceiverTest.kt
+++ b/sdk/location/src/test/java/com/klaviyo/location/KlaviyoBootReceiverTest.kt
@@ -1,0 +1,105 @@
+package com.klaviyo.location
+
+import android.content.Context
+import android.content.Intent
+import com.klaviyo.core.Registry
+import com.klaviyo.fixtures.BaseTest
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Tests for KlaviyoBootReceiver
+ *
+ * These tests verify that the boot receiver properly validates the intent action
+ * and delegates to LocationManager's handleBootEvent method when appropriate.
+ */
+internal class KlaviyoBootReceiverTest : BaseTest() {
+
+    private val mockLocationManager = mockk<LocationManager>(relaxed = true)
+    private val receiver = KlaviyoLocationBootReceiver()
+
+    @Before
+    override fun setup() {
+        super.setup()
+
+        // Register mock in Registry
+        Registry.register<LocationManager> { mockLocationManager }
+    }
+
+    @Test
+    fun `onReceive delegates to LocationManager when action is BOOT_COMPLETED`() {
+        val context = mockk<Context>(relaxed = true)
+        val mockIntent = mockk<Intent>(relaxed = true).apply {
+            every { action } returns Intent.ACTION_BOOT_COMPLETED
+        }
+
+        every { mockLocationManager.restoreGeofencesOnBoot(any()) } just runs
+
+        // Trigger the receiver
+        receiver.onReceive(context, mockIntent)
+
+        // Verify delegation
+        verify(exactly = 1) {
+            mockLocationManager.restoreGeofencesOnBoot(context)
+        }
+    }
+
+    @Test
+    fun `onReceive does NOT delegate when action is not BOOT_COMPLETED`() {
+        val context = mockk<Context>(relaxed = true)
+        val mockIntent = mockk<Intent>(relaxed = true).apply {
+            every { action } returns "android.intent.action.SOME_OTHER_ACTION"
+        }
+
+        every { mockLocationManager.restoreGeofencesOnBoot(any()) } just runs
+
+        // Trigger the receiver with wrong action
+        receiver.onReceive(context, mockIntent)
+
+        // Verify handleBootEvent was NOT called
+        verify(exactly = 0) {
+            mockLocationManager.restoreGeofencesOnBoot(any())
+        }
+    }
+
+    @Test
+    fun `onReceive does NOT delegate when action is null`() {
+        val context = mockk<Context>(relaxed = true)
+        val mockIntent = mockk<Intent>(relaxed = true).apply {
+            every { action } returns null
+        }
+
+        every { mockLocationManager.restoreGeofencesOnBoot(any()) } just runs
+
+        // Trigger the receiver with null action
+        receiver.onReceive(context, mockIntent)
+
+        // Verify handleBootEvent was NOT called (security check prevents spoofing)
+        verify(exactly = 0) {
+            mockLocationManager.restoreGeofencesOnBoot(any())
+        }
+    }
+
+    @Test
+    fun `onReceive does NOT crash when restoreGeofencesOnBoot throws`() {
+        val context = mockk<Context>(relaxed = true)
+        val mockIntent = mockk<Intent>(relaxed = true).apply {
+            every { action } returns Intent.ACTION_BOOT_COMPLETED
+        }
+
+        every { mockLocationManager.restoreGeofencesOnBoot(any()) } throws Exception()
+
+        // Trigger the receiver
+        receiver.onReceive(context, mockIntent)
+
+        // Verify delegation without throwing
+        verify(exactly = 1) {
+            mockLocationManager.restoreGeofencesOnBoot(context)
+        }
+    }
+}


### PR DESCRIPTION
# Description
<!-- Briefly describe the feature or bug that your pull request addresses, 1-2 sentences. -->
When a device reboots, the system location services will clear all geofences from memory. So this adds a boot receiver service to receive an intent when device reboots, check if app has geofencing level permissions, and re-add the geofences from storage.

## Due Diligence
<!-- Best practices before submitting, add additional notes below -->
<!-- If your changes are particularly affected by different Android version, please note API levels you tested on below  -->
- [ ] I have tested this on an emulator and/or a physical device.
- [ ] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [ ] I am confident these changes are compatible with all Android versions the SDK currently supports.


## Release/Versioning Considerations
<!-- Help determine how this should be categorized for release, add additional notes below. -->
<!-- Please add the planned version as a `milestone` label on this PR -->
- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API. 
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [ ] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->


## Test Plan
<!-- Provide reproducible testing steps. Link any artifacts, recordings, spreadsheets, etc. -->


## Related Issues/Tickets
<!-- Link to relevant Jira issues, Slack discussions, Google Docs --> 
 
 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a boot receiver and LocationManager logic to re-register stored geofences after device reboot, with manifest updates and tests.
> 
> - **Location SDK (Geofencing)**:
>   - **Boot handling**:
>     - Add `KlaviyoBootReceiver` to handle `BOOT_COMPLETED` and delegate to `Registry.locationManager.restoreGeofencesOnBoot`.
>     - Implement `restoreGeofencesOnBoot(context)` in `KlaviyoLocationManager` to check permissions, ensure config init, load stored geofences, and re-register them.
>     - Extend `LocationManager` interface with `restoreGeofencesOnBoot(context)`.
>   - **Manifest**:
>     - Request `android.permission.RECEIVE_BOOT_COMPLETED` and register `com.klaviyo.location.KlaviyoBootReceiver` with `BOOT_COMPLETED` intent filter.
>   - **Tests**:
>     - Add `KlaviyoBootReceiverTest` to verify BOOT intent handling.
>     - Add/expand boot-restore tests in `KlaviyoLocationManagerTest` to cover permission checks, empty storage, and successful re-registration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 10b9f482d43ab53e176c98901213bf0cbe912291. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->