### PR TITLE
refactor: extract BaseApiClient interface to core module

### DIFF
--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -21,6 +21,7 @@ import com.klaviyo.core.Operation
 import com.klaviyo.core.Registry
 import com.klaviyo.core.config.Config
 import com.klaviyo.core.config.LifecycleException
+import com.klaviyo.core.networking.BaseApiClient
 import com.klaviyo.core.safeApply
 import com.klaviyo.core.safeCall
 import com.klaviyo.core.utils.takeIf
@@ -60,6 +61,8 @@ object Klaviyo {
         }
 
         // Some APIs (such as deep linking) work without an API key, so we can register the core service now
+        // Register as both BaseApiClient (for core infrastructure) and ApiClient (for analytics operations)
+        Registry.registerOnce<BaseApiClient> { KlaviyoApiClient }
         Registry.registerOnce<ApiClient> { KlaviyoApiClient }
 
         // Register lifecycle callbacks to monitor app foreground/background state

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/ApiClient.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/ApiClient.kt
@@ -8,34 +8,18 @@ import com.klaviyo.analytics.networking.requests.FetchGeofencesCallback
 import com.klaviyo.analytics.networking.requests.FetchGeofencesResult
 import com.klaviyo.analytics.networking.requests.ResolveDestinationCallback
 import com.klaviyo.analytics.networking.requests.ResolveDestinationResult
+import com.klaviyo.core.networking.BaseApiClient
 
 typealias ApiObserver = (request: ApiRequest) -> Unit
 
 /**
  * Defines public API of the network coordinator service
+ *
+ * Extends BaseApiClient for generic queue operations and adds
+ * analytics-specific functionality for events, profiles, and other
+ * Klaviyo-specific operations.
  */
-interface ApiClient {
-
-    /**
-     * Launch the API client service
-     * Should be idempotent in case of re-initialization
-     */
-    fun startService()
-
-    /**
-     * Tell the client to write its queue to the persistent store
-     */
-    fun persistQueue()
-
-    /**
-     * Tell the client to restore its queue from the persistent store engine
-     */
-    fun restoreQueue()
-
-    /**
-     * Tell the client to attempt to flush network request queue now
-     */
-    fun flushQueue()
+interface ApiClient : BaseApiClient {
 
     /**
      * Queue an API request to save [Profile] data to Klaviyo

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/BaseApiClientTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/BaseApiClientTest.kt
@@ -1,0 +1,80 @@
+package com.klaviyo.analytics.networking
+
+import com.klaviyo.core.Registry
+import com.klaviyo.core.networking.BaseApiClient
+import com.klaviyo.fixtures.BaseTest
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+
+class BaseApiClientTest : BaseTest() {
+
+    @Before
+    override fun setup() {
+        super.setup()
+        // Register KlaviyoApiClient as both BaseApiClient and ApiClient
+        // This mimics what happens in Klaviyo.registerForLifecycleCallbacks without the full initialization
+        Registry.register<BaseApiClient>(KlaviyoApiClient)
+        Registry.register<ApiClient>(KlaviyoApiClient)
+    }
+
+    @After
+    override fun cleanup() {
+        Registry.unregister<BaseApiClient>()
+        Registry.unregister<ApiClient>()
+        super.cleanup()
+    }
+
+    @Test
+    fun `KlaviyoApiClient is registered as BaseApiClient`() {
+        // Act - get the BaseApiClient from registry
+        val baseApiClient = Registry.get<BaseApiClient>()
+
+        // Assert
+        Assert.assertNotNull("BaseApiClient should be registered", baseApiClient)
+        Assert.assertTrue(
+            "BaseApiClient should be KlaviyoApiClient instance",
+            baseApiClient is KlaviyoApiClient
+        )
+    }
+
+    @Test
+    fun `KlaviyoApiClient is registered as ApiClient`() {
+        // Act - get the ApiClient from registry
+        val apiClient = Registry.get<ApiClient>()
+
+        // Assert
+        Assert.assertNotNull("ApiClient should be registered", apiClient)
+        Assert.assertTrue(
+            "ApiClient should be KlaviyoApiClient instance",
+            apiClient is KlaviyoApiClient
+        )
+    }
+
+    @Test
+    fun `Both BaseApiClient and ApiClient resolve to same instance`() {
+        // Act - get both interfaces
+        val baseApiClient = Registry.get<BaseApiClient>()
+        val apiClient = Registry.get<ApiClient>()
+
+        // Assert - they should be the exact same instance
+        Assert.assertSame(
+            "BaseApiClient and ApiClient should resolve to the same KlaviyoApiClient instance",
+            baseApiClient,
+            apiClient
+        )
+    }
+
+    @Test
+    fun `BaseApiClient interface methods are available`() {
+        // Act - get BaseApiClient
+        val baseApiClient = Registry.get<BaseApiClient>()
+
+        // Assert - verify we can reference the methods (won't actually call them)
+        Assert.assertNotNull(baseApiClient::startService)
+        Assert.assertNotNull(baseApiClient::persistQueue)
+        Assert.assertNotNull(baseApiClient::restoreQueue)
+        Assert.assertNotNull(baseApiClient::flushQueue)
+    }
+}

--- a/sdk/core/src/main/java/com/klaviyo/core/networking/BaseApiClient.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/networking/BaseApiClient.kt
@@ -1,0 +1,33 @@
+package com.klaviyo.core.networking
+
+/**
+ * Base interface for API client functionality
+ *
+ * Defines generic queue management operations that don't depend on
+ * analytics-specific types. This allows networking infrastructure
+ * to be managed at the core level while specific request types
+ * remain in their respective modules.
+ */
+interface BaseApiClient {
+
+    /**
+     * Launch the API client service
+     * Should be idempotent in case of re-initialization
+     */
+    fun startService()
+
+    /**
+     * Tell the client to write its queue to the persistent store
+     */
+    fun persistQueue()
+
+    /**
+     * Tell the client to restore its queue from the persistent store engine
+     */
+    fun restoreQueue()
+
+    /**
+     * Tell the client to attempt to flush network request queue now
+     */
+    fun flushQueue()
+}


### PR DESCRIPTION
# Description
Extract generic queue operations to new BaseApiClient interface in core module. This is a pure refactoring with no behavior changes, preparing for future migration of networking infrastructure to core.

## Due Diligence
- [x] I have tested this on an emulator and/or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all Android versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API. 
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.
  - Part of WorkManager implementation for Doze mode support

## Changelog / Code Overview

### Changes Made:
1. **Created `BaseApiClient` interface in core module** (`sdk/core/src/main/java/com/klaviyo/core/networking/BaseApiClient.kt`)
   - Extracted generic queue operations: `startService()`, `persistQueue()`, `restoreQueue()`, `flushQueue()`
   - These operations don't depend on analytics-specific types

2. **Updated `ApiClient` interface** (`sdk/analytics/src/main/java/com/klaviyo/analytics/networking/ApiClient.kt`)
   - Now extends `BaseApiClient`
   - Removed method declarations that are now inherited from `BaseApiClient`
   - Added documentation explaining the inheritance

3. **Updated `Klaviyo` object registration** (`sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt`)
   - Register `KlaviyoApiClient` as both `BaseApiClient` and `ApiClient`
   - This allows core infrastructure to access queue operations without depending on analytics module

4. **Added tests** (`sdk/analytics/src/test/java/com/klaviyo/analytics/networking/BaseApiClientTest.kt`)
   - Verify both interfaces can be resolved from Registry
   - Verify they resolve to the same instance
   - Confirm all interface methods are available

### Why This Refactoring?
- **No behavior changes** - This is purely moving interfaces around
- **Prepares for future work** - Enables WorkManager (in core) to trigger queue flushes
- **Better module separation** - Core networking concepts belong in core module
- **Incremental migration** - First step toward moving networking infrastructure to core

## Test Plan

1. **Run unit tests:**
   ```bash
   export JAVA_HOME=/Users/evan.masseau/Library/Java/JavaVirtualMachines/temurin-17.0.15/Contents/Home
   ./gradlew :sdk:analytics:testDebugUnitTest --tests "*BaseApiClientTest*"
   ```

2. **Verify no regression:**
   ```bash
   ./gradlew :sdk:analytics:testDebugUnitTest
   ```

3. **Lint check:**
   ```bash
   ./gradlew ktlintCheck
   ```

All tests pass ✅

## Related Issues/Tickets
- Part of geofencing Doze mode improvements
- Preparation for WorkManager implementation (PR 2 and 3 to follow)
- Related to future networking migration to core module

🤖 Generated with [Claude Code](https://claude.com/claude-code)