### PR TITLE
feat(forms): JWT delivery to IAF WebView via evaluateJavascript

### DIFF
--- a/sdk/forms-core/src/main/java/com/klaviyo/forms/FormsProvider.kt
+++ b/sdk/forms-core/src/main/java/com/klaviyo/forms/FormsProvider.kt
@@ -19,4 +19,13 @@ interface FormsProvider {
      * and tearing down the WebView client.
      */
     fun unregister()
+
+    /**
+     * Deliver a JWT to the active IAF webview by calling `window.klaviyoIAFSetJWT`.
+     * If the webview bridge is not yet ready, the token will be queued and delivered once the
+     * handshake completes.
+     *
+     * @param token The JWT to deliver to the webview.
+     */
+    fun setJWT(token: String)
 }

--- a/sdk/forms-core/src/main/java/com/klaviyo/forms/InAppForms.kt
+++ b/sdk/forms-core/src/main/java/com/klaviyo/forms/InAppForms.kt
@@ -39,6 +39,22 @@ fun Klaviyo.unregisterFromInAppForms(): Klaviyo =
     } ?: throw MissingKlaviyoModule("forms")
 
 /**
+ * Deliver a JWT to the active IAF webview.
+ *
+ * Calls `window.klaviyoIAFSetJWT(token)` in the webview via `evaluateJavascript`.
+ * If the webview bridge is not yet ready, the token is queued and delivered after
+ * the bridge handshake completes.
+ *
+ * @param token The JWT string to deliver.
+ * @throws MissingKlaviyoModule if the `com.klaviyo:forms` module is not on the classpath.
+ */
+@UiThread
+fun Klaviyo.setJWT(token: String): Klaviyo =
+    Registry.getOrNull<FormsProvider>()?.let { provider ->
+        safeApply { provider.setJWT(token) }
+    } ?: throw MissingKlaviyoModule("forms")
+
+/**
  * Java-friendly static methods for In-App Forms.
  * Kotlin users should use the extension functions on [Klaviyo] instead.
  */
@@ -67,5 +83,18 @@ object KlaviyoForms {
     @UiThread
     fun unregisterFromInAppForms() {
         Klaviyo.unregisterFromInAppForms()
+    }
+
+    /**
+     * Deliver a JWT to the active IAF webview.
+     * Java-friendly static method.
+     *
+     * @param token The JWT string to deliver.
+     * @see Klaviyo.setJWT
+     */
+    @JvmStatic
+    @UiThread
+    fun setJWT(token: String) {
+        Klaviyo.setJWT(token)
     }
 }

--- a/sdk/forms-core/src/test/java/com/klaviyo/forms/InAppFormsNoOpTest.kt
+++ b/sdk/forms-core/src/test/java/com/klaviyo/forms/InAppFormsNoOpTest.kt
@@ -20,4 +20,11 @@ internal class InAppFormsNoOpTest : BaseTest() {
             Klaviyo.unregisterFromInAppForms()
         }
     }
+
+    @Test
+    fun `setJWT throws when provider not registered`() {
+        assertThrows(MissingKlaviyoModule::class.java) {
+            Klaviyo.setJWT("test-token")
+        }
+    }
 }

--- a/sdk/forms/src/main/java/com/klaviyo/forms/KlaviyoFormsProvider.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/KlaviyoFormsProvider.kt
@@ -32,6 +32,12 @@ internal fun Klaviyo.reInitializeInAppForms(): Klaviyo {
 }
 
 internal class KlaviyoFormsProvider : FormsProvider {
+
+    /**
+     * JWT queued before [registerForInAppForms] was called; forwarded to [WebViewClient] on register.
+     */
+    private var pendingJwt: String? = null
+
     override fun register(config: InAppFormsConfig) {
         Registry.apply {
             register<InAppFormsConfig>(config)
@@ -44,6 +50,10 @@ internal class KlaviyoFormsProvider : FormsProvider {
             registerOnce<JsBridgeObserverCollection> { KlaviyoObserverCollection() }
         }
         Registry.get<WebViewClient>().initializeWebView()
+        pendingJwt?.let { token ->
+            pendingJwt = null
+            Registry.get<WebViewClient>().setJWT(token)
+        }
     }
 
     override fun unregister() {
@@ -52,6 +62,13 @@ internal class KlaviyoFormsProvider : FormsProvider {
             Registry.get<WebViewClient>().destroyWebView()
         } else {
             Registry.log.warning("Cannot unregister In-App Forms, must be registered first.")
+        }
+    }
+
+    override fun setJWT(token: String) {
+        Registry.getOrNull<WebViewClient>()?.setJWT(token) ?: run {
+            Registry.log.verbose("IAF not yet registered, queuing JWT for delivery on register")
+            pendingJwt = token
         }
     }
 }

--- a/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
@@ -42,6 +42,16 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
     private var webView: KlaviyoWebView? by WeakReferenceDelegate()
 
     /**
+     * JWT queued before the bridge handshake completed; delivered in [onJsHandshakeCompleted].
+     */
+    private var pendingJwt: String? = null
+
+    /**
+     * Tracks whether the JS bridge handshake has completed and [window.klaviyoIAFSetJWT] is available.
+     */
+    private var isHandshakeCompleted: Boolean = false
+
+    /**
      * Initialize a webview instance, with protection against duplication
      * and initialize klaviyo.js for In-App Forms with handshake data injected in the document head
      */
@@ -87,12 +97,18 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
     }
 
     /**
-     * When the webview has loaded klaviyo.js, we can cancel the timeout
+     * When the webview has loaded klaviyo.js, we can cancel the timeout and flush any queued JWT.
      */
     override fun onJsHandshakeCompleted() {
-        Registry.get<JsBridgeObserverCollection>().startObservers(NativeBridgeMessage.HandShook)
         handshakeTimer?.cancel()
         handshakeTimer = null
+        isHandshakeCompleted = true
+        // Deliver JWT before form-triggering events to give onsite a head start on profile fetch
+        pendingJwt?.let { token ->
+            pendingJwt = null
+            deliverJwt(token)
+        }
+        Registry.get<JsBridgeObserverCollection>().startObservers(NativeBridgeMessage.HandShook)
     }
 
     /**
@@ -133,10 +149,31 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
     }
 
     /**
+     * Deliver a JWT to the webview, or queue it if the bridge handshake has not yet completed.
+     */
+    override fun setJWT(token: String) {
+        val escapedToken = token.replace("\\", "\\\\").replace("'", "\\'")
+        if (isHandshakeCompleted) {
+            deliverJwt(escapedToken)
+        } else {
+            Registry.log.verbose("IAF WebView bridge not ready, queuing JWT for delivery")
+            pendingJwt = escapedToken
+        }
+    }
+
+    private fun deliverJwt(escapedToken: String) {
+        evaluateJavascript("window.klaviyoIAFSetJWT('$escapedToken')") {
+            Registry.log.verbose("JWT delivered to IAF WebView")
+        }
+    }
+
+    /**
      * Destroy the webview and release the reference
      */
     override fun destroyWebView() = apply {
         handshakeTimer?.cancel()
+        pendingJwt = null
+        isHandshakeCompleted = false
         Registry.get<JsBridgeObserverCollection>().stopObservers()
         webView?.let { webView ->
             Registry.threadHelper.runOnUiThread {

--- a/sdk/forms/src/main/java/com/klaviyo/forms/webview/WebViewClient.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/webview/WebViewClient.kt
@@ -33,4 +33,10 @@ internal interface WebViewClient {
      * Destroy the webview and release the reference
      */
     fun destroyWebView(): WebViewClient
+
+    /**
+     * Deliver a JWT to the webview. If the webview bridge is not yet ready,
+     * the token is queued until the handshake completes.
+     */
+    fun setJWT(token: String)
 }

--- a/sdk/forms/src/test/java/com/klaviyo/forms/InAppFormsTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/InAppFormsTest.kt
@@ -14,8 +14,10 @@ import com.klaviyo.forms.webview.JavaScriptEvaluator
 import com.klaviyo.forms.webview.KlaviyoWebViewClient
 import com.klaviyo.forms.webview.WebViewClient
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkConstructor
+import io.mockk.runs
 import io.mockk.unmockkAll
 import io.mockk.verify
 import org.junit.After
@@ -143,5 +145,24 @@ internal class InAppFormsTest : BaseTest() {
         assert(!Registry.isRegistered<InAppFormsConfig>())
         verify(inverse = true) { anyConstructed<KlaviyoPresentationManager>().dismiss() }
         verify(inverse = true) { anyConstructed<KlaviyoWebViewClient>().destroyWebView() }
+    }
+
+    @Test
+    fun `setJWT before register queues token and delivers it on registerForInAppForms`() {
+        every { anyConstructed<KlaviyoWebViewClient>().setJWT(any()) } just runs
+        Klaviyo.setJWT("test-token")
+        verify { spyLog.verbose(match { it.contains("queuing") }) }
+        verify(inverse = true) { anyConstructed<KlaviyoWebViewClient>().setJWT(any()) }
+
+        Klaviyo.registerForInAppForms()
+        verify { anyConstructed<KlaviyoWebViewClient>().setJWT("test-token") }
+    }
+
+    @Test
+    fun `setJWT after register delegates to webview client`() {
+        Klaviyo.registerForInAppForms()
+        every { anyConstructed<KlaviyoWebViewClient>().setJWT(any()) } just runs
+        Klaviyo.setJWT("test-token")
+        verify { anyConstructed<KlaviyoWebViewClient>().setJWT("test-token") }
     }
 }

--- a/sdk/forms/src/test/java/com/klaviyo/forms/webview/KlaviyoWebViewClientTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/webview/KlaviyoWebViewClientTest.kt
@@ -463,4 +463,58 @@ class KlaviyoWebViewClientTest : BaseTest() {
         KlaviyoWebViewClient().onPageFinished(mockWebview, "https://example.com")
         verify { spyLog.debug(any()) }
     }
+
+    @Test
+    fun `setJWT on ready webview calls evaluateJavascript with escaped token`() {
+        val client = KlaviyoWebViewClient()
+        client.initializeWebView()
+        client.onJsHandshakeCompleted()
+
+        every { anyConstructed<KlaviyoWebView>().evaluateJavascript(any(), any()) } answers {
+            val callback = secondArg<ValueCallback<String>>()
+            callback.onReceiveValue("null")
+        }
+
+        client.setJWT("test-token")
+
+        verify {
+            anyConstructed<KlaviyoWebView>().evaluateJavascript(
+                "window.klaviyoIAFSetJWT('test-token')",
+                any()
+            )
+        }
+        verify { spyLog.verbose(match { it.contains("delivered") }) }
+    }
+
+    @Test
+    fun `setJWT before bridge ready queues token and delivers on handshake`() {
+        val client = KlaviyoWebViewClient()
+        client.initializeWebView()
+        // Notably: handshake has NOT completed yet
+
+        client.setJWT("test-token")
+
+        verify { spyLog.verbose(match { it.contains("queuing") }) }
+        verify(exactly = 0) {
+            anyConstructed<KlaviyoWebView>().evaluateJavascript(
+                "window.klaviyoIAFSetJWT('test-token')",
+                any()
+            )
+        }
+
+        every { anyConstructed<KlaviyoWebView>().evaluateJavascript(any(), any()) } answers {
+            val callback = secondArg<ValueCallback<String>>()
+            callback.onReceiveValue("null")
+        }
+
+        // Handshake completes — queued JWT should be flushed
+        client.onJsHandshakeCompleted()
+
+        verify(exactly = 1) {
+            anyConstructed<KlaviyoWebView>().evaluateJavascript(
+                "window.klaviyoIAFSetJWT('test-token')",
+                any()
+            )
+        }
+    }
 }


### PR DESCRIPTION
# Description

Adds `Klaviyo.setJWT(token)` (and `KlaviyoForms.setJWT(token)` for Java callers) to deliver a JWT to the active In-App Forms WebView by calling `window.klaviyoIAFSetJWT(token)` via `evaluateJavascript`. Implements the Android counterpart to the iOS JWT delivery ticket (MAGE-555).

The call is order-independent: the token is queued at whichever layer it arrives and delivered as soon as the WebView is ready.

| When `setJWT` is called | Behaviour |
|---|---|
| Before `registerForInAppForms` | Queued in `KlaviyoFormsProvider`; forwarded to `WebViewClient` on register |
| After register, before JS handshake | Queued in `KlaviyoWebViewClient`; delivered on handshake completion |
| After handshake | Delivered immediately via `evaluateJavascript` |

JWT delivery is flushed **before** `ProfileEventObserver` starts sending buffered events on handshake, giving onsite a head start on profile fetch before form evaluation is triggered.

## Due Diligence
- [ ] I have tested this on an emulator and/or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all Android versions the SDK currently supports.


## Release/Versioning Considerations
- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [x] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.


## Changelog / Code Overview

**New public API (`forms-core`)**
- `fun Klaviyo.setJWT(token: String): Klaviyo` — Kotlin extension
- `KlaviyoForms.setJWT(token: String)` — `@JvmStatic` for Java callers
- `FormsProvider.setJWT(token: String)` added to the service interface

**Internal (`forms`)**
- `WebViewClient.setJWT(token: String)` added to the internal interface
- `KlaviyoWebViewClient`: implements `setJWT` with single-quote escaping and a `pendingJwt` / `isHandshakeCompleted` queue that flushes on `onJsHandshakeCompleted` — JWT is enqueued before `ProfileEventObserver` fires
- `KlaviyoFormsProvider`: implements `setJWT` with a `pendingJwt` field that queues the token when `WebViewClient` is not yet registered, forwarding it into `WebViewClient` during `register()`

**Tests**
- `KlaviyoWebViewClientTest`: ready-webview delivery + pre-handshake queuing
- `InAppFormsTest`: pre-register queuing + post-register delegation
- `InAppFormsNoOpTest`: throws `MissingKlaviyoModule` when forms module absent


## Test Plan
- Call `Klaviyo.setJWT(token)` before `registerForInAppForms()` — verify delivery occurs once the webview handshake completes
- Call `Klaviyo.setJWT(token)` after `registerForInAppForms()` but before the webview has finished loading — verify delivery occurs on handshake
- Call `Klaviyo.setJWT(token)` after handshake — verify `window.klaviyoIAFSetJWT` is called immediately
- Verify tokens containing backslashes or single quotes are correctly escaped in the JS string


## Related Issues/Tickets

- Linear: [MAGE-555](https://linear.app/klaviyo/issue/MAGE-555/jwt-delivery-to-webview-via-evaluatejavascript-android)
- iOS counterpart: MAGE-554
- JS counterpart (defines `window.klaviyoIAFSetJWT`): MAGE-553