### PR TITLE
test(analytics): align JWTParser default leeway test with 30s constant

### DIFF
--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/auth/JWTParserTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/auth/JWTParserTest.kt
@@ -20,8 +20,8 @@ class JWTParserTest : BaseTest() {
     // MARK: - Happy path
 
     @Test
-    fun defaultLeewayIs15Seconds() {
-        assertEquals(15L, JWTParser.DEFAULT_LEEWAY_SECONDS)
+    fun defaultLeewayIs30Seconds() {
+        assertEquals(30L, JWTParser.DEFAULT_LEEWAY_SECONDS)
     }
 
     @Test


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Description
Updates `JWTParserTest` to reflect the reviewer-approved default leeway change (`DEFAULT_LEEWAY_SECONDS = 30L`) so the default-leeway test no longer asserts the old 15-second value.

## Due Diligence
- [ ] I have tested this on an emulator and/or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all Android versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API. 
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [ ] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.

## Changelog / Code Overview
- Renamed `defaultLeewayIs15Seconds` to `defaultLeewayIs30Seconds`.
- Updated assertion from `15L` to `30L` for `JWTParser.DEFAULT_LEEWAY_SECONDS`.

## Test Plan
- Run: `./gradlew :sdk:analytics:testDebugUnitTest --tests "com.klaviyo.analytics.auth.JWTParserTest"`

## Related Issues/Tickets
- N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d88d841-052b-40f1-aa79-2beeef23cc16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d88d841-052b-40f1-aa79-2beeef23cc16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

