### PR TITLE
fix(forms): floating form offset clamping + data-klaviyo-device device info

### DIFF
--- a/sdk/forms/src/main/assets/InAppFormsTemplate.html
+++ b/sdk/forms/src/main/assets/InAppFormsTemplate.html
@@ -7,6 +7,7 @@
       data-forms-data-environment='FORMS_ENVIRONMENT'
       data-klaviyo-local-tracking="1"
       data-klaviyo-profile="{}"
+      data-klaviyo-device='DEVICE_INFO'
 >
     <meta charset="UTF-8">
     <meta name="viewport"

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/DeviceInfo.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/DeviceInfo.kt
@@ -70,6 +70,13 @@ internal data class DeviceInfo(
              * Android's rotation values describe the counter-clockwise rotation applied to the
              * natural orientation; pairing that with whether the logical orientation is portrait
              * or landscape gives us enough to pick the `*-primary` vs `*-secondary` flavor.
+             *
+             * Caveat: this mapping assumes a natural-portrait device, which holds for all phones
+             * and is sufficient for our product scope. On natural-landscape devices (some tablets
+             * and foldables) the rotation-to-CSSOM mapping may diverge from
+             * [`screen.orientation.type`](https://drafts.csswg.org/screen-orientation/#dom-screenorientation-type):
+             * for example, `rotation = 90` on a natural-landscape device is reported here as
+             * `portrait-secondary`, where the web platform would report `portrait-primary`.
              */
             fun from(configOrientation: Int, rotation: Int): Orientation {
                 val isPortrait = configOrientation != Configuration.ORIENTATION_LANDSCAPE

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/DeviceInfo.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/DeviceInfo.kt
@@ -1,0 +1,184 @@
+package com.klaviyo.forms.bridge
+
+import android.content.res.Configuration
+import android.content.res.Resources
+import android.util.DisplayMetrics
+import android.view.Surface
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsCompat.Type.displayCutout
+import androidx.core.view.WindowInsetsCompat.Type.systemBars
+import com.klaviyo.core.Registry
+import kotlin.math.roundToInt
+import org.json.JSONObject
+
+/**
+ * Describes the device's current physical display characteristics, exposed to onsite JS
+ * via the `data-klaviyo-device` attribute on the HTML `<head>` element.
+ *
+ * The shape intentionally mirrors CSSOM conventions so onsite code can treat the payload
+ * as a reliable, orientation-aware substitute for `window.screen.*` during the synchronous
+ * HTML parse phase, before the webview attaches to the view hierarchy.
+ */
+internal data class DeviceInfo(
+    val screenWidthDp: Int,
+    val screenHeightDp: Int,
+    val insetTopDp: Int,
+    val insetBottomDp: Int,
+    val insetLeftDp: Int,
+    val insetRightDp: Int,
+    val orientation: Orientation,
+    val dpr: Int
+) {
+    /**
+     * Serializes the device info into its JSON representation as published on the
+     * `data-klaviyo-device` head attribute.
+     */
+    fun toJson(): String = JSONObject()
+        .put(
+            KEY_SCREEN,
+            JSONObject()
+                .put(KEY_WIDTH, screenWidthDp)
+                .put(KEY_HEIGHT, screenHeightDp)
+        )
+        .put(
+            KEY_SAFE_AREA_INSETS,
+            JSONObject()
+                .put(KEY_TOP, insetTopDp)
+                .put(KEY_BOTTOM, insetBottomDp)
+                .put(KEY_LEFT, insetLeftDp)
+                .put(KEY_RIGHT, insetRightDp)
+        )
+        .put(KEY_ORIENTATION, orientation.cssValue)
+        .put(KEY_DPR, dpr)
+        .toString()
+
+    /**
+     * CSSOM `ScreenOrientation.type` vocabulary.
+     * See https://drafts.csswg.org/screen-orientation/#enumdef-orientationtype
+     */
+    internal enum class Orientation(val cssValue: String) {
+        PortraitPrimary("portrait-primary"),
+        PortraitSecondary("portrait-secondary"),
+        LandscapePrimary("landscape-primary"),
+        LandscapeSecondary("landscape-secondary");
+
+        companion object {
+            /**
+             * Derives the CSSOM orientation label from the Android [Configuration.orientation]
+             * and [android.view.Display.getRotation] values.
+             *
+             * Android's rotation values describe the counter-clockwise rotation applied to the
+             * natural orientation; pairing that with whether the logical orientation is portrait
+             * or landscape gives us enough to pick the `*-primary` vs `*-secondary` flavor.
+             */
+            fun from(configOrientation: Int, rotation: Int): Orientation {
+                val isPortrait = configOrientation != Configuration.ORIENTATION_LANDSCAPE
+                return when (rotation) {
+                    Surface.ROTATION_0 -> if (isPortrait) PortraitPrimary else LandscapePrimary
+                    Surface.ROTATION_90 -> if (isPortrait) PortraitSecondary else LandscapePrimary
+                    Surface.ROTATION_180 -> if (isPortrait) PortraitSecondary else LandscapeSecondary
+                    Surface.ROTATION_270 -> if (isPortrait) PortraitPrimary else LandscapeSecondary
+                    else -> if (isPortrait) PortraitPrimary else LandscapePrimary
+                }
+            }
+        }
+    }
+
+    companion object {
+        private const val KEY_SCREEN = "screen"
+        private const val KEY_WIDTH = "width"
+        private const val KEY_HEIGHT = "height"
+        private const val KEY_SAFE_AREA_INSETS = "safeAreaInsets"
+        private const val KEY_TOP = "top"
+        private const val KEY_BOTTOM = "bottom"
+        private const val KEY_LEFT = "left"
+        private const val KEY_RIGHT = "right"
+        private const val KEY_ORIENTATION = "orientation"
+        private const val KEY_DPR = "dpr"
+
+        /**
+         * Build a [DeviceInfo] snapshot from the given display metrics and insets.
+         *
+         * Separating computation from Android platform lookups keeps the logic pure and
+         * testable. See [DeviceInfoProvider] for the live-device lookup entry point.
+         */
+        fun from(
+            displayMetrics: DisplayMetrics,
+            configuration: Configuration,
+            rotation: Int,
+            insetLeftPx: Int,
+            insetTopPx: Int,
+            insetRightPx: Int,
+            insetBottomPx: Int
+        ): DeviceInfo {
+            // Guard against pathological DisplayMetrics (density <= 0) which would cause
+            // NaN from pxToDp. This most commonly occurs in test doubles.
+            val safeDensity = displayMetrics.density.takeIf { it > 0f } ?: 1f
+            fun pxToDpRounded(px: Int): Int = (px / safeDensity).roundToInt()
+            return DeviceInfo(
+                screenWidthDp = pxToDpRounded(displayMetrics.widthPixels),
+                screenHeightDp = pxToDpRounded(displayMetrics.heightPixels),
+                insetTopDp = pxToDpRounded(insetTopPx),
+                insetBottomDp = pxToDpRounded(insetBottomPx),
+                insetLeftDp = pxToDpRounded(insetLeftPx),
+                insetRightDp = pxToDpRounded(insetRightPx),
+                orientation = Orientation.from(configuration.orientation, rotation),
+                dpr = safeDensity.roundToInt().coerceAtLeast(1)
+            )
+        }
+    }
+}
+
+/**
+ * Live-device lookup for [DeviceInfo]. Reads from the currently tracked activity when available,
+ * falling back to the system-wide resources so early callers (before activity attachment) still
+ * produce a reasonable snapshot.
+ */
+internal object DeviceInfoProvider {
+
+    /**
+     * Snapshot the current device state. Prefers values from the tracked activity so that
+     * safe-area insets and rotation reflect the actual window placement rather than the raw
+     * display.
+     */
+    fun current(): DeviceInfo {
+        val activity = Registry.lifecycleMonitor.currentActivity
+        val resources = activity?.resources ?: Resources.getSystem()
+        val displayMetrics = resources.displayMetrics
+        val configuration = resources.configuration
+
+        val rotation = runCatching {
+            @Suppress("DEPRECATION")
+            activity?.windowManager?.defaultDisplay?.rotation ?: Surface.ROTATION_0
+        }.getOrDefault(Surface.ROTATION_0)
+
+        data class InsetsPx(val left: Int, val top: Int, val right: Int, val bottom: Int)
+        val insetsPx = runCatching {
+            activity?.window?.decorView?.rootWindowInsets?.let { raw ->
+                val compat = WindowInsetsCompat.toWindowInsetsCompat(raw)
+                val insets = compat.getInsets(systemBars() or displayCutout())
+                InsetsPx(insets.left, insets.top, insets.right, insets.bottom)
+            }
+        }.getOrNull() ?: InsetsPx(0, 0, 0, 0)
+
+        return DeviceInfo.from(
+            displayMetrics = displayMetrics,
+            configuration = configuration,
+            rotation = rotation,
+            insetLeftPx = insetsPx.left,
+            insetTopPx = insetsPx.top,
+            insetRightPx = insetsPx.right,
+            insetBottomPx = insetsPx.bottom
+        )
+    }
+}
+
+/**
+ * Escapes a JSON payload for embedding inside a single-quoted JS string literal.
+ *
+ * Only backslashes and single quotes need escaping — JSON is otherwise JS-safe because
+ * [JSONObject] already escapes double quotes, control characters, and non-ASCII characters.
+ */
+internal fun String.jsEscape(): String = this
+    .replace("\\", "\\\\")
+    .replace("'", "\\'")

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/DeviceInfo.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/DeviceInfo.kt
@@ -3,7 +3,6 @@ package com.klaviyo.forms.bridge
 import android.content.res.Configuration
 import android.content.res.Resources
 import android.os.Build
-import android.util.DisplayMetrics
 import android.view.Surface
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsCompat.Type.displayCutout
@@ -111,7 +110,9 @@ internal data class DeviceInfo(
          * testable. See [DeviceInfoProvider] for the live-device lookup entry point.
          */
         fun from(
-            displayMetrics: DisplayMetrics,
+            screenWidthPx: Int,
+            screenHeightPx: Int,
+            density: Float,
             configuration: Configuration,
             rotation: Int,
             insetLeftPx: Int,
@@ -119,13 +120,13 @@ internal data class DeviceInfo(
             insetRightPx: Int,
             insetBottomPx: Int
         ): DeviceInfo {
-            // Guard against pathological DisplayMetrics (density <= 0) which would cause
-            // NaN from pxToDp. This most commonly occurs in test doubles.
-            val safeDensity = displayMetrics.density.takeIf { it > 0f } ?: 1f
+            // Guard against pathological density (<= 0) which would cause NaN from pxToDp.
+            // This most commonly occurs in test doubles.
+            val safeDensity = density.takeIf { it > 0f } ?: 1f
             fun pxToDpRounded(px: Int): Int = (px / safeDensity).roundToInt()
             return DeviceInfo(
-                screenWidthDp = pxToDpRounded(displayMetrics.widthPixels),
-                screenHeightDp = pxToDpRounded(displayMetrics.heightPixels),
+                screenWidthDp = pxToDpRounded(screenWidthPx),
+                screenHeightDp = pxToDpRounded(screenHeightPx),
                 insetTopDp = pxToDpRounded(insetTopPx),
                 insetBottomDp = pxToDpRounded(insetBottomPx),
                 insetLeftDp = pxToDpRounded(insetLeftPx),
@@ -152,8 +153,21 @@ internal object DeviceInfoProvider {
     fun current(): DeviceInfo {
         val activity = Registry.lifecycleMonitor.currentActivity
         val resources = activity?.resources ?: Resources.getSystem()
-        val displayMetrics = resources.displayMetrics
         val configuration = resources.configuration
+        val density = resources.displayMetrics.density
+
+        // Source window dimensions from `currentWindowMetrics` on API 30+ so we report the
+        // activity's actual drawable rect in multi-window scenarios (matches the offset-math
+        // path in FloatingFormWindow). Fall back to resources.displayMetrics on older APIs,
+        // which is activity-scoped and already window-aware post-N in practice.
+        val (screenWidthPx, screenHeightPx) = runCatching {
+            if (activity != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                val bounds = activity.windowManager.currentWindowMetrics.bounds
+                bounds.width() to bounds.height()
+            } else {
+                resources.displayMetrics.let { it.widthPixels to it.heightPixels }
+            }
+        }.getOrElse { resources.displayMetrics.let { it.widthPixels to it.heightPixels } }
 
         val rotation = runCatching {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
@@ -174,7 +188,9 @@ internal object DeviceInfoProvider {
         }.getOrNull() ?: InsetsPx(0, 0, 0, 0)
 
         return DeviceInfo.from(
-            displayMetrics = displayMetrics,
+            screenWidthPx = screenWidthPx,
+            screenHeightPx = screenHeightPx,
+            density = density,
             configuration = configuration,
             rotation = rotation,
             insetLeftPx = insetsPx.left,

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/DeviceInfo.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/DeviceInfo.kt
@@ -184,13 +184,3 @@ internal object DeviceInfoProvider {
         )
     }
 }
-
-/**
- * Escapes a JSON payload for embedding inside a single-quoted JS string literal.
- *
- * Only backslashes and single quotes need escaping — JSON is otherwise JS-safe because
- * [JSONObject] already escapes double quotes, control characters, and non-ASCII characters.
- */
-internal fun String.jsEscape(): String = this
-    .replace("\\", "\\\\")
-    .replace("'", "\\'")

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/DeviceInfo.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/DeviceInfo.kt
@@ -2,6 +2,7 @@ package com.klaviyo.forms.bridge
 
 import android.content.res.Configuration
 import android.content.res.Resources
+import android.os.Build
 import android.util.DisplayMetrics
 import android.view.Surface
 import androidx.core.view.WindowInsetsCompat
@@ -155,8 +156,12 @@ internal object DeviceInfoProvider {
         val configuration = resources.configuration
 
         val rotation = runCatching {
-            @Suppress("DEPRECATION")
-            activity?.windowManager?.defaultDisplay?.rotation ?: Surface.ROTATION_0
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                activity?.display
+            } else {
+                @Suppress("DEPRECATION")
+                activity?.windowManager?.defaultDisplay
+            }?.rotation ?: Surface.ROTATION_0
         }.getOrDefault(Surface.ROTATION_0)
 
         data class InsetsPx(val left: Int, val top: Int, val right: Int, val bottom: Int)

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/FormLayout.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/FormLayout.kt
@@ -17,16 +17,6 @@ internal enum class FormPosition {
     CENTER;
 
     /**
-     * Returns true if this position uses horizontal centering (CENTER_HORIZONTAL or CENTER).
-     * These positions need width adjusted for horizontal safe area insets so forms
-     * don't extend into display cutouts in landscape.
-     */
-    fun isHorizontallyCentered(): Boolean = when (this) {
-        TOP, BOTTOM, CENTER, FULLSCREEN -> true
-        TOP_LEFT, TOP_RIGHT, BOTTOM_LEFT, BOTTOM_RIGHT -> false
-    }
-
-    /**
      * Convert form position to Android Gravity flags
      */
     fun toGravity(): Int = when (this) {

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/FormLayout.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/FormLayout.kt
@@ -1,8 +1,6 @@
 package com.klaviyo.forms.bridge
 
 import android.view.Gravity
-import com.klaviyo.core.Registry
-import java.util.concurrent.atomic.AtomicBoolean
 import org.json.JSONObject
 
 /**
@@ -155,15 +153,6 @@ internal data class FormLayout(
         get() = position == FormPosition.FULLSCREEN
 
     companion object {
-        /**
-         * Guards the one-time deprecation log emitted when a payload uses the legacy
-         * `margin` wire key instead of the new `offsets` key. Scoped to the process
-         * lifetime — the webview is re-created per session, so this effectively emits
-         * at most once per webview session (and at most once per process, whichever
-         * comes first).
-         */
-        private val loggedMarginDeprecation = AtomicBoolean(false)
-
         fun fromJson(json: JSONObject?): FormLayout? {
             if (json == null) return null
 
@@ -171,18 +160,7 @@ internal data class FormLayout(
             val width = Dimension.fromJson(json.optJSONObject("width")) ?: return null
             val height = Dimension.fromJson(json.optJSONObject("height")) ?: return null
 
-            // Prefer the new `offsets` wire key; fall back to legacy `margin` for
-            // backward compatibility with older onsite payloads. Log once per session
-            // when we hit the fallback so we can track deprecation in the wild.
-            val offsetsJson = json.optJSONObject("offsets") ?: json.optJSONObject("margin")?.also {
-                if (loggedMarginDeprecation.compareAndSet(false, true)) {
-                    Registry.log.verbose(
-                        "FormLayout payload used deprecated `margin` key; " +
-                            "expected `offsets`. Update onsite to emit `offsets`."
-                    )
-                }
-            }
-            val offsets = Offsets.fromJson(offsetsJson)
+            val offsets = Offsets.fromJson(json.optJSONObject("offsets"))
             val addSafeAreaInsetsToOffsets = json.optBoolean("addSafeAreaInsetsToOffsets", true)
 
             return FormLayout(

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/FormLayout.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/FormLayout.kt
@@ -1,6 +1,8 @@
 package com.klaviyo.forms.bridge
 
 import android.view.Gravity
+import com.klaviyo.core.Registry
+import java.util.concurrent.atomic.AtomicBoolean
 import org.json.JSONObject
 
 /**
@@ -137,7 +139,14 @@ internal data class FormLayout(
     val position: FormPosition,
     val width: Dimension,
     val height: Dimension,
-    val offsets: Offsets = Offsets()
+    val offsets: Offsets = Offsets(),
+    /**
+     * When true (default), the SDK adds safe-area insets to the provided [offsets]
+     * when positioning the form. When false, the SDK uses [offsets] as-is and does
+     * not account for safe-area at all — onsite is fully responsible for baking
+     * any safe-area inset it wants into [offsets].
+     */
+    val addSafeAreaInsetsToOffsets: Boolean = true
 ) {
     /**
      * Returns true if this layout represents a fullscreen form
@@ -146,19 +155,42 @@ internal data class FormLayout(
         get() = position == FormPosition.FULLSCREEN
 
     companion object {
+        /**
+         * Guards the one-time deprecation log emitted when a payload uses the legacy
+         * `margin` wire key instead of the new `offsets` key. Scoped to the process
+         * lifetime — the webview is re-created per session, so this effectively emits
+         * at most once per webview session (and at most once per process, whichever
+         * comes first).
+         */
+        private val loggedMarginDeprecation = AtomicBoolean(false)
+
         fun fromJson(json: JSONObject?): FormLayout? {
             if (json == null) return null
 
             val position = FormPosition.fromString(json.optString("position"))
             val width = Dimension.fromJson(json.optJSONObject("width")) ?: return null
             val height = Dimension.fromJson(json.optJSONObject("height")) ?: return null
-            val offsets = Offsets.fromJson(json.optJSONObject("margin"))
+
+            // Prefer the new `offsets` wire key; fall back to legacy `margin` for
+            // backward compatibility with older onsite payloads. Log once per session
+            // when we hit the fallback so we can track deprecation in the wild.
+            val offsetsJson = json.optJSONObject("offsets") ?: json.optJSONObject("margin")?.also {
+                if (loggedMarginDeprecation.compareAndSet(false, true)) {
+                    Registry.log.verbose(
+                        "FormLayout payload used deprecated `margin` key; " +
+                            "expected `offsets`. Update onsite to emit `offsets`."
+                    )
+                }
+            }
+            val offsets = Offsets.fromJson(offsetsJson)
+            val addSafeAreaInsetsToOffsets = json.optBoolean("addSafeAreaInsetsToOffsets", true)
 
             return FormLayout(
                 position = position,
                 width = width,
                 height = height,
-                offsets = offsets
+                offsets = offsets,
+                addSafeAreaInsetsToOffsets = addSafeAreaInsetsToOffsets
             )
         }
     }

--- a/sdk/forms/src/main/java/com/klaviyo/forms/presentation/FloatingFormWindow.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/presentation/FloatingFormWindow.kt
@@ -455,10 +455,20 @@ internal class FloatingFormWindow(private val context: Context) {
                 return ComputedLayout(width = screenWidth, height = screenHeight, x = 0, y = 0)
             }
 
-            val marginTop = safeAreaTop + (layout.offsets.top * density).toInt()
-            val marginBottom = safeAreaBottom + (layout.offsets.bottom * density).toInt()
-            val marginLeft = safeAreaLeft + (layout.offsets.left * density).toInt()
-            val marginRight = safeAreaRight + (layout.offsets.right * density).toInt()
+            // When addSafeAreaInsetsToOffsets=false, onsite owns safe-area handling end-to-end:
+            // offsets are treated as the absolute distance from the screen edge and the
+            // SDK does not touch safe-area at all (position math and clamping both skip
+            // the safe-area term). Default (true) preserves the historical behavior of
+            // SDK-managed safe-area insets.
+            val effectiveSafeTop = if (layout.addSafeAreaInsetsToOffsets) safeAreaTop else 0
+            val effectiveSafeBottom = if (layout.addSafeAreaInsetsToOffsets) safeAreaBottom else 0
+            val effectiveSafeLeft = if (layout.addSafeAreaInsetsToOffsets) safeAreaLeft else 0
+            val effectiveSafeRight = if (layout.addSafeAreaInsetsToOffsets) safeAreaRight else 0
+
+            val marginTop = effectiveSafeTop + (layout.offsets.top * density).toInt()
+            val marginBottom = effectiveSafeBottom + (layout.offsets.bottom * density).toInt()
+            val marginLeft = effectiveSafeLeft + (layout.offsets.left * density).toInt()
+            val marginRight = effectiveSafeRight + (layout.offsets.right * density).toInt()
 
             val availableWidth = (screenWidth - marginLeft - marginRight).coerceAtLeast(0)
             val availableHeight = (screenHeight - marginTop - marginBottom).coerceAtLeast(0)
@@ -515,8 +525,12 @@ internal class FloatingFormWindow(private val context: Context) {
             safeAreaTop: Int,
             safeAreaBottom: Int
         ): Int {
-            val topMargin = safeAreaTop + (layout.offsets.top * density).toInt()
-            val bottomMargin = safeAreaBottom + (layout.offsets.bottom * density).toInt()
+            // Mirror the addSafeAreaInsetsToOffsets semantics used by [calculateLayoutParams]
+            // so keyboard-overlap math stays consistent with the form's actual position.
+            val effectiveSafeTop = if (layout.addSafeAreaInsetsToOffsets) safeAreaTop else 0
+            val effectiveSafeBottom = if (layout.addSafeAreaInsetsToOffsets) safeAreaBottom else 0
+            val topMargin = effectiveSafeTop + (layout.offsets.top * density).toInt()
+            val bottomMargin = effectiveSafeBottom + (layout.offsets.bottom * density).toInt()
 
             val gap = when (layout.position) {
                 FormPosition.BOTTOM,

--- a/sdk/forms/src/main/java/com/klaviyo/forms/presentation/FloatingFormWindow.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/presentation/FloatingFormWindow.kt
@@ -518,7 +518,7 @@ internal class FloatingFormWindow(private val context: Context) {
             val topMargin = safeAreaTop + (layout.offsets.top * density).toInt()
             val bottomMargin = safeAreaBottom + (layout.offsets.bottom * density).toInt()
 
-            return when (layout.position) {
+            val gap = when (layout.position) {
                 FormPosition.BOTTOM,
                 FormPosition.BOTTOM_LEFT,
                 FormPosition.BOTTOM_RIGHT -> bottomMargin
@@ -531,6 +531,10 @@ internal class FloatingFormWindow(private val context: Context) {
 
                 FormPosition.FULLSCREEN -> 0
             }
+            // Forms taller than available space (or heavily asymmetric CENTER margins)
+            // can push the form bottom edge off-screen, which would otherwise produce a
+            // negative gap and over-shift the keyboard adjustment.
+            return gap.coerceAtLeast(0)
         }
     }
 }

--- a/sdk/forms/src/main/java/com/klaviyo/forms/presentation/FloatingFormWindow.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/presentation/FloatingFormWindow.kt
@@ -465,13 +465,13 @@ internal class FloatingFormWindow(private val context: Context) {
             val effectiveSafeLeft = if (layout.addSafeAreaInsetsToOffsets) safeAreaLeft else 0
             val effectiveSafeRight = if (layout.addSafeAreaInsetsToOffsets) safeAreaRight else 0
 
-            val marginTop = effectiveSafeTop + (layout.offsets.top * density).toInt()
-            val marginBottom = effectiveSafeBottom + (layout.offsets.bottom * density).toInt()
-            val marginLeft = effectiveSafeLeft + (layout.offsets.left * density).toInt()
-            val marginRight = effectiveSafeRight + (layout.offsets.right * density).toInt()
+            val offsetTop = effectiveSafeTop + (layout.offsets.top * density).toInt()
+            val offsetBottom = effectiveSafeBottom + (layout.offsets.bottom * density).toInt()
+            val offsetLeft = effectiveSafeLeft + (layout.offsets.left * density).toInt()
+            val offsetRight = effectiveSafeRight + (layout.offsets.right * density).toInt()
 
-            val availableWidth = (screenWidth - marginLeft - marginRight).coerceAtLeast(0)
-            val availableHeight = (screenHeight - marginTop - marginBottom).coerceAtLeast(0)
+            val availableWidth = (screenWidth - offsetLeft - offsetRight).coerceAtLeast(0)
+            val availableHeight = (screenHeight - offsetTop - offsetBottom).coerceAtLeast(0)
 
             val requestedWidth = layout.width.toPixels(screenWidth, density)
             val requestedHeight = layout.height.toPixels(screenHeight, density)
@@ -484,15 +484,15 @@ internal class FloatingFormWindow(private val context: Context) {
             // centered within [marginStart, screenDim - marginEnd] instead of the raw
             // screen bounds.
             val x = when (layout.position) {
-                FormPosition.TOP_LEFT, FormPosition.BOTTOM_LEFT -> marginLeft
-                FormPosition.TOP_RIGHT, FormPosition.BOTTOM_RIGHT -> marginRight
-                FormPosition.TOP, FormPosition.BOTTOM, FormPosition.CENTER -> (marginLeft - marginRight) / 2
+                FormPosition.TOP_LEFT, FormPosition.BOTTOM_LEFT -> offsetLeft
+                FormPosition.TOP_RIGHT, FormPosition.BOTTOM_RIGHT -> offsetRight
+                FormPosition.TOP, FormPosition.BOTTOM, FormPosition.CENTER -> (offsetLeft - offsetRight) / 2
                 FormPosition.FULLSCREEN -> 0
             }
             val y = when (layout.position) {
-                FormPosition.TOP, FormPosition.TOP_LEFT, FormPosition.TOP_RIGHT -> marginTop
-                FormPosition.BOTTOM, FormPosition.BOTTOM_LEFT, FormPosition.BOTTOM_RIGHT -> marginBottom
-                FormPosition.CENTER -> (marginTop - marginBottom) / 2
+                FormPosition.TOP, FormPosition.TOP_LEFT, FormPosition.TOP_RIGHT -> offsetTop
+                FormPosition.BOTTOM, FormPosition.BOTTOM_LEFT, FormPosition.BOTTOM_RIGHT -> offsetBottom
+                FormPosition.CENTER -> (offsetTop - offsetBottom) / 2
                 FormPosition.FULLSCREEN -> 0
             }
 

--- a/sdk/forms/src/main/java/com/klaviyo/forms/presentation/FloatingFormWindow.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/presentation/FloatingFormWindow.kt
@@ -129,6 +129,20 @@ internal class FloatingFormWindow(private val context: Context) {
         val safeAreaLeft = safeInsets?.left ?: 0
         val safeAreaRight = safeInsets?.right ?: 0
 
+        // Compute clamped size and gravity-relative offsets in a single pass so
+        // width/height/x/y stay consistent with the offset-priority model (see
+        // [calculateLayoutParams]). FULLSCREEN short-circuits to full bounds.
+        val computed = calculateLayoutParams(
+            layout = layout,
+            screenWidth = screenWidth,
+            screenHeight = screenHeight,
+            density = density,
+            safeAreaTop = safeAreaTop,
+            safeAreaBottom = safeAreaBottom,
+            safeAreaLeft = safeAreaLeft,
+            safeAreaRight = safeAreaRight
+        )
+
         val params = WindowManager.LayoutParams().apply {
             // TYPE_APPLICATION_PANEL (1000) doesn't require special permissions
             // It attaches as a panel to the parent window
@@ -137,23 +151,16 @@ internal class FloatingFormWindow(private val context: Context) {
             // Get the window token from the host activity's decor view
             token = hostActivity.window.decorView.applicationWindowToken
 
-            // Calculate dimensions. For horizontally-centered positions, use the safe
-            // screen width so percentage-based forms don't extend into display cutouts
-            // (e.g. punch holes in landscape orientation).
-            val effectiveScreenWidth = if (layout.position.isHorizontallyCentered()) {
-                screenWidth - safeAreaLeft - safeAreaRight
-            } else {
-                screenWidth
-            }
-            width = layout.width.toPixels(effectiveScreenWidth, density)
-            height = layout.height.toPixels(screenHeight, density)
+            width = computed.width
+            height = computed.height
 
             // Set gravity based on position
             gravity = layout.position.toGravity()
 
-            // Calculate offsets based on position, including safe area insets
-            x = calculateHorizontalOffset(layout, density, safeAreaLeft, safeAreaRight)
-            y = calculateVerticalOffset(layout, density, safeAreaTop, safeAreaBottom)
+            // Gravity-relative offsets (Android's x/y on LayoutParams are offsets
+            // from the gravity anchor, not absolute coordinates).
+            x = computed.x
+            y = computed.y
 
             // FLAG_NOT_TOUCH_MODAL: Allow touches outside the window to pass through
             // FLAG_NOT_FOCUSABLE: Let the host activity retain input focus so its keyboard
@@ -179,6 +186,10 @@ internal class FloatingFormWindow(private val context: Context) {
             density,
             safeAreaTop,
             safeAreaBottom
+        )
+        Registry.log.verbose(
+            "FloatingFormWindow layout: pos=${layout.position} size=${params.width}x${params.height} " +
+                "offset=(${params.x},${params.y}) bottomGap=$formBottomGap"
         )
         isBottomAnchored = layout.position in listOf(
             FormPosition.BOTTOM,
@@ -403,15 +414,98 @@ internal class FloatingFormWindow(private val context: Context) {
         }
     }
 
+    /**
+     * Fully resolved [WindowManager.LayoutParams] dimensions for a floating form:
+     * clamped [width] / [height] (after honoring safe-area + user margins) and
+     * gravity-relative [x] / [y] offsets.
+     */
+    internal data class ComputedLayout(
+        val width: Int,
+        val height: Int,
+        val x: Int,
+        val y: Int
+    )
+
     companion object {
+        /**
+         * Compute the clamped form size and gravity-relative x / y offsets for a given
+         * [FormLayout], mirroring the iOS `calculateFrame` behavior:
+         *
+         * Margins are the sum of safe-area insets and user-provided offsets on each edge,
+         * and they take priority over the requested form dimensions — the form shrinks to
+         * fit inside `screen - margins` when it would otherwise overflow. When the form
+         * already fits, margins still anchor it away from the edge but do not shrink it.
+         *
+         * FULLSCREEN ignores offsets and fills the full screen bounds.
+         *
+         * For centered axes with asymmetric margins, the form shifts toward the smaller
+         * margin so it remains visually centered within the available space (matches iOS).
+         */
+        internal fun calculateLayoutParams(
+            layout: FormLayout,
+            screenWidth: Int,
+            screenHeight: Int,
+            density: Float,
+            safeAreaTop: Int,
+            safeAreaBottom: Int,
+            safeAreaLeft: Int,
+            safeAreaRight: Int
+        ): ComputedLayout {
+            if (layout.position == FormPosition.FULLSCREEN) {
+                return ComputedLayout(width = screenWidth, height = screenHeight, x = 0, y = 0)
+            }
+
+            val marginTop = safeAreaTop + (layout.offsets.top * density).toInt()
+            val marginBottom = safeAreaBottom + (layout.offsets.bottom * density).toInt()
+            val marginLeft = safeAreaLeft + (layout.offsets.left * density).toInt()
+            val marginRight = safeAreaRight + (layout.offsets.right * density).toInt()
+
+            val availableWidth = (screenWidth - marginLeft - marginRight).coerceAtLeast(0)
+            val availableHeight = (screenHeight - marginTop - marginBottom).coerceAtLeast(0)
+
+            val requestedWidth = layout.width.toPixels(screenWidth, density)
+            val requestedHeight = layout.height.toPixels(screenHeight, density)
+            val clampedWidth = minOf(requestedWidth, availableWidth)
+            val clampedHeight = minOf(requestedHeight, availableHeight)
+
+            // Android gravity places the clamped view anchored to the gravity edge; our
+            // x/y are additive offsets from that anchor. Cornered anchors take the full
+            // margin; centered anchors use half the margin asymmetry so the form is
+            // centered within [marginStart, screenDim - marginEnd] instead of the raw
+            // screen bounds.
+            val x = when (layout.position) {
+                FormPosition.TOP_LEFT, FormPosition.BOTTOM_LEFT -> marginLeft
+                FormPosition.TOP_RIGHT, FormPosition.BOTTOM_RIGHT -> marginRight
+                FormPosition.TOP, FormPosition.BOTTOM, FormPosition.CENTER -> (marginLeft - marginRight) / 2
+                FormPosition.FULLSCREEN -> 0
+            }
+            val y = when (layout.position) {
+                FormPosition.TOP, FormPosition.TOP_LEFT, FormPosition.TOP_RIGHT -> marginTop
+                FormPosition.BOTTOM, FormPosition.BOTTOM_LEFT, FormPosition.BOTTOM_RIGHT -> marginBottom
+                FormPosition.CENTER -> (marginTop - marginBottom) / 2
+                FormPosition.FULLSCREEN -> 0
+            }
+
+            return ComputedLayout(
+                width = clampedWidth,
+                height = clampedHeight,
+                x = x,
+                y = y
+            )
+        }
+
         /**
          * Calculate the gap between the form's bottom edge and the screen bottom (in pixels).
          * Used to determine keyboard overlap — if keyboardHeight > formBottomGap, the keyboard
-         * overlaps the form and we need to shift.
+         * overlaps the form and we need to shift. [formHeight] is the CLAMPED pixel height
+         * already stored on the window params (post-shrink-to-fit).
          *
-         * For BOTTOM gravity: gap = vertical offset (safe area + user offset)(form sits at bottom, offset pushes it up)
-         * For TOP gravity: gap = screenHeight - totalTopOffset - formHeight
-         * For CENTER gravity: gap = (screenHeight - formHeight) / 2
+         * - BOTTOM-anchored: gap = safe area + user bottom offset (form sits above that margin)
+         * - TOP-anchored:    gap = screenHeight - (safeAreaTop + user top offset) - formHeight
+         * - CENTER:          gap = (screenHeight - formHeight) / 2 + (bottomMargin - topMargin) / 2,
+         *                    accounting for the asymmetric-margin shift applied by
+         *                    [calculateLayoutParams]
+         * - FULLSCREEN:      gap = 0 (form covers the bottom edge)
          */
         internal fun calculateFormBottomGap(
             layout: FormLayout,
@@ -421,76 +515,21 @@ internal class FloatingFormWindow(private val context: Context) {
             safeAreaTop: Int,
             safeAreaBottom: Int
         ): Int {
-            val topOffset = (layout.offsets.top * density).toInt()
-            val bottomOffset = (layout.offsets.bottom * density).toInt()
+            val topMargin = safeAreaTop + (layout.offsets.top * density).toInt()
+            val bottomMargin = safeAreaBottom + (layout.offsets.bottom * density).toInt()
 
             return when (layout.position) {
                 FormPosition.BOTTOM,
                 FormPosition.BOTTOM_LEFT,
-                FormPosition.BOTTOM_RIGHT -> safeAreaBottom + bottomOffset
+                FormPosition.BOTTOM_RIGHT -> bottomMargin
 
                 FormPosition.TOP,
                 FormPosition.TOP_LEFT,
-                FormPosition.TOP_RIGHT -> screenHeight - safeAreaTop - topOffset - formHeight
+                FormPosition.TOP_RIGHT -> screenHeight - topMargin - formHeight
 
-                // TODO: If center-aligned forms support top/bottom offsets in the future,
-                //  this calculation should account for the offset shifting the form from center
-                FormPosition.CENTER -> (screenHeight - formHeight) / 2
+                FormPosition.CENTER -> (screenHeight - formHeight) / 2 + (bottomMargin - topMargin) / 2
 
                 FormPosition.FULLSCREEN -> 0
-            }
-        }
-
-        /**
-         * Calculate horizontal offset based on position, user offsets, and safe area insets.
-         * Safe area insets ensure the form clears notches, display cutouts, and system UI.
-         * User offsets are additive on top of safe area.
-         *
-         * @param safeAreaLeft Left safe area inset in pixels
-         * @param safeAreaRight Right safe area inset in pixels
-         */
-        internal fun calculateHorizontalOffset(
-            layout: FormLayout,
-            density: Float,
-            safeAreaLeft: Int,
-            safeAreaRight: Int
-        ): Int {
-            val leftOffset = (layout.offsets.left * density).toInt()
-            val rightOffset = (layout.offsets.right * density).toInt()
-
-            return when (layout.position) {
-                FormPosition.TOP_LEFT, FormPosition.BOTTOM_LEFT -> safeAreaLeft + leftOffset
-                FormPosition.TOP_RIGHT, FormPosition.BOTTOM_RIGHT -> safeAreaRight + rightOffset
-                FormPosition.TOP, FormPosition.BOTTOM, FormPosition.CENTER, FormPosition.FULLSCREEN ->
-                    (safeAreaLeft - safeAreaRight) / 2
-            }
-        }
-
-        /**
-         * Calculate vertical offset based on position, user offsets, and safe area insets.
-         * Safe area insets ensure the form clears notches, display cutouts, and system UI.
-         * User offsets are additive on top of safe area.
-         *
-         * @param safeAreaTop Top safe area inset in pixels
-         * @param safeAreaBottom Bottom safe area inset in pixels
-         */
-        internal fun calculateVerticalOffset(
-            layout: FormLayout,
-            density: Float,
-            safeAreaTop: Int,
-            safeAreaBottom: Int
-        ): Int {
-            val topOffset = (layout.offsets.top * density).toInt()
-            val bottomOffset = (layout.offsets.bottom * density).toInt()
-
-            return when (layout.position) {
-                FormPosition.TOP, FormPosition.TOP_LEFT, FormPosition.TOP_RIGHT ->
-                    safeAreaTop + topOffset
-
-                FormPosition.BOTTOM, FormPosition.BOTTOM_LEFT, FormPosition.BOTTOM_RIGHT ->
-                    safeAreaBottom + bottomOffset
-
-                FormPosition.CENTER, FormPosition.FULLSCREEN -> 0
             }
         }
     }

--- a/sdk/forms/src/main/java/com/klaviyo/forms/presentation/KlaviyoPresentationManager.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/presentation/KlaviyoPresentationManager.kt
@@ -145,6 +145,11 @@ internal class KlaviyoPresentationManager() : PresentationManager {
     private fun onConfigurationChanged(event: ActivityEvent.ConfigurationChanged) = safeCall {
         event.newConfig.orientation.takeIf { it != orientation }
             ?.also { newOrientation -> orientation = newOrientation }?.let {
+                // Update the `data-klaviyo-device` head attribute so onsite-in-app sees
+                // the new orientation/dimensions even when the webview is preloaded but
+                // not currently presented.
+                Registry.get<WebViewClient>().pushDeviceInfo()
+
                 // Cancel any pending per-activity cleanup — rotation handles its own re-presentation.
                 // Must be inside the orientation guard so non-orientation config changes (locale,
                 // dark mode, font scale) don't cancel the timer without scheduling a replacement.

--- a/sdk/forms/src/main/java/com/klaviyo/forms/presentation/KlaviyoPresentationManager.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/presentation/KlaviyoPresentationManager.kt
@@ -43,6 +43,21 @@ internal class KlaviyoPresentationManager() : PresentationManager {
     private var rotationObserver: ActivityObserver? = null
 
     /**
+     * One-shot observer waiting for the next Resumed activity after a rotation, used to push
+     * fresh device info to the webview. ConfigurationChanged fires before the new activity is
+     * resumed, so reading Display.rotation/rootWindowInsets at that moment yields stale values
+     * one rotation behind. Deferring to the next Resumed ensures the payload reflects the
+     * NEW orientation. Tracked at class level for cleanup/timeout.
+     */
+    private var deviceInfoPushObserver: ActivityObserver? = null
+
+    /**
+     * Safety timeout to unregister [deviceInfoPushObserver] if a Resumed event never arrives
+     * (e.g. activity permanently destroyed). Prevents leaks.
+     */
+    private var deviceInfoPushTimeout: Clock.Cancellable? = null
+
+    /**
      * Delayed cleanup for multi-activity transitions. When the host activity stops,
      * we schedule cleanup after a grace period. If AllStopped fires within the grace
      * period (app backgrounding), it cancels this and handles re-presentation instead.
@@ -145,10 +160,11 @@ internal class KlaviyoPresentationManager() : PresentationManager {
     private fun onConfigurationChanged(event: ActivityEvent.ConfigurationChanged) = safeCall {
         event.newConfig.orientation.takeIf { it != orientation }
             ?.also { newOrientation -> orientation = newOrientation }?.let {
-                // Update the `data-klaviyo-device` head attribute so onsite-in-app sees
-                // the new orientation/dimensions even when the webview is preloaded but
-                // not currently presented.
-                Registry.get<WebViewClient>().pushDeviceInfo()
+                // Defer the `data-klaviyo-device` head attribute update until the NEXT
+                // Resumed activity. ConfigurationChanged fires before the old activity is
+                // destroyed, so Display.rotation/rootWindowInsets still reflect the prior
+                // orientation. Pushing now would leave the attribute one rotation behind.
+                scheduleDeviceInfoPushOnNextResume()
 
                 // Cancel any pending per-activity cleanup — rotation handles its own re-presentation.
                 // Must be inside the orientation guard so non-orientation config changes (locale,
@@ -425,6 +441,49 @@ internal class KlaviyoPresentationManager() : PresentationManager {
         hostActivityStoppedCleanup = null
     }
 
+    /**
+     * Register a one-shot observer that calls [WebViewClient.pushDeviceInfo] once the next
+     * activity Resumes. If a prior rotation is still pending (rapid rotate-rotate), the
+     * previous observer is discarded so only the latest orientation is reported. A safety
+     * timeout unregisters the observer if no Resumed event arrives (e.g. activity is
+     * permanently destroyed while backgrounded).
+     */
+    private fun scheduleDeviceInfoPushOnNextResume() {
+        // Drop any in-flight observer from an earlier rotation so we only push once per
+        // completed orientation change (and always with the latest values).
+        deviceInfoPushObserver?.let { Registry.lifecycleMonitor.offActivityEvent(it) }
+        deviceInfoPushObserver = null
+        deviceInfoPushTimeout?.cancel()
+        deviceInfoPushTimeout = null
+
+        val observer: ActivityObserver = { activityEvent ->
+            activityEvent.takeIf<ActivityEvent.Resumed>()?.let {
+                deviceInfoPushObserver?.let { obs ->
+                    Registry.lifecycleMonitor.offActivityEvent(obs)
+                }
+                deviceInfoPushObserver = null
+                deviceInfoPushTimeout?.cancel()
+                deviceInfoPushTimeout = null
+                Registry.get<WebViewClient>().pushDeviceInfo()
+            }
+        }
+        deviceInfoPushObserver = observer
+        Registry.lifecycleMonitor.onActivityEvent(observer)
+
+        // Fallback: if the next Resumed never arrives (activity destroyed permanently),
+        // clean up the observer to avoid leaking it indefinitely.
+        deviceInfoPushTimeout = Registry.clock.schedule(DEVICE_INFO_PUSH_TIMEOUT) {
+            deviceInfoPushObserver?.let { obs ->
+                Registry.lifecycleMonitor.offActivityEvent(obs)
+            }
+            deviceInfoPushObserver = null
+            deviceInfoPushTimeout = null
+            Registry.log.verbose(
+                "Device-info push observer timed out waiting for next Resumed activity"
+            )
+        }
+    }
+
     private companion object {
         /**
          * Grace period to close a form with animation, before we just dismiss
@@ -433,5 +492,13 @@ internal class KlaviyoPresentationManager() : PresentationManager {
          *  or else teardown will kill the webview's rendering before formDisappeared can be sent.
          */
         private const val CLOSE_TIMEOUT = 600L
+
+        /**
+         * Upper bound for how long to wait for the next Resumed activity before giving up
+         * on pushing fresh device info after a rotation. Chosen to comfortably exceed a
+         * typical activity recreation (tens of ms) while bounding the leak window if the
+         * activity is permanently destroyed.
+         */
+        private const val DEVICE_INFO_PUSH_TIMEOUT = 5_000L
     }
 }

--- a/sdk/forms/src/main/java/com/klaviyo/forms/presentation/KlaviyoPresentationManager.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/presentation/KlaviyoPresentationManager.kt
@@ -48,12 +48,19 @@ internal class KlaviyoPresentationManager() : PresentationManager {
      * resumed, so reading Display.rotation/rootWindowInsets at that moment yields stale values
      * one rotation behind. Deferring to the next Resumed ensures the payload reflects the
      * NEW orientation. Tracked at class level for cleanup/timeout.
+     *
+     * Intentionally NOT cleared in [clearTimers] — the attribute should stay current on the
+     * preloaded webview regardless of whether a form is presenting. `dismiss()` does not
+     * destroy the webview (only [destroyWebviewAndListeners] does), so an in-flight observer
+     * firing post-dismiss simply refreshes `data-klaviyo-device` on the idle preloaded webview
+     * ready for the next form. [pushDeviceInfo] already no-ops on a null webview.
      */
     private var deviceInfoPushObserver: ActivityObserver? = null
 
     /**
      * Safety timeout to unregister [deviceInfoPushObserver] if a Resumed event never arrives
-     * (e.g. activity permanently destroyed). Prevents leaks.
+     * (e.g. activity permanently destroyed). Prevents leaks. Intentionally NOT cleared in
+     * [clearTimers] for the same reason as [deviceInfoPushObserver].
      */
     private var deviceInfoPushTimeout: Clock.Cancellable? = null
 

--- a/sdk/forms/src/main/java/com/klaviyo/forms/presentation/KlaviyoPresentationManager.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/presentation/KlaviyoPresentationManager.kt
@@ -495,10 +495,10 @@ internal class KlaviyoPresentationManager() : PresentationManager {
 
         /**
          * Upper bound for how long to wait for the next Resumed activity before giving up
-         * on pushing fresh device info after a rotation. Chosen to comfortably exceed a
-         * typical activity recreation (tens of ms) while bounding the leak window if the
-         * activity is permanently destroyed.
+         * on pushing fresh device info after a rotation. Typical rotation-to-Resumed is
+         * well under 300 ms; this bounds the observer lifetime if the activity is
+         * permanently destroyed without replacement.
          */
-        private const val DEVICE_INFO_PUSH_TIMEOUT = 5_000L
+        private const val DEVICE_INFO_PUSH_TIMEOUT = 1_000L
     }
 }

--- a/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebView.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebView.kt
@@ -6,7 +6,7 @@ import android.graphics.Color
 import android.util.AttributeSet
 import android.webkit.WebSettings
 import android.webkit.WebView
-import android.webkit.WebViewClient
+import android.webkit.WebViewClient as AndroidWebViewClient
 import androidx.core.util.TypedValueCompat.pxToDp
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
@@ -34,7 +34,7 @@ internal class KlaviyoWebView : WebView {
 
     constructor(context: Context, attrs: AttributeSet?) : super(context, attrs, 0)
 
-    fun loadTemplate(html: String, client: WebViewClient, bridge: NativeBridge) = configure()
+    fun loadTemplate(html: String, client: AndroidWebViewClient, bridge: NativeBridge) = configure()
         .apply { webViewClient = client }
         .addBridge(bridge)
         .monitorSafeArea()
@@ -109,6 +109,10 @@ internal class KlaviyoWebView : WebView {
                     pxToDp(safeDrawingInsets.right.toFloat(), displayMetrics),
                     pxToDp(safeDrawingInsets.bottom.toFloat(), displayMetrics)
                 )
+
+                // Keep the `data-klaviyo-device` head attribute in sync with the latest
+                // insets — onsite-in-app reads this for pre-render layout decisions.
+                Registry.get<WebViewClient>().pushDeviceInfo()
 
                 WindowInsetsCompat.CONSUMED
             }

--- a/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
@@ -225,18 +225,18 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
      * `data-klaviyo-device` head attribute. This keeps onsite-in-app in sync with orientation
      * changes and safe-area inset updates without reloading the template.
      */
-    override fun pushDeviceInfo() = webView?.let { webView ->
-        // DeviceInfoProvider.current() reads UI-thread-only APIs (Display.rotation,
-        // decorView.rootWindowInsets). Building the snapshot off-thread would yield silently
-        // degraded payloads because DeviceInfoProvider swallows CalledFromWrongThreadException.
-        // Dispatch the entire body — snapshot, serialize, escape, evaluate — onto the UI thread.
-        Registry.threadHelper.runOnUiThread {
-            val json = DeviceInfoProvider.current().toJson().jsEscape()
-            val script = "document.head.setAttribute('data-klaviyo-device', '$json')"
-            webView.evaluateJavascript(script, null)
+    override fun pushDeviceInfo() {
+        webView?.let { webView ->
+            // DeviceInfoProvider.current() reads UI-thread-only APIs (Display.rotation,
+            // decorView.rootWindowInsets). Building the snapshot off-thread would yield silently
+            // degraded payloads because DeviceInfoProvider swallows CalledFromWrongThreadException.
+            // Dispatch the entire body — snapshot, serialize, escape, evaluate — onto the UI thread.
+            Registry.threadHelper.runOnUiThread {
+                val json = DeviceInfoProvider.current().toJson().jsEscape()
+                val script = "document.head.setAttribute('data-klaviyo-device', '$json')"
+                webView.evaluateJavascript(script, null)
+            }
         }
-    } ?: run {
-        Registry.log.verbose("Unable to push device info - null WebView reference")
     }
 
     /**

--- a/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
@@ -77,6 +77,9 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
             .replace("BRIDGE_HANDSHAKE", handshake.compileJson())
             .replace("KLAVIYO_JS_URL", klaviyoJsUrl.toString())
             .replace("FORMS_ENVIRONMENT", Registry.config.formEnvironment.templateName)
+            // Raw JSON is safe inside the single-quoted HTML attribute because JSONObject emits
+            // double-quoted strings; jsEscape is only needed when injecting into a JS string literal
+            // (see pushDeviceInfo).
             .replace("DEVICE_INFO", DeviceInfoProvider.current().toJson())
             .let { html ->
                 webView.loadTemplate(html, this, nativeBridge)
@@ -223,9 +226,13 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
      * changes and safe-area inset updates without reloading the template.
      */
     override fun pushDeviceInfo() = webView?.let { webView ->
-        val json = DeviceInfoProvider.current().toJson().jsEscape()
-        val script = "document.head.setAttribute('data-klaviyo-device', '$json')"
+        // DeviceInfoProvider.current() reads UI-thread-only APIs (Display.rotation,
+        // decorView.rootWindowInsets). Building the snapshot off-thread would yield silently
+        // degraded payloads because DeviceInfoProvider swallows CalledFromWrongThreadException.
+        // Dispatch the entire body — snapshot, serialize, escape, evaluate — onto the UI thread.
         Registry.threadHelper.runOnUiThread {
+            val json = DeviceInfoProvider.current().toJson().jsEscape()
+            val script = "document.head.setAttribute('data-klaviyo-device', '$json')"
             webView.evaluateJavascript(script, null)
         }
     } ?: run {

--- a/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
@@ -25,7 +25,6 @@ import com.klaviyo.forms.bridge.JsBridgeObserverCollection
 import com.klaviyo.forms.bridge.NativeBridge
 import com.klaviyo.forms.bridge.NativeBridgeMessage
 import com.klaviyo.forms.bridge.compileJson
-import com.klaviyo.forms.bridge.jsEscape
 import com.klaviyo.forms.presentation.PresentationManager
 import java.io.BufferedReader
 
@@ -78,8 +77,7 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
             .replace("KLAVIYO_JS_URL", klaviyoJsUrl.toString())
             .replace("FORMS_ENVIRONMENT", Registry.config.formEnvironment.templateName)
             // Raw JSON is safe inside the single-quoted HTML attribute because JSONObject emits
-            // double-quoted strings; jsEscape is only needed when injecting into a JS string literal
-            // (see pushDeviceInfo).
+            // double-quoted strings.
             .replace("DEVICE_INFO", DeviceInfoProvider.current().toJson())
             .let { html ->
                 webView.loadTemplate(html, this, nativeBridge)
@@ -230,10 +228,12 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
             // DeviceInfoProvider.current() reads UI-thread-only APIs (Display.rotation,
             // decorView.rootWindowInsets). Building the snapshot off-thread would yield silently
             // degraded payloads because DeviceInfoProvider swallows CalledFromWrongThreadException.
-            // Dispatch the entire body — snapshot, serialize, escape, evaluate — onto the UI thread.
+            // Dispatch the entire body — snapshot, serialize, evaluate — onto the UI thread.
             Registry.threadHelper.runOnUiThread {
-                val json = DeviceInfoProvider.current().toJson().jsEscape()
-                val script = "document.head.setAttribute('data-klaviyo-device', '$json')"
+                // JSON is a subset of JS: embedding the raw JSON as a JS object expression and
+                // letting the engine stringify it avoids any JS string-literal escaping concerns.
+                val json = DeviceInfoProvider.current().toJson()
+                val script = "document.head.setAttribute('data-klaviyo-device', JSON.stringify($json))"
                 webView.evaluateJavascript(script, null)
             }
         }

--- a/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
@@ -18,12 +18,14 @@ import com.klaviyo.core.Registry
 import com.klaviyo.core.config.Clock
 import com.klaviyo.core.utils.WeakReferenceDelegate
 import com.klaviyo.core.utils.startActivityIfResolved
+import com.klaviyo.forms.bridge.DeviceInfoProvider
 import com.klaviyo.forms.bridge.HandshakeSpec
 import com.klaviyo.forms.bridge.JsBridge
 import com.klaviyo.forms.bridge.JsBridgeObserverCollection
 import com.klaviyo.forms.bridge.NativeBridge
 import com.klaviyo.forms.bridge.NativeBridgeMessage
 import com.klaviyo.forms.bridge.compileJson
+import com.klaviyo.forms.bridge.jsEscape
 import com.klaviyo.forms.presentation.PresentationManager
 import java.io.BufferedReader
 
@@ -75,6 +77,7 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
             .replace("BRIDGE_HANDSHAKE", handshake.compileJson())
             .replace("KLAVIYO_JS_URL", klaviyoJsUrl.toString())
             .replace("FORMS_ENVIRONMENT", Registry.config.formEnvironment.templateName)
+            .replace("DEVICE_INFO", DeviceInfoProvider.current().toJson())
             .let { html ->
                 webView.loadTemplate(html, this, nativeBridge)
                 handshakeTimer?.cancel()
@@ -212,6 +215,21 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
             return true
         }
         return false
+    }
+
+    /**
+     * Re-publish the current [com.klaviyo.forms.bridge.DeviceInfo] snapshot to the webview's
+     * `data-klaviyo-device` head attribute. This keeps onsite-in-app in sync with orientation
+     * changes and safe-area inset updates without reloading the template.
+     */
+    override fun pushDeviceInfo() = webView?.let { webView ->
+        val json = DeviceInfoProvider.current().toJson().jsEscape()
+        val script = "document.head.setAttribute('data-klaviyo-device', '$json')"
+        Registry.threadHelper.runOnUiThread {
+            webView.evaluateJavascript(script, null)
+        }
+    } ?: run {
+        Registry.log.verbose("Unable to push device info - null WebView reference")
     }
 
     /**

--- a/sdk/forms/src/main/java/com/klaviyo/forms/webview/WebViewClient.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/webview/WebViewClient.kt
@@ -39,4 +39,11 @@ internal interface WebViewClient {
      * Destroy the webview and release the reference
      */
     fun destroyWebView(): WebViewClient
+
+    /**
+     * Push a fresh [com.klaviyo.forms.bridge.DeviceInfo] snapshot into the webview's
+     * `data-klaviyo-device` head attribute. Safe to call at any point after the webview
+     * is initialized — no-ops if the webview is not ready.
+     */
+    fun pushDeviceInfo()
 }

--- a/sdk/forms/src/test/java/com/klaviyo/forms/bridge/DeviceInfoTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/bridge/DeviceInfoTest.kt
@@ -1,20 +1,12 @@
 package com.klaviyo.forms.bridge
 
 import android.content.res.Configuration
-import android.util.DisplayMetrics
 import android.view.Surface
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class DeviceInfoTest {
-
-    private fun displayMetrics(widthPx: Int, heightPx: Int, density: Float): DisplayMetrics =
-        DisplayMetrics().apply {
-            this.widthPixels = widthPx
-            this.heightPixels = heightPx
-            this.density = density
-        }
 
     private fun configuration(orientation: Int): Configuration =
         Configuration().apply {
@@ -72,7 +64,7 @@ class DeviceInfoTest {
     @Test
     fun `from converts pixels to dp at density 1`() {
         val info = DeviceInfo.from(
-            displayMetrics = displayMetrics(widthPx = 400, heightPx = 800, density = 1f),
+            screenWidthPx = 400, screenHeightPx = 800, density = 1f,
             configuration = configuration(Configuration.ORIENTATION_PORTRAIT),
             rotation = Surface.ROTATION_0,
             insetLeftPx = 0,
@@ -91,7 +83,7 @@ class DeviceInfoTest {
     @Test
     fun `from converts pixels to dp at density 2`() {
         val info = DeviceInfo.from(
-            displayMetrics = displayMetrics(widthPx = 800, heightPx = 1600, density = 2f),
+            screenWidthPx = 800, screenHeightPx = 1600, density = 2f,
             configuration = configuration(Configuration.ORIENTATION_PORTRAIT),
             rotation = Surface.ROTATION_0,
             insetLeftPx = 0,
@@ -110,7 +102,7 @@ class DeviceInfoTest {
     @Test
     fun `from converts pixels to dp at density 3`() {
         val info = DeviceInfo.from(
-            displayMetrics = displayMetrics(widthPx = 1206, heightPx = 2622, density = 3f),
+            screenWidthPx = 1206, screenHeightPx = 2622, density = 3f,
             configuration = configuration(Configuration.ORIENTATION_PORTRAIT),
             rotation = Surface.ROTATION_0,
             insetLeftPx = 0,
@@ -129,7 +121,7 @@ class DeviceInfoTest {
     @Test
     fun `from defends against zero density`() {
         val info = DeviceInfo.from(
-            displayMetrics = displayMetrics(widthPx = 100, heightPx = 200, density = 0f),
+            screenWidthPx = 100, screenHeightPx = 200, density = 0f,
             configuration = configuration(Configuration.ORIENTATION_UNDEFINED),
             rotation = Surface.ROTATION_0,
             insetLeftPx = 0,
@@ -147,7 +139,7 @@ class DeviceInfoTest {
     @Test
     fun `from coerces sub-unit density to dpr 1`() {
         val info = DeviceInfo.from(
-            displayMetrics = displayMetrics(widthPx = 100, heightPx = 200, density = 0.5f),
+            screenWidthPx = 100, screenHeightPx = 200, density = 0.5f,
             configuration = configuration(Configuration.ORIENTATION_PORTRAIT),
             rotation = Surface.ROTATION_0,
             insetLeftPx = 0,
@@ -163,7 +155,7 @@ class DeviceInfoTest {
     @Test
     fun `from rounds density 1_5 up to dpr 2`() {
         val info = DeviceInfo.from(
-            displayMetrics = displayMetrics(widthPx = 600, heightPx = 1200, density = 1.5f),
+            screenWidthPx = 600, screenHeightPx = 1200, density = 1.5f,
             configuration = configuration(Configuration.ORIENTATION_PORTRAIT),
             rotation = Surface.ROTATION_0,
             insetLeftPx = 0,
@@ -178,7 +170,7 @@ class DeviceInfoTest {
     @Test
     fun `from rounds density 2_75 to dpr 3`() {
         val info = DeviceInfo.from(
-            displayMetrics = displayMetrics(widthPx = 1100, heightPx = 2200, density = 2.75f),
+            screenWidthPx = 1100, screenHeightPx = 2200, density = 2.75f,
             configuration = configuration(Configuration.ORIENTATION_PORTRAIT),
             rotation = Surface.ROTATION_0,
             insetLeftPx = 0,
@@ -194,7 +186,7 @@ class DeviceInfoTest {
     fun `from preserves asymmetric insets like a landscape cutout`() {
         // A landscape cutout may leave a non-zero left inset with a zero right inset.
         val info = DeviceInfo.from(
-            displayMetrics = displayMetrics(widthPx = 800, heightPx = 400, density = 1f),
+            screenWidthPx = 800, screenHeightPx = 400, density = 1f,
             configuration = configuration(Configuration.ORIENTATION_LANDSCAPE),
             rotation = Surface.ROTATION_90,
             insetLeftPx = 40,
@@ -212,7 +204,7 @@ class DeviceInfoTest {
     @Test
     fun `toJson is deterministic for identical inputs`() {
         val info = DeviceInfo.from(
-            displayMetrics = displayMetrics(widthPx = 1206, heightPx = 2622, density = 3f),
+            screenWidthPx = 1206, screenHeightPx = 2622, density = 3f,
             configuration = configuration(Configuration.ORIENTATION_PORTRAIT),
             rotation = Surface.ROTATION_0,
             insetLeftPx = 0,

--- a/sdk/forms/src/test/java/com/klaviyo/forms/bridge/DeviceInfoTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/bridge/DeviceInfoTest.kt
@@ -223,19 +223,4 @@ class DeviceInfoTest {
 
         assertEquals(info.toJson(), info.toJson())
     }
-
-    @Test
-    fun `jsEscape escapes backslashes and single quotes`() {
-        val raw = "it's a back\\slash"
-        val escaped = raw.jsEscape()
-        assertEquals("it\\'s a back\\\\slash", escaped)
-    }
-
-    @Test
-    fun `jsEscape leaves double quotes untouched since caller wraps in single quotes`() {
-        // JSONObject already escapes double-quotes inside string values, but the JSON's
-        // outer syntax uses them freely — those must survive embedding in a JS single-quote literal.
-        val raw = """{"screen":{"width":402}}"""
-        assertEquals(raw, raw.jsEscape())
-    }
 }

--- a/sdk/forms/src/test/java/com/klaviyo/forms/bridge/DeviceInfoTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/bridge/DeviceInfoTest.kt
@@ -145,6 +145,86 @@ class DeviceInfoTest {
     }
 
     @Test
+    fun `from coerces sub-unit density to dpr 1`() {
+        val info = DeviceInfo.from(
+            displayMetrics = displayMetrics(widthPx = 100, heightPx = 200, density = 0.5f),
+            configuration = configuration(Configuration.ORIENTATION_PORTRAIT),
+            rotation = Surface.ROTATION_0,
+            insetLeftPx = 0,
+            insetTopPx = 0,
+            insetRightPx = 0,
+            insetBottomPx = 0
+        )
+
+        // 0.5.roundToInt() rounds to 1; coerceAtLeast(1) ensures any sub-unit density floors at 1
+        assertEquals(1, info.dpr)
+    }
+
+    @Test
+    fun `from rounds density 1_5 up to dpr 2`() {
+        val info = DeviceInfo.from(
+            displayMetrics = displayMetrics(widthPx = 600, heightPx = 1200, density = 1.5f),
+            configuration = configuration(Configuration.ORIENTATION_PORTRAIT),
+            rotation = Surface.ROTATION_0,
+            insetLeftPx = 0,
+            insetTopPx = 0,
+            insetRightPx = 0,
+            insetBottomPx = 0
+        )
+
+        assertEquals(2, info.dpr)
+    }
+
+    @Test
+    fun `from rounds density 2_75 to dpr 3`() {
+        val info = DeviceInfo.from(
+            displayMetrics = displayMetrics(widthPx = 1100, heightPx = 2200, density = 2.75f),
+            configuration = configuration(Configuration.ORIENTATION_PORTRAIT),
+            rotation = Surface.ROTATION_0,
+            insetLeftPx = 0,
+            insetTopPx = 0,
+            insetRightPx = 0,
+            insetBottomPx = 0
+        )
+
+        assertEquals(3, info.dpr)
+    }
+
+    @Test
+    fun `from preserves asymmetric insets like a landscape cutout`() {
+        // A landscape cutout may leave a non-zero left inset with a zero right inset.
+        val info = DeviceInfo.from(
+            displayMetrics = displayMetrics(widthPx = 800, heightPx = 400, density = 1f),
+            configuration = configuration(Configuration.ORIENTATION_LANDSCAPE),
+            rotation = Surface.ROTATION_90,
+            insetLeftPx = 40,
+            insetTopPx = 0,
+            insetRightPx = 0,
+            insetBottomPx = 0
+        )
+
+        assertEquals(40, info.insetLeftDp)
+        assertEquals(0, info.insetRightDp)
+        assertEquals(0, info.insetTopDp)
+        assertEquals(0, info.insetBottomDp)
+    }
+
+    @Test
+    fun `toJson is deterministic for identical inputs`() {
+        val info = DeviceInfo.from(
+            displayMetrics = displayMetrics(widthPx = 1206, heightPx = 2622, density = 3f),
+            configuration = configuration(Configuration.ORIENTATION_PORTRAIT),
+            rotation = Surface.ROTATION_0,
+            insetLeftPx = 0,
+            insetTopPx = 141,
+            insetRightPx = 0,
+            insetBottomPx = 102
+        )
+
+        assertEquals(info.toJson(), info.toJson())
+    }
+
+    @Test
     fun `jsEscape escapes backslashes and single quotes`() {
         val raw = "it's a back\\slash"
         val escaped = raw.jsEscape()

--- a/sdk/forms/src/test/java/com/klaviyo/forms/bridge/DeviceInfoTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/bridge/DeviceInfoTest.kt
@@ -1,0 +1,161 @@
+package com.klaviyo.forms.bridge
+
+import android.content.res.Configuration
+import android.util.DisplayMetrics
+import android.view.Surface
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DeviceInfoTest {
+
+    private fun displayMetrics(widthPx: Int, heightPx: Int, density: Float): DisplayMetrics =
+        DisplayMetrics().apply {
+            this.widthPixels = widthPx
+            this.heightPixels = heightPx
+            this.density = density
+        }
+
+    private fun configuration(orientation: Int): Configuration =
+        Configuration().apply {
+            this.orientation = orientation
+        }
+
+    @Test
+    fun `toJson emits the documented shape`() {
+        val info = DeviceInfo(
+            screenWidthDp = 402,
+            screenHeightDp = 874,
+            insetTopDp = 47,
+            insetBottomDp = 34,
+            insetLeftDp = 0,
+            insetRightDp = 0,
+            orientation = DeviceInfo.Orientation.PortraitPrimary,
+            dpr = 3
+        )
+
+        val json = JSONObject(info.toJson())
+
+        assertEquals(402, json.getJSONObject("screen").getInt("width"))
+        assertEquals(874, json.getJSONObject("screen").getInt("height"))
+        assertEquals(47, json.getJSONObject("safeAreaInsets").getInt("top"))
+        assertEquals(34, json.getJSONObject("safeAreaInsets").getInt("bottom"))
+        assertEquals(0, json.getJSONObject("safeAreaInsets").getInt("left"))
+        assertEquals(0, json.getJSONObject("safeAreaInsets").getInt("right"))
+        assertEquals("portrait-primary", json.getString("orientation"))
+        assertEquals(3, json.getInt("dpr"))
+    }
+
+    @Test
+    fun `Orientation maps rotation and config to CSSOM labels`() {
+        val portrait = Configuration.ORIENTATION_PORTRAIT
+        val landscape = Configuration.ORIENTATION_LANDSCAPE
+
+        assertEquals(
+            DeviceInfo.Orientation.PortraitPrimary,
+            DeviceInfo.Orientation.from(portrait, Surface.ROTATION_0)
+        )
+        assertEquals(
+            DeviceInfo.Orientation.PortraitSecondary,
+            DeviceInfo.Orientation.from(portrait, Surface.ROTATION_180)
+        )
+        assertEquals(
+            DeviceInfo.Orientation.LandscapePrimary,
+            DeviceInfo.Orientation.from(landscape, Surface.ROTATION_90)
+        )
+        assertEquals(
+            DeviceInfo.Orientation.LandscapeSecondary,
+            DeviceInfo.Orientation.from(landscape, Surface.ROTATION_270)
+        )
+    }
+
+    @Test
+    fun `from converts pixels to dp at density 1`() {
+        val info = DeviceInfo.from(
+            displayMetrics = displayMetrics(widthPx = 400, heightPx = 800, density = 1f),
+            configuration = configuration(Configuration.ORIENTATION_PORTRAIT),
+            rotation = Surface.ROTATION_0,
+            insetLeftPx = 0,
+            insetTopPx = 50,
+            insetRightPx = 0,
+            insetBottomPx = 30
+        )
+
+        assertEquals(400, info.screenWidthDp)
+        assertEquals(800, info.screenHeightDp)
+        assertEquals(50, info.insetTopDp)
+        assertEquals(30, info.insetBottomDp)
+        assertEquals(1, info.dpr)
+    }
+
+    @Test
+    fun `from converts pixels to dp at density 2`() {
+        val info = DeviceInfo.from(
+            displayMetrics = displayMetrics(widthPx = 800, heightPx = 1600, density = 2f),
+            configuration = configuration(Configuration.ORIENTATION_PORTRAIT),
+            rotation = Surface.ROTATION_0,
+            insetLeftPx = 0,
+            insetTopPx = 94,
+            insetRightPx = 0,
+            insetBottomPx = 68
+        )
+
+        assertEquals(400, info.screenWidthDp)
+        assertEquals(800, info.screenHeightDp)
+        assertEquals(47, info.insetTopDp)
+        assertEquals(34, info.insetBottomDp)
+        assertEquals(2, info.dpr)
+    }
+
+    @Test
+    fun `from converts pixels to dp at density 3`() {
+        val info = DeviceInfo.from(
+            displayMetrics = displayMetrics(widthPx = 1206, heightPx = 2622, density = 3f),
+            configuration = configuration(Configuration.ORIENTATION_PORTRAIT),
+            rotation = Surface.ROTATION_0,
+            insetLeftPx = 0,
+            insetTopPx = 141,
+            insetRightPx = 0,
+            insetBottomPx = 102
+        )
+
+        assertEquals(402, info.screenWidthDp)
+        assertEquals(874, info.screenHeightDp)
+        assertEquals(47, info.insetTopDp)
+        assertEquals(34, info.insetBottomDp)
+        assertEquals(3, info.dpr)
+    }
+
+    @Test
+    fun `from defends against zero density`() {
+        val info = DeviceInfo.from(
+            displayMetrics = displayMetrics(widthPx = 100, heightPx = 200, density = 0f),
+            configuration = configuration(Configuration.ORIENTATION_UNDEFINED),
+            rotation = Surface.ROTATION_0,
+            insetLeftPx = 0,
+            insetTopPx = 0,
+            insetRightPx = 0,
+            insetBottomPx = 0
+        )
+
+        // density 0 should fall back to 1, so px == dp
+        assertEquals(100, info.screenWidthDp)
+        assertEquals(200, info.screenHeightDp)
+        assertEquals(1, info.dpr)
+    }
+
+    @Test
+    fun `jsEscape escapes backslashes and single quotes`() {
+        val raw = "it's a back\\slash"
+        val escaped = raw.jsEscape()
+        assertEquals("it\\'s a back\\\\slash", escaped)
+    }
+
+    @Test
+    fun `jsEscape leaves double quotes untouched since caller wraps in single quotes`() {
+        // JSONObject already escapes double-quotes inside string values, but the JSON's
+        // outer syntax uses them freely — those must survive embedding in a JS single-quote literal.
+        val raw = """{"screen":{"width":402}}"""
+        assertEquals(raw, raw.jsEscape())
+    }
+}

--- a/sdk/forms/src/test/java/com/klaviyo/forms/bridge/FormLayoutTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/bridge/FormLayoutTest.kt
@@ -1,6 +1,9 @@
 package com.klaviyo.forms.bridge
 
 import android.view.Gravity
+import com.klaviyo.fixtures.BaseTest
+import io.mockk.verify
+import java.util.concurrent.atomic.AtomicBoolean
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -12,7 +15,7 @@ import org.junit.Test
 /**
  * Tests for [FormLayout] and related data classes
  */
-class FormLayoutTest {
+class FormLayoutTest : BaseTest() {
 
     // ===== FormPosition tests =====
 
@@ -255,6 +258,117 @@ class FormLayoutTest {
             height = Dimension.percent(100f)
         )
         assertTrue(layout.isFullscreen)
+    }
+
+    @Test
+    fun `FormLayout fromJson reads offsets key when present`() {
+        val json = JSONObject(
+            """
+            {
+                "position": "top",
+                "width": {"value": 300, "unit": "fixed"},
+                "height": {"value": 200, "unit": "fixed"},
+                "offsets": {"top": 8, "bottom": 12, "left": 4, "right": 6}
+            }
+            """.trimIndent()
+        )
+        val layout = FormLayout.fromJson(json)
+        assertNotNull(layout)
+        assertEquals(8f, layout!!.offsets.top, 0.01f)
+        assertEquals(12f, layout.offsets.bottom, 0.01f)
+        assertEquals(4f, layout.offsets.left, 0.01f)
+        assertEquals(6f, layout.offsets.right, 0.01f)
+    }
+
+    @Test
+    fun `FormLayout fromJson falls back to margin key when offsets is absent`() {
+        resetMarginDeprecationLogFlag()
+        val json = JSONObject(
+            """
+            {
+                "position": "top",
+                "width": {"value": 300, "unit": "fixed"},
+                "height": {"value": 200, "unit": "fixed"},
+                "margin": {"top": 8, "bottom": 12, "left": 4, "right": 6}
+            }
+            """.trimIndent()
+        )
+        val layout = FormLayout.fromJson(json)
+        assertNotNull(layout)
+        assertEquals(8f, layout!!.offsets.top, 0.01f)
+        assertEquals(12f, layout.offsets.bottom, 0.01f)
+        verify(atLeast = 1) { spyLog.verbose(any(), any()) }
+    }
+
+    @Test
+    fun `FormLayout fromJson offsets wins when both offsets and margin are present`() {
+        val json = JSONObject(
+            """
+            {
+                "position": "top",
+                "width": {"value": 300, "unit": "fixed"},
+                "height": {"value": 200, "unit": "fixed"},
+                "offsets": {"top": 1, "bottom": 2, "left": 3, "right": 4},
+                "margin": {"top": 99, "bottom": 99, "left": 99, "right": 99}
+            }
+            """.trimIndent()
+        )
+        val layout = FormLayout.fromJson(json)
+        assertNotNull(layout)
+        assertEquals(1f, layout!!.offsets.top, 0.01f)
+        assertEquals(2f, layout.offsets.bottom, 0.01f)
+        assertEquals(3f, layout.offsets.left, 0.01f)
+        assertEquals(4f, layout.offsets.right, 0.01f)
+    }
+
+    @Test
+    fun `FormLayout fromJson defaults addSafeAreaInsetsToOffsets to true when absent`() {
+        val json = JSONObject(
+            """
+            {
+                "position": "top",
+                "width": {"value": 300, "unit": "fixed"},
+                "height": {"value": 200, "unit": "fixed"},
+                "offsets": {"top": 0, "bottom": 0, "left": 0, "right": 0}
+            }
+            """.trimIndent()
+        )
+        val layout = FormLayout.fromJson(json)
+        assertNotNull(layout)
+        assertTrue(layout!!.addSafeAreaInsetsToOffsets)
+    }
+
+    @Test
+    fun `FormLayout fromJson parses addSafeAreaInsetsToOffsets false`() {
+        val json = JSONObject(
+            """
+            {
+                "position": "top",
+                "width": {"value": 300, "unit": "fixed"},
+                "height": {"value": 200, "unit": "fixed"},
+                "offsets": {"top": 0, "bottom": 0, "left": 0, "right": 0},
+                "addSafeAreaInsetsToOffsets": false
+            }
+            """.trimIndent()
+        )
+        val layout = FormLayout.fromJson(json)
+        assertNotNull(layout)
+        assertFalse(layout!!.addSafeAreaInsetsToOffsets)
+    }
+
+    /**
+     * Reset the process-wide one-time deprecation log guard so tests that exercise the
+     * `margin` fallback path can reliably observe the emitted log regardless of test
+     * ordering.
+     */
+    private fun resetMarginDeprecationLogFlag() {
+        // The `private val` on the companion object is compiled to a static field on
+        // the enclosing FormLayout class (with a synthetic Companion accessor). Reach
+        // for the static directly so we don't depend on internal accessor shape.
+        val field = FormLayout::class.java.getDeclaredField("loggedMarginDeprecation")
+        field.isAccessible = true
+        val atomic = field.get(null) as AtomicBoolean
+        atomic.set(false)
     }
 
     @Test

--- a/sdk/forms/src/test/java/com/klaviyo/forms/bridge/FormLayoutTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/bridge/FormLayoutTest.kt
@@ -2,8 +2,6 @@ package com.klaviyo.forms.bridge
 
 import android.view.Gravity
 import com.klaviyo.fixtures.BaseTest
-import io.mockk.verify
-import java.util.concurrent.atomic.AtomicBoolean
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -178,7 +176,7 @@ class FormLayoutTest : BaseTest() {
                 "position": "bottom_right",
                 "width": {"value": 300, "unit": "fixed"},
                 "height": {"value": 200, "unit": "fixed"},
-                "margin": {"top": 0, "bottom": 16, "left": 0, "right": 16}
+                "offsets": {"top": 0, "bottom": 16, "left": 0, "right": 16}
             }
             """.trimIndent()
         )
@@ -203,7 +201,7 @@ class FormLayoutTest : BaseTest() {
                 "position": "BOTTOM_RIGHT",
                 "width": {"value": 350, "unit": "FIXED"},
                 "height": {"value": 400, "unit": "FIXED"},
-                "margin": {"top": 0, "bottom": 0, "left": 0, "right": 0}
+                "offsets": {"top": 0, "bottom": 0, "left": 0, "right": 0}
             }
             """.trimIndent()
         )
@@ -281,47 +279,6 @@ class FormLayoutTest : BaseTest() {
     }
 
     @Test
-    fun `FormLayout fromJson falls back to margin key when offsets is absent`() {
-        resetMarginDeprecationLogFlag()
-        val json = JSONObject(
-            """
-            {
-                "position": "top",
-                "width": {"value": 300, "unit": "fixed"},
-                "height": {"value": 200, "unit": "fixed"},
-                "margin": {"top": 8, "bottom": 12, "left": 4, "right": 6}
-            }
-            """.trimIndent()
-        )
-        val layout = FormLayout.fromJson(json)
-        assertNotNull(layout)
-        assertEquals(8f, layout!!.offsets.top, 0.01f)
-        assertEquals(12f, layout.offsets.bottom, 0.01f)
-        verify(atLeast = 1) { spyLog.verbose(any(), any()) }
-    }
-
-    @Test
-    fun `FormLayout fromJson offsets wins when both offsets and margin are present`() {
-        val json = JSONObject(
-            """
-            {
-                "position": "top",
-                "width": {"value": 300, "unit": "fixed"},
-                "height": {"value": 200, "unit": "fixed"},
-                "offsets": {"top": 1, "bottom": 2, "left": 3, "right": 4},
-                "margin": {"top": 99, "bottom": 99, "left": 99, "right": 99}
-            }
-            """.trimIndent()
-        )
-        val layout = FormLayout.fromJson(json)
-        assertNotNull(layout)
-        assertEquals(1f, layout!!.offsets.top, 0.01f)
-        assertEquals(2f, layout.offsets.bottom, 0.01f)
-        assertEquals(3f, layout.offsets.left, 0.01f)
-        assertEquals(4f, layout.offsets.right, 0.01f)
-    }
-
-    @Test
     fun `FormLayout fromJson defaults addSafeAreaInsetsToOffsets to true when absent`() {
         val json = JSONObject(
             """
@@ -354,21 +311,6 @@ class FormLayoutTest : BaseTest() {
         val layout = FormLayout.fromJson(json)
         assertNotNull(layout)
         assertFalse(layout!!.addSafeAreaInsetsToOffsets)
-    }
-
-    /**
-     * Reset the process-wide one-time deprecation log guard so tests that exercise the
-     * `margin` fallback path can reliably observe the emitted log regardless of test
-     * ordering.
-     */
-    private fun resetMarginDeprecationLogFlag() {
-        // The `private val` on the companion object is compiled to a static field on
-        // the enclosing FormLayout class (with a synthetic Companion accessor). Reach
-        // for the static directly so we don't depend on internal accessor shape.
-        val field = FormLayout::class.java.getDeclaredField("loggedMarginDeprecation")
-        field.isAccessible = true
-        val atomic = field.get(null) as AtomicBoolean
-        atomic.set(false)
     }
 
     @Test

--- a/sdk/forms/src/test/java/com/klaviyo/forms/presentation/FloatingFormWindowTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/presentation/FloatingFormWindowTest.kt
@@ -10,308 +10,251 @@ import org.junit.Test
 /**
  * Tests for [FloatingFormWindow] pure calculation functions.
  *
- * These cover the offset, positioning, and keyboard-overlap math
- * without requiring Android framework mocks.
+ * These cover the offset / sizing / keyboard-overlap math without requiring
+ * Android framework mocks. Screen bounds are expressed in raw pixels and all
+ * input offsets are in dp, scaled by [density] to match production behavior.
  */
 class FloatingFormWindowTest {
 
     private val density = 2.0f
+    private val screenWidth = 1080
+    private val screenHeight = 1920
 
-    private fun layoutAt(
+    private fun layout(
         position: FormPosition,
+        width: Dimension = Dimension.dp(300f),
+        height: Dimension = Dimension.dp(200f),
         offsets: Offsets = Offsets()
     ) = FormLayout(
         position = position,
-        width = Dimension.dp(300f),
-        height = Dimension.dp(200f),
+        width = width,
+        height = height,
         offsets = offsets
     )
 
-    // ===== calculateVerticalOffset =====
+    private fun compute(
+        layout: FormLayout,
+        screenW: Int = screenWidth,
+        screenH: Int = screenHeight,
+        safeTop: Int = 0,
+        safeBottom: Int = 0,
+        safeLeft: Int = 0,
+        safeRight: Int = 0
+    ) = FloatingFormWindow.calculateLayoutParams(
+        layout = layout,
+        screenWidth = screenW,
+        screenHeight = screenH,
+        density = density,
+        safeAreaTop = safeTop,
+        safeAreaBottom = safeBottom,
+        safeAreaLeft = safeLeft,
+        safeAreaRight = safeRight
+    )
+
+    // ===== Clamping =====
 
     @Test
-    fun `vertical offset for TOP positions uses top offset in pixels`() {
-        val layout = layoutAt(FormPosition.TOP, Offsets(top = 16f))
-        assertEquals(32, FloatingFormWindow.calculateVerticalOffset(layout, density, 0, 0))
-    }
-
-    @Test
-    fun `vertical offset for TOP_LEFT uses top offset`() {
-        val layout = layoutAt(FormPosition.TOP_LEFT, Offsets(top = 10f))
-        assertEquals(20, FloatingFormWindow.calculateVerticalOffset(layout, density, 0, 0))
-    }
-
-    @Test
-    fun `vertical offset for BOTTOM positions uses bottom offset in pixels`() {
-        val layout = layoutAt(FormPosition.BOTTOM, Offsets(bottom = 24f))
-        assertEquals(48, FloatingFormWindow.calculateVerticalOffset(layout, density, 0, 0))
-    }
-
-    @Test
-    fun `vertical offset for BOTTOM_RIGHT uses bottom offset`() {
-        val layout = layoutAt(FormPosition.BOTTOM_RIGHT, Offsets(bottom = 8f))
-        assertEquals(16, FloatingFormWindow.calculateVerticalOffset(layout, density, 0, 0))
-    }
-
-    @Test
-    fun `vertical offset for CENTER is zero`() {
-        val layout = layoutAt(FormPosition.CENTER, Offsets(top = 50f, bottom = 50f))
-        assertEquals(0, FloatingFormWindow.calculateVerticalOffset(layout, density, 0, 0))
-    }
-
-    @Test
-    fun `vertical offset for FULLSCREEN is zero`() {
-        val layout = layoutAt(FormPosition.FULLSCREEN)
-        assertEquals(0, FloatingFormWindow.calculateVerticalOffset(layout, density, 0, 0))
-    }
-
-    @Test
-    fun `vertical offset for TOP includes safe area inset`() {
-        val layout = layoutAt(FormPosition.TOP, Offsets(top = 10f))
-        // safeAreaTop (50) + topOffset (10 * 2.0) = 70
-        assertEquals(70, FloatingFormWindow.calculateVerticalOffset(layout, density, 50, 0))
-    }
-
-    @Test
-    fun `vertical offset for BOTTOM includes safe area inset`() {
-        val layout = layoutAt(FormPosition.BOTTOM, Offsets(bottom = 10f))
-        // safeAreaBottom (30) + bottomOffset (10 * 2.0) = 50
-        assertEquals(50, FloatingFormWindow.calculateVerticalOffset(layout, density, 0, 30))
-    }
-
-    // ===== calculateHorizontalOffset =====
-
-    @Test
-    fun `horizontal offset for LEFT positions uses left offset`() {
-        val layout = layoutAt(FormPosition.TOP_LEFT, Offsets(left = 12f))
-        assertEquals(24, FloatingFormWindow.calculateHorizontalOffset(layout, density, 0, 0))
-    }
-
-    @Test
-    fun `horizontal offset for BOTTOM_LEFT uses left offset`() {
-        val layout = layoutAt(FormPosition.BOTTOM_LEFT, Offsets(left = 8f))
-        assertEquals(16, FloatingFormWindow.calculateHorizontalOffset(layout, density, 0, 0))
-    }
-
-    @Test
-    fun `horizontal offset for RIGHT positions uses positive right offset`() {
-        val layout = layoutAt(FormPosition.TOP_RIGHT, Offsets(right = 16f))
-        assertEquals(32, FloatingFormWindow.calculateHorizontalOffset(layout, density, 0, 0))
-    }
-
-    @Test
-    fun `horizontal offset for BOTTOM_RIGHT uses positive right offset`() {
-        val layout = layoutAt(FormPosition.BOTTOM_RIGHT, Offsets(right = 10f))
-        assertEquals(20, FloatingFormWindow.calculateHorizontalOffset(layout, density, 0, 0))
-    }
-
-    @Test
-    fun `horizontal offset for centered positions is zero`() {
-        val offsets = Offsets(left = 50f, right = 50f)
-        assertEquals(
-            0,
-            FloatingFormWindow.calculateHorizontalOffset(
-                layoutAt(FormPosition.TOP, offsets),
-                density,
-                0,
-                0
-            )
+    fun `width clamps to available when requested equals screen and offsets shrink it`() {
+        // 500px form on 500px screen with 25px offsets (left and right) -> 450px
+        val l = layout(
+            position = FormPosition.TOP_LEFT,
+            width = Dimension.dp(250f), // * density 2 = 500px
+            offsets = Offsets(left = 12.5f, right = 12.5f) // * density 2 = 25px each
         )
-        assertEquals(
-            0,
-            FloatingFormWindow.calculateHorizontalOffset(
-                layoutAt(FormPosition.BOTTOM, offsets),
-                density,
-                0,
-                0
-            )
-        )
-        assertEquals(
-            0,
-            FloatingFormWindow.calculateHorizontalOffset(
-                layoutAt(FormPosition.CENTER, offsets),
-                density,
-                0,
-                0
-            )
-        )
-        assertEquals(
-            0,
-            FloatingFormWindow.calculateHorizontalOffset(
-                layoutAt(FormPosition.FULLSCREEN, offsets),
-                density,
-                0,
-                0
-            )
-        )
+        val computed = compute(l, screenW = 500, screenH = 500)
+        assertEquals(450, computed.width)
     }
 
     @Test
-    fun `horizontal offset for centered positions shifts for asymmetric safe areas`() {
-        val layout = layoutAt(FormPosition.TOP)
-        // Punch hole on left only: (100 - 0) / 2 = 50
-        assertEquals(50, FloatingFormWindow.calculateHorizontalOffset(layout, density, 100, 0))
-        // Punch hole on right only: (0 - 100) / 2 = -50
-        assertEquals(-50, FloatingFormWindow.calculateHorizontalOffset(layout, density, 0, 100))
-        // Symmetric safe areas: (60 - 60) / 2 = 0
-        assertEquals(0, FloatingFormWindow.calculateHorizontalOffset(layout, density, 60, 60))
+    fun `width does not shrink when form already fits within available space`() {
+        // 400px form on 500px screen with 25px offsets -> 400px (no shrink)
+        val l = layout(
+            position = FormPosition.TOP_LEFT,
+            width = Dimension.dp(200f), // 400px
+            offsets = Offsets(left = 12.5f, right = 12.5f) // 25 + 25
+        )
+        val computed = compute(l, screenW = 500, screenH = 500)
+        assertEquals(400, computed.width)
     }
 
     @Test
-    fun `horizontal offset for LEFT includes safe area inset`() {
-        val layout = layoutAt(FormPosition.TOP_LEFT, Offsets(left = 10f))
-        // safeAreaLeft (40) + leftOffset (10 * 2.0) = 60
-        assertEquals(60, FloatingFormWindow.calculateHorizontalOffset(layout, density, 40, 0))
+    fun `height clamps to available when requested equals screen and offsets shrink it`() {
+        // 500px form on 500px screen, 25 top + 25 bottom -> 450px
+        val l = layout(
+            position = FormPosition.TOP_LEFT,
+            height = Dimension.dp(250f),
+            offsets = Offsets(top = 12.5f, bottom = 12.5f)
+        )
+        val computed = compute(l, screenW = 500, screenH = 500)
+        assertEquals(450, computed.height)
     }
 
     @Test
-    fun `horizontal offset for RIGHT includes safe area inset`() {
-        val layout = layoutAt(FormPosition.TOP_RIGHT, Offsets(right = 10f))
-        // safeAreaRight (40) + rightOffset (10 * 2.0) = 60
-        assertEquals(60, FloatingFormWindow.calculateHorizontalOffset(layout, density, 0, 40))
+    fun `height does not shrink when form already fits within available space`() {
+        val l = layout(
+            position = FormPosition.TOP_LEFT,
+            height = Dimension.dp(200f), // 400px
+            offsets = Offsets(top = 12.5f, bottom = 12.5f)
+        )
+        val computed = compute(l, screenW = 500, screenH = 500)
+        assertEquals(400, computed.height)
+    }
+
+    @Test
+    fun `safe area insets are folded into available space alongside offsets`() {
+        // screen 500, safeLeft 30 + safeRight 20 + leftOffset 25 + rightOffset 25 = 100
+        // available = 400; requested 500 clamps to 400.
+        val l = layout(
+            position = FormPosition.TOP_LEFT,
+            width = Dimension.dp(250f),
+            offsets = Offsets(left = 12.5f, right = 12.5f)
+        )
+        val computed = compute(l, screenW = 500, screenH = 500, safeLeft = 30, safeRight = 20)
+        assertEquals(400, computed.width)
+    }
+
+    @Test
+    fun `available space floors at zero when offsets exceed screen`() {
+        // huge offsets, clamped width must be >= 0
+        val l = layout(
+            position = FormPosition.TOP_LEFT,
+            width = Dimension.dp(100f),
+            height = Dimension.dp(100f),
+            offsets = Offsets(left = 1000f, right = 1000f, top = 1000f, bottom = 1000f)
+        )
+        val computed = compute(l, screenW = 500, screenH = 500)
+        assertEquals(0, computed.width)
+        assertEquals(0, computed.height)
+    }
+
+    // ===== Corner positioning =====
+
+    @Test
+    fun `TOP_LEFT x is safeAreaLeft plus left offset`() {
+        val l = layout(FormPosition.TOP_LEFT, offsets = Offsets(left = 10f, top = 5f))
+        val computed = compute(l, safeLeft = 40, safeTop = 50)
+        assertEquals(60, computed.x) // 40 + 20
+        assertEquals(60, computed.y) // 50 + 10
+    }
+
+    @Test
+    fun `BOTTOM_RIGHT x and y use right and bottom margins`() {
+        val l = layout(FormPosition.BOTTOM_RIGHT, offsets = Offsets(right = 10f, bottom = 5f))
+        val computed = compute(l, safeRight = 40, safeBottom = 50)
+        assertEquals(60, computed.x) // 40 + 20
+        assertEquals(60, computed.y) // 50 + 10
+    }
+
+    // ===== Centered positioning (asymmetric offsets) =====
+
+    @Test
+    fun `centered horizontal anchor shifts toward smaller left-right margin`() {
+        // leftMargin 100, rightMargin 0 => x = (100 - 0) / 2 = 50 (shift right of center)
+        val l = layout(FormPosition.TOP, offsets = Offsets(left = 50f))
+        assertEquals(50, compute(l).x)
+
+        // leftMargin 0, rightMargin 100 => x = -50 (shift left of center)
+        val l2 = layout(FormPosition.TOP, offsets = Offsets(right = 50f))
+        assertEquals(-50, compute(l2).x)
+
+        // Symmetric offsets => 0
+        val l3 = layout(FormPosition.TOP, offsets = Offsets(left = 30f, right = 30f))
+        assertEquals(0, compute(l3).x)
+    }
+
+    @Test
+    fun `CENTER vertical anchor shifts for asymmetric top-bottom margins`() {
+        // topMargin 100, bottomMargin 0 => y = 50 (shift down from center)
+        val l = layout(FormPosition.CENTER, offsets = Offsets(top = 50f))
+        assertEquals(50, compute(l).y)
+
+        val l2 = layout(FormPosition.CENTER, offsets = Offsets(bottom = 50f))
+        assertEquals(-50, compute(l2).y)
+    }
+
+    @Test
+    fun `centered position folds safe area into margin asymmetry`() {
+        val l = layout(FormPosition.TOP)
+        // safeLeft 100, no offsets: x = (100 - 0) / 2 = 50
+        assertEquals(50, compute(l, safeLeft = 100).x)
+        // safeRight 100: x = -50
+        assertEquals(-50, compute(l, safeRight = 100).x)
+        // Symmetric safe areas cancel out
+        assertEquals(0, compute(l, safeLeft = 60, safeRight = 60).x)
+    }
+
+    // ===== FULLSCREEN =====
+
+    @Test
+    fun `FULLSCREEN ignores offsets and fills screen`() {
+        val l = layout(
+            FormPosition.FULLSCREEN,
+            offsets = Offsets(top = 50f, bottom = 50f, left = 50f, right = 50f)
+        )
+        val computed = compute(l, safeTop = 100, safeBottom = 100, safeLeft = 100, safeRight = 100)
+        assertEquals(screenWidth, computed.width)
+        assertEquals(screenHeight, computed.height)
+        assertEquals(0, computed.x)
+        assertEquals(0, computed.y)
     }
 
     // ===== calculateFormBottomGap =====
 
     @Test
-    fun `bottom gap for BOTTOM position equals bottom offset in pixels`() {
-        val layout = layoutAt(FormPosition.BOTTOM, Offsets(bottom = 16f))
-        val formHeight = 400
-        val screenHeight = 1920
+    fun `bottom gap for BOTTOM uses safe area plus bottom offset`() {
+        val l = layout(FormPosition.BOTTOM, offsets = Offsets(bottom = 10f))
         assertEquals(
-            32,
-            FloatingFormWindow.calculateFormBottomGap(
-                layout,
-                formHeight,
-                screenHeight,
-                density,
-                0,
-                0
-            )
+            50,
+            FloatingFormWindow.calculateFormBottomGap(l, 400, screenHeight, density, 0, 30)
         )
     }
 
     @Test
-    fun `bottom gap for BOTTOM with zero offset is zero`() {
-        val layout = layoutAt(FormPosition.BOTTOM)
+    fun `bottom gap for TOP equals screenHeight minus top margin minus form height`() {
+        val l = layout(FormPosition.TOP, offsets = Offsets(top = 10f))
+        // 1920 - (50 + 20) - 400 = 1450
         assertEquals(
-            0,
-            FloatingFormWindow.calculateFormBottomGap(layout, 400, 1920, density, 0, 0)
+            1450,
+            FloatingFormWindow.calculateFormBottomGap(l, 400, screenHeight, density, 50, 0)
         )
     }
 
     @Test
-    fun `bottom gap for TOP position is screen minus top offset minus form height`() {
-        val layout = layoutAt(FormPosition.TOP, Offsets(top = 16f))
-        val formHeight = 400
-        val screenHeight = 1920
-        // gap = 1920 - 0 - (16*2) - 400 = 1488
-        assertEquals(
-            1488,
-            FloatingFormWindow.calculateFormBottomGap(
-                layout,
-                formHeight,
-                screenHeight,
-                density,
-                0,
-                0
-            )
-        )
-    }
-
-    @Test
-    fun `bottom gap for TOP with tall form leaves small gap`() {
-        val layout = layoutAt(FormPosition.TOP, Offsets(top = 0f))
-        // gap = 1920 - 0 - 0 - 1800 = 120
-        assertEquals(
-            120,
-            FloatingFormWindow.calculateFormBottomGap(layout, 1800, 1920, density, 0, 0)
-        )
-    }
-
-    @Test
-    fun `bottom gap for CENTER is half the remaining space`() {
-        val layout = layoutAt(FormPosition.CENTER)
-        val formHeight = 400
-        val screenHeight = 1920
-        // gap = (1920 - 400) / 2 = 760
+    fun `bottom gap for CENTER with symmetric margins is centered`() {
+        val l = layout(FormPosition.CENTER)
+        // (1920 - 400) / 2 = 760, asymmetry term is 0
         assertEquals(
             760,
-            FloatingFormWindow.calculateFormBottomGap(
-                layout,
-                formHeight,
-                screenHeight,
-                density,
-                0,
-                0
-            )
+            FloatingFormWindow.calculateFormBottomGap(l, 400, screenHeight, density, 0, 0)
+        )
+    }
+
+    @Test
+    fun `bottom gap for CENTER reflects margin asymmetry`() {
+        val l = layout(FormPosition.CENTER, offsets = Offsets(top = 50f))
+        // topMargin 100, bottomMargin 0 -> form shifts down by 50 -> bottomGap shrinks by 50
+        // baseline centered gap = (1920 - 400) / 2 = 760; with (bottomMargin-topMargin)/2 = -50
+        assertEquals(
+            710,
+            FloatingFormWindow.calculateFormBottomGap(l, 400, screenHeight, density, 0, 0)
         )
     }
 
     @Test
     fun `bottom gap for FULLSCREEN is zero`() {
-        val layout = layoutAt(FormPosition.FULLSCREEN)
+        val l = layout(FormPosition.FULLSCREEN)
         assertEquals(
             0,
-            FloatingFormWindow.calculateFormBottomGap(layout, 1920, 1920, density, 0, 0)
+            FloatingFormWindow.calculateFormBottomGap(l, screenHeight, screenHeight, density, 0, 0)
         )
     }
 
     @Test
-    fun `bottom gap for BOTTOM_LEFT uses bottom offset`() {
-        val layout = layoutAt(FormPosition.BOTTOM_LEFT, Offsets(bottom = 20f))
-        assertEquals(
-            40,
-            FloatingFormWindow.calculateFormBottomGap(layout, 400, 1920, density, 0, 0)
-        )
-    }
-
-    @Test
-    fun `bottom gap for TOP_RIGHT uses top offset and form height`() {
-        val layout = layoutAt(FormPosition.TOP_RIGHT, Offsets(top = 8f))
-        // gap = 1920 - 0 - (8*2) - 400 = 1504
-        assertEquals(
-            1504,
-            FloatingFormWindow.calculateFormBottomGap(layout, 400, 1920, density, 0, 0)
-        )
-    }
-
-    @Test
-    fun `bottom gap for BOTTOM includes safe area inset`() {
-        val layout = layoutAt(FormPosition.BOTTOM, Offsets(bottom = 10f))
-        // safeAreaBottom (30) + bottomOffset (10 * 2.0) = 50
-        assertEquals(
-            50,
-            FloatingFormWindow.calculateFormBottomGap(layout, 400, 1920, density, 0, 30)
-        )
-    }
-
-    @Test
-    fun `bottom gap for TOP includes safe area inset`() {
-        val layout = layoutAt(FormPosition.TOP, Offsets(top = 10f))
-        // gap = 1920 - safeAreaTop (50) - topOffset (10 * 2.0) - 400 = 1450
-        assertEquals(
-            1450,
-            FloatingFormWindow.calculateFormBottomGap(layout, 400, 1920, density, 50, 0)
-        )
-    }
-
-    // ===== Zero offset edge cases =====
-
-    @Test
-    fun `all calculations handle zero offsets correctly`() {
-        val layout = layoutAt(FormPosition.TOP)
-        assertEquals(0, FloatingFormWindow.calculateVerticalOffset(layout, density, 0, 0))
-        assertEquals(0, FloatingFormWindow.calculateHorizontalOffset(layout, density, 0, 0))
-    }
-
-    @Test
-    fun `calculations with density 1 produce dp values directly`() {
-        val layout = layoutAt(FormPosition.BOTTOM, Offsets(bottom = 16f))
-        assertEquals(16, FloatingFormWindow.calculateVerticalOffset(layout, 1.0f, 0, 0))
+    fun `bottom gap with density 1 uses raw dp values`() {
+        val l = layout(FormPosition.BOTTOM, offsets = Offsets(bottom = 16f))
         assertEquals(
             16,
-            FloatingFormWindow.calculateFormBottomGap(layout, 400, 1920, 1.0f, 0, 0)
+            FloatingFormWindow.calculateFormBottomGap(l, 400, screenHeight, 1.0f, 0, 0)
         )
     }
 }

--- a/sdk/forms/src/test/java/com/klaviyo/forms/presentation/FloatingFormWindowTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/presentation/FloatingFormWindowTest.kt
@@ -257,4 +257,131 @@ class FloatingFormWindowTest {
             FloatingFormWindow.calculateFormBottomGap(l, 400, screenHeight, 1.0f, 0, 0)
         )
     }
+
+    // ===== addSafeAreaInsetsToOffsets flag =====
+
+    private fun layoutNoSafeArea(
+        position: FormPosition,
+        width: Dimension = Dimension.dp(300f),
+        height: Dimension = Dimension.dp(200f),
+        offsets: Offsets = Offsets()
+    ) = FormLayout(
+        position = position,
+        width = width,
+        height = height,
+        offsets = offsets,
+        addSafeAreaInsetsToOffsets = false
+    )
+
+    @Test
+    fun `addSafeAreaInsetsToOffsets false skips safe-area for TOP_LEFT position math`() {
+        val l = layoutNoSafeArea(
+            position = FormPosition.TOP_LEFT,
+            offsets = Offsets(top = 10f, left = 20f)
+        )
+        val computed = compute(l, safeTop = 100, safeLeft = 50)
+        // Without safe-area: x = left offset only (20 * density 2 = 40), y = top offset only (10 * 2 = 20)
+        assertEquals(40, computed.x)
+        assertEquals(20, computed.y)
+    }
+
+    @Test
+    fun `addSafeAreaInsetsToOffsets false skips safe-area for TOP_RIGHT position math`() {
+        val l = layoutNoSafeArea(
+            position = FormPosition.TOP_RIGHT,
+            offsets = Offsets(top = 10f, right = 20f)
+        )
+        val computed = compute(l, safeTop = 100, safeRight = 50)
+        assertEquals(40, computed.x)
+        assertEquals(20, computed.y)
+    }
+
+    @Test
+    fun `addSafeAreaInsetsToOffsets false skips safe-area for BOTTOM_LEFT position math`() {
+        val l = layoutNoSafeArea(
+            position = FormPosition.BOTTOM_LEFT,
+            offsets = Offsets(bottom = 10f, left = 20f)
+        )
+        val computed = compute(l, safeBottom = 100, safeLeft = 50)
+        assertEquals(40, computed.x)
+        assertEquals(20, computed.y)
+    }
+
+    @Test
+    fun `addSafeAreaInsetsToOffsets false skips safe-area for BOTTOM_RIGHT position math`() {
+        val l = layoutNoSafeArea(
+            position = FormPosition.BOTTOM_RIGHT,
+            offsets = Offsets(bottom = 10f, right = 20f)
+        )
+        val computed = compute(l, safeBottom = 100, safeRight = 50)
+        assertEquals(40, computed.x)
+        assertEquals(20, computed.y)
+    }
+
+    @Test
+    fun `addSafeAreaInsetsToOffsets false skips safe-area from available-space clamping`() {
+        // 500px form on 500px screen, zero offsets, 50px safe insets on each side.
+        // With flag=true the available width collapses to 500-50-50=400 and the form clamps to 400.
+        // With flag=false the SDK ignores safe-area entirely: available = 500, form fits at 500.
+        val l = FormLayout(
+            position = FormPosition.TOP_LEFT,
+            width = Dimension.dp(250f), // * density 2 = 500px
+            height = Dimension.dp(250f),
+            offsets = Offsets(),
+            addSafeAreaInsetsToOffsets = false
+        )
+        val computed = compute(
+            l,
+            screenW = 500,
+            screenH = 500,
+            safeLeft = 50,
+            safeRight = 50,
+            safeTop = 50,
+            safeBottom = 50
+        )
+        assertEquals(500, computed.width)
+        assertEquals(500, computed.height)
+    }
+
+    @Test
+    fun `addSafeAreaInsetsToOffsets true (default) preserves safe-area additive behavior`() {
+        val l = layout(
+            position = FormPosition.TOP_LEFT,
+            offsets = Offsets(top = 10f, left = 20f)
+        )
+        val computed = compute(l, safeTop = 100, safeLeft = 50)
+        // With safe-area: x = 50 + (20*2) = 90, y = 100 + (10*2) = 120
+        assertEquals(90, computed.x)
+        assertEquals(120, computed.y)
+    }
+
+    @Test
+    fun `addSafeAreaInsetsToOffsets false on FULLSCREEN still fills screen (flag ignored)`() {
+        val l = layoutNoSafeArea(position = FormPosition.FULLSCREEN)
+        val computed = compute(l, safeTop = 100, safeBottom = 100, safeLeft = 50, safeRight = 50)
+        assertEquals(screenWidth, computed.width)
+        assertEquals(screenHeight, computed.height)
+        assertEquals(0, computed.x)
+        assertEquals(0, computed.y)
+    }
+
+    @Test
+    fun `addSafeAreaInsetsToOffsets false skips safe-area in bottom gap math for BOTTOM position`() {
+        val l = layoutNoSafeArea(FormPosition.BOTTOM, offsets = Offsets(bottom = 16f))
+        // flag=false: gap = bottom offset only (16 * density 2 = 32), safeBottom=100 ignored
+        assertEquals(
+            32,
+            FloatingFormWindow.calculateFormBottomGap(l, 400, screenHeight, density, 0, 100)
+        )
+    }
+
+    @Test
+    fun `addSafeAreaInsetsToOffsets true (default) includes safe-area in bottom gap for BOTTOM position`() {
+        val l = layout(FormPosition.BOTTOM, offsets = Offsets(bottom = 16f))
+        // flag=true: gap = safeBottom (100) + bottom offset (16 * 2 = 32) = 132
+        assertEquals(
+            132,
+            FloatingFormWindow.calculateFormBottomGap(l, 400, screenHeight, density, 0, 100)
+        )
+    }
 }

--- a/sdk/forms/src/test/java/com/klaviyo/forms/presentation/KlaviyoPresentationManagerTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/presentation/KlaviyoPresentationManagerTest.kt
@@ -31,17 +31,40 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class KlaviyoPresentationManagerTest : BaseTest() {
+    /**
+     * Tracks every observer the manager registers via [LifecycleMonitor.onActivityEvent].
+     * The manager registers the primary observer from its `init` block and may register
+     * additional one-shot observers for rotation / device-info push. Tests dispatch events
+     * to all currently-registered observers via [dispatchEvent], mirroring how the real
+     * [LifecycleMonitor] broadcasts events to every registered observer.
+     */
+    private val registeredObservers = mutableListOf<ActivityObserver>()
+
+    /**
+     * Convenience slot for legacy tests that only care about the most recently registered
+     * observer. Prefer [dispatchEvent] for new tests that exercise observer interleaving.
+     */
     private val slotOnActivityEvent = slot<ActivityObserver>()
     private val mockWebViewClient = mockk<WebViewClient>(relaxed = true)
     private val mockOverlayActivity: Activity = mockk<KlaviyoFormsOverlayActivity>(relaxed = true)
     private val mockLaunchIntent = mockk<Intent>(relaxed = true)
+
+    private fun dispatchEvent(event: ActivityEvent) {
+        // Iterate over a snapshot — observers may register/unregister others during dispatch
+        registeredObservers.toList().forEach { it(event) }
+    }
 
     override fun setup() {
         super.setup()
         mockkObject(KlaviyoFormsOverlayActivity).apply {
             every { KlaviyoFormsOverlayActivity.launchIntent } returns mockLaunchIntent
         }
-        every { mockLifecycleMonitor.onActivityEvent(capture(slotOnActivityEvent)) } just runs
+        every { mockLifecycleMonitor.onActivityEvent(capture(slotOnActivityEvent)) } answers {
+            registeredObservers.add(slotOnActivityEvent.captured)
+        }
+        every { mockLifecycleMonitor.offActivityEvent(any()) } answers {
+            registeredObservers.remove(firstArg<ActivityObserver>())
+        }
         every { mockContext.startActivity(mockLaunchIntent) } just runs
         Registry.register<WebViewClient>(mockWebViewClient)
         Registry.register<InAppFormsConfig>(InAppFormsConfig())
@@ -60,7 +83,7 @@ class KlaviyoPresentationManagerTest : BaseTest() {
     private fun KlaviyoPresentationManager.mockPresent() = apply {
         present(null)
         assert(slotOnActivityEvent.isCaptured) { "Lifecycle listener should be captured" }
-        slotOnActivityEvent.captured(ActivityEvent.Created(mockOverlayActivity, null))
+        dispatchEvent(ActivityEvent.Created(mockOverlayActivity, null))
     }
 
     private fun withHiddenState() = KlaviyoPresentationManager().apply {
@@ -87,7 +110,7 @@ class KlaviyoPresentationManagerTest : BaseTest() {
     fun `verify it ignores non-klaviyo activities`() {
         val manager = withHiddenState()
 
-        slotOnActivityEvent.captured(ActivityEvent.Created(mockActivity, null))
+        dispatchEvent(ActivityEvent.Created(mockActivity, null))
 
         verify(exactly = 0) { mockWebViewClient.attachWebView(mockOverlayActivity) }
         assertEquals(
@@ -106,13 +129,118 @@ class KlaviyoPresentationManagerTest : BaseTest() {
         }
 
         // Initial orientation event must be a change
-        slotOnActivityEvent.captured(ActivityEvent.ConfigurationChanged(mockConfig))
+        dispatchEvent(ActivityEvent.ConfigurationChanged(mockConfig))
         verify { mockWebViewClient.detachWebView() }
 
         // After configuration change, the activity gets re-created,
         // at which point we should re-attach if we were previously presenting
-        slotOnActivityEvent.captured(ActivityEvent.Created(mockOverlayActivity, mockk()))
+        dispatchEvent(ActivityEvent.Created(mockOverlayActivity, mockk()))
         verify { mockWebViewClient.attachWebView(mockOverlayActivity) }
+    }
+
+    @Test
+    fun `pushDeviceInfo is deferred until next Resumed activity after orientation change`() {
+        withPresentedState()
+
+        val mockConfig = mockk<Configuration>(relaxed = true) {
+            orientation = Configuration.ORIENTATION_LANDSCAPE
+        }
+
+        // ConfigurationChanged fires while the stale activity is still current —
+        // pushDeviceInfo must NOT be called yet, or it would capture pre-rotation
+        // Display.rotation/rootWindowInsets values.
+        dispatchEvent(ActivityEvent.ConfigurationChanged(mockConfig))
+        verify(exactly = 0) { mockWebViewClient.pushDeviceInfo() }
+
+        // The next Resumed activity represents the rotated activity with fresh
+        // Display metrics — pushDeviceInfo should fire exactly once here.
+        dispatchEvent(ActivityEvent.Resumed(mockk(relaxed = true)))
+        verify(exactly = 1) { mockWebViewClient.pushDeviceInfo() }
+
+        // Subsequent Resumed events (e.g. backgrounding/foregrounding after rotation)
+        // must NOT re-trigger pushDeviceInfo — the one-shot observer is consumed.
+        dispatchEvent(ActivityEvent.Resumed(mockk(relaxed = true)))
+        dispatchEvent(ActivityEvent.Resumed(mockk(relaxed = true)))
+        verify(exactly = 1) { mockWebViewClient.pushDeviceInfo() }
+    }
+
+    @Test
+    fun `pushDeviceInfo fires on rotation even when no form is presenting`() {
+        // Preloaded-but-not-presenting webview case: no present() was called.
+        KlaviyoPresentationManager()
+
+        val mockConfig = mockk<Configuration>(relaxed = true) {
+            orientation = Configuration.ORIENTATION_LANDSCAPE
+        }
+
+        dispatchEvent(ActivityEvent.ConfigurationChanged(mockConfig))
+        verify(exactly = 0) { mockWebViewClient.pushDeviceInfo() }
+
+        dispatchEvent(ActivityEvent.Resumed(mockk(relaxed = true)))
+        verify(exactly = 1) { mockWebViewClient.pushDeviceInfo() }
+    }
+
+    @Test
+    fun `pushDeviceInfo is not triggered by non-orientation configuration changes`() {
+        withPresentedState()
+
+        // Same orientation — e.g. locale change, dark-mode toggle, font scale update.
+        // The manager's initial orientation is null, so the first ConfigurationChanged
+        // with any orientation value is treated as a change. Establish a baseline first.
+        val portrait = mockk<Configuration>(relaxed = true) {
+            orientation = Configuration.ORIENTATION_PORTRAIT
+        }
+        dispatchEvent(ActivityEvent.ConfigurationChanged(portrait))
+        // Baseline push after first orientation is observed
+        dispatchEvent(ActivityEvent.Resumed(mockk(relaxed = true)))
+        verify(exactly = 1) { mockWebViewClient.pushDeviceInfo() }
+
+        // Now a non-orientation config change (same PORTRAIT) — must not schedule
+        // or fire another device-info push.
+        val portraitAgain = mockk<Configuration>(relaxed = true) {
+            orientation = Configuration.ORIENTATION_PORTRAIT
+        }
+        dispatchEvent(ActivityEvent.ConfigurationChanged(portraitAgain))
+        dispatchEvent(ActivityEvent.Resumed(mockk(relaxed = true)))
+        verify(exactly = 1) { mockWebViewClient.pushDeviceInfo() }
+    }
+
+    @Test
+    fun `pushDeviceInfo observer times out if no Resumed ever arrives`() {
+        withPresentedState()
+
+        val mockConfig = mockk<Configuration>(relaxed = true) {
+            orientation = Configuration.ORIENTATION_LANDSCAPE
+        }
+        dispatchEvent(ActivityEvent.ConfigurationChanged(mockConfig))
+
+        // Advance well past the safety timeout — observer should have unregistered itself.
+        staticClock.execute(10_000L)
+
+        // Late Resumed arrives after the observer timed out — must not fire pushDeviceInfo.
+        dispatchEvent(ActivityEvent.Resumed(mockk(relaxed = true)))
+        verify(exactly = 0) { mockWebViewClient.pushDeviceInfo() }
+    }
+
+    @Test
+    fun `rapid rotation replaces prior pushDeviceInfo observer so only latest fires`() {
+        withPresentedState()
+
+        val landscape = mockk<Configuration>(relaxed = true) {
+            orientation = Configuration.ORIENTATION_LANDSCAPE
+        }
+        val portrait = mockk<Configuration>(relaxed = true) {
+            orientation = Configuration.ORIENTATION_PORTRAIT
+        }
+
+        // Two rotations land before the next Resumed.
+        dispatchEvent(ActivityEvent.ConfigurationChanged(landscape))
+        dispatchEvent(ActivityEvent.ConfigurationChanged(portrait))
+
+        dispatchEvent(ActivityEvent.Resumed(mockk(relaxed = true)))
+        // Should only push once — the second ConfigurationChanged should have dropped the
+        // first one-shot observer, so only the latest fires on Resumed.
+        verify(exactly = 1) { mockWebViewClient.pushDeviceInfo() }
     }
 
     @Test
@@ -120,12 +248,12 @@ class KlaviyoPresentationManagerTest : BaseTest() {
         withPresentedState()
         verify(exactly = 1) { mockWebViewClient.attachWebView(mockOverlayActivity) }
 
-        slotOnActivityEvent.captured(ActivityEvent.Started(mockk()))
-        slotOnActivityEvent.captured(ActivityEvent.Resumed(mockk()))
-        slotOnActivityEvent.captured(ActivityEvent.SaveInstanceState(mockk(), mockk()))
-        slotOnActivityEvent.captured(ActivityEvent.Paused(mockk()))
-        slotOnActivityEvent.captured(ActivityEvent.Stopped(mockk()))
-        slotOnActivityEvent.captured(ActivityEvent.AllStopped())
+        dispatchEvent(ActivityEvent.Started(mockk()))
+        dispatchEvent(ActivityEvent.Resumed(mockk()))
+        dispatchEvent(ActivityEvent.SaveInstanceState(mockk(), mockk()))
+        dispatchEvent(ActivityEvent.Paused(mockk()))
+        dispatchEvent(ActivityEvent.Stopped(mockk()))
+        dispatchEvent(ActivityEvent.AllStopped())
 
         verify(inverse = true) { mockWebViewClient.detachWebView() }
         verify(exactly = 1) { mockWebViewClient.attachWebView(mockOverlayActivity) }
@@ -177,7 +305,7 @@ class KlaviyoPresentationManagerTest : BaseTest() {
         )
 
         // Simulate activity creation lifecycle event
-        slotOnActivityEvent.captured(ActivityEvent.Created(mockOverlayActivity, null))
+        dispatchEvent(ActivityEvent.Created(mockOverlayActivity, null))
 
         verify(exactly = 1) { mockWebViewClient.attachWebView(mockOverlayActivity) }
         assertEquals(
@@ -338,7 +466,7 @@ class KlaviyoPresentationManagerTest : BaseTest() {
         val manager = withFloatingPresentedState()
         try {
             // Simulate the host activity stopping (multi-activity transition)
-            slotOnActivityEvent.captured(ActivityEvent.Stopped(mockHostActivity))
+            dispatchEvent(ActivityEvent.Stopped(mockHostActivity))
 
             // Before grace period: still presented
             assertEquals(PresentationState.Presented("floatingFormId"), manager.presentationState)
@@ -359,7 +487,7 @@ class KlaviyoPresentationManagerTest : BaseTest() {
         val manager = withFloatingPresentedState()
         try {
             val otherActivity = mockk<Activity>(relaxed = true)
-            slotOnActivityEvent.captured(ActivityEvent.Stopped(otherActivity))
+            dispatchEvent(ActivityEvent.Stopped(otherActivity))
 
             staticClock.execute(LifecycleMonitor.ACTIVITY_TRANSITION_GRACE_PERIOD)
 
@@ -375,8 +503,8 @@ class KlaviyoPresentationManagerTest : BaseTest() {
         val manager = withFloatingPresentedState()
         try {
             // Simulate backgrounding: Stopped then AllStopped in quick succession
-            slotOnActivityEvent.captured(ActivityEvent.Stopped(mockHostActivity))
-            slotOnActivityEvent.captured(ActivityEvent.AllStopped())
+            dispatchEvent(ActivityEvent.Stopped(mockHostActivity))
+            dispatchEvent(ActivityEvent.AllStopped())
 
             // AllStopped should cancel the per-activity cleanup and set Presenting for re-presentation
             assertEquals(PresentationState.Presenting("floatingFormId"), manager.presentationState)
@@ -404,7 +532,7 @@ class KlaviyoPresentationManagerTest : BaseTest() {
 
             // Trigger rotation — this dismisses the window, sets floatingFormWindow = null,
             // and registers a rotation observer for re-presentation
-            slotOnActivityEvent.captured(ActivityEvent.ConfigurationChanged(mockConfig))
+            dispatchEvent(ActivityEvent.ConfigurationChanged(mockConfig))
             assertEquals(PresentationState.Presenting("floatingFormId"), manager.presentationState)
 
             // Dismiss cancels the rotation observer via clearTimers() and resets state
@@ -417,7 +545,7 @@ class KlaviyoPresentationManagerTest : BaseTest() {
 
             // Simulate new activity resuming — should NOT re-present the floating window
             // because the rotation observer was cleaned up by dismiss/clearTimers
-            slotOnActivityEvent.captured(ActivityEvent.Resumed(mockk(relaxed = true)))
+            dispatchEvent(ActivityEvent.Resumed(mockk(relaxed = true)))
             assertEquals(
                 "Resumed should not change state after dismiss cancels rotation observer",
                 PresentationState.Hidden,
@@ -433,8 +561,8 @@ class KlaviyoPresentationManagerTest : BaseTest() {
         val manager = withFloatingPresentedState()
         try {
             // Background the app
-            slotOnActivityEvent.captured(ActivityEvent.Stopped(mockHostActivity))
-            slotOnActivityEvent.captured(ActivityEvent.AllStopped())
+            dispatchEvent(ActivityEvent.Stopped(mockHostActivity))
+            dispatchEvent(ActivityEvent.AllStopped())
             assertEquals(PresentationState.Presenting("floatingFormId"), manager.presentationState)
 
             // Simulate session timeout (default from InAppFormsConfig)


### PR DESCRIPTION
# Description

Floating-form rendering tweaks and a new `data-klaviyo-device` attribute on the onsite `<head>` so onsite JS can read device dimensions / safe-area insets / orientation / DPR during synchronous HTML parse, before the webview attaches. Plus a wire-contract rename (`margin` → `offsets`) and a new `addSafeAreaInsetsToOffsets` flag that lets onsite opt out of SDK-managed safe-area math entirely.

## Due Diligence
- [x] I have tested this on an emulator and/or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all Android versions the SDK currently supports.

## Release/Versioning Considerations
- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [x] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

## Changelog / Code Overview

### Offset clamping
- Clamp floating-form width/height so `offsets` can't drive the computed size negative or push the form off-screen.
- Clamp the bottom-gap used for keyboard-overlap math to `>= 0` so we don't spuriously report overlap when the form sits above the keyboard.

### `data-klaviyo-device` attribute
- New `DeviceInfo` model (`screen`, `safeAreaInsets`, `orientation`, `dpr`) shaped to CSSOM `screen.*` conventions.
- Baked into the HTML template at initial load and pushed via `evaluateJavascript` on orientation / inset changes, so onsite code can read it synchronously before the webview attaches.
- Injection sidesteps JS string-escape concerns by emitting the raw JSON as a JS object expression wrapped in `JSON.stringify(...)` — the engine parses it natively.

### Rotation-lag fix
- `pushDeviceInfo()` now defers to the **next** `ActivityEvent.Resumed` after `onConfigurationChanged`, rather than firing on the config-change callback itself. `ConfigurationChanged` fires while the old activity / display is still being torn down, so reading `Display.rotation` / `decorView.rootWindowInsets` at that moment yields stale values one rotation behind. Uses a one-shot observer with a 1s safety timeout.

### Wire rename + safe-area opt-out
- **`margin` → `offsets`** in the `formWillAppear.layout` payload. The legacy `margin` fallback has been removed now that onsite is fully migrated in production.
- **`addSafeAreaInsetsToOffsets: Boolean`** (optional, defaults to `true`). When `false`, the SDK uses `offsets` as absolute distances from the screen edge — no safe-area inflation in position math, available-space clamping, or keyboard-gap math. Onsite takes responsibility for safe-area policy.

### Misc hardening
- `DeviceInfoProvider.current()` reads UI-thread-only APIs; entire `pushDeviceInfo` chain now dispatches through `runOnUiThread` to avoid silent off-thread degradation.
- `Activity.display` on API 30+ (falling back to `windowManager.defaultDisplay` on 23-29) — avoids blanket `@Suppress("DEPRECATION")` and correctly scopes to the activity's actual display in multi-display setups.
- `pushDeviceInfo` is silent on a null webview (expected idle state during preload / between register-unregister cycles).
- Orientation mapping documented with a KDoc note on the natural-landscape-device caveat (our product scope is natural-portrait phones).

## Wire-contract changes for Fender coordination
- **`margin` → `offsets`** on `formWillAppear.layout`. No backward-compat fallback.
- **New `addSafeAreaInsetsToOffsets: Boolean`** on `formWillAppear.layout`, defaults to `true`.
- **`<head data-klaviyo-device='{…}'>`** attribute with CSSOM-shaped JSON; updated on rotation and inset changes.

## Test Plan

- [x] `./gradlew :sdk:forms:testDebugUnitTest` passes (new coverage in `FormLayoutTest`, `FloatingFormWindowTest`, `DeviceInfoTest`, `KlaviyoPresentationManagerTest`).
- [x] `./gradlew :sdk:forms:ktlintCheck` clean.
- [ ] Manual device verification:
  - [ ] Floating form with large `offsets` clamps to screen bounds instead of overflowing.
  - [ ] `data-klaviyo-device` attribute appears on `<head>` at load and refreshes after rotation (verify via `chrome://inspect` web inspector).
  - [ ] Rotation-lag — rotate twice in rapid succession; the attribute's `orientation` always reflects the final device orientation after the second rotation settles.
  - [ ] `addSafeAreaInsetsToOffsets: false` payload from Fender positions the form at absolute edge-relative offsets (no safe-area padding added).
  - [ ] Fullscreen form still fills the screen regardless of the flag.

## Related Issues/Tickets

Related to [MAGE-541](https://linear.app/klaviyo/issue/MAGE-541)
