### PR TITLE
docs(push): restore push action buttons README section

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ send them timely push notifications via [FCM (Firebase Cloud Messaging)](https:/
   - [Collecting Push Tokens](#collecting-push-tokens)
   - [Receiving Push Notifications](#receiving-push-notifications)
     - [Rich Push](#rich-push)
+    - [Push Action Buttons](#push-action-buttons)
     - [Tracking Open Events](#tracking-open-events)
     - [Silent Push Notifications](#silent-push-notifications)
     - [Custom Data](#custom-data)
@@ -478,6 +479,11 @@ push notification messages. No additional setup is needed to support rich push. 
 attaching it to the notification is handled within `KlaviyoPushService`. If an image fails to download
 (e.g. if the device has a poor network connection) the notification will be displayed without an image
 after the download times out.
+
+#### Push Action Buttons
+[Push Action Buttons](https://help.klaviyo.com/hc/en-us/article/46285872166683) provide the ability to add clickable buttons to
+push notification messages. These buttons can show custom text, and, when clicked, deep link or open your app.
+A notification can include up to 3 buttons. No additional SDK setup is required.
 
 #### Tracking Open Events
 To track push notification opens, you must call `Klaviyo.handlePush(intent)` when your app is launched from an intent.


### PR DESCRIPTION
# Description
Restore the "Push Action Buttons" README section ahead of the 4.4.0 release. The section was previously added in #410 then reverted in 5e8256274 to keep `master` clean while the feature soaked on the release branch. Wording is aligned with the parallel RN SDK README update (klaviyo/klaviyo-react-native-sdk#309) for cross-platform consistency — uses "provide the ability", "A notification can include up to 3 buttons", and "No additional SDK setup is required".

## Due Diligence
- [x] I have tested this on an emulator and/or a physical device. _(N/A — doc-only)_
- [x] I have added sufficient unit/integration tests of my changes. _(N/A — doc-only)_
- [x] I have adjusted or added new test cases to team test docs, if applicable. _(N/A — doc-only)_
- [x] I am confident these changes are compatible with all Android versions the SDK currently supports. _(N/A — doc-only)_


## Release/Versioning Considerations
- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [x] Contains readme or migration guide changes.
  - Targeting `rel/4.4.0` so the docs go live with the 4.4.0 release.
- [x] This is planned work for an upcoming release.


## Changelog / Code Overview
- README.md: restored the "Push Action Buttons" section (6 lines) covering the feature surface added in #440 / #442.
- Wording matches RN SDK README PR #309 to keep the platform docs consistent.
- No code changes — pure documentation.


## Test Plan
- Render README.md locally / on GitHub and confirm the new section renders correctly under the push notifications area.


## Related Issues/Tickets
- Original Android README addition: #410 (by @ab1470)
- Revert that this restores: 5e8256274
- Parallel RN SDK README update: klaviyo/klaviyo-react-native-sdk#309