### PR TITLE
fix: Add FLAG_ACTIVITY_CLEAR_TOP to push notification intents

### DIFF
--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoNotification.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoNotification.kt
@@ -5,6 +5,7 @@ import android.annotation.SuppressLint
 import android.app.Notification
 import android.app.PendingIntent
 import android.content.Context
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
@@ -230,6 +231,9 @@ class KlaviyoNotification(private val message: RemoteMessage) {
                 }
             // Else, just launch the app
             else -> DeepLinking.makeLaunchIntent(context)
-        }?.appendKlaviyoExtras(message)
+        }?.apply {
+            addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+            appendKlaviyoExtras(message)
+        }
     }
 }

--- a/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoNotificationTest.kt
+++ b/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoNotificationTest.kt
@@ -321,6 +321,47 @@ class KlaviyoNotificationTest : BaseTest() {
     }
 
     @Test
+    fun `opened intent adds CLEAR_TOP flag for launch intent`() {
+        val mockLaunchIntent = mockk<Intent>(relaxed = true)
+        val intentSlot = slot<Intent>()
+
+        with(KlaviyoRemoteMessage) {
+            every { mockRemoteMessage.deepLink } returns null
+        }
+
+        every { DeepLinking.makeLaunchIntent(any()) } returns mockLaunchIntent
+
+        every {
+            PendingIntent.getActivity(any(), any(), capture(intentSlot), any())
+        } returns mockk(relaxed = true)
+
+        notification.displayNotification(mockContext)
+
+        verify { mockLaunchIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP) }
+    }
+
+    @Test
+    fun `opened intent adds CLEAR_TOP flag for deep link intent`() {
+        val mockDeepLinkUri = mockk<Uri>(relaxed = true)
+        val mockDeepLinkIntent = mockk<Intent>(relaxed = true)
+
+        with(KlaviyoRemoteMessage) {
+            every { mockRemoteMessage.deepLink } returns mockDeepLinkUri
+        }
+
+        every { DeepLinking.makeDeepLinkIntent(mockDeepLinkUri, any()) } returns mockDeepLinkIntent
+        every { mockDeepLinkIntent.resolveActivity(any()) } returns mockk()
+
+        every {
+            PendingIntent.getActivity(any(), any(), any(), any())
+        } returns mockk(relaxed = true)
+
+        notification.displayNotification(mockContext)
+
+        verify { mockDeepLinkIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP) }
+    }
+
+    @Test
     fun `pending intent created with correct flags`() {
         val flagsSlot = slot<Int>()
 


### PR DESCRIPTION
## Summary

Fixes a bug where tapping a Klaviyo push notification in multi-activity apps doesn't route the intent to the launcher activity. When a secondary activity is on top of the back stack, `FLAG_ACTIVITY_SINGLE_TOP` alone doesn't pop back to the launcher — the intent gets delivered to the wrong activity and `handlePush()` never fires.

## Changes

- Add `FLAG_ACTIVITY_CLEAR_TOP` in `KlaviyoNotification.makeOpenedIntent` (push-fcm module)
- Combined `CLEAR_TOP | SINGLE_TOP` pops the back stack to the launcher activity and reuses it via `onNewIntent()` without recreation
- 2 new unit tests verifying the flag is added for both launch and deep link intents
- `DeepLinking.kt` is **intentionally unchanged** — forms deep link navigation is unaffected

## Ticket

[MAGE-265](https://linear.app/klaviyo/issue/MAGE-265)

## Test plan

- [x] B1: Cold start — push tap opens SampleActivity via onCreate, handlePush fires
- [x] B2: Backgrounded, SampleActivity on top — onNewIntent, handlePush fires
- [x] B3: Backgrounded, SecondActivity on top — SecondActivity destroyed, SampleActivity gets onNewIntent
- [x] B4: Foreground, SampleActivity visible — onNewIntent, handlePush fires
- [x] B5: Foreground, SecondActivity visible — SecondActivity destroyed, SampleActivity gets onNewIntent
- [x] B6-B7: Back stack clean after B3/B5 (no duplicates)
- [x] B8: Double notification — both route correctly, no crash
- [x] B9: Normal flow regression — push after returning from SecondActivity
- [x] B10: IAF deep link regression — forms behavior unchanged

This can be tested out prior to release by referencing the branch or commit hash in your `build.gradle` e.g.
```
implementation 'com.github.klaviyo.klaviyo-android-sdk:push-fcm:a238b35ff0'
```

This will resolve #409 