### PR TITLE
docs: Add form lifecycle callbacks section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,8 +559,6 @@ in response to form interactions.
 
 ```kotlin
 import com.klaviyo.analytics.Klaviyo
-import com.klaviyo.forms.FormContext
-import com.klaviyo.forms.FormLifecycleCallback
 import com.klaviyo.forms.FormLifecycleEvent
 import com.klaviyo.forms.registerFormLifecycleCallback
 
@@ -580,6 +578,23 @@ Klaviyo.registerFormLifecycleCallback { event, context ->
 }
 ```
 
+```java
+import com.klaviyo.forms.FormLifecycleCallback;
+import com.klaviyo.forms.FormLifecycleEvent;
+import com.klaviyo.forms.KlaviyoFormLifecycleCallbacks;
+
+KlaviyoFormLifecycleCallbacks.registerFormLifecycleCallback((event, context) -> {
+    if (event == FormLifecycleEvent.FORM_SHOWN) {
+        // A form became visible to the user
+        // context.getFormId() and context.getFormName() identify the form
+    } else if (event == FormLifecycleEvent.FORM_DISMISSED) {
+        // The user closed or the form was programmatically dismissed
+    } else if (event == FormLifecycleEvent.FORM_CTA_CLICKED) {
+        // The user tapped a call-to-action button
+    }
+});
+```
+
 All callbacks are invoked on the UI thread. Only one callback can be registered at a time —
 registering a new callback replaces any previously registered one.
 
@@ -589,6 +604,10 @@ To unregister the callback:
 import com.klaviyo.forms.unregisterFormLifecycleCallback
 
 Klaviyo.unregisterFormLifecycleCallback()
+```
+
+```java
+KlaviyoFormLifecycleCallbacks.unregisterFormLifecycleCallback();
 ```
 
 ## Deep Linking

--- a/README.md
+++ b/README.md
@@ -559,14 +559,16 @@ in response to form interactions.
 
 ```kotlin
 import com.klaviyo.analytics.Klaviyo
+import com.klaviyo.forms.FormContext
 import com.klaviyo.forms.FormLifecycleCallback
 import com.klaviyo.forms.FormLifecycleEvent
 import com.klaviyo.forms.registerFormLifecycleCallback
 
-Klaviyo.registerFormLifecycleCallback { event, formId ->
+Klaviyo.registerFormLifecycleCallback { event, context ->
     when (event) {
         FormLifecycleEvent.FORM_SHOWN -> {
             // A form became visible to the user
+            // context.formId and context.formName identify the form
         }
         FormLifecycleEvent.FORM_DISMISSED -> {
             // The user closed or the form was programmatically dismissed

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ send them timely push notifications via [FCM (Firebase Cloud Messaging)](https:/
   - [Prerequisites](#prerequisites-1)
   - [Setup](#setup-1)
   - [In-App Forms Session Configuration](#in-app-forms-session-configuration)
+  - [Form Lifecycle Callbacks](#form-lifecycle-callbacks)
   - [Unregistering from In-App Forms](#unregistering-from-in-app-forms)
 - [Deep Linking](#deep-linking)
 - [Troubleshooting](#troubleshooting)
@@ -549,6 +550,44 @@ Klaviyo.unregisterFromInAppForms()
 ```
 
 Note that after unregistering, the next call to `registerForInAppForms()` will be considered a new session by the SDK.
+
+#### Form Lifecycle Callbacks
+
+You can optionally register a callback to be notified when key form lifecycle events occur.
+This is useful for integrating with your own analytics platform or triggering app-side behavior
+in response to form interactions.
+
+```kotlin
+import com.klaviyo.analytics.Klaviyo
+import com.klaviyo.forms.FormLifecycleCallback
+import com.klaviyo.forms.FormLifecycleEvent
+import com.klaviyo.forms.registerFormLifecycleCallback
+
+Klaviyo.registerFormLifecycleCallback { event, formId ->
+    when (event) {
+        FormLifecycleEvent.FORM_SHOWN -> {
+            // A form became visible to the user
+        }
+        FormLifecycleEvent.FORM_DISMISSED -> {
+            // The user closed or the form was programmatically dismissed
+        }
+        FormLifecycleEvent.FORM_CTA_CLICKED -> {
+            // The user tapped a call-to-action button
+        }
+    }
+}
+```
+
+All callbacks are invoked on the UI thread. Only one callback can be registered at a time —
+registering a new callback replaces any previously registered one.
+
+To unregister the callback:
+
+```kotlin
+import com.klaviyo.forms.unregisterFormLifecycleCallback
+
+Klaviyo.unregisterFormLifecycleCallback()
+```
 
 ## Deep Linking
 Klaviyo [Deep Links](https://help.klaviyo.com/hc/en-us/articles/14750403974043) allow you to navigate to a


### PR DESCRIPTION
## Summary

- Adds a new **Form Lifecycle Callbacks** subsection to the In-App Forms documentation
- Covers `registerFormLifecycleCallback`, the three `FormLifecycleEvent` values, and `unregisterFormLifecycleCallback`
- Adds the new anchor to the table of contents

## Notes

Kept separate from the feature PR (#414) so it can be merged after the feature is released and the version number is confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)