### PR TITLE
Remove initial enter trigger

### DIFF
--- a/sdk/location/src/main/java/com/klaviyo/location/KlaviyoLocationManager.kt
+++ b/sdk/location/src/main/java/com/klaviyo/location/KlaviyoLocationManager.kt
@@ -292,6 +292,7 @@ internal class KlaviyoLocationManager : LocationManager {
         }.let { geofencesToAdd ->
             GeofencingRequest.Builder().apply {
                 addGeofences(geofencesToAdd)
+                setInitialTrigger(0) // To match iOS behavior, we will NOT treat initial occupancy of a geofence as a triggering event.
             }.build()
         }.also { geofenceRequest ->
             client.addGeofences(geofenceRequest, intent).run {


### PR DESCRIPTION
# Description
<!-- Briefly describe the feature or bug that your pull request addresses, 1-2 sentences. -->
Tiny! This will remove the undesirable behavior on android where killing the app and re-opening it while still inside a geofence causes a duplicate ENTER event to be generated.

## Due Diligence
<!-- Best practices before submitting, add additional notes below -->
<!-- If your changes are particularly affected by different Android version, please note API levels you tested on below  -->
- [ ] I have tested this on an emulator and/or a physical device.
- [ ] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [ ] I am confident these changes are compatible with all Android versions the SDK currently supports.


## Release/Versioning Considerations
<!-- Help determine how this should be categorized for release, add additional notes below. -->
<!-- Please add the planned version as a `milestone` label on this PR -->
- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API. 
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [ ] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->


## Test Plan
<!-- Provide reproducible testing steps. Link any artifacts, recordings, spreadsheets, etc. -->


## Related Issues/Tickets
<!-- Link to relevant Jira issues, Slack discussions, Google Docs --> 
 
 