### PR TITLE
Fix stale template load on destroyed forms WebView

### DIFF
--- a/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
@@ -91,6 +91,11 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
             }
 
             Registry.threadHelper.runOnUiThread {
+                if (this@KlaviyoWebViewClient.webView !== webView) {
+                    Registry.log.debug("Skipping IAF template load on stale WebView reference")
+                    return@runOnUiThread
+                }
+
                 Registry.config.applicationContext.assets
                     .open("InAppFormsTemplate.html")
                     .bufferedReader()

--- a/sdk/forms/src/test/java/com/klaviyo/forms/webview/KlaviyoWebViewClientTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/webview/KlaviyoWebViewClientTest.kt
@@ -39,6 +39,7 @@ import java.io.ByteArrayInputStream
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.After
@@ -292,7 +293,7 @@ class KlaviyoWebViewClientTest : BaseTest() {
 
     @Test
     fun `initializeWebView skips stale load when webview is destroyed before auth token resolves`() = runTest {
-        val pendingToken = CompletableDeferred<String?>()
+        val pendingToken = CompletableDeferred<String>()
         every { mockAuthTokenManager.coroutineScope } returns this
         coEvery { mockAuthTokenManager.currentToken() } coAnswers { pendingToken.await() }
 
@@ -305,7 +306,7 @@ class KlaviyoWebViewClientTest : BaseTest() {
         client.initializeWebView()
         client.destroyWebView()
 
-        pendingToken.complete(null)
+        pendingToken.complete("delayed-token")
         advanceUntilIdle()
 
         assertEquals(2, uiTasks.size)

--- a/sdk/forms/src/test/java/com/klaviyo/forms/webview/KlaviyoWebViewClientTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/webview/KlaviyoWebViewClientTest.kt
@@ -36,9 +36,11 @@ import io.mockk.runs
 import io.mockk.slot
 import io.mockk.verify
 import java.io.ByteArrayInputStream
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -286,6 +288,34 @@ class KlaviyoWebViewClientTest : BaseTest() {
             htmlSlot.captured.contains("data-klaviyo-jwt=''")
         )
         verify { spyLog.info("Auth token unavailable at load — proceeding without token") }
+    }
+
+    @Test
+    fun `initializeWebView skips stale load when webview is destroyed before auth token resolves`() = runTest {
+        val pendingToken = CompletableDeferred<String?>()
+        every { mockAuthTokenManager.coroutineScope } returns this
+        coEvery { mockAuthTokenManager.currentToken() } coAnswers { pendingToken.await() }
+
+        val uiTasks = mutableListOf<() -> Unit>()
+        every { mockThreadHelper.runOnUiThread(any()) } answers {
+            uiTasks.add(firstArg())
+        }
+
+        val client = KlaviyoWebViewClient()
+        client.initializeWebView()
+        client.destroyWebView()
+
+        pendingToken.complete(null)
+        advanceUntilIdle()
+
+        assertEquals(2, uiTasks.size)
+        uiTasks[0].invoke()
+        uiTasks[1].invoke()
+
+        verify { anyConstructed<KlaviyoWebView>().destroy() }
+        verify(inverse = true) { anyConstructed<KlaviyoWebView>().loadTemplate(any(), any(), any()) }
+        verify { spyLog.debug("Skipping IAF template load on stale WebView reference") }
+        assertEquals(0, staticClock.scheduledTasks.size)
     }
 
     @Test

--- a/sdk/forms/src/test/java/com/klaviyo/forms/webview/KlaviyoWebViewClientTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/webview/KlaviyoWebViewClientTest.kt
@@ -39,8 +39,8 @@ import java.io.ByteArrayInputStream
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Description
Guard `initializeWebView` template loading against stale WebView references so async auth-token completion cannot load into a WebView that was destroyed during the fetch window.

## Due Diligence
- [ ] I have tested this on an emulator and/or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all Android versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API. 
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [ ] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.

## Changelog / Code Overview
- Added a stale-instance guard in the async `runOnUiThread` load path of `KlaviyoWebViewClient.initializeWebView()`.
- If `destroyWebView()` clears/replaces `this.webView` before template load runs, the load is skipped and handshake timer is not started.
- Added a regression test that suspends token fetch, destroys the WebView, then resumes fetch and confirms stale load does not occur.
- Follow-up fix: corrected new test compile issues (`CompletableDeferred<String>` + `advanceUntilIdle` import).
- Follow-up fix: corrected import ordering in `KlaviyoWebViewClientTest` to satisfy ktlint.

## Test Plan
- Added unit test: `initializeWebView skips stale load when webview is destroyed before auth token resolves`.
- Ran locally: `./gradlew :sdk:forms:ktlintTestSourceSetCheck --no-daemon` ✅
- Local cloud run is still blocked for full Android Gradle test execution without SDK config (`sdk.dir` / `ANDROID_HOME`).

## Related Issues/Tickets
- MAGE-619
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-52b510e4-f07c-4921-ace7-afd5a3a21129"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-52b510e4-f07c-4921-ace7-afd5a3a21129"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

