### PR TITLE
Add manual trigger and Slack alerts to dokka workflow

### DIFF
--- a/.github/workflows/doc-bot.yml
+++ b/.github/workflows/doc-bot.yml
@@ -4,6 +4,7 @@ name: Documentation Bot
 on:
   release:
     types: [released]
+  workflow_dispatch:
 
 jobs:
   dokka:
@@ -54,6 +55,29 @@ jobs:
             echo "No documentation to change"
             exit 0
           fi
-          
+
           git commit -m "${{ env.CI_COMMIT_MESSAGE }}"
           git push
+
+      # Send Slack notification on failure
+      - name: Send Slack notification on failure
+        if: failure()
+        uses: slackapi/slack-github-action@v2.1.1
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: "🚨 Documentation Bot Workflow Failed"
+            blocks:
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: "🚨 Documentation Bot Workflow Failed\n"
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: "*Repository:* ${{ github.repository }}\n*Ref:* `${{ github.ref_name }}`\n*Event:* ${{ github.event_name }}\n*Common Issue:* Check if GH_ACTION_ACCESS_TOKEN has expired"
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: "*Workflow Run:* <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Details>"


### PR DESCRIPTION
## Summary
The github access token for this workflow is about to expire. I noticed it before it expired, but made me realize that this script fails silently right now.

- Add Slack notification on workflow failure with helpful context
- Include note about common issue (expired GH_ACTION_ACCESS_TOKEN)
- Add `workflow_dispatch` trigger to enable manual execution of the dokka documentation workflow

## Changes
1. **Manual Trigger**: Added `workflow_dispatch` to the workflow triggers so the workflow can be run manually from GitHub Actions UI
2. **Slack Alerts**: Added failure notification step that:
   - Triggers only on workflow failure
   - Uses the same Slack action pattern as other workflows in the repo (version-guard, ci, etc.)
   - Provides context: repository, ref, event type, and common issue callout
   - Links directly to the failed workflow run

## Testing
- Workflow syntax follows existing patterns in the repo
- Slack notification format matches other workflows (e.g., version-guard.yml)

🤖 Generated with [Claude Code](https://claude.com/claude-code)