### PR TITLE
ci: add PR target branch check workflow

### DIFF
--- a/.github/workflows/pr-target-check.yml
+++ b/.github/workflows/pr-target-check.yml
@@ -1,0 +1,50 @@
+name: PR Target Branch Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+    branches:
+      - master
+
+jobs:
+  check-pr-target:
+    name: Check PR targets a release branch
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Validate source branch
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          if [[ "$HEAD_REF" == rel/* ]] || [[ "$HEAD_REF" == ci/* ]]; then
+            echo "Branch '$HEAD_REF' is allowed to target master."
+            exit 0
+          fi
+
+          # Post a comment only if one hasn't been posted already
+          MARKER="<!-- pr-target-check-warning -->"
+          EXISTING=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+            --jq ".[] | select(.body | contains(\"$MARKER\")) | .id" | head -1)
+
+          if [ -z "$EXISTING" ]; then
+            gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+              --method POST \
+              --field body="${MARKER}
+          **:warning: This PR needs to target a release branch before it can merge to \`master\`.**
+
+          All changes — including hotfixes, dependency bumps, and feature work — should flow through a \`rel/*\` branch rather than merging directly to \`master\`. This keeps commit history clean and ensures every change is tied to a release.
+
+          **To fix:** change the base branch of this PR to the appropriate \`rel/*\` branch. You can do this without closing the PR — use the base branch dropdown at the top of the PR.
+
+          - If the release version isn't decided yet, create a placeholder: \`rel/X.Y.Z\`
+          - If this is CI/tooling work, rename your branch with a \`ci/\` prefix and this check will pass
+
+          _Enforced by the \`pr-target-check\` workflow._"
+          fi
+
+          echo "Branch '$HEAD_REF' cannot target master directly. Must use rel/* or ci/*."
+          exit 1

--- a/.github/workflows/pr-target-check.yml
+++ b/.github/workflows/pr-target-check.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      issues: write
     steps:
       - name: Validate source branch
         env:
@@ -19,9 +20,11 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
+          LABEL: "needs: release branch"
         run: |
           if [[ "$HEAD_REF" == rel/* ]] || [[ "$HEAD_REF" == ci/* ]]; then
             echo "Branch '$HEAD_REF' is allowed to target master."
+            gh pr edit $PR_NUMBER --repo $REPO --remove-label "$LABEL" 2>/dev/null || true
             exit 0
           fi
 
@@ -45,6 +48,8 @@ jobs:
 
           _Enforced by the \`pr-target-check\` workflow._"
           fi
+
+          gh pr edit $PR_NUMBER --repo $REPO --add-label "$LABEL"
 
           echo "Branch '$HEAD_REF' cannot target master directly. Must use rel/* or ci/*."
           exit 1

--- a/.github/workflows/pr-target-check.yml
+++ b/.github/workflows/pr-target-check.yml
@@ -22,7 +22,7 @@ jobs:
           REPO: ${{ github.repository }}
           LABEL: "needs: release branch"
         run: |
-          if [[ "$HEAD_REF" == rel/* ]] || [[ "$HEAD_REF" == ci/* ]]; then
+          if [[ "$HEAD_REF" == rel/* ]] || [[ "$HEAD_REF" == ci/* ]] || [[ "$HEAD_REF" == docs/* ]]; then
             echo "Branch '$HEAD_REF' is allowed to target master."
             gh pr edit $PR_NUMBER --repo $REPO --remove-label "$LABEL" 2>/dev/null || true
             exit 0

--- a/.github/workflows/pr-target-check.yml
+++ b/.github/workflows/pr-target-check.yml
@@ -2,7 +2,7 @@ name: PR Target Branch Check
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, edited]
+    types: [opened, synchronize, reopened, edited, labeled, unlabeled]
     branches:
       - master
 
@@ -28,6 +28,16 @@ jobs:
             exit 0
           fi
 
+          # Check for manual-merge override label
+          HAS_OVERRIDE=$(gh api "repos/$REPO/issues/$PR_NUMBER/labels" \
+            --jq '.[] | select(.name == "manual-merge") | .name' | head -1)
+
+          if [ -n "$HAS_OVERRIDE" ]; then
+            echo "manual-merge label present — bypassing check. This PR will merge directly to master without a release branch."
+            gh pr edit $PR_NUMBER --repo $REPO --remove-label "$LABEL" 2>/dev/null || true
+            exit 0
+          fi
+
           # Post a comment only if one hasn't been posted already
           MARKER="<!-- pr-target-check-warning -->"
           EXISTING=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
@@ -45,11 +55,14 @@ jobs:
 
           - If the release version isn't decided yet, create a placeholder: \`rel/X.Y.Z\`
           - If this is CI/tooling work, rename your branch with a \`ci/\` prefix and this check will pass
+          - If this is documentation-only work, rename your branch with a \`docs/\` prefix and this check will pass
+
+          > **Override:** In exceptional circumstances, a maintainer may add the \`manual-merge\` label to bypass this check and merge directly to \`master\`. This should be used sparingly — it skips the release branch entirely and may result in changes not being included in a release or loss of commit attribution if not handled carefully.
 
           _Enforced by the \`pr-target-check\` workflow._"
           fi
 
           gh pr edit $PR_NUMBER --repo $REPO --add-label "$LABEL"
 
-          echo "Branch '$HEAD_REF' cannot target master directly. Must use rel/* or ci/*."
+          echo "Branch '$HEAD_REF' cannot target master directly. Must use rel/*, ci/*, or docs/*. Add the manual-merge label to override."
           exit 1

--- a/.github/workflows/pr-target-check.yml
+++ b/.github/workflows/pr-target-check.yml
@@ -51,9 +51,8 @@ jobs:
 
           All changes — including hotfixes, dependency bumps, and feature work — should flow through a \`rel/*\` branch rather than merging directly to \`master\`. This keeps commit history clean and ensures every change is tied to a release.
 
-          **To fix:** change the base branch of this PR to the appropriate \`rel/*\` branch. You can do this without closing the PR — use the base branch dropdown at the top of the PR.
+          **To fix:** change the base branch of this PR to the appropriate \`rel/*\` branch when available. You can do this without closing the PR — use the base branch dropdown at the top of the PR.
 
-          - If the release version isn't decided yet, create a placeholder: \`rel/X.Y.Z\`
           - If this is CI/tooling work, rename your branch with a \`ci/\` prefix and this check will pass
           - If this is documentation-only work, rename your branch with a \`docs/\` prefix and this check will pass
 

--- a/.github/workflows/pr-target-check.yml
+++ b/.github/workflows/pr-target-check.yml
@@ -16,6 +16,7 @@ jobs:
         env:
           HEAD_REF: ${{ github.head_ref }}
           BASE_REF: ${{ github.base_ref }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
@@ -28,8 +29,18 @@ jobs:
             exit 0
           fi
 
-          if [[ "$HEAD_REF" == rel/* ]] || [[ "$HEAD_REF" == ci/* ]] || [[ "$HEAD_REF" == docs/* ]]; then
+          if [[ "$HEAD_REF" == rel/* ]] || [[ "$HEAD_REF" == ci/* ]] || [[ "$HEAD_REF" == docs/* ]] || [[ "$HEAD_REF" == dependabot/* ]]; then
             echo "Branch '$HEAD_REF' is allowed to target master."
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "$LABEL" 2>/dev/null || true
+            exit 0
+          fi
+
+          # A conventional-commit PR title is another valid path: ci, chore, docs, or rel
+          # (case-insensitive, optional scope and breaking-change marker, e.g. "ci(workflows)!: ...")
+          TITLE_LC=$(printf '%s' "$PR_TITLE" | tr '[:upper:]' '[:lower:]')
+          TITLE_REGEX='^(ci|chore|docs|rel)(\([^)]*\))?!?:[[:space:]]'
+          if [[ "$TITLE_LC" =~ $TITLE_REGEX ]]; then
+            echo "PR title '$PR_TITLE' has an allowed conventional-commit prefix — allowed to target master."
             gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "$LABEL" 2>/dev/null || true
             exit 0
           fi
@@ -55,12 +66,13 @@ jobs:
               --field body="${MARKER}
           **:warning: This PR needs to target a release branch before it can merge to \`master\`.**
 
-          All changes — including hotfixes, dependency bumps, and feature work — should flow through a \`rel/*\` branch rather than merging directly to \`master\`. This keeps commit history clean and ensures every change is tied to a release.
+          All changes — including hotfixes and feature work — should flow through a \`rel/*\` branch rather than merging directly to \`master\`. This keeps commit history clean and ensures every change is tied to a release.
 
           **To fix:** change the base branch of this PR to the appropriate \`rel/*\` branch when available. You can do this without closing the PR — use the base branch dropdown at the top of the PR.
 
           - If this is CI/tooling work, rename your branch with a \`ci/\` prefix and this check will pass
           - If this is documentation-only work, rename your branch with a \`docs/\` prefix and this check will pass
+          - Alternatively, give the PR a conventional-commit title prefixed with \`ci:\`, \`chore:\`, \`docs:\`, or \`rel:\` (scopes like \`ci(workflows):\` also work) and this check will pass
 
           > **Override:** In exceptional circumstances, a maintainer may add the \`manual-merge\` label to bypass this check and merge directly to \`master\`. This should be used sparingly — it skips the release branch entirely and may result in changes not being included in a release or loss of commit attribution if not handled carefully.
 
@@ -69,5 +81,5 @@ jobs:
 
           gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "$LABEL"
 
-          echo "Branch '$HEAD_REF' cannot target master directly. Must use rel/*, ci/*, or docs/*. Add the manual-merge label to override."
+          echo "Branch '$HEAD_REF' cannot target master directly. Use a rel/*, ci/*, docs/*, or dependabot/* branch, a ci:/chore:/docs:/rel: PR title, or add the manual-merge label to override."
           exit 1

--- a/.github/workflows/pr-target-check.yml
+++ b/.github/workflows/pr-target-check.yml
@@ -3,8 +3,6 @@ name: PR Target Branch Check
 on:
   pull_request:
     types: [opened, synchronize, reopened, edited, labeled, unlabeled]
-    branches:
-      - master
 
 jobs:
   check-pr-target:
@@ -17,11 +15,19 @@ jobs:
       - name: Validate source branch
         env:
           HEAD_REF: ${{ github.head_ref }}
+          BASE_REF: ${{ github.base_ref }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           LABEL: "needs: release branch"
         run: |
+          # If PR doesn't target master, this check doesn't apply — clean up any stale label and pass
+          if [[ "$BASE_REF" != "master" ]]; then
+            echo "PR targets '$BASE_REF' (not master) — check not required."
+            gh pr edit $PR_NUMBER --repo $REPO --remove-label "$LABEL" 2>/dev/null || true
+            exit 0
+          fi
+
           if [[ "$HEAD_REF" == rel/* ]] || [[ "$HEAD_REF" == ci/* ]] || [[ "$HEAD_REF" == docs/* ]]; then
             echo "Branch '$HEAD_REF' is allowed to target master."
             gh pr edit $PR_NUMBER --repo $REPO --remove-label "$LABEL" 2>/dev/null || true

--- a/.github/workflows/pr-target-check.yml
+++ b/.github/workflows/pr-target-check.yml
@@ -24,13 +24,13 @@ jobs:
           # If PR doesn't target master, this check doesn't apply — clean up any stale label and pass
           if [[ "$BASE_REF" != "master" ]]; then
             echo "PR targets '$BASE_REF' (not master) — check not required."
-            gh pr edit $PR_NUMBER --repo $REPO --remove-label "$LABEL" 2>/dev/null || true
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "$LABEL" 2>/dev/null || true
             exit 0
           fi
 
           if [[ "$HEAD_REF" == rel/* ]] || [[ "$HEAD_REF" == ci/* ]] || [[ "$HEAD_REF" == docs/* ]]; then
             echo "Branch '$HEAD_REF' is allowed to target master."
-            gh pr edit $PR_NUMBER --repo $REPO --remove-label "$LABEL" 2>/dev/null || true
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "$LABEL" 2>/dev/null || true
             exit 0
           fi
 
@@ -40,7 +40,7 @@ jobs:
 
           if [ -n "$HAS_OVERRIDE" ]; then
             echo "manual-merge label present — bypassing check. This PR will merge directly to master without a release branch."
-            gh pr edit $PR_NUMBER --repo $REPO --remove-label "$LABEL" 2>/dev/null || true
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "$LABEL" 2>/dev/null || true
             exit 0
           fi
 
@@ -67,7 +67,7 @@ jobs:
           _Enforced by the \`pr-target-check\` workflow._"
           fi
 
-          gh pr edit $PR_NUMBER --repo $REPO --add-label "$LABEL"
+          gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "$LABEL"
 
           echo "Branch '$HEAD_REF' cannot target master directly. Must use rel/*, ci/*, or docs/*. Add the manual-merge label to override."
           exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,18 @@ The Klaviyo Android SDK is organized into multiple modules, each with specific r
 
 ## Development Workflow
 
+### Branch Naming & PR Targets
+
+| Prefix | Purpose | May target `master` directly |
+|--------|---------|------------------------------|
+| `rel/*` | Release branches | Yes |
+| `ci/*` | CI/tooling changes (GitHub Actions, scripts, build config) | Yes |
+| `docs/*` | Documentation-only changes | Yes |
+| `feat/*` | New features | No — target active `rel/*` |
+| `{initials}/*` | Personal/WIP branches | No — target active `rel/*` |
+
+A required status check blocks merges to `master` from any branch not in the allowed list. The check posts a comment with retargeting instructions and applies a `needs: release branch` label. To bypass in exceptional cases, a maintainer can add the `manual-merge` label — use sparingly.
+
 ### CI/CD Pipeline
 
 The project uses GitHub Actions for CI/CD, particularly for running tests and lint checks on pull requests.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,7 +133,7 @@ The Klaviyo Android SDK is organized into multiple modules, each with specific r
 | `feat/*` | New features | No — target active `rel/*` |
 | `{initials}/*` | Personal/WIP branches | No — target active `rel/*` |
 
-A required status check blocks merges to `master` from any branch not in the allowed list. The check posts a comment with retargeting instructions and applies a `needs: release branch` label. To bypass in exceptional cases, a maintainer can add the `manual-merge` label — use sparingly.
+A required status check blocks merges to `master` from any branch not in the allowed list. A conventional-commit PR title prefixed with `ci:`, `chore:`, `docs:`, or `rel:` (case-insensitive, scopes allowed) also satisfies the check. The check posts a comment with retargeting instructions and applies a `needs: release branch` label. To bypass in exceptional cases, a maintainer can add the `manual-merge` label — use sparingly.
 
 ### CI/CD Pipeline
 


### PR DESCRIPTION
## Summary

Adds a required status check that enforces our branching strategy: only `rel/*` and `ci/*` branches may open PRs against `master`.

- PRs from any other branch (hotfixes, dependabot, personal, feat) are **blocked from merging** and receive a one-time comment explaining how to retarget to the appropriate `rel/*` branch
- `ci/*` branches pass through freely (internal tooling doesn't need a release)
- Comment deduplication: the workflow checks for an existing marker comment before posting, so retargeting an already-commented PR won't spam it

## Related

Part of the SDK branch guardrails work. Companion PR for `klaviyo-swift-sdk`: https://github.com/klaviyo/klaviyo-swift-sdk/pull/573

## Test plan

- [ ] Verify a `feat/*` → `master` PR shows a failing `check-pr-target` check and the warning comment
- [ ] Verify this PR (`ci/*` → `master`) passes the check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for branch naming and pull request targeting rules.
  * Documented status-check requirements and the `manual-merge` exception for approved special cases.

* **Chores**
  * Added automated validation for pull requests targeting the release branch.
  * Allowed branches and approved titles pass automatically, while unsupported pull requests receive a warning and enforcement status.
  * Non-applicable or approved pull requests have outdated enforcement labels removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->