### PR TITLE
Lower auth token injection success log to debug

### DIFF
--- a/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
@@ -85,7 +85,7 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
             }
 
             if (authToken != null) {
-                Registry.log.info("Auth token injected at load")
+                Registry.log.debug("Auth token injected at load")
             } else {
                 Registry.log.warning("Auth token unavailable at load — proceeding without token")
             }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Description
Adjusts the auth-token success path log level in `KlaviyoWebViewClient` from `info` to `debug` to align with the SDK logging guidelines for internal diagnostic service-status messages.

## Due Diligence
- [ ] I have tested this on an emulator and/or a physical device.
- [ ] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all Android versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API. 
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [ ] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.

## Changelog / Code Overview
- Changed `Registry.log.info("Auth token injected at load")` to `Registry.log.debug(...)` in `sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt`.
- No behavior changes beyond logging severity.

## Test Plan
- Not run (log-level-only change).

## Related Issues/Tickets
- User-reported logging-level mismatch in `KlaviyoWebViewClient` around auth token injection success path.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-35120996-7a52-4837-b13d-52ceef5ee665"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-35120996-7a52-4837-b13d-52ceef5ee665"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

