### PR TITLE
[MAGE-432] A11y labels sample app

### DIFF
--- a/sample/src/main/java/com/klaviyo/sample/LocationView.kt
+++ b/sample/src/main/java/com/klaviyo/sample/LocationView.kt
@@ -31,6 +31,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
@@ -87,7 +89,7 @@ fun LocationView(
                 shape = CircleShape,
                 onClick = onRegisterForGeofencing,
                 enabled = !isGeofencingRegistered,
-                modifier = Modifier.weight(1f)
+                modifier = Modifier.weight(1f).semantics { testTag = LocationTestTags.BTN_REGISTER_GEOFENCING }
             ) {
                 Text(text = LocationViewConstants.REGISTER_GEOFENCING)
             }
@@ -95,7 +97,7 @@ fun LocationView(
                 shape = CircleShape,
                 onClick = onUnregisterFromGeofencing,
                 enabled = isGeofencingRegistered,
-                modifier = Modifier.weight(1f)
+                modifier = Modifier.weight(1f).semantics { testTag = LocationTestTags.BTN_UNREGISTER_GEOFENCING }
             ) {
                 Text(text = LocationViewConstants.UNREGISTER_GEOFENCING)
             }
@@ -109,6 +111,7 @@ fun LocationView(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 8.dp)
+                    .semantics { testTag = LocationTestTags.BTN_REQUEST_LOCATION_PERMISSION }
             ) {
                 Text(text = LocationViewConstants.REQUEST_LOCATION_PERMISSION)
             }
@@ -120,6 +123,7 @@ fun LocationView(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 8.dp)
+                    .semantics { testTag = LocationTestTags.BTN_REQUEST_BACKGROUND_LOCATION_PERMISSION }
             ) {
                 Text(text = LocationViewConstants.REQUEST_BACKGROUND_LOCATION_PERMISSION)
             }
@@ -134,7 +138,9 @@ fun LocationView(
                 text = LocationViewConstants.BACKGROUND_PERMISSION_GRANTED,
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.padding(horizontal = 8.dp)
+                modifier = Modifier
+                    .padding(horizontal = 8.dp)
+                    .semantics { testTag = LocationTestTags.TEXT_BACKGROUND_LOCATION_GRANTED }
             )
         }
 
@@ -337,7 +343,7 @@ private fun MapContent(
         ) {
             IconButton(
                 onClick = onToggleExpand,
-                modifier = Modifier.size(38.dp)
+                modifier = Modifier.size(38.dp).semantics { testTag = LocationTestTags.BTN_TOGGLE_MAP_EXPAND }
             ) {
                 Icon(
                     imageVector = if (isExpanded) Icons.Default.ZoomInMap else Icons.Default.ZoomOutMap,
@@ -363,7 +369,7 @@ private fun MapContent(
         ) {
             IconButton(
                 onClick = onRefreshGeofences,
-                modifier = Modifier.size(38.dp)
+                modifier = Modifier.size(38.dp).semantics { testTag = LocationTestTags.BTN_REFRESH_GEOFENCES }
             ) {
                 Icon(
                     imageVector = Icons.Default.Refresh,

--- a/sample/src/main/java/com/klaviyo/sample/SampleView.kt
+++ b/sample/src/main/java/com/klaviyo/sample/SampleView.kt
@@ -38,6 +38,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
@@ -281,8 +283,12 @@ private fun SampleViewContent(
             keyboardType = KeyboardType.Ascii,
             imeAction = ImeAction.Next,
             keyboardActions = keyboardActions,
+            testTag = SampleTestTags.FIELD_EXTERNAL_ID,
             trailingIcon = {
-                EntryTrailingButton(onClick = setExternalId)
+                EntryTrailingButton(
+                    onClick = setExternalId,
+                    modifier = Modifier.semantics { testTag = SampleTestTags.BTN_SET_EXTERNAL_ID }
+                )
             }
         )
         ProfileTextField(
@@ -292,8 +298,12 @@ private fun SampleViewContent(
             keyboardType = KeyboardType.Email,
             imeAction = ImeAction.Next,
             keyboardActions = keyboardActions,
+            testTag = SampleTestTags.FIELD_EMAIL,
             trailingIcon = {
-                EntryTrailingButton(onClick = setEmail)
+                EntryTrailingButton(
+                    onClick = setEmail,
+                    modifier = Modifier.semantics { testTag = SampleTestTags.BTN_SET_EMAIL }
+                )
             }
         )
         ProfileTextField(
@@ -303,22 +313,26 @@ private fun SampleViewContent(
             keyboardType = KeyboardType.Phone,
             imeAction = ImeAction.Send,
             keyboardActions = keyboardActions,
+            testTag = SampleTestTags.FIELD_PHONE,
             trailingIcon = {
-                EntryTrailingButton(onClick = setPhoneNumber)
+                EntryTrailingButton(
+                    onClick = setPhoneNumber,
+                    modifier = Modifier.semantics { testTag = SampleTestTags.BTN_SET_PHONE }
+                )
             }
         )
         ViewRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
             ActionButton(
                 text = UiConstants.SET_PROFILE,
                 onClick = setProfile,
-                modifier = Modifier.weight(1f)
+                modifier = Modifier.weight(1f).semantics { testTag = SampleTestTags.BTN_SET_PROFILE }
             )
 
             ActionButton(
                 text = UiConstants.RESET_PROFILE,
                 onClick = resetProfile,
                 enabled = externalId.isNotEmpty() || email.isNotEmpty() || phoneNumber.isNotEmpty(),
-                modifier = Modifier.weight(1f)
+                modifier = Modifier.weight(1f).semantics { testTag = SampleTestTags.BTN_RESET_PROFILE }
             )
         }
 
@@ -329,7 +343,7 @@ private fun SampleViewContent(
             ActionButton(
                 text = UiConstants.CREATE_TEST_EVENT,
                 onClick = createTestEvent,
-                modifier = Modifier.weight(1f),
+                modifier = Modifier.weight(1f).semantics { testTag = SampleTestTags.BTN_CREATE_TEST_EVENT },
                 icon = {
                     Icon(
                         imageVector = Icons.Default.Science,
@@ -341,12 +355,12 @@ private fun SampleViewContent(
             ActionButton(
                 text = UiConstants.VIEWED_PRODUCT,
                 onClick = createViewedProductEvent,
-                modifier = Modifier.weight(1f),
+                modifier = Modifier.weight(1f).semantics { testTag = SampleTestTags.BTN_VIEWED_PRODUCT },
                 icon = {
                     Icon(
                         imageVector = Icons.Default.ShoppingCart,
                         tint = MaterialTheme.colorScheme.primary,
-                        contentDescription = "Create Test Event"
+                        contentDescription = "Viewed Product"
                     )
                 }
             )
@@ -360,13 +374,13 @@ private fun SampleViewContent(
                 text = UiConstants.REGISTER,
                 onClick = registerForInAppForms,
                 enabled = !isFormsRegistered,
-                modifier = Modifier.weight(1f)
+                modifier = Modifier.weight(1f).semantics { testTag = SampleTestTags.BTN_REGISTER_FORMS }
             )
             ActionButton(
                 text = UiConstants.UNREGISTER,
                 onClick = unregisterFromInAppForms,
                 enabled = isFormsRegistered,
-                modifier = Modifier.weight(1f)
+                modifier = Modifier.weight(1f).semantics { testTag = SampleTestTags.BTN_UNREGISTER_FORMS }
             )
         }
 
@@ -375,12 +389,15 @@ private fun SampleViewContent(
         SectionHeader(UiConstants.PUSH_SECTION)
         ViewRow {
             if (hasNotificationPermission) {
-                Text(text = UiConstants.PERMISSION_GRANTED)
+                Text(
+                    text = UiConstants.PERMISSION_GRANTED,
+                    modifier = Modifier.semantics { testTag = SampleTestTags.TEXT_NOTIFICATION_PERMISSION_GRANTED }
+                )
             } else {
                 ActionButton(
                     text = UiConstants.REQUEST_PERMISSION,
                     onClick = requestPermission,
-                    modifier = Modifier.weight(1f)
+                    modifier = Modifier.weight(1f).semantics { testTag = SampleTestTags.BTN_REQUEST_NOTIFICATION_PERMISSION }
                 )
             }
         }
@@ -388,7 +405,11 @@ private fun SampleViewContent(
             Text(text = UiConstants.PUSH_TOKEN_LABEL, style = MaterialTheme.typography.labelMedium)
         }
         ViewRow {
-            Text(text = pushToken, style = MaterialTheme.typography.bodySmall)
+            Text(
+                text = pushToken,
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier.semantics { testTag = SampleTestTags.TEXT_PUSH_TOKEN }
+            )
         }
 
         ViewRow { HorizontalDivider(Modifier, DividerDefaults.Thickness, DividerDefaults.color) }
@@ -444,6 +465,7 @@ private fun ProfileTextField(
     keyboardType: KeyboardType,
     imeAction: ImeAction,
     keyboardActions: KeyboardActions,
+    testTag: String = "",
     trailingIcon: @Composable (() -> Unit)? = null
 ) {
     ViewRow {
@@ -454,7 +476,11 @@ private fun ProfileTextField(
             keyboardOptions = KeyboardOptions(imeAction = imeAction, keyboardType = keyboardType),
             keyboardActions = keyboardActions,
             trailingIcon = trailingIcon,
-            modifier = Modifier.weight(1f, fill = true)
+            modifier = Modifier
+                .weight(1f, fill = true)
+                .then(
+                    if (testTag.isNotEmpty()) Modifier.semantics { this.testTag = testTag } else Modifier
+                )
         )
     }
 }
@@ -481,12 +507,13 @@ private fun ActionButton(
 @Composable
 private fun EntryTrailingButton(
     text: String = "Set",
-    onClick: () -> Unit
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
 ) {
     OutlinedButton(
         onClick = onClick,
         shape = CircleShape,
-        modifier = Modifier.padding(end = 16.dp)
+        modifier = Modifier.padding(end = 16.dp).then(modifier)
     ) {
         Text(text = text)
     }

--- a/sample/src/main/java/com/klaviyo/sample/TestTags.kt
+++ b/sample/src/main/java/com/klaviyo/sample/TestTags.kt
@@ -1,0 +1,36 @@
+package com.klaviyo.sample
+
+object SampleTestTags {
+    // Profile section
+    const val FIELD_EXTERNAL_ID = "field_external_id"
+    const val FIELD_EMAIL = "field_email"
+    const val FIELD_PHONE = "field_phone_number"
+    const val BTN_SET_EXTERNAL_ID = "btn_set_external_id"
+    const val BTN_SET_EMAIL = "btn_set_email"
+    const val BTN_SET_PHONE = "btn_set_phone_number"
+    const val BTN_SET_PROFILE = "btn_set_profile"
+    const val BTN_RESET_PROFILE = "btn_reset_profile"
+
+    // Events section
+    const val BTN_CREATE_TEST_EVENT = "btn_create_test_event"
+    const val BTN_VIEWED_PRODUCT = "btn_viewed_product"
+
+    // Forms section
+    const val BTN_REGISTER_FORMS = "btn_register_forms"
+    const val BTN_UNREGISTER_FORMS = "btn_unregister_forms"
+
+    // Push section
+    const val BTN_REQUEST_NOTIFICATION_PERMISSION = "btn_request_notification_permission"
+    const val TEXT_NOTIFICATION_PERMISSION_GRANTED = "text_notification_permission_granted"
+    const val TEXT_PUSH_TOKEN = "text_push_token"
+}
+
+object LocationTestTags {
+    const val BTN_REGISTER_GEOFENCING = "btn_register_geofencing"
+    const val BTN_UNREGISTER_GEOFENCING = "btn_unregister_geofencing"
+    const val BTN_REQUEST_LOCATION_PERMISSION = "btn_request_location_permission"
+    const val BTN_REQUEST_BACKGROUND_LOCATION_PERMISSION = "btn_request_background_location_permission"
+    const val TEXT_BACKGROUND_LOCATION_GRANTED = "text_background_location_granted"
+    const val BTN_TOGGLE_MAP_EXPAND = "btn_toggle_map_expand"
+    const val BTN_REFRESH_GEOFENCES = "btn_refresh_geofences"
+}


### PR DESCRIPTION
  Description
                                                                                                                                                                                                                                                                                         
  Add accessibility testTag semantics to all key interactive elements in the Android sample app to enable reliable MCP-driven automated testing across the standard SDK flows: profile identification, event tracking, in-app forms, push notifications, and location/geofencing.      

  ---
  Due Diligence
  - I have tested this on an emulator and/or a physical device.
  - I have added sufficient unit/integration tests of my changes. (N/A — sample app UI, no logic changed)
  - I have adjusted or added new test cases to team test docs, if applicable.
  - I am confident these changes are compatible with all Android versions the SDK currently supports. (Only adds Modifier.semantics which has no minimum API level requirement)

  ---
  Release/Versioning Considerations
  - Patch Contains internal changes or backwards-compatible bug fixes.
  - Minor
  - Major
  - Contains readme or migration guide changes.
  - This is planned work for an upcoming release.

  Changes are limited to the sample app and do not affect any public SDK API surface or behavior.

  ---
  Changelog / Code Overview

  - Added TestTags.kt to the sample app — a single constants file containing SampleTestTags and LocationTestTags objects with stable string identifiers for all key UI elements.
  - Applied Modifier.semantics { testTag = ... } to interactive elements across SampleView.kt and LocationView.kt, covering:
    - Profile text fields and per-field "Set" buttons
    - Set Profile / Reset Profile buttons
    - Create Test Event / Viewed Product buttons
    - Register / Unregister In-App Forms buttons
    - Request Notification Permission button and permission status text
    - Push token display text
    - Request Location / Background Location Permission buttons and granted status text
    - Register / Unregister Geofencing buttons
    - Map expand/collapse and refresh geofences icon buttons
  - No visual or behavioral changes to the app.

  ---
  Test Plan

  1. Build and install the sample app (./gradlew :sample:installDebug)
  2. Connect a device/emulator via ADB
  3. Use uiautomatorviewer or an MCP device tool to inspect the UI — confirm elements are findable by their testTag resource IDs (e.g. field_external_id, btn_set_profile, btn_register_forms, etc.)
  4. Verify no visual regressions in the app UI

  ---
  Related Issues/Tickets

  - https://linear.app/klaviyo/issue/MAGE-432/android-sample-app-add-a11y-labels-for-mcp-testability
  - https://klaviyo.atlassian.net/browse/MAG-224
