### PR TITLE
Proguard tweaks

### DIFF
--- a/sdk/location/consumer-rules.pro
+++ b/sdk/location/consumer-rules.pro
@@ -1,0 +1,2 @@
+# Keep only class names for stack traces, allow member obfuscation
+-keepnames class com.klaviyo.location.**


### PR DESCRIPTION
# Description
<!-- Briefly describe the feature or bug that your pull request addresses, 1-2 sentences. -->
While reviewing logs from a production build I noticed some class names are dropped, while others are retained. So I took a pass over the consumer rules and found that we're being a bit inconsistent, and overly broad. I made the following updates, which we'll need to test in a prod build of both RN and Anrdoid (more below)

- Use `keepnames` across the board -- Keeping class names has minimal impact to shrinking, because proguard/R8 can still obfuscate the rest of the code. But keeping names addresses one of two categories of shrinker issues we hit in the past: that we sometimes use reflection to access class names as constants/keywords, which renaming breaks.
- Targeted `keep` rules -- Keeping a whole package prevents the shrinker from doing its job _at all_. We do still have some classes that we know get referenced dynamically by reflection, so we can be targeted to keep just those. 
- Modules own their own rules -- We were relying, for example, on the `push` module to tell the consumer to keep the `analytics` symbols. If someone happened to only use analytics package, the rule wouldn't have actually applied.


## Due Diligence
<!-- Best practices before submitting, add additional notes below -->
<!-- If your changes are particularly affected by different Android version, please note API levels you tested on below  -->
- [ ] I have tested this on an emulator and/or a physical device.
- [ ] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [ ] I am confident these changes are compatible with all Android versions the SDK currently supports.


## Release/Versioning Considerations
<!-- Help determine how this should be categorized for release, add additional notes below. -->
<!-- Please add the planned version as a `milestone` label on this PR -->
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API. 
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [ ] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.

Targeting this at `feat/geofencing` in part because it includes location module changes, and because that is our only in progress feature for Q4 so it'd be a good to merge there so we include it in upcoming tests.

## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->
Potentially breaking changes that we need to test carefully in a release build of both RN and Android test apps:
- Using `keepnames` on all class names now, we were missing the push and location modules
- Keep _names_ from `core`, but not all symbols. I'm not sure why we ever kept all of `core`, I suspect it was just a precaution.
- Only keep names from `analytics`, not _all_ symbols
  - BUT keep all  `analytics.model` classes. Particularly _keywords_ are a case that we definitely reference dynamically and a shrinker might try to treeshake out.

## Test Plan
<!-- Provide reproducible testing steps. Link any artifacts, recordings, spreadsheets, etc. -->
In a release build of both RN and Android, re-test the issues we've had with shrinkers in the past: 
- RN: creating an event using a named event keyword constant, like Opened Push or Viewed Product
- Both platforms:  deep linking with a handler callback function used to fail because the shrinker would drop an important typealias
- Both platforms: in-app forms used to fail because we use some class name constants as keywords. If they get renamed, it would break JS/Native bridging logic.

Here is a breakdown of size differences. The middle row is from using `keepnames class com.klaviyo.package { * }` which keeps names of all members, functions names, etc. I think we only need to keep class names. That row was actually larger, because before this change we were allowing location and push modules to be fully obfuscated. The third row is allowing obfuscator to rename members while retaining class names.

  | Version                                       | APK Size        | vs Baseline            | DEX Size        | vs Baseline           |
  |-----------------------------------------------|-----------------|------------------------|-----------------|-----------------------|
  | Baseline (feat/geofencing)                    | 2,490,642 bytes | -                      | 2,916,896 bytes | -                     |
  | Keepnames all members | 2,490,642 bytes | 0 bytes                | 2,922,816 bytes | +5,920 bytes          |
  | This branch (ecm/location-proguard)             | 2,474,258 bytes | -16,384 bytes (-0.66%) | 2,852,312 bytes | -64,584 bytes (-2.2%) |


## Related Issues/Tickets
<!-- Link to relevant Jira issues, Slack discussions, Google Docs --> 
Might sound silly, but this is related to enterprise readiness and SLOs for SDK size. This will allow shrinkers to be a little more effective on our SDK. 
 