### PR TITLE
test(analytics): fix nullable warning matcher in JWTParserTest

### DIFF
--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/auth/JWTParserTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/auth/JWTParserTest.kt
@@ -351,7 +351,7 @@ class JWTParserTest : BaseTest() {
         }
 
         val messages = mutableListOf<String>()
-        verify { spyLog.warning(capture(messages), any()) }
+        verify { spyLog.warning(capture(messages), null) }
 
         // Sanity: at least one warning per failure path.
         assertTrue(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Description
Fixes a MockK matcher issue in `JWTParserTest` by replacing `any()` with explicit `null` for the nullable throwable argument in `verify { spyLog.warning(...) }`. This keeps the verify aligned with `warning(message: String, ex: Throwable? = null)` behavior in mockk 1.13.9.

## Due Diligence
- [ ] I have tested this on an emulator and/or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all Android versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API. 
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [ ] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.

## Changelog / Code Overview
- Updated one line in `sdk/analytics/src/test/java/com/klaviyo/analytics/auth/JWTParserTest.kt`:
  - `verify { spyLog.warning(capture(messages), any()) }`
  - to `verify { spyLog.warning(capture(messages), null) }`
- No production code changes.

## Test Plan
- Attempted: `./gradlew :sdk:analytics:testDebugUnitTest --tests "com.klaviyo.analytics.auth.JWTParserTest"`
- Result in cloud env: failed before test execution due missing Android SDK config (`ANDROID_HOME` / `local.properties sdk.dir`).

## Related Issues/Tickets
- MAGE-617
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bb067129-1e7e-4557-8b72-756ee175ebff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb067129-1e7e-4557-8b72-756ee175ebff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

