### PR TITLE
Review and update of AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,9 +125,9 @@ The Klaviyo Android SDK is organized into multiple modules, each with specific r
 
 ### CI/CD Pipeline
 
-The project uses GitHub Actions for CI/CD, particularly for running tests and link checks on pull requests.
-Ensure that all tests pass and lint checks are successful before committing any changes.
-Do not use --no-verify as a way to work around pre-commit checks unless prompted.
+The project uses GitHub Actions for CI/CD, particularly for running tests and lint checks on pull requests.
+Ensure that relevant tests pass and lint checks are successful before committing any changes.
+NEVER use --no-verify as a way to work around pre-commit checks unless prompted.
 
 ### Testing Approach
 


### PR DESCRIPTION
## Summary
- Condensed verbose intro paragraph into a single concise sentence
- Replaced per-module build/test command examples with a generic `{module}` pattern listing all modules
- Added documentation for the new `forms-core`, `location`, and `location-core` modules in the architecture overview
- Fixed CI/CD Pipeline section: "link checks" → "lint checks", "all tests" → "relevant tests", strengthened --no-verify prohibition ("Do not" → "NEVER")
- Brings AGENTS.md in line with the already-updated CLAUDE.md

## Test plan
- [x] Verify modules listed match actual `sdk/` subdirectories (confirmed locally: all 7 exist)
- [x] No code changes -- documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)