### PR TITLE
fix(push): dismiss notification on action button tap

### DIFF
--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -342,7 +342,7 @@ object Klaviyo {
             intent?.getStringExtra(Constants.NOTIFICATION_TAG_EXTRA)?.let { tag ->
                 NotificationManagerCompat
                     .from(Registry.config.applicationContext)
-                    .cancel(tag, 0)
+                    .cancel(tag, Constants.NOTIFICATION_ID)
             }
         }?.safeApply {
             // If a Klaviyo notification is deep linked, invoke the developer's deep link handler

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import androidx.core.app.NotificationManagerCompat
 import androidx.core.net.toUri
 import com.klaviyo.analytics.linking.DeepLinkHandler
 import com.klaviyo.analytics.linking.DeepLinking
@@ -17,6 +18,7 @@ import com.klaviyo.analytics.networking.KlaviyoApiClient
 import com.klaviyo.analytics.state.KlaviyoState
 import com.klaviyo.analytics.state.State
 import com.klaviyo.analytics.state.StateSideEffects
+import com.klaviyo.core.Constants
 import com.klaviyo.core.Constants.KEY_VALUE_PAIRS
 import com.klaviyo.core.Constants.PACKAGE_PREFIX
 import com.klaviyo.core.Constants.TRACKING_PARAMETER
@@ -333,6 +335,15 @@ object Klaviyo {
 
             // Not using createEvent here to avoid nested safeApply calls
             Registry.get<State>().createEvent(event, Registry.get<State>().getAsProfile())
+        }?.safeApply {
+            // Dismiss the notification if opened via an action button.
+            // Body taps are handled by setAutoCancel(true) on the notification builder,
+            // but action button taps don't trigger auto-cancel (standard Android behavior).
+            intent?.getStringExtra(Constants.NOTIFICATION_TAG_EXTRA)?.let { tag ->
+                NotificationManagerCompat
+                    .from(Registry.config.applicationContext)
+                    .cancel(tag, 0)
+            }
         }?.safeApply {
             // If a Klaviyo notification is deep linked, invoke the developer's deep link handler
             // if registered. If not, do nothing. The host already received the appropriate intent.

--- a/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
@@ -18,4 +18,10 @@ object Constants {
      * Klaviyo push messages contain metadata to associate an event with its original transmission
      */
     const val TRACKING_PARAMETER = "_k"
+
+    /**
+     * Intent extra key for the notification tag, used to dismiss the notification
+     * when an action button is tapped and [handlePush] processes the intent
+     */
+    const val NOTIFICATION_TAG_EXTRA = PACKAGE_PREFIX + "notification_tag"
 }

--- a/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
@@ -24,4 +24,10 @@ object Constants {
      * when an action button is tapped and [handlePush] processes the intent
      */
     const val NOTIFICATION_TAG_EXTRA = PACKAGE_PREFIX + "notification_tag"
+
+    /**
+     * Fixed notification ID used in all notify/cancel calls.
+     * Notifications are uniquely identified by their string tag, not this ID.
+     */
+    const val NOTIFICATION_ID = 0
 }

--- a/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
@@ -21,9 +21,13 @@ object Constants {
 
     /**
      * Intent extra key for the notification tag, used to dismiss the notification
-     * when an action button is tapped and [handlePush] processes the intent
+     * when an action button is tapped and [handlePush] processes the intent.
+     *
+     * Uses [INTERNAL_PREFIX] instead of [PACKAGE_PREFIX] to avoid being swept into
+     * analytics event properties by [appendKlaviyoExtras].
      */
-    const val NOTIFICATION_TAG_EXTRA = PACKAGE_PREFIX + "notification_tag"
+    private const val INTERNAL_PREFIX = "_klaviyo."
+    const val NOTIFICATION_TAG_EXTRA = INTERNAL_PREFIX + "notification_tag"
 
     /**
      * Fixed notification ID used in all notify/cancel calls.

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoNotification.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoNotification.kt
@@ -161,7 +161,7 @@ class KlaviyoNotification(private val message: RemoteMessage) {
      */
     internal fun buildNotification(
         context: Context,
-        notificationTag: String = message.notificationTag ?: generateId().toString()
+        notificationTag: String
     ): NotificationCompat.Builder {
         val requestCodeBase = generateId()
         return NotificationCompat.Builder(context, message.channel_id)

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoNotification.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoNotification.kt
@@ -77,6 +77,11 @@ class KlaviyoNotification(private val message: RemoteMessage) {
         private const val ACTION_REQUEST_CODE_OFFSET = 1
 
         /**
+         * @see Constants.NOTIFICATION_ID
+         */
+        private const val NOTIFICATION_ID = Constants.NOTIFICATION_ID
+
+        /**
          * Get an integer ID to associate with a notification or its pending intent
          * The notification system service will de-dupe on this if we get a null
          * notification tag from the payload
@@ -127,7 +132,7 @@ class KlaviyoNotification(private val message: RemoteMessage) {
 
         NotificationManagerCompat
             .from(context)
-            .notify(notificationTag, 0, notification.build())
+            .notify(notificationTag, NOTIFICATION_ID, notification.build())
 
         return true
     }

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoNotification.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoNotification.kt
@@ -119,14 +119,15 @@ class KlaviyoNotification(private val message: RemoteMessage) {
 
         createNotificationChannel(context)
 
-        val notification = buildNotification(context)
+        val notificationTag = message.notificationTag ?: generateId().toString()
+        val notification = buildNotification(context, notificationTag)
 
         // Check for valid rich push image url, download and apply to the notification
         message.imageUrl?.applyToNotification(builder = notification)
 
         NotificationManagerCompat
             .from(context)
-            .notify(message.notificationTag ?: generateId().toString(), 0, notification.build())
+            .notify(notificationTag, 0, notification.build())
 
         return true
     }
@@ -153,7 +154,10 @@ class KlaviyoNotification(private val message: RemoteMessage) {
      * @param context
      * @return [Notification.Builder] to display
      */
-    internal fun buildNotification(context: Context): NotificationCompat.Builder {
+    internal fun buildNotification(
+        context: Context,
+        notificationTag: String = message.notificationTag ?: generateId().toString()
+    ): NotificationCompat.Builder {
         val requestCodeBase = generateId()
         return NotificationCompat.Builder(context, message.channel_id)
             .setContentIntent(makePendingIntent(context, requestCodeBase))
@@ -166,7 +170,7 @@ class KlaviyoNotification(private val message: RemoteMessage) {
             .setNumber(message.notificationCount)
             .setPriority(message.notificationPriority)
             .setAutoCancel(true)
-            .addActionButtons(context, requestCodeBase)
+            .addActionButtons(context, requestCodeBase, notificationTag)
     }
 
     private fun URL.applyToNotification(builder: NotificationCompat.Builder) {
@@ -260,7 +264,8 @@ class KlaviyoNotification(private val message: RemoteMessage) {
      */
     private fun NotificationCompat.Builder.addActionButtons(
         context: Context,
-        requestCodeBase: Int
+        requestCodeBase: Int,
+        notificationTag: String
     ): NotificationCompat.Builder {
         val actionButtons = message.actionButtons ?: return this
 
@@ -269,7 +274,7 @@ class KlaviyoNotification(private val message: RemoteMessage) {
             // request codes need to be unique, add index + offset to generate unique code
             // offset required due to zero index, so body and first button have unique codes
             val requestCode = requestCodeBase + index + ACTION_REQUEST_CODE_OFFSET
-            val action = createButtonAction(context, index, requestCode, button) ?: return@forEachIndexed
+            val action = createButtonAction(context, index, requestCode, button, notificationTag) ?: return@forEachIndexed
             addAction(action)
 
             val actionType = when (button) {
@@ -294,7 +299,8 @@ class KlaviyoNotification(private val message: RemoteMessage) {
         context: Context,
         index: Int,
         requestCode: Int,
-        button: ActionButton
+        button: ActionButton,
+        notificationTag: String
     ): NotificationCompat.Action? {
         val intent = when (button) {
             is ActionButton.DeepLink -> {
@@ -310,6 +316,7 @@ class KlaviyoNotification(private val message: RemoteMessage) {
             }
         }?.apply {
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            putExtra(Constants.NOTIFICATION_TAG_EXTRA, notificationTag)
         }?.appendKlaviyoExtras(message)
             ?.appendActionButtonExtras(button)
 

--- a/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoNotificationTest.kt
+++ b/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoNotificationTest.kt
@@ -648,7 +648,7 @@ class KlaviyoNotificationTest : BaseTest() {
 
         verify {
             mockLaunchIntent.putExtra(
-                "com.klaviyo.notification_tag",
+                "_klaviyo.notification_tag",
                 "test_tag"
             )
         }
@@ -681,7 +681,7 @@ class KlaviyoNotificationTest : BaseTest() {
         // Should still have a notification tag extra (generated from timestamp)
         verify {
             mockLaunchIntent.putExtra(
-                "com.klaviyo.notification_tag",
+                "_klaviyo.notification_tag",
                 any<String>()
             )
         }

--- a/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoNotificationTest.kt
+++ b/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoNotificationTest.kt
@@ -141,7 +141,7 @@ class KlaviyoNotificationTest : BaseTest() {
     fun `displayNotification calls buildNotification with context`() {
         notification.displayNotification(mockContext)
 
-        verify { notification.buildNotification(mockContext) }
+        verify { notification.buildNotification(mockContext, any()) }
     }
 
     @Test
@@ -149,7 +149,7 @@ class KlaviyoNotificationTest : BaseTest() {
         val result = notification.displayNotification(mockContext)
 
         assertTrue(result)
-        verify { notification.buildNotification(mockContext) }
+        verify { notification.buildNotification(mockContext, any()) }
         verify { mockNotificationManager.notify(any<String>(), eq(0), any()) }
     }
 
@@ -618,6 +618,71 @@ class KlaviyoNotificationTest : BaseTest() {
             mockDeepLinkIntent.putExtra(
                 "com.klaviyo.Button Link",
                 "klaviyotest://order/123"
+            )
+        }
+    }
+
+    @Test
+    fun `action button intent includes notification tag for dismissal`() {
+        val mockLaunchIntent = spyk<Intent>()
+
+        with(KlaviyoRemoteMessage) {
+            every { mockRemoteMessage.notificationTag } returns "test_tag"
+            every { mockRemoteMessage.actionButtons } returns listOf(
+                ActionButton.OpenApp(
+                    id = "open",
+                    label = "Open"
+                )
+            )
+        }
+
+        every { DeepLinking.makeLaunchIntent(any()) } returns mockLaunchIntent
+        every { mockLaunchIntent.putExtra(any<String>(), any<String>()) } returns mockLaunchIntent
+        every { mockLaunchIntent.addFlags(any()) } returns mockLaunchIntent
+
+        every {
+            PendingIntent.getActivity(any(), any(), any(), any())
+        } returns mockk(relaxed = true)
+
+        notification.displayNotification(mockContext)
+
+        verify {
+            mockLaunchIntent.putExtra(
+                "com.klaviyo.notification_tag",
+                "test_tag"
+            )
+        }
+    }
+
+    @Test
+    fun `action button intent includes generated tag when no notification tag in payload`() {
+        val mockLaunchIntent = spyk<Intent>()
+
+        with(KlaviyoRemoteMessage) {
+            every { mockRemoteMessage.notificationTag } returns null
+            every { mockRemoteMessage.actionButtons } returns listOf(
+                ActionButton.OpenApp(
+                    id = "open",
+                    label = "Open"
+                )
+            )
+        }
+
+        every { DeepLinking.makeLaunchIntent(any()) } returns mockLaunchIntent
+        every { mockLaunchIntent.putExtra(any<String>(), any<String>()) } returns mockLaunchIntent
+        every { mockLaunchIntent.addFlags(any()) } returns mockLaunchIntent
+
+        every {
+            PendingIntent.getActivity(any(), any(), any(), any())
+        } returns mockk(relaxed = true)
+
+        notification.displayNotification(mockContext)
+
+        // Should still have a notification tag extra (generated from timestamp)
+        verify {
+            mockLaunchIntent.putExtra(
+                "com.klaviyo.notification_tag",
+                any<String>()
             )
         }
     }


### PR DESCRIPTION
## Summary
- `setAutoCancel(true)` only dismisses notifications on body tap, not action button taps (standard Android behavior)
- Action button intents now carry the notification tag as an extra (`NOTIFICATION_TAG_EXTRA`)
- `handlePush()` cancels the notification via `NotificationManagerCompat` when it sees this extra
- Notification tag is computed once in `displayNotification` and threaded through to `buildNotification` → `addActionButtons` → `createButtonAction`

## Test plan
- [ ] Existing tests pass (2 updated for new `buildNotification` signature)
- [ ] New test: action button intent includes notification tag from payload
- [ ] New test: action button intent includes generated tag when payload has no tag
- [ ] Manual: send push with action buttons → tap button → notification dismisses
- [ ] Manual: send push without action buttons → tap body → still auto-cancels (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)