### PR TITLE
fix: remove WebMessageListener before WebView.destroy() to prevent memory leaks

### DIFF
--- a/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
@@ -11,6 +11,9 @@ import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import android.webkit.WebViewClient as AndroidWebViewClient
 import androidx.core.net.toUri
+import androidx.webkit.WebViewCompat
+import androidx.webkit.WebViewFeature.WEB_MESSAGE_LISTENER
+import androidx.webkit.WebViewFeature.isFeatureSupported
 import com.klaviyo.core.Registry
 import com.klaviyo.core.config.Clock
 import com.klaviyo.core.utils.WeakReferenceDelegate
@@ -141,6 +144,18 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
         webView?.let { webView ->
             Registry.threadHelper.runOnUiThread {
                 Registry.log.verbose("Clear IAF WebView reference")
+                val nativeBridge = Registry.get<NativeBridge>()
+
+                if (isFeatureSupported(WEB_MESSAGE_LISTENER)) {
+                    // Explicitly remove the listener: On some vendors' implementation of webview,
+                    // failure to remove the listener results in a memory leak.
+                    WebViewCompat.removeWebMessageListener(webView, nativeBridge.name)
+                } else {
+                    // For completeness, remove the JS interface if WEB_MESSAGE_LISTENER
+                    // is not supported, although [destroy] should clean this up internally
+                    webView.removeJavascriptInterface(nativeBridge.name)
+                }
+
                 webView.destroy()
                 this.webView = null
             }

--- a/sdk/forms/src/test/java/com/klaviyo/forms/webview/KlaviyoWebViewClientTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/webview/KlaviyoWebViewClientTest.kt
@@ -151,6 +151,9 @@ class KlaviyoWebViewClientTest : BaseTest() {
 
         mockkStatic(WebViewCompat::class)
         every { WebViewCompat.addWebMessageListener(any(), any(), any(), any()) } just runs
+        every { WebViewCompat.removeWebMessageListener(any(), any()) } just runs
+
+        every { anyConstructed<KlaviyoWebView>().removeJavascriptInterface(any()) } just runs
     }
 
     @After
@@ -343,6 +346,28 @@ class KlaviyoWebViewClientTest : BaseTest() {
         verify { mockThreadHelper.runOnUiThread(any()) }
 
         verifyDestroy()
+    }
+
+    @Test
+    fun `destroyWebView removes WebMessageListener when supported`() {
+        val client = KlaviyoWebViewClient()
+        client.initializeWebView()
+        client.destroyWebView()
+
+        verify { WebViewCompat.removeWebMessageListener(any(), eq("MockNativeBridge")) }
+    }
+
+    @Test
+    fun `destroyWebView removes JavascriptInterface when WebMessageListener unsupported`() {
+        every { WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER) } returns false
+        every { anyConstructed<KlaviyoWebView>().addJavascriptInterface(any(), any()) } just runs
+
+        val client = KlaviyoWebViewClient()
+        client.initializeWebView()
+        client.destroyWebView()
+
+        verify { anyConstructed<KlaviyoWebView>().removeJavascriptInterface(eq("MockNativeBridge")) }
+        verify(inverse = true) { WebViewCompat.removeWebMessageListener(any(), any()) }
     }
 
     @Test


### PR DESCRIPTION
# Description
Adds defensive cleanup in `destroyWebView()` by calling `WebViewCompat.removeWebMessageListener()` before `webView.destroy()`. The listener registered during WebView initialization was never explicitly removed, which can cause memory leaks on devices with vendor-specific WebView implementations that retain internal references after `destroy()` is called.

## Due Diligence
- [ ] I have tested this on an emulator and/or a physical device.
- [ ] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all Android versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

## Changelog / Code Overview
- `KlaviyoWebViewClient.destroyWebView()`: added a feature-detection guard (`isFeatureSupported(WEB_MESSAGE_LISTENER)`) and a call to `WebViewCompat.removeWebMessageListener(webView, nativeBridge.name)` immediately before `webView.destroy()`.
- No public API changes; purely defensive cleanup in teardown path.

## Test Plan
1. Launch a form in-app on a device/emulator.
2. Navigate away so the form is dismissed and `destroyWebView()` is triggered.
3. Verify no crash or error log related to WebMessageListener removal.
4. Run existing forms unit tests: `./gradlew :sdk:forms:testDebugUnitTest`

## Related Issues/Tickets
- Closes #430
- Part of MAGE-457