### PR TITLE
feat(analytics): AuthTokenManager skeleton and registerAuthTokenProvider public API

### DIFF
--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -6,6 +6,9 @@ import android.content.Intent
 import android.net.Uri
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.net.toUri
+import com.klaviyo.analytics.auth.AuthTokenManager
+import com.klaviyo.analytics.auth.AuthTokenProvider
+import com.klaviyo.analytics.auth.KlaviyoAuthTokenManager
 import com.klaviyo.analytics.linking.DeepLinkHandler
 import com.klaviyo.analytics.linking.DeepLinking
 import com.klaviyo.analytics.model.Event
@@ -28,6 +31,7 @@ import com.klaviyo.core.config.Config
 import com.klaviyo.core.config.LifecycleException
 import com.klaviyo.core.safeApply
 import com.klaviyo.core.safeCall
+import com.klaviyo.core.safeLaunch
 import com.klaviyo.core.utils.JSONUtil.toHashMap
 import com.klaviyo.core.utils.takeIf
 import java.io.Serializable
@@ -103,6 +107,8 @@ object Klaviyo {
             }
         }
 
+        Registry.registerOnce<AuthTokenManager> { KlaviyoAuthTokenManager() }
+
         Registry.get<ApiClient>().startService()
 
         Registry.get<State>().apiKey = apiKey
@@ -139,6 +145,21 @@ object Klaviyo {
     @JvmStatic
     fun unregisterDeepLinkHandler() = safeApply {
         Registry.unregister<DeepLinkHandler>()
+    }
+
+    /**
+     * Register an [AuthTokenProvider] that supplies JWTs to authenticate personalized Klaviyo
+     * features (such as in-app forms that target a known profile).
+     *
+     * Re-registering replaces the previously registered provider and discards any cached token.
+     * The SDK will invoke [AuthTokenProvider.fetchToken] whenever a fresh token is needed; the
+     * host MUST invoke exactly one of [AuthTokenProvider.Callback.onSuccess] or
+     * [AuthTokenProvider.Callback.onFailure] per call.
+     */
+    @JvmStatic
+    fun registerAuthTokenProvider(provider: AuthTokenProvider) = safeApply {
+        val manager = Registry.get<AuthTokenManager>()
+        manager.coroutineScope.safeLaunch { manager.registerProvider(provider) }
     }
 
     /**

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/auth/AuthTokenManager.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/auth/AuthTokenManager.kt
@@ -1,0 +1,34 @@
+package com.klaviyo.analytics.auth
+
+import kotlinx.coroutines.CoroutineScope
+
+/**
+ * Manages the lifecycle of the host-supplied [AuthTokenProvider] and the resulting JWTs used by
+ * personalized Klaviyo features.
+ *
+ * Public for [com.klaviyo.core.Registry] lookup from outside the analytics module (e.g. the forms
+ * module's WebView injection layer). Implementation is internal.
+ */
+interface AuthTokenManager {
+
+    /**
+     * Coroutine scope owned by the manager. The public [com.klaviyo.analytics.Klaviyo] API uses
+     * this scope to launch fire-and-forget calls to the manager's suspending methods.
+     */
+    val coroutineScope: CoroutineScope
+
+    /**
+     * Replace the registered [AuthTokenProvider] (if any), discard any cached token, and eagerly
+     * fetch a fresh token via the new provider.
+     */
+    suspend fun registerProvider(provider: AuthTokenProvider)
+
+    /**
+     * Return a currently-valid JWT, fetching from the registered provider if no cached token is
+     * available or the cached token has expired.
+     *
+     * @throws IllegalStateException if no provider is registered, the provider invokes
+     *   [AuthTokenProvider.Callback.onFailure], or the returned token fails validation.
+     */
+    suspend fun currentToken(): String
+}

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/auth/AuthTokenProvider.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/auth/AuthTokenProvider.kt
@@ -1,0 +1,17 @@
+package com.klaviyo.analytics.auth
+
+/**
+ * Host-app-supplied source of authentication tokens (JWTs) for personalized Klaviyo features.
+ *
+ * Implementations are invoked by the SDK when a fresh token is required. The host MUST invoke
+ * exactly one of [Callback.onSuccess] or [Callback.onFailure] for each call to [fetchToken].
+ */
+fun interface AuthTokenProvider {
+    fun fetchToken(callback: Callback)
+
+    interface Callback {
+        fun onSuccess(jwt: String)
+
+        fun onFailure(error: Throwable)
+    }
+}

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/auth/KlaviyoAuthTokenManager.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/auth/KlaviyoAuthTokenManager.kt
@@ -84,8 +84,9 @@ internal class KlaviyoAuthTokenManager : AuthTokenManager {
             is JWTValidationResult.Valid -> result.token
             else -> {
                 val reason = result::class.simpleName ?: "Unknown"
-                Registry.log.error("Auth token validation failed: $reason")
-                throw IllegalStateException("Auth token validation failed: $reason")
+                val error = IllegalStateException("Auth token validation failed: $reason")
+                Registry.log.error("Auth token validation failed: $reason", error)
+                throw error
             }
         }
 

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/auth/KlaviyoAuthTokenManager.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/auth/KlaviyoAuthTokenManager.kt
@@ -1,0 +1,96 @@
+package com.klaviyo.analytics.auth
+
+import com.klaviyo.core.Registry
+import com.klaviyo.core.safeLaunch
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+internal class KlaviyoAuthTokenManager : AuthTokenManager {
+
+    override val coroutineScope: CoroutineScope =
+        CoroutineScope(SupervisorJob() + Registry.dispatcher)
+
+    private val mutex = Mutex()
+
+    private var provider: AuthTokenProvider? = null
+    private var cachedToken: ValidatedToken? = null
+
+    // Reserved for MAGE-628 (concurrent-caller deduplication).
+    @Suppress("unused")
+    private var inFlightFetch: Deferred<String>? = null
+
+    // Reserved for MAGE-629 (proactive refresh scheduling).
+    @Suppress("unused")
+    private var refreshJob: Job? = null
+
+    // Reserved for MAGE-630 (onTokenRefresh/offTokenRefresh observers); typed as a function for
+    // now — the formal observer interface will be introduced alongside the public API.
+    @Suppress("unused")
+    private val refreshObservers = mutableListOf<(String) -> Unit>()
+
+    override suspend fun registerProvider(provider: AuthTokenProvider) {
+        mutex.withLock {
+            this.provider = provider
+            this.cachedToken = null
+        }
+        Registry.log.info("AuthTokenProvider registered")
+
+        coroutineScope.safeLaunch {
+            runCatching { currentToken() }
+                .onFailure { Registry.log.warning("Eager auth token fetch failed", it) }
+        }
+    }
+
+    override suspend fun currentToken(): String {
+        val cached = mutex.withLock { cachedToken }
+        if (cached != null && isStillValid(cached)) {
+            return cached.rawToken
+        }
+
+        val jwt = invokeProvider()
+        val token = validateOrThrow(jwt)
+
+        mutex.withLock { cachedToken = token }
+        Registry.log.info(
+            "Auth token acquired (exp=${token.expiresAtEpochSeconds}, iat=${token.issuedAtEpochSeconds})"
+        )
+        return token.rawToken
+    }
+
+    private suspend fun invokeProvider(): String = suspendCancellableCoroutine { continuation ->
+        val callback = object : AuthTokenProvider.Callback {
+            override fun onSuccess(jwt: String) {
+                if (continuation.isActive) continuation.resume(jwt)
+            }
+
+            override fun onFailure(error: Throwable) {
+                if (continuation.isActive) continuation.resumeWithException(error)
+            }
+        }
+        provider?.fetchToken(callback) ?: continuation.resumeWithException(
+            IllegalStateException("No auth token provider registered")
+        )
+    }
+
+    private fun validateOrThrow(jwt: String): ValidatedToken =
+        when (val result = JWTParser.parseAndValidate(jwt)) {
+            is JWTValidationResult.Valid -> result.token
+            else -> {
+                val reason = result::class.simpleName ?: "Unknown"
+                Registry.log.error("Auth token validation failed: $reason")
+                throw IllegalStateException("Auth token validation failed: $reason")
+            }
+        }
+
+    private fun isStillValid(token: ValidatedToken): Boolean {
+        val now = Registry.clock.currentTimeMillis() / 1000L
+        return now < token.expiresAtEpochSeconds - JWTParser.DEFAULT_LEEWAY_SECONDS
+    }
+}

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/auth/KlaviyoAuthTokenManager.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/auth/KlaviyoAuthTokenManager.kt
@@ -4,6 +4,7 @@ import com.klaviyo.core.Registry
 import com.klaviyo.core.safeLaunch
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Job
@@ -43,8 +44,14 @@ internal class KlaviyoAuthTokenManager : AuthTokenManager {
         Registry.log.info("AuthTokenProvider registered")
 
         coroutineScope.safeLaunch {
-            runCatching { currentToken() }
-                .onFailure { Registry.log.warning("Eager auth token fetch failed", it) }
+            try {
+                currentToken()
+            } catch (e: CancellationException) {
+                // Preserve structured concurrency by rethrowing cancellation.
+                throw e
+            } catch (e: Exception) {
+                Registry.log.warning("Eager auth token fetch failed", e)
+            }
         }
     }
 

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoJavaApiTest.java
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoJavaApiTest.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 
+import com.klaviyo.analytics.auth.AuthTokenProvider;
 import com.klaviyo.analytics.linking.DeepLinkHandler;
 import com.klaviyo.analytics.model.Event;
 import com.klaviyo.analytics.model.EventKey;
@@ -307,6 +308,19 @@ public class KlaviyoJavaApiTest {
         assertEquals(Klaviyo.INSTANCE, result2);
 
         KlaviyoMock.verifyUnregisterDeepLinkHandlerCalled(2);
+    }
+
+    @Test
+    public void testRegisterAuthTokenProvider() {
+        AuthTokenProvider provider = callback -> callback.onSuccess("eyJ.eyJ.sig");
+
+        Klaviyo result1 = Klaviyo.INSTANCE.registerAuthTokenProvider(provider);
+        assertEquals(Klaviyo.INSTANCE, result1);
+
+        Klaviyo result2 = Klaviyo.registerAuthTokenProvider(provider);
+        assertEquals(Klaviyo.INSTANCE, result2);
+
+        KlaviyoMock.verifyRegisterAuthTokenProviderCalled(2);
     }
 
     @Test

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/auth/KlaviyoAuthTokenManagerTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/auth/KlaviyoAuthTokenManagerTest.kt
@@ -128,7 +128,12 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
             )
         }
 
-        verify { spyLog.error(match { it.startsWith("Auth token validation failed:") }) }
+        verify {
+            spyLog.error(
+                match { it.startsWith("Auth token validation failed:") },
+                match { it is IllegalStateException }
+            )
+        }
     }
 
     @Test

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/auth/KlaviyoAuthTokenManagerTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/auth/KlaviyoAuthTokenManagerTest.kt
@@ -3,7 +3,9 @@ package com.klaviyo.analytics.auth
 import com.klaviyo.fixtures.BaseTest
 import io.mockk.verify
 import java.util.Base64
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.runTest
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
@@ -93,6 +95,22 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
             "registerProvider should have eagerly invoked the provider",
             provider.callCount >= 1
         )
+    }
+
+    @Test
+    fun `registerProvider cancellation during eager fetch does not log warning`() = runTest {
+        val provider = DeferredProvider()
+        val manager = KlaviyoAuthTokenManager()
+
+        manager.registerProvider(provider)
+        dispatcher.scheduler.runCurrent()
+        manager.coroutineScope.cancel(CancellationException("teardown"))
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(1, provider.callCount)
+        verify(exactly = 0) {
+            spyLog.warning(any(), any<Throwable>())
+        }
     }
 
     @Test
@@ -188,6 +206,15 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
     private class FailureProvider(private val error: Throwable) : AuthTokenProvider {
         override fun fetchToken(callback: AuthTokenProvider.Callback) {
             callback.onFailure(error)
+        }
+    }
+
+    private class DeferredProvider : AuthTokenProvider {
+        var callCount: Int = 0
+            private set
+
+        override fun fetchToken(callback: AuthTokenProvider.Callback) {
+            callCount++
         }
     }
 

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/auth/KlaviyoAuthTokenManagerTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/auth/KlaviyoAuthTokenManagerTest.kt
@@ -1,0 +1,204 @@
+package com.klaviyo.analytics.auth
+
+import com.klaviyo.fixtures.BaseTest
+import io.mockk.verify
+import java.util.Base64
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class KlaviyoAuthTokenManagerTest : BaseTest() {
+
+    companion object {
+        // staticClock returns TIME = 1234567890000ms → 1234567890s
+        private const val NOW_SECONDS = 1234567890L
+        private const val IAT_SECONDS = NOW_SECONDS - 60
+        private const val EXP_SECONDS = NOW_SECONDS + 3600
+    }
+
+    @Test
+    fun `currentToken throws when no provider registered`() = runTest {
+        val manager = KlaviyoAuthTokenManager()
+
+        try {
+            manager.currentToken()
+            fail("Expected IllegalStateException")
+        } catch (e: IllegalStateException) {
+            assertEquals("No auth token provider registered", e.message)
+        }
+    }
+
+    @Test
+    fun `currentToken returns provider token on first fetch`() = runTest {
+        val token = makeJwt(EXP_SECONDS, IAT_SECONDS)
+        val manager = KlaviyoAuthTokenManager()
+        manager.registerProvider(SuccessProvider(token))
+        dispatcher.scheduler.advanceUntilIdle()
+
+        val result = manager.currentToken()
+
+        assertEquals(token, result)
+    }
+
+    @Test
+    fun `currentToken returns cached token without re-invoking provider`() = runTest {
+        val token = makeJwt(EXP_SECONDS, IAT_SECONDS)
+        val provider = SuccessProvider(token)
+        val manager = KlaviyoAuthTokenManager()
+        manager.registerProvider(provider)
+        dispatcher.scheduler.advanceUntilIdle()
+        // Eager fetch in registerProvider already invoked the provider once
+        val callsAfterRegister = provider.callCount
+
+        val result = manager.currentToken()
+
+        assertEquals(token, result)
+        assertEquals(callsAfterRegister, provider.callCount)
+    }
+
+    @Test
+    fun `registerProvider replaces previous provider and discards cached token`() = runTest {
+        val firstToken = makeJwt(EXP_SECONDS, IAT_SECONDS)
+        val secondToken = makeJwt(EXP_SECONDS + 1, IAT_SECONDS + 1)
+        val firstProvider = SuccessProvider(firstToken)
+        val secondProvider = SuccessProvider(secondToken)
+
+        val manager = KlaviyoAuthTokenManager()
+        manager.registerProvider(firstProvider)
+        dispatcher.scheduler.advanceUntilIdle()
+        manager.currentToken()
+
+        manager.registerProvider(secondProvider)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        val result = manager.currentToken()
+        assertEquals(secondToken, result)
+    }
+
+    @Test
+    fun `registerProvider triggers eager fetch`() = runTest {
+        val token = makeJwt(EXP_SECONDS, IAT_SECONDS)
+        val provider = SuccessProvider(token)
+        val manager = KlaviyoAuthTokenManager()
+
+        manager.registerProvider(provider)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertTrue(
+            "registerProvider should have eagerly invoked the provider",
+            provider.callCount >= 1
+        )
+    }
+
+    @Test
+    fun `currentToken throws when provider invokes onFailure`() = runTest {
+        val failure = RuntimeException("network down")
+        val manager = KlaviyoAuthTokenManager()
+        // Use a provider that fails on the explicit currentToken() call. The eager fetch
+        // in registerProvider will also fail, but its error is logged and not surfaced.
+        manager.registerProvider(FailureProvider(failure))
+        dispatcher.scheduler.advanceUntilIdle()
+
+        try {
+            manager.currentToken()
+            fail("Expected RuntimeException")
+        } catch (e: RuntimeException) {
+            assertEquals("network down", e.message)
+        }
+    }
+
+    @Test
+    fun `currentToken throws and logs error when returned jwt is malformed`() = runTest {
+        val manager = KlaviyoAuthTokenManager()
+        manager.registerProvider(SuccessProvider("not-a-jwt"))
+        dispatcher.scheduler.advanceUntilIdle()
+
+        try {
+            manager.currentToken()
+            fail("Expected IllegalStateException")
+        } catch (e: IllegalStateException) {
+            assertTrue(
+                "Expected validation failure message, got: ${e.message}",
+                e.message?.startsWith("Auth token validation failed:") == true
+            )
+        }
+
+        verify { spyLog.error(match { it.startsWith("Auth token validation failed:") }) }
+    }
+
+    @Test
+    fun `currentToken throws when returned jwt is expired on receipt`() = runTest {
+        // exp within leeway of NOW → ExpiredOnReceipt
+        val expired = makeJwt(NOW_SECONDS, IAT_SECONDS)
+        val manager = KlaviyoAuthTokenManager()
+        manager.registerProvider(SuccessProvider(expired))
+        dispatcher.scheduler.advanceUntilIdle()
+
+        try {
+            manager.currentToken()
+            fail("Expected IllegalStateException")
+        } catch (e: IllegalStateException) {
+            assertTrue(
+                "Expected ExpiredOnReceipt failure, got: ${e.message}",
+                e.message?.contains("ExpiredOnReceipt") == true
+            )
+        }
+    }
+
+    @Test
+    fun `currentToken does not invoke onFailure-and-then-onSuccess twice`() = runTest {
+        // Late callback resolution should be harmlessly ignored (isActive guard).
+        val token = makeJwt(EXP_SECONDS, IAT_SECONDS)
+        val provider = AuthTokenProvider { callback ->
+            callback.onSuccess(token)
+            // Simulate buggy host calling back twice — should not throw.
+            callback.onSuccess(token)
+            callback.onFailure(RuntimeException("late failure"))
+        }
+        val manager = KlaviyoAuthTokenManager()
+        manager.registerProvider(provider)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        val result = manager.currentToken()
+        assertEquals(token, result)
+    }
+
+    // MARK: - Helpers
+
+    private class SuccessProvider(private val jwt: String) : AuthTokenProvider {
+        var callCount: Int = 0
+            private set
+
+        override fun fetchToken(callback: AuthTokenProvider.Callback) {
+            callCount++
+            callback.onSuccess(jwt)
+        }
+    }
+
+    private class FailureProvider(private val error: Throwable) : AuthTokenProvider {
+        override fun fetchToken(callback: AuthTokenProvider.Callback) {
+            callback.onFailure(error)
+        }
+    }
+
+    private fun makeJwt(expSeconds: Long, iatSeconds: Long): String {
+        val header = JSONObject(mapOf("alg" to "HS256", "typ" to "JWT"))
+        val payload = JSONObject(
+            mapOf(
+                "exp" to expSeconds.toDouble(),
+                "iat" to iatSeconds.toDouble()
+            )
+        )
+        val headerSegment = base64UrlEncode(header.toString().toByteArray())
+        val payloadSegment = base64UrlEncode(payload.toString().toByteArray())
+        return "$headerSegment.$payloadSegment.signature"
+    }
+
+    private fun base64UrlEncode(bytes: ByteArray): String =
+        Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
+}

--- a/sdk/fixtures/src/main/java/com/klaviyo/fixtures/KlaviyoMock.kt
+++ b/sdk/fixtures/src/main/java/com/klaviyo/fixtures/KlaviyoMock.kt
@@ -63,6 +63,7 @@ object KlaviyoMock {
         every { Klaviyo.handlePush(any()) } returns Klaviyo
         every { Klaviyo.registerDeepLinkHandler(any()) } returns Klaviyo
         every { Klaviyo.unregisterDeepLinkHandler() } returns Klaviyo
+        every { Klaviyo.registerAuthTokenProvider(any()) } returns Klaviyo
 
         // Mock getters to return test values
         every { Klaviyo.getEmail() } returns "test@example.com"
@@ -196,6 +197,12 @@ object KlaviyoMock {
     @JvmOverloads
     fun verifyUnregisterDeepLinkHandlerCalled(count: Int = 1) {
         verify(exactly = count) { Klaviyo.unregisterDeepLinkHandler() }
+    }
+
+    @JvmStatic
+    @JvmOverloads
+    fun verifyRegisterAuthTokenProviderCalled(count: Int = 1) {
+        verify(exactly = count) { Klaviyo.registerAuthTokenProvider(any()) }
     }
 
     @JvmStatic


### PR DESCRIPTION
# Description

Foundational layer for personalized in-app form authentication. Introduces the `AuthTokenProvider` callback API and the internal `AuthTokenManager` service that the SDK uses to acquire JWTs from the host app. Happy-path acquisition only — concurrency hardening, refresh scheduling, and observer/reset wiring are deferred to sibling sub-issues so this can land focused.

## Due Diligence
- [ ] I have tested this on an emulator and/or a physical device. _(skeleton + unit-tested only; e2e validation lands with [MAGE-619](https://linear.app/klaviyo/issue/MAGE-619) WebView injection)_
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable. _(deferred until full auth flow lands)_
- [x] I am confident these changes are compatible with all Android versions the SDK currently supports.

## Release/Versioning Considerations
- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [x] `Minor` Contains changes to the public API. _(adds `Klaviyo.registerAuthTokenProvider` + `AuthTokenProvider` type)_
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

## Changelog / Code Overview

**New public API**
- `Klaviyo.registerAuthTokenProvider(provider: AuthTokenProvider): Klaviyo` — `@JvmStatic`, chainable, fire-and-forget from the host's perspective.
- `fun interface AuthTokenProvider { fun fetchToken(callback: Callback) }` with nested `Callback { onSuccess(jwt) / onFailure(error) }`.

**Internal scaffolding**
- `AuthTokenManager` interface (public for `Registry` lookup from outside `analytics`, e.g. `forms` in [MAGE-619](https://linear.app/klaviyo/issue/MAGE-619)).
- `KlaviyoAuthTokenManager` (`internal`) implementing happy-path `registerProvider` + `currentToken`:
  - Owns `CoroutineScope(SupervisorJob() + Registry.dispatcher)`.
  - `Mutex` guards `provider` / `cachedToken` mutations (held only around state reads/writes — not across the suspend provider invocation).
  - `suspendCancellableCoroutine` bridge with `isActive` guard on both callback paths — late or double callbacks from a buggy host are harmlessly dropped.
  - Returned JWTs are validated via `JWTParser.parseAndValidate`; failure reasons logged at ERROR with the variant name. Token contents are never logged.
  - `inFlightFetch: Deferred<String>?`, `refreshJob: Job?`, and `refreshObservers` are declared as `@Suppress(\"unused\")` placeholders so siblings can fill them in without churning the class signature.
- `Registry.registerOnce<AuthTokenManager>` wired into `Klaviyo.initialize()` next to the existing `State` registration.

**Tests**
- `KlaviyoAuthTokenManagerTest` (9 cases): no-provider error, first-fetch happy path, cache hit, re-register replaces cache, eager fetch on register, `onFailure` propagation, malformed-JWT validation failure (with `Registry.log.error` verification), expired-on-receipt rejection, idempotent late-callback safety.
- `KlaviyoJavaApiTest.testRegisterAuthTokenProvider` confirms Java callers can register via lambda and that the method chains.
- `KlaviyoMock` updated with the new method's mock setup + `verifyRegisterAuthTokenProviderCalled` helper for downstream Java tests.

**Out of scope (sibling sub-issues)**
- Concurrent-caller deduplication + 5s/500ms timeouts → [MAGE-628](https://linear.app/klaviyo/issue/MAGE-628)
- Proactive refresh scheduling → [MAGE-629](https://linear.app/klaviyo/issue/MAGE-629)
- `onTokenRefresh` / `offTokenRefresh` observers and `Klaviyo.resetProfile()` reset wiring → [MAGE-630](https://linear.app/klaviyo/issue/MAGE-630)
- WebView injection consumer → [MAGE-619](https://linear.app/klaviyo/issue/MAGE-619)

## Test Plan

Local (already run):
- `./gradlew :sdk:analytics:testDebugUnitTest` ✅ — full analytics suite green
- `./gradlew :sdk:analytics:testDebugUnitTest --tests \"com.klaviyo.analytics.auth.KlaviyoAuthTokenManagerTest\"` ✅
- `./gradlew :sdk:analytics:testDebugUnitTest --tests \"com.klaviyo.analytics.KlaviyoJavaApiTest.testRegisterAuthTokenProvider\"` ✅
- `./gradlew ktlintCheck` ✅
- `./gradlew :sdk:analytics:build` ✅ (includes lint)

End-to-end validation lands with [MAGE-619](https://linear.app/klaviyo/issue/MAGE-619) when the WebView injection consumer can exercise `currentToken()` against a live in-app form.

## Related Issues/Tickets

- [MAGE-627](https://linear.app/klaviyo/issue/MAGE-627) — this PR
- Parent: [MAGE-618](https://linear.app/klaviyo/issue/MAGE-618) (AuthTokenManager class and public API)
- Spec: [Personalized In-App Forms — Auth Token Integration](https://linear.app/klaviyo/document/personalized-in-app-forms-auth-token-integration-03d3495f6093)

## Base branch note

Stacked on `MAGE-617` (PR #449, in review) because this PR consumes `ValidatedToken` from that change. GitHub will auto-retarget the base to `master` once #449 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)