### PR TITLE
Clean up geofence intent broadcast receiver

### DIFF
--- a/sdk/location/src/main/java/com/klaviyo/location/KlaviyoGeofenceReceiver.kt
+++ b/sdk/location/src/main/java/com/klaviyo/location/KlaviyoGeofenceReceiver.kt
@@ -10,8 +10,7 @@ class KlaviyoGeofenceReceiver : BroadcastReceiver() {
         try {
             Registry.locationManager.handleGeofenceIntent(
                 context.applicationContext,
-                intent,
-                goAsync()
+                intent
             )
         } catch (e: Exception) {
             Registry.log.error("Unexpected error handling geofence transition intent", e)

--- a/sdk/location/src/main/java/com/klaviyo/location/KlaviyoLocationManager.kt
+++ b/sdk/location/src/main/java/com/klaviyo/location/KlaviyoLocationManager.kt
@@ -2,7 +2,6 @@ package com.klaviyo.location
 
 import android.annotation.SuppressLint
 import android.app.PendingIntent
-import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import com.google.android.gms.location.Geofence
@@ -17,15 +16,12 @@ import com.google.android.gms.location.LocationServices
 import com.klaviyo.analytics.Klaviyo
 import com.klaviyo.analytics.model.Event
 import com.klaviyo.analytics.networking.ApiClient
-import com.klaviyo.analytics.networking.ApiObserver
 import com.klaviyo.analytics.networking.requests.FetchGeofencesResult
 import com.klaviyo.analytics.state.State
 import com.klaviyo.core.Registry
-import com.klaviyo.core.config.Clock
 import com.klaviyo.core.config.Config
 import com.klaviyo.core.safeLaunch
 import java.util.concurrent.CopyOnWriteArrayList
-import java.util.concurrent.atomic.AtomicBoolean
 import kotlinx.coroutines.CoroutineScope
 import org.json.JSONArray
 
@@ -61,18 +57,12 @@ internal class KlaviyoLocationManager : LocationManager {
          * Geofence transition types to monitor (enter and exit)
          */
         private const val TRANSITIONS = GEOFENCE_TRANSITION_ENTER or GEOFENCE_TRANSITION_EXIT
-
-        /**
-         * Timeout for waiting for broadcast receiver processing to complete
-         * We'll use 9.5 seconds (Android docs recommend ~10s)
-         */
-        private const val BROADCAST_RECEIVER_TIMEOUT = 9_500L
     }
 
     /**
      * Tracker for managing geofence transition cooldown periods
      */
-    private val cooldownTracker = GeofenceCooldownTracker()
+    private val cooldownTracker by lazy { GeofenceCooldownTracker() }
 
     /**
      * Lazy-loaded access to the system geofencing APIs
@@ -333,119 +323,49 @@ internal class KlaviyoLocationManager : LocationManager {
      */
     override fun handleGeofenceIntent(
         context: Context,
-        intent: Intent,
-        pendingResult: BroadcastReceiver.PendingResult
+        intent: Intent
     ) {
         val geofencingEvent = GeofencingEvent.fromIntent(intent) ?: run {
             Registry.log.warning("Received invalid geofence intent")
-            pendingResult.finish()
             return
         }
 
         if (geofencingEvent.hasError()) {
             val errorMessage = GeofenceStatusCodes.getStatusCodeString(geofencingEvent.errorCode)
             Registry.log.error("Received geofence error: $errorMessage")
-            pendingResult.finish()
             return
         }
 
         val geofenceTransition = geofencingEvent.toKlaviyoGeofenceEvent() ?: run {
-            Registry.log.error(
-                "Received unknown geofence transition ${geofencingEvent.geofenceTransition}"
-            )
-            pendingResult.finish()
+            val transition = geofencingEvent.geofenceTransition
+            Registry.log.error("Received unknown geofence transition $transition")
             return
         }
 
-        // Track the UUIDs of all the API requests we're creating (note, this is typically just 1 request, but can be a handful)
-        val requestUuids = geofencingEvent.triggeringGeofences?.map { it.toKlaviyoGeofence() }
-            ?.mapNotNull { kGeofence ->
-                if (Registry.getOrNull<State>()?.apiKey == null) {
-                    Registry.log.info("Automatically initialized Klaviyo from geofence event")
-                    Klaviyo.initialize(kGeofence.companyId, context.applicationContext)
-                }
-
-                if (Registry.getOrNull<State>()?.apiKey != kGeofence.companyId) {
-                    // Safeguard against initialization error, or non-matching company ID (this should be impossible though)
-                    Registry.log.error("Skipping geofence event for non-matching company ID.")
-                    return@mapNotNull null
-                }
-
-                // Check cooldown before creating event
-                if (!cooldownTracker.isAllowed(kGeofence.id, geofenceTransition)) {
-                    return@mapNotNull null
-                }
-
-                Registry.log.info("Triggered geofence $geofenceTransition $kGeofence")
-
-                // Create the event and record the transition time
-                cooldownTracker.recordTransition(kGeofence.id, geofenceTransition)
-                createGeofenceEvent(geofenceTransition, kGeofence)
-            } ?: emptyList()
-
-        // Set up observer and timeout to monitor request completion
-        waitForRequestCompletion(requestUuids, pendingResult)
-    }
-
-    /**
-     * Wait for API requests to complete before finishing the broadcast receiver
-     * Uses the API observer pattern to monitor request status
-     * Includes timeout safety to ensure pendingResult.finish() is always called
-     */
-    private fun waitForRequestCompletion(
-        requestUuids: List<String>,
-        pendingResult: BroadcastReceiver.PendingResult
-    ) {
-        val pendingRequests = requestUuids.toMutableSet()
-        val hasFinished = AtomicBoolean(false)
-        var observer: ApiObserver? = null
-        var timeout: Clock.Cancellable? = null
-
-        // Wrapped finish function, to ensure we can't call it twice (which causes a crash)
-        fun finish(observer: ApiObserver? = null, timeout: Clock.Cancellable? = null) {
-            if (hasFinished.compareAndSet(false, true)) {
-                // Clean up observer/timer
-                observer?.let { Registry.get<ApiClient>().offApiRequest(it) }
-                timeout?.cancel()
-
-                // And tell broadcast receiver that we've finished
-                pendingResult.finish()
+        // Create a geofencing event via analytics package for each geofence transition reported
+        geofencingEvent.triggeringGeofences?.map { it.toKlaviyoGeofence() }?.forEach { kGeofence ->
+            if (Registry.getOrNull<State>()?.apiKey == null) {
+                Registry.log.info("Automatically initialized Klaviyo from geofence event")
+                Klaviyo.initialize(kGeofence.companyId, context.applicationContext)
             }
-        }
 
-        // If no requests were created, finish immediately
-        if (pendingRequests.isEmpty()) {
-            finish()
-            return
-        }
-
-        // Timeout - ensure we finish even if network calls don't complete in time
-        timeout = Registry.clock.schedule(BROADCAST_RECEIVER_TIMEOUT) {
-            val remaining = synchronized(pendingRequests) {
-                pendingRequests.size
+            if (Registry.getOrNull<State>()?.apiKey != kGeofence.companyId) {
+                // Safeguard against initialization error, or non-matching company ID (this should be impossible though)
+                Registry.log.error("Skipping geofence event for non-matching company ID.")
+                return@forEach
             }
-            if (remaining > 0) {
-                Registry.log.warning(
-                    "Timeout creating geofence transition events: $remaining remain in queue"
-                )
-            }
-            finish(observer, timeout)
-        }
 
-        // As requests complete, remove from pending list, and call finish when all complete
-        observer = { request ->
-            if (request.responseCode is Int) {
-                val remaining = synchronized(pendingRequests) {
-                    pendingRequests.remove(request.uuid)
-                    pendingRequests.size
-                }
-                if (remaining == 0) {
-                    finish(observer, timeout)
-                }
+            // Check cooldown before creating event
+            if (!cooldownTracker.isAllowed(kGeofence.id, geofenceTransition)) {
+                return@forEach
             }
-        }
 
-        Registry.get<ApiClient>().onApiRequest(true, observer)
+            Registry.log.info("Triggered geofence $geofenceTransition $kGeofence")
+
+            // Create the event and record the transition time
+            cooldownTracker.recordTransition(kGeofence.id, geofenceTransition)
+            createGeofenceEvent(geofenceTransition, kGeofence)
+        }
     }
 
     /**
@@ -453,24 +373,21 @@ internal class KlaviyoLocationManager : LocationManager {
      *
      * @param transition The type of transition that occurred
      * @param geofence The geofence that triggered the event
-     * @return The API request that was enqueued
      */
     private fun createGeofenceEvent(
         transition: KlaviyoGeofenceTransition,
         geofence: KlaviyoGeofence
-    ): String? = when (transition) {
-        KlaviyoGeofenceTransition.Entered -> GeofenceEventMetric.ENTER
-        KlaviyoGeofenceTransition.Exited -> GeofenceEventMetric.EXIT
-        KlaviyoGeofenceTransition.Dwelt -> GeofenceEventMetric.DWELL
-    }.let { metric ->
-        Event(metric, mapOf(GeofenceEventProperty.GEOFENCE_ID to geofence.locationId))
-    }.let { event ->
-        Registry.log.debug(
-            "Created geofence event: ${event.metric.name} for geofence ${geofence.id}"
-        )
-        Registry.get<State>().run {
-            createEvent(event, getAsProfile())
-        }.uniqueId
+    ) {
+        val event = when (transition) {
+            KlaviyoGeofenceTransition.Entered -> GeofenceEventMetric.ENTER
+            KlaviyoGeofenceTransition.Exited -> GeofenceEventMetric.EXIT
+            KlaviyoGeofenceTransition.Dwelt -> GeofenceEventMetric.DWELL
+        }.let { metric ->
+            Event(metric, mapOf(GeofenceEventProperty.GEOFENCE_ID to geofence.locationId))
+        }
+
+        Registry.log.debug("Create geofence event: ${event.metric} for geofence ${geofence.id}")
+        Klaviyo.createEvent(event)
     }
 
     /**

--- a/sdk/location/src/main/java/com/klaviyo/location/LocationManager.kt
+++ b/sdk/location/src/main/java/com/klaviyo/location/LocationManager.kt
@@ -1,6 +1,5 @@
 package com.klaviyo.location
 
-import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 
@@ -46,12 +45,10 @@ interface LocationManager {
      *
      * @param context The application context
      * @param intent The geofence intent from the system
-     * @param pendingResult The pending result from goAsync() to be finished when processing completes
      */
     fun handleGeofenceIntent(
         context: Context,
-        intent: Intent,
-        pendingResult: BroadcastReceiver.PendingResult
+        intent: Intent
     )
 
     /**

--- a/sdk/location/src/test/java/com/klaviyo/location/KlaviyoGeofenceReceiverTest.kt
+++ b/sdk/location/src/test/java/com/klaviyo/location/KlaviyoGeofenceReceiverTest.kt
@@ -1,12 +1,10 @@
 package com.klaviyo.location
 
-import android.content.BroadcastReceiver
 import android.content.Intent
 import com.klaviyo.core.Registry
 import com.klaviyo.fixtures.BaseTest
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.spyk
 import io.mockk.verify
 import org.junit.Before
 import org.junit.Test
@@ -15,16 +13,13 @@ import org.junit.Test
  * Tests for KlaviyoGeofenceReceiver
  *
  * These tests verify that the geofence receiver properly delegates to LocationManager's
- * handleGeofenceIntent method with the correct context, intent, and PendingResult.
+ * handleGeofenceIntent method with the correct context and intent.
  */
 internal class KlaviyoGeofenceReceiverTest : BaseTest() {
 
     private val mockIntent = mockk<Intent>(relaxed = true)
     private val mockLocationManager = mockk<LocationManager>(relaxed = true)
-    private val mockPendingResult = mockk<BroadcastReceiver.PendingResult>(relaxed = true)
-    private val receiver = spyk(KlaviyoGeofenceReceiver()).apply {
-        every { goAsync() } returns mockPendingResult
-    }
+    private val receiver = KlaviyoGeofenceReceiver()
 
     @Before
     override fun setup() {
@@ -38,7 +33,7 @@ internal class KlaviyoGeofenceReceiverTest : BaseTest() {
     }
 
     @Test
-    fun `onReceive delegates to LocationManager handleGeofenceIntent async`() {
+    fun `onReceive delegates to LocationManager handleGeofenceIntent`() {
         // Trigger the receiver
         receiver.onReceive(mockContext, mockIntent)
 
@@ -46,18 +41,14 @@ internal class KlaviyoGeofenceReceiverTest : BaseTest() {
         verify(exactly = 1) {
             mockLocationManager.handleGeofenceIntent(
                 mockContext,
-                mockIntent,
-                mockPendingResult
+                mockIntent
             )
         }
-
-        // Verify goAsync was called
-        verify(exactly = 1) { receiver.goAsync() }
     }
 
     @Test
     fun `onReceive handles any exceptions to avoid a crash`() {
-        every { mockLocationManager.handleGeofenceIntent(any(), any(), any()) } throws Exception()
+        every { mockLocationManager.handleGeofenceIntent(any(), any()) } throws Exception()
 
         // Trigger the receiver
         receiver.onReceive(mockContext, mockIntent)
@@ -65,8 +56,7 @@ internal class KlaviyoGeofenceReceiverTest : BaseTest() {
         verify(exactly = 1) {
             mockLocationManager.handleGeofenceIntent(
                 mockContext,
-                mockIntent,
-                mockPendingResult
+                mockIntent
             )
         }
     }


### PR DESCRIPTION
# Description
<!-- Briefly describe the feature or bug that your pull request addresses, 1-2 sentences. -->
Removes the async aspects of geofence broadcast receiver. Queueing of the requests is synchronous, and the work manager added in #367 should handle the asynchronous aspect of actually sending the API requests now.

## Due Diligence
<!-- Best practices before submitting, add additional notes below -->
<!-- If your changes are particularly affected by different Android version, please note API levels you tested on below  -->
- [x] I have tested this on an emulator and/or a physical device.
- [ ] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [ ] I am confident these changes are compatible with all Android versions the SDK currently supports.


## Release/Versioning Considerations
<!-- Help determine how this should be categorized for release, add additional notes below. -->
<!-- Please add the planned version as a `milestone` label on this PR -->
- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API. 
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [ ] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->


## Test Plan
<!-- Provide reproducible testing steps. Link any artifacts, recordings, spreadsheets, etc. -->
Substantial testing description in this slack thread
https://klaviyo.slack.com/archives/C092G8ASQH1/p1764791056903339

## Related Issues/Tickets
<!-- Link to relevant Jira issues, Slack discussions, Google Docs --> 
Follow up from #367 which moved all the async logic of sending high priority events to a workmanager
 