### PR TITLE
Remove early access disclaimer for universal linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,8 +590,7 @@ class YourApplication : Application() {
 ```
 
 ### Handling Universal Links
->  ℹ️ Support for Deep Linking from Email is currently available for early access to select Klaviyo customers. Please contact your CSM to be enrolled.
->  Full trackable universal links support is available in Klaviyo Android SDK version 4.1.0 and higher.
+>  ℹ️ Full trackable universal links support is available in Klaviyo Android SDK version 4.1.0 and higher.
 
 Klaviyo supports embedding universal links with click tracking in email messages. To ensure these links are properly tracked as 
 profile events *and* your app opens and processes the links correctly, you need to configure your app to handle them. At a high level, the process works like this:


### PR DESCRIPTION
## Summary

The universal linking (deep linking from email) feature is no longer in early access and is fully available to all customers. This PR removes the disclaimer that previously limited it to select customers only.

## Changes

- Removed the line in README.md stating that universal linking support was "currently available for early access to select Klaviyo customers"
- Kept the information about SDK version 4.1.0+ support intact

## Impact

- Documentation now accurately reflects that universal linking is generally available to all Klaviyo customers
- Developers will no longer see messaging suggesting they need special access to use this feature

🤖 Generated with Reca