### PR TITLE
Add getForegroundInfo() to QueueFlushWorker for expedited work support

### DIFF
--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/QueueFlushWorker.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/QueueFlushWorker.kt
@@ -1,6 +1,5 @@
 package com.klaviyo.analytics.networking
 
-import android.R
 import android.app.Notification
 import android.content.Context
 import androidx.core.app.NotificationChannelCompat
@@ -11,6 +10,7 @@ import androidx.work.CoroutineWorker
 import androidx.work.ForegroundInfo
 import androidx.work.WorkerParameters
 import com.klaviyo.analytics.Klaviyo
+import com.klaviyo.analytics.R
 import com.klaviyo.core.Registry
 import com.klaviyo.core.config.Config
 
@@ -85,7 +85,6 @@ internal class QueueFlushWorker(
          * Notification channel for SDK background operations
          */
         const val BG_SYNC_CHANNEL_ID = "klaviyo_sdk_background"
-        const val BG_SYNC_CHANNEL_NAME = "Background Sync"
         const val BG_SYNC_NOTIFICATION_ID = 1001
 
         /**
@@ -95,8 +94,8 @@ internal class QueueFlushWorker(
          */
         fun buildSyncNotification(context: Context): Notification = NotificationCompat
             .Builder(context, createNotificationChannel(context))
-            .setContentText("Syncing...")
-            .setSmallIcon(R.drawable.stat_sys_upload)
+            .setContentText(context.getString(R.string.klaviyo_bg_sync_notification_text))
+            .setSmallIcon(android.R.drawable.stat_sys_upload)
             .setPriority(NotificationCompat.PRIORITY_LOW)
             .setOngoing(true)
             .setAutoCancel(true)
@@ -110,8 +109,8 @@ internal class QueueFlushWorker(
             .from(context)
             .createNotificationChannel(
                 NotificationChannelCompat.Builder(BG_SYNC_CHANNEL_ID, IMPORTANCE_LOW)
-                    .setName(BG_SYNC_CHANNEL_NAME)
-                    .setDescription("SDK background synchronization")
+                    .setName(context.getString(R.string.klaviyo_bg_sync_channel_name))
+                    .setDescription(context.getString(R.string.klaviyo_bg_sync_channel_description))
                     .setShowBadge(false)
                     .build()
             ).let { BG_SYNC_CHANNEL_ID }

--- a/sdk/analytics/src/main/res/values/strings.xml
+++ b/sdk/analytics/src/main/res/values/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Background sync notification strings -->
+    <string name="klaviyo_bg_sync_channel_name">Background Sync</string>
+    <string name="klaviyo_bg_sync_notification_text">Syncing…</string>
+    <string name="klaviyo_bg_sync_channel_description">Background synchronization</string>
+</resources>


### PR DESCRIPTION
# Description
Add `getForegroundInfo()` implementation to QueueFlushWorker to support expedited WorkManager jobs on Android 11 and below.

On older Android versions, expedited work manager jobs are actually just implemented with a foreground service. So you have to implement this method, which puts a low priority notification in the system tray to indicate that the app is running in the background. So I added a very simple little "syncing" message (it flashes so fast that I can't even see it anyways, I can attest as a long time Android user this used to be a fairly common thing, you'd have to be watching pretty closely to even see it). 

[Additional context](https://klaviyo.slack.com/archives/C092G8ASQH1/p1768250371126219)

## Due Diligence
- [x] I have tested this on an emulator and/or a physical device.
- [ ] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all Android versions the SDK currently supports.


## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API. 
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [x] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.


## Changelog / Code Overview
- Added `getForegroundInfo()` method to QueueFlushWorker that provides a low-priority notification for foreground service support
- Creates notification channel for SDK background operations (low importance, no badge)
- Uses system upload icon 
- Uses string resources for the text of the notification and channel name so the dev could override/localize it if desired.
- On Android 12+, expedited jobs don't run as foreground services, so notification won't be shown
- On Android 11 and below, provides required foreground service notification when expedited work runs.
- Using a low priority notification, and on this version of android, no user permission is required for notifications.

## Test Plan
- [x] Build and run on Android 11 and below to verify foreground service notification appears when queue flush is triggered
- [x] Verify notification uses upload icon
- [x] Test on Android 12+ to ensure expedited work still functions without notification

Here's what it looks like (it flashes so fast that I had to add an artificial delay to capture a screenshot)
<img width="1440" height="2880" alt="Screenshot_20260114_112231" src="https://github.com/user-attachments/assets/f9139998-7357-4448-87a0-55f45c28d09f" />

[Screen_recording_20260114_111319.webm](https://github.com/user-attachments/assets/1794f4a4-0aca-4d96-b854-bc45d31d560e)

## Impact
I was able to repro the bug, the user impact would have been pretty minimal, since it specifically only crashed while the app was backgrounded, so it wouldn't have interrupted user interactions. In some cases they might have gotten a "XYZ Application Stopped" alert. But it seems like if the app were running, it would just sync without using a foreground service.

## Related Issues/Tickets
<!-- Link to relevant Jira issues, Slack discussions, Google Docs --> 
CHNL-30224
