### PR TITLE
docs(forms): add form lifecycle events section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -802,13 +802,7 @@ object to the `registerForInAppForms()` method. For example, to set a session ti
 You can register a handler to receive callbacks whenever a form is shown, dismissed, or a CTA button is tapped.
 This is useful for forwarding engagement data to a third-party analytics platform such as Amplitude, Segment, or Mixpanel.
 
-The handler is always invoked on the **main thread**, so avoid performing long-running or blocking work inside it.
-Two behaviors to be aware of:
-
-- **`FormCtaClicked`** only fires when the tapped CTA button has a deep link URL configured. Tapping a button
-  with no URL action does not emit this event.
-- **`FormDismissed`** only fires for user-initiated dismissals (tapping outside the form or pressing the close button).
-  It does **not** fire when the SDK tears down a form internally (session timeout, `unregisterFromInAppForms()`).
+The handler is invoked on the **main thread**, so avoid performing long-running or blocking work inside it.
 
 <details open>
    <summary>Kotlin</summary>
@@ -830,7 +824,6 @@ Two behaviors to be aware of:
                // e.g. myAnalytics.track("Form Dismissed", mapOf("formId" to event.formId, "formName" to event.formName))
            }
            is FormCtaClicked -> {
-               // Only fires when the CTA has a deep link URL configured
                // e.g. myAnalytics.track("Form CTA Clicked", mapOf(
                //     "formId" to event.formId,
                //     "formName" to event.formName,
@@ -859,7 +852,6 @@ Two behaviors to be aware of:
        } else if (event instanceof FormLifecycleEvent.FormDismissed dismissed) {
            // e.g. myAnalytics.track("Form Dismissed", ...)
        } else if (event instanceof FormLifecycleEvent.FormCtaClicked ctaClicked) {
-           // Only fires when the CTA has a deep link URL configured
            // e.g. myAnalytics.track("Form CTA Clicked", ...)
        }
    });

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ send them timely push notifications via [FCM (Firebase Cloud Messaging)](https:/
   - [Setup](#setup-1)
   - [In-App Forms Session Configuration](#in-app-forms-session-configuration)
   - [Unregistering from In-App Forms](#unregistering-from-in-app-forms)
+  - [Monitoring Form Lifecycle Events](#monitoring-form-lifecycle-events)
 - [Geofencing](#geofencing)
   - [Setup](#setup-2)
   - [Requesting Permissions](#requesting-permissions)
@@ -701,6 +702,7 @@ See the table below to understand available features by SDK version.
 | Time Delay           | 4.0.0               |
 | Audience Targeting   | 4.0.0               |
 | Event Triggers       | 4.1.0               |
+| Form Lifecycle Hooks | 4.4.0               |
 
 ### Setup
 To begin, call `Klaviyo.registerForInAppForms()` after initializing the SDK with your public API key.
@@ -792,6 +794,84 @@ object to the `registerForInAppForms()` method. For example, to set a session ti
 </details>
 
 **Note:** After unregistering, the next call to `registerForInAppForms()` will be considered a new session by the SDK.
+
+### Monitoring Form Lifecycle Events
+
+> Form lifecycle events are available in SDK version 4.4.0 and higher.
+
+You can register a handler to receive callbacks whenever a form is shown, dismissed, or a CTA button is tapped.
+This is useful for forwarding engagement data to a third-party analytics platform such as Amplitude, Segment, or Mixpanel.
+
+The handler is always invoked on the **main thread**, so avoid performing long-running or blocking work inside it.
+Two behaviors to be aware of:
+
+- **`FormCtaClicked`** only fires when the tapped CTA button has a deep link URL configured. Tapping a button
+  with no URL action does not emit this event.
+- **`FormDismissed`** only fires for user-initiated dismissals (tapping outside the form or pressing the close button).
+  It does **not** fire when the SDK tears down a form internally (session timeout, `unregisterFromInAppForms()`).
+
+<details open>
+   <summary>Kotlin</summary>
+
+   ```kotlin
+   import com.klaviyo.analytics.Klaviyo
+   import com.klaviyo.forms.FormLifecycleEvent.FormCtaClicked
+   import com.klaviyo.forms.FormLifecycleEvent.FormDismissed
+   import com.klaviyo.forms.FormLifecycleEvent.FormShown
+   import com.klaviyo.forms.registerFormLifecycleHandler
+   import com.klaviyo.forms.unregisterFormLifecycleHandler
+
+   Klaviyo.registerFormLifecycleHandler { event ->
+       when (event) {
+           is FormShown -> {
+               // e.g. myAnalytics.track("Form Shown", mapOf("formId" to event.formId, "formName" to event.formName))
+           }
+           is FormDismissed -> {
+               // e.g. myAnalytics.track("Form Dismissed", mapOf("formId" to event.formId, "formName" to event.formName))
+           }
+           is FormCtaClicked -> {
+               // Only fires when the CTA has a deep link URL configured
+               // e.g. myAnalytics.track("Form CTA Clicked", mapOf(
+               //     "formId" to event.formId,
+               //     "formName" to event.formName,
+               //     "buttonLabel" to event.buttonLabel,
+               //     "deepLinkUrl" to event.deepLinkUrl.toString()
+               // ))
+           }
+       }
+   }
+
+   // To stop receiving events, unregister the handler
+   Klaviyo.unregisterFormLifecycleHandler()
+   ```
+</details>
+
+<details>
+   <summary>Java</summary>
+
+   ```java
+   import com.klaviyo.forms.FormLifecycleEvent;
+   import com.klaviyo.forms.KlaviyoForms;
+
+   KlaviyoForms.registerFormLifecycleHandler(event -> {
+       if (event instanceof FormLifecycleEvent.FormShown shown) {
+           // e.g. myAnalytics.track("Form Shown", ...)
+       } else if (event instanceof FormLifecycleEvent.FormDismissed dismissed) {
+           // e.g. myAnalytics.track("Form Dismissed", ...)
+       } else if (event instanceof FormLifecycleEvent.FormCtaClicked ctaClicked) {
+           // Only fires when the CTA has a deep link URL configured
+           // e.g. myAnalytics.track("Form CTA Clicked", ...)
+       }
+   });
+
+   // To stop receiving events, unregister the handler
+   KlaviyoForms.unregisterFormLifecycleHandler();
+   ```
+</details>
+
+Registering a lifecycle handler is optional and does not affect normal form behavior — forms are displayed and dismissed
+regardless of whether a handler is registered. Only one handler can be registered at a time; calling
+`registerFormLifecycleHandler` again replaces the previous registration.
 
 ## Geofencing
 


### PR DESCRIPTION
## Summary

Documents the `FormLifecycleEvent` API that shipped in [#434 (feat(iaf) Android in-app form lifecycle hook support)](https://github.com/klaviyo/klaviyo-android-sdk/pull/434). This is the Android companion to [klaviyo-swift-sdk #517](https://github.com/klaviyo/klaviyo-swift-sdk/pull/517).

- Adds a new `### Monitoring Form Lifecycle Events` section after the In-App Forms session config / unregister content and before Geofencing
- Adds a TOC entry and feature matrix row (`Form Lifecycle Hooks | 4.4.0`)
- Covers registration, threading guarantee (main thread), per-event semantics (`FormCtaClicked` deep-link-only, `FormDismissed` user-initiated only), and unregistration
- Includes Kotlin (expanded) and Java (collapsed) code blocks
- Example snippet compile-verified via `:sample:assembleDebug` — the sample app already demonstrates the API in `SampleApplication.kt`

## Checklist

- [x] README or migration guide changes
- [ ] New public APIs
- [ ] Unit tests
- [ ] Integration/sample app changes (sample already wired, no net change needed)

## Notes

Planned for the **4.4.0** release. No code changes — pure documentation.

Android API quirks relative to iOS (see cross-platform notes in PR description of #517):
- `deepLinkUrl` is typed as `android.net.Uri` (non-nullable), not `String` — callers need `.toString()` to pass it to string-based analytics SDKs
- Only one handler can be registered at a time (replaces on re-registration), same as iOS
- Threading guarantee is explicitly documented in `FormLifecycleHandler.kt` KDoc: main thread, callbacks fire **after** the SDK has already acted (presentation/dismissal/navigation already initiated)