### PR TITLE
Fix cancellation handling in eager auth token fetch

### DIFF
--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/auth/KlaviyoAuthTokenManager.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/auth/KlaviyoAuthTokenManager.kt
@@ -4,6 +4,7 @@ import com.klaviyo.core.Registry
 import com.klaviyo.core.safeLaunch
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Job
@@ -43,8 +44,14 @@ internal class KlaviyoAuthTokenManager : AuthTokenManager {
         Registry.log.info("AuthTokenProvider registered")
 
         coroutineScope.safeLaunch {
-            runCatching { currentToken() }
-                .onFailure { Registry.log.warning("Eager auth token fetch failed", it) }
+            try {
+                currentToken()
+            } catch (e: CancellationException) {
+                // Preserve structured concurrency by rethrowing cancellation.
+                throw e
+            } catch (e: Exception) {
+                Registry.log.warning("Eager auth token fetch failed", e)
+            }
         }
     }
 

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/auth/KlaviyoAuthTokenManagerTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/auth/KlaviyoAuthTokenManagerTest.kt
@@ -109,7 +109,7 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
 
         assertEquals(1, provider.callCount)
         verify(exactly = 0) {
-            spyLog.warning("Eager auth token fetch failed", any<Throwable?>())
+            spyLog.warning("Eager auth token fetch failed", any<Throwable>())
         }
     }
 

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/auth/KlaviyoAuthTokenManagerTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/auth/KlaviyoAuthTokenManagerTest.kt
@@ -3,7 +3,9 @@ package com.klaviyo.analytics.auth
 import com.klaviyo.fixtures.BaseTest
 import io.mockk.verify
 import java.util.Base64
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.runTest
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
@@ -93,6 +95,22 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
             "registerProvider should have eagerly invoked the provider",
             provider.callCount >= 1
         )
+    }
+
+    @Test
+    fun `registerProvider cancellation during eager fetch does not log warning`() = runTest {
+        val provider = DeferredProvider()
+        val manager = KlaviyoAuthTokenManager()
+
+        manager.registerProvider(provider)
+        dispatcher.scheduler.runCurrent()
+        manager.coroutineScope.cancel(CancellationException("teardown"))
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(1, provider.callCount)
+        verify(exactly = 0) {
+            spyLog.warning("Eager auth token fetch failed", any<Throwable?>())
+        }
     }
 
     @Test
@@ -188,6 +206,15 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
     private class FailureProvider(private val error: Throwable) : AuthTokenProvider {
         override fun fetchToken(callback: AuthTokenProvider.Callback) {
             callback.onFailure(error)
+        }
+    }
+
+    private class DeferredProvider : AuthTokenProvider {
+        var callCount: Int = 0
+            private set
+
+        override fun fetchToken(callback: AuthTokenProvider.Callback) {
+            callCount++
         }
     }
 

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/auth/KlaviyoAuthTokenManagerTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/auth/KlaviyoAuthTokenManagerTest.kt
@@ -109,7 +109,7 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
 
         assertEquals(1, provider.callCount)
         verify(exactly = 0) {
-            spyLog.warning("Eager auth token fetch failed", any<Throwable>())
+            spyLog.warning(any(), any<Throwable>())
         }
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Description
Prevent `CancellationException` from being swallowed during eager auth token fetch in `KlaviyoAuthTokenManager.registerProvider`. The eager fetch now rethrows cancellation and only logs real failures.

## Due Diligence
- [ ] I have tested this on an emulator and/or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all Android versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [ ] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.

## Changelog / Code Overview
- Replaced `runCatching { currentToken() }` in eager fetch coroutine with explicit `try/catch`.
- Added explicit `CancellationException` rethrow to preserve structured concurrency semantics.
- Kept warning log behavior for non-cancellation exceptions (`"Eager auth token fetch failed"`).
- Added regression test: `registerProvider cancellation during eager fetch does not log warning`.
- Fixed CI compile issue in the new test by changing `any<Throwable?>()` to `any<Throwable>()` in MockK verification.

## Test Plan
- Intended: `./gradlew :sdk:analytics:testDebugUnitTest --tests "com.klaviyo.analytics.auth.KlaviyoAuthTokenManagerTest"`
- Result in cloud environment: failed before test execution due missing Android SDK (`ANDROID_HOME` / `sdk.dir` not configured).
- CI issue fixed: `:sdk:analytics:compileDebugUnitTestKotlin` / `compileReleaseUnitTestKotlin` type-bound error in test matcher.

## Related Issues/Tickets
- Cancellation swallowed by `runCatching` in eager auth token fetch path (`KlaviyoAuthTokenManager.kt`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d15c8a2-2df8-4530-821b-b4ca3d8a335f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d15c8a2-2df8-4530-821b-b4ca3d8a335f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

