### PR TITLE
Allow mixed content in WebView for local forms development

### DIFF
--- a/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebView.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebView.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.Color
 import android.util.AttributeSet
+import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.core.util.TypedValueCompat.pxToDp
@@ -52,8 +53,14 @@ internal class KlaviyoWebView : WebView {
         setBackgroundColor(Color.TRANSPARENT)
         if (Registry.config.isDebugBuild) {
             setWebContentsDebuggingEnabled(true)
+
             // Disable webview resources cache when debugging:
             // settings.cacheMode = WebSettings.LOAD_NO_CACHE
+
+            // Allow mixed content when CDN URL is HTTP (local development only)
+            if (Registry.config.baseCdnUrl.startsWith("http://")) {
+                settings.mixedContentMode = WebSettings.MIXED_CONTENT_ALWAYS_ALLOW
+            }
         }
     }
 


### PR DESCRIPTION
# Description

Allow `MIXED_CONTENT_ALWAYS_ALLOW` in the forms WebView when the CDN URL is HTTP and the build is a debug build, enabling local in-app forms development with a local Fender dev server.

## Due Diligence

- [x] I have tested this on an emulator and/or a physical device.
- [ ] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all Android versions the SDK currently supports.

Notes: Tested on Android 36 emulator with local Fender dev server. `WebSettings.MIXED_CONTENT_ALWAYS_ALLOW` is available since API 21 (our min SDK). No unit test added — the change is a one-liner guarded by two runtime conditions that can't be triggered in test without mocking the full WebView stack.

## Release/Versioning Considerations

- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [ ] This is planned work for an upcoming release.

Notes: Internal-only change, no public API impact. Only activates in debug builds with HTTP CDN URL — production builds are unaffected.

## Changelog / Code Overview

When `baseCdnUrl` starts with `http://` (local development) AND the build is a debug build, set `mixedContentMode = MIXED_CONTENT_ALWAYS_ALLOW` on the forms WebView. This allows the WebView template (loaded with HTTPS base URL `a.klaviyo.com`) to fetch scripts from `http://localhost:4001` (local Fender dev server).

Double-guarded: `isDebugBuild && baseCdnUrl.startsWith("http://")` — impossible to trigger in production.

## Test Plan

- [x] Verify local forms load in emulator with `localKlaviyoCdnUrl=http://localhost:4001` and `klaviyoAssetSource=development` in `local.properties`
- [x] Verify production forms still load normally without the local.properties overrides
- [x] CI passes

## Related Issues/Tickets

- [MAGE-403](https://linear.app/klaviyo/issue/MAGE-403): Investigate `assetSource=development` for mobile onsite testing