### PR TITLE
Fix form activity presentation context

### DIFF
--- a/sdk/forms/src/main/java/com/klaviyo/forms/presentation/KlaviyoFormsOverlayActivity.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/presentation/KlaviyoFormsOverlayActivity.kt
@@ -32,7 +32,6 @@ internal class KlaviyoFormsOverlayActivity : AppCompatActivity() {
                     Registry.config.applicationContext.packageName,
                     KlaviyoFormsOverlayActivity::class.java.name
                 )
-                flags = Intent.FLAG_ACTIVITY_NEW_TASK
             }
     }
 }

--- a/sdk/forms/src/main/java/com/klaviyo/forms/presentation/KlaviyoPresentationManager.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/presentation/KlaviyoPresentationManager.kt
@@ -89,11 +89,11 @@ internal class KlaviyoPresentationManager() : PresentationManager {
         clearTimers()
         cancelPostponedPresent = Registry.lifecycleMonitor.runWithCurrentOrNextActivity(
             timeout = Registry.get<InAppFormsConfig>().getSessionTimeoutDuration().inWholeMilliseconds
-        ) {
+        ) { activity ->
             presentationState.takeIf<Hidden>()?.let {
                 presentationState = Presenting(formId)
                 Registry.log.debug("Presentation State: $presentationState")
-                Registry.config.applicationContext.startActivity(
+                activity.startActivity(
                     KlaviyoFormsOverlayActivity.launchIntent
                 )
             } ?: run {

--- a/sdk/forms/src/test/java/com/klaviyo/forms/presentation/KlaviyoFormsOverlayActivityTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/presentation/KlaviyoFormsOverlayActivityTest.kt
@@ -1,10 +1,10 @@
 package com.klaviyo.forms.presentation
 
-import android.content.Intent
 import com.klaviyo.core.BuildConfig
 import com.klaviyo.fixtures.BaseTest
 import com.klaviyo.fixtures.MockIntent
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 
@@ -19,6 +19,7 @@ class KlaviyoFormsOverlayActivityTest : BaseTest() {
             "com.klaviyo.forms.presentation.KlaviyoFormsOverlayActivity",
             mockIntent.className.captured
         )
-        assertEquals(Intent.FLAG_ACTIVITY_NEW_TASK, mockIntent.flags.captured)
+        // Form intent
+        assertFalse(null, mockIntent.flags.isCaptured)
     }
 }

--- a/sdk/forms/src/test/java/com/klaviyo/forms/presentation/KlaviyoPresentationManagerTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/presentation/KlaviyoPresentationManagerTest.kt
@@ -125,9 +125,9 @@ class KlaviyoPresentationManagerTest : BaseTest() {
     @Test
     fun `present should not start a duplicate activity`() {
         val manager = withPresentedState()
-        verify(exactly = 1) { mockContext.startActivity(mockLaunchIntent) }
+        verify(exactly = 1) { mockActivity.startActivity(mockLaunchIntent) }
         manager.present("formId")
-        verify(exactly = 1) { mockContext.startActivity(mockLaunchIntent) }
+        verify(exactly = 1) { mockActivity.startActivity(mockLaunchIntent) }
     }
 
     @Test
@@ -160,7 +160,7 @@ class KlaviyoPresentationManagerTest : BaseTest() {
         manager.present("formId")
 
         // Expect start activity to be called and state to be Presenting
-        verify(exactly = 1) { mockContext.startActivity(mockLaunchIntent) }
+        verify(exactly = 1) { mockActivity.startActivity(mockLaunchIntent) }
         assertEquals(
             "PresentationState should transition to Presenting",
             PresentationState.Presenting("formId"),


### PR DESCRIPTION
# Description
<!-- Briefly describe the feature or bug that your pull request addresses, 1-2 sentences. -->
Flutter integration work exposed an issue with how we display the in-app form overlay activity. By using application context, we are forced to use the "new task" flag, which in turn can lead to the form winding up in its own task, separate from the host app's main activity.

## Due Diligence
<!-- Best practices before submitting, add additional notes below -->
<!-- If your changes are particularly affected by different Android version, please note API levels you tested on below  -->
- [ ] I have tested this on an emulator and/or a physical device.
- [ ] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [ ] I am confident these changes are compatible with all Android versions the SDK currently supports.


## Release/Versioning Considerations
<!-- Help determine how this should be categorized for release, add additional notes below. -->
<!-- Please add the planned version as a `milestone` label on this PR -->
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API. 
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [ ] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.

Not yet planned, but I think at least a patch version 4.2.1 might be in order here.  Maybe we do a backward patch to 4.1 as well, not sure if worth it since this hasn't been externally reported, so it may be unique to flutter, or at least an activity setup that is uncommon outside of flutter

## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->
- Use the activity context instead of app context
- Take out the new task flag from the intent

## Test Plan
<!-- Provide reproducible testing steps. Link any artifacts, recordings, spreadsheets, etc. -->
We never encountered this on RN or vanilla Android, but I suspect it might be an unfortunate timing thing on flutter. We should verify on Android, RN and Flutter that this still works to display the form above the app's primary task / main activity. 

## Related Issues/Tickets
<!-- Link to relevant Jira issues, Slack discussions, Google Docs --> 
 https://klaviyo.atlassian.net/browse/CHNL-30554
