### PR TITLE
Update SDK revision to 2026-01-15, add geofence help doc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -789,7 +789,7 @@ object to the `registerForInAppForms()` method. For example, to set a session ti
 
 ## Geofencing
 
-Geofencing allows you to trigger events when users enter or exit geographic regions defined in your Klaviyo account.
+[Geofencing](https://help.klaviyo.com/hc/en-us/articles/45194892526747) allows you to trigger events when users enter or exit geographic regions defined in your Klaviyo account.
 The SDK monitors permission, syncs geofence data from Klaviyo, registers them with device location services, 
 and creates events when transitions occur. These events can be used to trigger flows, segment profiles, 
 and drive location-based marketing.

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,7 +30,7 @@ klaviyoServerUrl=https://a.klaviyo.com
 klaviyoCdnUrl=https://static.klaviyo.com
 
 # Klaviyo API Revision
-klaviyoApiRevision=2025-10-15
+klaviyoApiRevision=2026-01-15
 
 # Group ID prefix for all our published modules
 klaviyoGroupId=com.klaviyo

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/FetchGeofencesRequest.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/FetchGeofencesRequest.kt
@@ -39,7 +39,7 @@ internal class FetchGeofencesRequest(
 
     init {
         // Override the API revision for geofence fetching to use pre-release version
-        headers[HEADER_REVISION] = "2025-10-15.pre"
+        headers[HEADER_REVISION] = "2026-01-15.pre"
 
         // Add location filter header if coordinates provided
         if (latitude != null && longitude != null) {

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/FetchGeofencesRequestTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/FetchGeofencesRequestTest.kt
@@ -20,7 +20,7 @@ internal class FetchGeofencesRequestTest : BaseApiRequestTest<FetchGeofencesRequ
 
     override val expectedHeaders: Map<String, String>
         get() = super.expectedHeaders.toMutableMap() + mapOf(
-            "Revision" to "2025-10-15.pre"
+            "Revision" to "2026-01-15.pre"
         )
 
     override fun makeTestRequest(): FetchGeofencesRequest = FetchGeofencesRequest()


### PR DESCRIPTION
## Summary
- Update API revision from 2025-10-15 to 2026-01-15 for all endpoints (waiting to merge, since that will require VPN until the 15th)
- Keep .pre suffix for geofence fetching endpoint
- Add help doc link to geofencing section in README

## Test plan
- [ ] CI passes
- [ ] Verify revision header in network requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)