### PR TITLE
Refactor observers to use CopyOnWriteArrayList exclusively

### DIFF
--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/KlaviyoApiClient.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/KlaviyoApiClient.kt
@@ -19,7 +19,6 @@ import com.klaviyo.analytics.networking.requests.UniversalClickTrackRequest
 import com.klaviyo.analytics.networking.requests.UnregisterPushTokenApiRequest
 import com.klaviyo.core.Registry
 import com.klaviyo.core.lifecycle.ActivityEvent
-import java.util.Collections
 import java.util.concurrent.ConcurrentLinkedDeque
 import java.util.concurrent.CopyOnWriteArrayList
 import kotlinx.coroutines.CoroutineScope
@@ -46,9 +45,7 @@ internal object KlaviyoApiClient : ApiClient {
     /**
      * List of registered API observers
      */
-    private val apiObservers = Collections.synchronizedList(
-        CopyOnWriteArrayList<ApiObserver>()
-    )
+    private val apiObservers = CopyOnWriteArrayList<ApiObserver>()
 
     /**
      * Initialize logic including lifecycle observers and reviving the queue from persistent store
@@ -200,9 +197,7 @@ internal object KlaviyoApiClient : ApiClient {
             Registry.log.verbose("${request.responseCode} $response")
         }
 
-        synchronized(apiObservers) {
-            apiObservers.forEach { it(request) }
-        }
+        apiObservers.forEach { it(request) }
     }
 
     /**

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/state/KlaviyoState.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/state/KlaviyoState.kt
@@ -20,7 +20,6 @@ import com.klaviyo.core.DeviceProperties
 import com.klaviyo.core.Registry
 import com.klaviyo.core.utils.AdvancedAPI
 import java.io.Serializable
-import java.util.Collections
 import java.util.UUID
 import java.util.concurrent.CopyOnWriteArrayList
 
@@ -67,16 +66,12 @@ internal class KlaviyoState : State {
     /**
      * List of registered state change observers
      */
-    private val stateChangeObservers = Collections.synchronizedList(
-        CopyOnWriteArrayList<StateChangeObserver>()
-    )
+    private val stateChangeObservers = CopyOnWriteArrayList<StateChangeObserver>()
 
     /**
      * List of registered profile event observers
      */
-    private val eventObserver = Collections.synchronizedList(
-        CopyOnWriteArrayList<ProfileEventObserver>()
-    )
+    private val eventObserver = CopyOnWriteArrayList<ProfileEventObserver>()
 
     /**
      * Register an observer to be notified when state changes
@@ -192,10 +187,8 @@ internal class KlaviyoState : State {
         }
         // Add enriched event to buffer for multi-consumer access
         GenericEventBuffer.addEvent(shadowedEvent)
-        synchronized(eventObserver) {
-            eventObserver.forEach {
-                it?.invoke(shadowedEvent)
-            }
+        eventObserver.forEach {
+            it?.invoke(shadowedEvent)
         }
     }
 
@@ -242,7 +235,7 @@ internal class KlaviyoState : State {
      *
      * @param change - the state change to broadcast
      */
-    private fun broadcastChange(change: StateChange) = synchronized(stateChangeObservers) {
+    private fun broadcastChange(change: StateChange) {
         stateChangeObservers.forEach { it(change) }
     }
 

--- a/sdk/core/src/main/java/com/klaviyo/core/lifecycle/KlaviyoLifecycleMonitor.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/lifecycle/KlaviyoLifecycleMonitor.kt
@@ -8,7 +8,6 @@ import android.os.Bundle
 import com.klaviyo.core.Registry
 import com.klaviyo.core.utils.AdvancedAPI
 import com.klaviyo.core.utils.WeakReferenceDelegate
-import java.util.Collections
 import java.util.concurrent.CopyOnWriteArrayList
 
 /**
@@ -18,9 +17,7 @@ internal object KlaviyoLifecycleMonitor : LifecycleMonitor, Application.Activity
 
     private var activeActivities = 0
 
-    private val activityObservers = Collections.synchronizedList(
-        CopyOnWriteArrayList<ActivityObserver>()
-    )
+    private val activityObservers = CopyOnWriteArrayList<ActivityObserver>()
 
     override var currentActivity: Activity? by WeakReferenceDelegate()
         private set
@@ -44,9 +41,7 @@ internal object KlaviyoLifecycleMonitor : LifecycleMonitor, Application.Activity
 
     private fun broadcastEvent(event: ActivityEvent) {
         Registry.log.verbose(event.type)
-        synchronized(activityObservers) {
-            activityObservers.forEach { it(event) }
-        }
+        activityObservers.forEach { it(event) }
     }
 
     //region ActivityLifecycleCallbacks

--- a/sdk/core/src/main/java/com/klaviyo/core/model/SharedPreferencesDataStore.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/model/SharedPreferencesDataStore.kt
@@ -3,7 +3,6 @@ package com.klaviyo.core.model
 import android.content.Context
 import android.content.SharedPreferences
 import com.klaviyo.core.Registry
-import java.util.Collections
 import java.util.concurrent.CopyOnWriteArrayList
 
 /**
@@ -20,9 +19,7 @@ internal object SharedPreferencesDataStore : DataStore {
     /**
      * List of registered observers
      */
-    private val storeObservers = Collections.synchronizedList(
-        CopyOnWriteArrayList<StoreObserver>()
-    )
+    private val storeObservers = CopyOnWriteArrayList<StoreObserver>()
 
     override fun onStoreChange(observer: StoreObserver) {
         storeObservers += observer
@@ -34,9 +31,7 @@ internal object SharedPreferencesDataStore : DataStore {
 
     private fun broadcastStoreChange(key: String, value: String?) {
         Registry.log.verbose("$key=$value")
-        synchronized(storeObservers) {
-            storeObservers.forEach { it(key, value) }
-        }
+        storeObservers.forEach { it(key, value) }
     }
 
     /**

--- a/sdk/core/src/main/java/com/klaviyo/core/networking/KlaviyoNetworkMonitor.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/networking/KlaviyoNetworkMonitor.kt
@@ -6,7 +6,6 @@ import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.NetworkRequest
 import com.klaviyo.core.Registry
-import java.util.Collections
 import java.util.concurrent.CopyOnWriteArrayList
 
 /**
@@ -25,9 +24,7 @@ internal object KlaviyoNetworkMonitor : NetworkMonitor {
     /**
      * List of registered network change observers
      */
-    private val networkChangeObservers = Collections.synchronizedList(
-        CopyOnWriteArrayList<NetworkObserver>()
-    )
+    private val networkChangeObservers = CopyOnWriteArrayList<NetworkObserver>()
 
     /**
      * Callback object to register with system
@@ -73,9 +70,7 @@ internal object KlaviyoNetworkMonitor : NetworkMonitor {
 
         Registry.log.verbose("Network ${if (isConnected) "available" else "unavailable"}")
 
-        synchronized(networkChangeObservers) {
-            networkChangeObservers.forEach { it(isConnected) }
-        }
+        networkChangeObservers.forEach { it(isConnected) }
     }
 
     /**


### PR DESCRIPTION
# Description
<!-- Briefly describe the feature or bug that your pull request addresses, 1-2 sentences. -->
Remove redundant Collections.synchronizedList wrappers and synchronized blocks. CopyOnWriteArrayList provides thread-safe iteration by design, making additional synchronization unnecessary and improving code clarity.

## Due Diligence
<!-- Best practices before submitting, add additional notes below -->
<!-- If your changes are particularly affected by different Android version, please note API levels you tested on below  -->
- [ ] I have tested this on an emulator and/or a physical device.
- [ ] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [ ] I am confident these changes are compatible with all Android versions the SDK currently supports.


## Release/Versioning Considerations
<!-- Help determine how this should be categorized for release, add additional notes below. -->
<!-- Please add the planned version as a `milestone` label on this PR -->
- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API. 
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [ ] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->


## Test Plan
<!-- Provide reproducible testing steps. Link any artifacts, recordings, spreadsheets, etc. -->


## Related Issues/Tickets
<!-- Link to relevant Jira issues, Slack discussions, Google Docs --> 
 
 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace synchronized observer lists and blocks with direct CopyOnWriteArrayList usage across analytics and core, simplifying thread-safe iteration.
> 
> - **Observers refactor (thread-safety simplification)**:
>   - **Analytics**:
>     - `KlaviyoApiClient`: use `CopyOnWriteArrayList` for `apiObservers`; remove `synchronized` around broadcasts.
>     - `KlaviyoState`: use `CopyOnWriteArrayList` for `stateChangeObservers` and `eventObserver`; remove `synchronized` in event/state broadcasts.
>   - **Core**:
>     - `KlaviyoLifecycleMonitor`: use `CopyOnWriteArrayList` for `activityObservers`; remove `synchronized` in `broadcastEvent`.
>     - `SharedPreferencesDataStore`: use `CopyOnWriteArrayList` for `storeObservers`; remove `synchronized` in `broadcastStoreChange`.
>     - `KlaviyoNetworkMonitor`: use `CopyOnWriteArrayList` for `networkChangeObservers`; remove `synchronized` in `broadcastNetworkChange`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da2c944a773afb55fce86bcded2723fd49ae905a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->