### PR TITLE
Use warning log level for missing auth token fallback

### DIFF
--- a/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
@@ -87,7 +87,7 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
             if (authToken != null) {
                 Registry.log.info("Auth token injected at load")
             } else {
-                Registry.log.info("Auth token unavailable at load — proceeding without token")
+                Registry.log.warning("Auth token unavailable at load — proceeding without token")
             }
 
             Registry.threadHelper.runOnUiThread {

--- a/sdk/forms/src/test/java/com/klaviyo/forms/webview/KlaviyoWebViewClientTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/webview/KlaviyoWebViewClientTest.kt
@@ -288,7 +288,7 @@ class KlaviyoWebViewClientTest : BaseTest() {
             "Expected loaded HTML to contain data-klaviyo-jwt='' (empty), got:\n${htmlSlot.captured}",
             htmlSlot.captured.contains("data-klaviyo-jwt=''")
         )
-        verify { spyLog.info("Auth token unavailable at load — proceeding without token") }
+        verify { spyLog.warning("Auth token unavailable at load — proceeding without token") }
     }
 
     @Test


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Description
Adjust forms WebView auth-token fallback logging to use `warning` severity instead of `info`, matching SDK logging guidelines for degraded functionality/missing resources.

## Due Diligence
- [ ] I have tested this on an emulator and/or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [ ] I am confident these changes are compatible with all Android versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [ ] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.

## Changelog / Code Overview
- Changed `Registry.log.info("Auth token unavailable at load — proceeding without token")` to `Registry.log.warning(...)` in `KlaviyoWebViewClient`.
- Updated `KlaviyoWebViewClientTest` to assert `warning` level for the no-token path.

## Test Plan
- Run: `./gradlew :sdk:forms:testDebugUnitTest --tests "com.klaviyo.forms.webview.KlaviyoWebViewClientTest"`

## Related Issues/Tickets
- User-reported logging severity mismatch in `KlaviyoWebViewClient`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2b5a1a67-9f8d-4a95-89fb-b950c4e5dc26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2b5a1a67-9f8d-4a95-89fb-b950c4e5dc26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

