### PR TITLE
feat(forms): inject JWT auth token into IAF WebView at load (MAGE-619)

### DIFF
--- a/sdk/core/src/main/java/com/klaviyo/core/auth/AuthTokenManager.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/AuthTokenManager.kt
@@ -27,12 +27,16 @@ interface AuthTokenManager {
     fun registerProvider(provider: AuthTokenProvider)
 
     /**
-     * Return a currently-valid JWT, fetching from the registered provider if no cached token is
-     * available or the cached token has expired.
+     * Return a currently-valid [ValidatedToken], fetching from the registered provider if no
+     * cached token is available or the cached token has expired. Callers that only need the raw
+     * JWT string should read [ValidatedToken.rawToken]; consumers that benefit from the parsed
+     * `exp`/`iat` metadata (e.g. cache-aware short-circuiting, refresh scheduling) read it
+     * directly. [ValidatedToken.toString] is redacted, so the wrapper is safer to handle than
+     * the raw string.
      *
      * @throws [AuthTokenException.NoProviderRegistered] if no provider has been registered.
      * @throws [AuthTokenException.ValidationFailed] if the returned token fails validation.
      * @throws Throwable whatever error the provider passed to [AuthTokenProvider.Callback.onFailure].
      */
-    suspend fun currentToken(): String
+    suspend fun currentToken(): ValidatedToken
 }

--- a/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
@@ -66,10 +66,10 @@ internal class KlaviyoAuthTokenManager(
         }
     }
 
-    override suspend fun currentToken(): String {
+    override suspend fun currentToken(): ValidatedToken {
         val cached = cachedToken
         if (cached != null && isStillValid(cached)) {
-            return cached.rawToken
+            return cached
         }
 
         val jwt = invokeProvider()
@@ -79,7 +79,7 @@ internal class KlaviyoAuthTokenManager(
         Registry.log.info(
             "Auth token acquired (exp=${token.expiresAtEpochSeconds}, iat=${token.issuedAtEpochSeconds})"
         )
-        return token.rawToken
+        return token
     }
 
     private suspend fun invokeProvider(): String = suspendCancellableCoroutine { continuation ->

--- a/sdk/core/src/main/java/com/klaviyo/core/auth/ValidatedToken.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/ValidatedToken.kt
@@ -1,6 +1,14 @@
 package com.klaviyo.core.auth
 
-internal data class ValidatedToken(
+/**
+ * A JWT that has been parsed and validated by [JWTParser]. Returned by
+ * [AuthTokenManager.currentToken] so consumers get both the raw token (for transport/injection)
+ * and the parsed claim metadata (`exp`, `iat`) without re-parsing.
+ *
+ * Public so cross-module consumers (e.g. the forms module's WebView injection layer) can read
+ * the metadata; [toString] is redacted to keep the raw token out of accidental log statements.
+ */
+data class ValidatedToken(
     val rawToken: String,
     val expiresAtEpochSeconds: Long,
     val issuedAtEpochSeconds: Long

--- a/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerTest.kt
@@ -44,7 +44,9 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
 
         val result = manager.currentToken()
 
-        assertEquals(token, result)
+        assertEquals(token, result.rawToken)
+        assertEquals(EXP_SECONDS, result.expiresAtEpochSeconds)
+        assertEquals(IAT_SECONDS, result.issuedAtEpochSeconds)
     }
 
     @Test
@@ -59,7 +61,7 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
 
         val result = manager.currentToken()
 
-        assertEquals(token, result)
+        assertEquals(token, result.rawToken)
         assertEquals(callsAfterRegister, provider.callCount)
     }
 
@@ -79,7 +81,7 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
         dispatcher.scheduler.advanceUntilIdle()
 
         val result = manager.currentToken()
-        assertEquals(secondToken, result)
+        assertEquals(secondToken, result.rawToken)
     }
 
     @Test
@@ -187,7 +189,7 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
         dispatcher.scheduler.advanceUntilIdle()
 
         val result = manager.currentToken()
-        assertEquals(token, result)
+        assertEquals(token, result.rawToken)
     }
 
     // MARK: - Helpers

--- a/sdk/forms/src/main/assets/InAppFormsTemplate.html
+++ b/sdk/forms/src/main/assets/InAppFormsTemplate.html
@@ -8,6 +8,7 @@
       data-klaviyo-local-tracking="1"
       data-klaviyo-profile="{}"
       data-klaviyo-device='DEVICE_INFO'
+      data-klaviyo-jwt='JWT_TOKEN'
 >
     <meta charset="UTF-8">
     <meta name="viewport"

--- a/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
@@ -122,9 +122,9 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
             }
 
             if (authToken != null) {
-                Registry.log.info("Auth token injected at load")
+                Registry.log.debug("Auth token injected at load")
             } else {
-                Registry.log.info("Auth token unavailable at load — proceeding without token")
+                Registry.log.warning("Auth token unavailable at load — proceeding without token")
             }
 
             Registry.threadHelper.runOnUiThread {

--- a/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
@@ -16,6 +16,7 @@ import androidx.webkit.WebViewFeature.WEB_MESSAGE_LISTENER
 import androidx.webkit.WebViewFeature.isFeatureSupported
 import com.klaviyo.core.Registry
 import com.klaviyo.core.auth.AuthTokenManager
+import com.klaviyo.core.auth.ValidatedToken
 import com.klaviyo.core.config.Clock
 import com.klaviyo.core.safeLaunch
 import com.klaviyo.core.utils.WeakReferenceDelegate
@@ -111,44 +112,57 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
             .replace("DEVICE_INFO", DeviceInfoProvider.current().toJson())
 
         initJob = scope.safeLaunch {
-            // TODO: [MAGE-628] AuthTokenManager will enforce its own 500ms best-effort deadline.
-            // TODO: [MAGE-630] Subscribe to AuthTokenManager.onTokenRefresh for live updates.
-            val authToken: String? = try {
-                Registry.get<AuthTokenManager>().currentToken()
-            } catch (e: CancellationException) {
-                throw e
-            } catch (_: Exception) {
-                null
-            }
+            loadTemplateWithAuthToken(webView, partialHtml, nativeBridge)
+        }
+    }
 
-            if (authToken != null) {
-                Registry.log.debug("Auth token injected at load")
-            } else {
-                Registry.log.warning("Auth token unavailable at load — proceeding without token")
-            }
+    /**
+     * Fetch the auth token, log the outcome, then dispatch back to the UI thread to inject the
+     * (escaped) JWT into [partialHtml] and load it. [webView] is the locally-captured reference
+     * from [initializeWebView]; the body re-checks `this.webView !== webView` after the dispatch
+     * because the field is held weakly and may be cleared by destroy or GC mid-fetch.
+     */
+    private suspend fun loadTemplateWithAuthToken(
+        webView: KlaviyoWebView,
+        partialHtml: String,
+        nativeBridge: NativeBridge
+    ) {
+        // TODO: [MAGE-628] AuthTokenManager will enforce its own 500ms best-effort deadline.
+        // TODO: [MAGE-630] Subscribe to AuthTokenManager.onTokenRefresh for live updates.
+        val token: ValidatedToken? = try {
+            Registry.get<AuthTokenManager>().currentToken()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            null
+        }
 
-            Registry.threadHelper.runOnUiThread {
-                // webView is held weakly; may be cleared by destroy or GC mid-fetch.
-                if (this@KlaviyoWebViewClient.webView !== webView) {
-                    Registry.log.debug("Skipping IAF template load: WebView no longer current")
-                    return@runOnUiThread
-                }
-                val jwtValue = authToken?.let(::escapeForHtmlAttribute).orEmpty()
-                partialHtml.replace(JWT_TOKEN_PLACEHOLDER, jwtValue).let { html ->
-                    webView.loadTemplate(html, this@KlaviyoWebViewClient, nativeBridge)
-                    handshakeTimer?.cancel()
-                    handshakeTimer = Registry.clock.schedule(
-                        Registry.config.networkTimeout.toLong(),
-                        ::onJsHandshakeTimeout
-                    )
-                }
+        if (token != null) {
+            Registry.log.debug("Auth token injected at load")
+        } else {
+            Registry.log.warning("Auth token unavailable at load — proceeding without token")
+        }
+
+        Registry.threadHelper.runOnUiThread {
+            if (this.webView !== webView) {
+                Registry.log.debug("Skipping IAF template load: WebView no longer current")
+                return@runOnUiThread
+            }
+            val jwtValue = token?.rawToken?.let(::escapeForHtmlAttribute).orEmpty()
+            partialHtml.replace(JWT_TOKEN_PLACEHOLDER, jwtValue).let { html ->
+                webView.loadTemplate(html, this, nativeBridge)
+                handshakeTimer?.cancel()
+                handshakeTimer = Registry.clock.schedule(
+                    Registry.config.networkTimeout.toLong(),
+                    ::onJsHandshakeTimeout
+                )
             }
         }
     }
 
     /**
      * Defense-in-depth escape for the single-quoted `data-klaviyo-jwt` attribute. Valid JWTs
-     * cannot contain these characters, but a custom [AuthTokenProvider] could bypass validation.
+     * cannot contain these characters, but a custom `AuthTokenProvider` could bypass validation.
      */
     private fun escapeForHtmlAttribute(value: String): String =
         value

--- a/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
@@ -15,6 +15,7 @@ import androidx.webkit.WebViewCompat
 import androidx.webkit.WebViewFeature.WEB_MESSAGE_LISTENER
 import androidx.webkit.WebViewFeature.isFeatureSupported
 import com.klaviyo.core.Registry
+import com.klaviyo.core.auth.AuthTokenException
 import com.klaviyo.core.auth.AuthTokenManager
 import com.klaviyo.core.auth.ValidatedToken
 import com.klaviyo.core.config.Clock
@@ -129,18 +130,28 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
     ) {
         // TODO: [MAGE-628] AuthTokenManager will enforce its own 500ms best-effort deadline.
         // TODO: [MAGE-630] Subscribe to AuthTokenManager.onTokenRefresh for live updates.
-        val token: ValidatedToken? = try {
-            Registry.get<AuthTokenManager>().currentToken()
+        // NoProviderRegistered is split out from generic fetch failures: the former is the
+        // expected state for apps not using JWT auth (logged at debug), the latter is degraded
+        // functionality with a fallback (logged at warning). Matches the AuthTokenException
+        // KDoc intent — "treat NoProviderRegistered as 'auth is not enabled' rather than 'auth
+        // failed.'"
+        val outcome: AuthOutcome = try {
+            AuthOutcome.Success(Registry.get<AuthTokenManager>().currentToken())
         } catch (e: CancellationException) {
             throw e
+        } catch (_: AuthTokenException.NoProviderRegistered) {
+            AuthOutcome.NotEnabled
         } catch (_: Exception) {
-            null
+            AuthOutcome.FetchFailed
         }
 
-        if (token != null) {
-            Registry.log.debug("Auth token injected at load")
-        } else {
-            Registry.log.warning("Auth token unavailable at load — proceeding without token")
+        when (outcome) {
+            is AuthOutcome.Success ->
+                Registry.log.debug("Auth token injected at load")
+            AuthOutcome.NotEnabled ->
+                Registry.log.debug("Auth not enabled — proceeding without token")
+            AuthOutcome.FetchFailed ->
+                Registry.log.warning("Auth token fetch failed — proceeding without token")
         }
 
         Registry.threadHelper.runOnUiThread {
@@ -148,6 +159,7 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
                 Registry.log.debug("Skipping IAF template load: WebView no longer current")
                 return@runOnUiThread
             }
+            val token = (outcome as? AuthOutcome.Success)?.token
             val jwtValue = token?.rawToken?.let(::escapeForHtmlAttribute).orEmpty()
             partialHtml.replace(JWT_TOKEN_PLACEHOLDER, jwtValue).let { html ->
                 webView.loadTemplate(html, this, nativeBridge)
@@ -169,6 +181,17 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
             .replace("&", "&amp;") // must escape first to avoid double-encoding entities below
             .replace("'", "&#x27;")
             .replace("<", "&lt;")
+
+    /**
+     * Three-way result of the auth-token fetch in [loadTemplateWithAuthToken]. Lets the call site
+     * differentiate "auth not enabled" (debug-level log) from "auth fetch failed" (warning-level
+     * log) without re-throwing or re-checking exception types after the catch block.
+     */
+    private sealed interface AuthOutcome {
+        data class Success(val token: ValidatedToken) : AuthOutcome
+        data object NotEnabled : AuthOutcome
+        data object FetchFailed : AuthOutcome
+    }
 
     override fun onLocalJsReady() {
         Registry.get<JsBridgeObserverCollection>().startObservers(NativeBridgeMessage.JsReady)

--- a/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
@@ -15,7 +15,9 @@ import androidx.webkit.WebViewCompat
 import androidx.webkit.WebViewFeature.WEB_MESSAGE_LISTENER
 import androidx.webkit.WebViewFeature.isFeatureSupported
 import com.klaviyo.core.Registry
+import com.klaviyo.core.auth.AuthTokenManager
 import com.klaviyo.core.config.Clock
+import com.klaviyo.core.safeLaunch
 import com.klaviyo.core.utils.WeakReferenceDelegate
 import com.klaviyo.core.utils.startActivityIfResolved
 import com.klaviyo.forms.bridge.DeviceInfoProvider
@@ -27,6 +29,10 @@ import com.klaviyo.forms.bridge.NativeBridgeMessage
 import com.klaviyo.forms.bridge.compileJson
 import com.klaviyo.forms.presentation.PresentationManager
 import java.io.BufferedReader
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 
 /**
  * Manages the [KlaviyoWebView] instance that powers In-App Forms behavior, triggering, rendering and display,
@@ -46,17 +52,37 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
     private var webView: KlaviyoWebView? by WeakReferenceDelegate()
 
     /**
-     * Initialize a webview instance, with protection against duplication
-     * and initialize klaviyo.js for In-App Forms with handshake data injected in the document head
+     * Coroutine scope for asynchronous work bound to this client's lifecycle.
+     * Uses [Registry.dispatcher] so tests can substitute a [kotlinx.coroutines.test.TestCoroutineDispatcher].
      */
-    override fun initializeWebView(): Unit = webView?.let {
-        Registry.log.debug("Klaviyo webview is already initialized")
-    } ?: KlaviyoWebView().let { webView ->
+    private val scope = CoroutineScope(SupervisorJob() + Registry.dispatcher)
+
+    /**
+     * Tracks the in-flight initialization coroutine so it can be cancelled if the WebView is
+     * destroyed before the auth token resolves.
+     */
+    private var initJob: Job? = null
+
+    /**
+     * Initialize a webview instance, with protection against duplication
+     * and initialize klaviyo.js for In-App Forms with handshake data injected in the document head.
+     *
+     * Template substitutions that don't require async work (SDK metadata, bridge config, device
+     * info) are applied synchronously on the calling (UI) thread. Auth token injection requires
+     * an async provider call, so the final [KlaviyoWebView.loadTemplate] invocation is deferred
+     * to a background coroutine that calls [AuthTokenManager.currentToken] and then dispatches
+     * back to the UI thread.
+     */
+    override fun initializeWebView() {
+        if (webView != null) {
+            Registry.log.debug("Klaviyo webview is already initialized")
+            return
+        }
+
+        val webView = KlaviyoWebView().also { this.webView = it }
         val nativeBridge = Registry.get<NativeBridge>()
         val jsBridge = Registry.get<JsBridge>()
         val handshake: List<HandshakeSpec> = nativeBridge.handshake + jsBridge.handshake
-
-        this.webView = webView
 
         val klaviyoJsUrl = Registry.config.baseCdnUrl.toUri()
             .buildUpon()
@@ -66,7 +92,10 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
             .appendAssetSource()
             .build()
 
-        Registry.config.applicationContext.assets
+        // Apply all substitutions that can run synchronously on the calling (UI) thread.
+        // DeviceInfoProvider.current() reads UI-thread-only APIs (Display.rotation,
+        // decorView.rootWindowInsets) — snapshot it here while we are still on the main thread.
+        val partialHtml = Registry.config.applicationContext.assets
             .open("InAppFormsTemplate.html")
             .bufferedReader()
             .use(BufferedReader::readText)
@@ -79,14 +108,41 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
             // Raw JSON is safe inside the single-quoted HTML attribute because JSONObject emits
             // double-quoted strings.
             .replace("DEVICE_INFO", DeviceInfoProvider.current().toJson())
-            .let { html ->
-                webView.loadTemplate(html, this, nativeBridge)
-                handshakeTimer?.cancel()
-                handshakeTimer = Registry.clock.schedule(
-                    Registry.config.networkTimeout.toLong(),
-                    ::onJsHandshakeTimeout
-                )
+
+        initJob = scope.safeLaunch {
+            // TODO: [MAGE-628] AuthTokenManager will enforce its own 500ms best-effort deadline
+            // internally. No external timeout is needed here; once MAGE-628 lands, this call site
+            // is correct as-is.
+            val authToken: String? = try {
+                Registry.get<AuthTokenManager>().currentToken()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Exception) {
+                null
             }
+
+            if (authToken != null) {
+                Registry.log.debug("Auth token injected at load")
+            } else {
+                Registry.log.warning("Auth token unavailable at load — proceeding without token")
+            }
+
+            Registry.threadHelper.runOnUiThread {
+                // Guard against the WebView being destroyed while the token fetch was in flight.
+                if (this@KlaviyoWebViewClient.webView !== webView) {
+                    Registry.log.debug("Skipping IAF template load on stale WebView reference")
+                    return@runOnUiThread
+                }
+                partialHtml.replace("JWT_TOKEN", authToken ?: "").let { html ->
+                    webView.loadTemplate(html, this@KlaviyoWebViewClient, nativeBridge)
+                    handshakeTimer?.cancel()
+                    handshakeTimer = Registry.clock.schedule(
+                        Registry.config.networkTimeout.toLong(),
+                        ::onJsHandshakeTimeout
+                    )
+                }
+            }
+        }
     }
 
     override fun onLocalJsReady() {
@@ -149,6 +205,8 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
      */
     override fun destroyWebView() = apply {
         handshakeTimer?.cancel()
+        initJob?.cancel()
+        initJob = null
         Registry.get<JsBridgeObserverCollection>().stopObservers()
         webView?.let { webView ->
             Registry.threadHelper.runOnUiThread {

--- a/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
@@ -52,16 +52,17 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
     private var webView: KlaviyoWebView? by WeakReferenceDelegate()
 
     /**
-     * Coroutine scope for asynchronous work bound to this client's lifecycle.
-     * Uses [Registry.dispatcher] so tests can substitute a [kotlinx.coroutines.test.TestCoroutineDispatcher].
+     * Retained across [destroyWebView] so the client can be reinitialized. Individual jobs
+     * (currently [initJob]) are cancelled in [destroyWebView]; future `safeLaunch` callers must
+     * track their own [Job] or migrate to `scope.coroutineContext.cancelChildren()`.
      */
     private val scope = CoroutineScope(SupervisorJob() + Registry.dispatcher)
 
-    /**
-     * Tracks the in-flight initialization coroutine so it can be cancelled if the WebView is
-     * destroyed before the auth token resolves.
-     */
     private var initJob: Job? = null
+
+    private companion object {
+        const val JWT_TOKEN_PLACEHOLDER = "JWT_TOKEN"
+    }
 
     /**
      * Initialize a webview instance, with protection against duplication
@@ -110,9 +111,8 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
             .replace("DEVICE_INFO", DeviceInfoProvider.current().toJson())
 
         initJob = scope.safeLaunch {
-            // TODO: [MAGE-628] AuthTokenManager will enforce its own 500ms best-effort deadline
-            // internally. No external timeout is needed here; once MAGE-628 lands, this call site
-            // is correct as-is.
+            // TODO: [MAGE-628] AuthTokenManager will enforce its own 500ms best-effort deadline.
+            // TODO: [MAGE-630] Subscribe to AuthTokenManager.onTokenRefresh for live updates.
             val authToken: String? = try {
                 Registry.get<AuthTokenManager>().currentToken()
             } catch (e: CancellationException) {
@@ -122,18 +122,19 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
             }
 
             if (authToken != null) {
-                Registry.log.debug("Auth token injected at load")
+                Registry.log.info("Auth token injected at load")
             } else {
-                Registry.log.warning("Auth token unavailable at load — proceeding without token")
+                Registry.log.info("Auth token unavailable at load — proceeding without token")
             }
 
             Registry.threadHelper.runOnUiThread {
-                // Guard against the WebView being destroyed while the token fetch was in flight.
+                // webView is held weakly; may be cleared by destroy or GC mid-fetch.
                 if (this@KlaviyoWebViewClient.webView !== webView) {
-                    Registry.log.debug("Skipping IAF template load on stale WebView reference")
+                    Registry.log.debug("Skipping IAF template load: WebView no longer current")
                     return@runOnUiThread
                 }
-                partialHtml.replace("JWT_TOKEN", authToken ?: "").let { html ->
+                val jwtValue = authToken?.let(::escapeForHtmlAttribute).orEmpty()
+                partialHtml.replace(JWT_TOKEN_PLACEHOLDER, jwtValue).let { html ->
                     webView.loadTemplate(html, this@KlaviyoWebViewClient, nativeBridge)
                     handshakeTimer?.cancel()
                     handshakeTimer = Registry.clock.schedule(
@@ -144,6 +145,16 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
             }
         }
     }
+
+    /**
+     * Defense-in-depth escape for the single-quoted `data-klaviyo-jwt` attribute. Valid JWTs
+     * cannot contain these characters, but a custom [AuthTokenProvider] could bypass validation.
+     */
+    private fun escapeForHtmlAttribute(value: String): String =
+        value
+            .replace("&", "&amp;") // must escape first to avoid double-encoding entities below
+            .replace("'", "&#x27;")
+            .replace("<", "&lt;")
 
     override fun onLocalJsReady() {
         Registry.get<JsBridgeObserverCollection>().startObservers(NativeBridgeMessage.JsReady)

--- a/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
@@ -118,10 +118,10 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
     }
 
     /**
-     * Fetch the auth token, log the outcome, then dispatch back to the UI thread to inject the
-     * (escaped) JWT into [partialHtml] and load it. [webView] is the locally-captured reference
-     * from [initializeWebView]; the body re-checks `this.webView !== webView` after the dispatch
-     * because the field is held weakly and may be cleared by destroy or GC mid-fetch.
+     * Fetch the auth token, then dispatch back to the UI thread to inject the (escaped) JWT into
+     * [partialHtml], load it, and log the auth outcome. [webView] is the locally-captured
+     * reference from [initializeWebView]; the body re-checks `this.webView !== webView` after the
+     * dispatch because the field is held weakly and may be cleared by destroy or GC mid-fetch.
      */
     private suspend fun loadTemplateWithAuthToken(
         webView: KlaviyoWebView,
@@ -145,15 +145,6 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
             AuthOutcome.FetchFailed
         }
 
-        when (outcome) {
-            is AuthOutcome.Success ->
-                Registry.log.debug("Auth token injected at load")
-            AuthOutcome.NotEnabled ->
-                Registry.log.debug("Auth not enabled — proceeding without token")
-            AuthOutcome.FetchFailed ->
-                Registry.log.warning("Auth token fetch failed — proceeding without token")
-        }
-
         Registry.threadHelper.runOnUiThread {
             if (this.webView !== webView) {
                 Registry.log.debug("Skipping IAF template load: WebView no longer current")
@@ -163,6 +154,14 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
             val jwtValue = token?.rawToken?.let(::escapeForHtmlAttribute).orEmpty()
             partialHtml.replace(JWT_TOKEN_PLACEHOLDER, jwtValue).let { html ->
                 webView.loadTemplate(html, this, nativeBridge)
+                when (outcome) {
+                    is AuthOutcome.Success ->
+                        Registry.log.debug("Auth token injected at load")
+                    AuthOutcome.NotEnabled ->
+                        Registry.log.debug("Auth not enabled — proceeding without token")
+                    AuthOutcome.FetchFailed ->
+                        Registry.log.warning("Auth token fetch failed — proceeding without token")
+                }
                 handshakeTimer?.cancel()
                 handshakeTimer = Registry.clock.schedule(
                     Registry.config.networkTimeout.toLong(),

--- a/sdk/forms/src/test/java/com/klaviyo/forms/webview/KlaviyoWebViewClientTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/webview/KlaviyoWebViewClientTest.kt
@@ -535,6 +535,34 @@ class KlaviyoWebViewClientTest : BaseTest() {
     }
 
     @Test
+    fun `initializeWebView does not log injected token when stale webview skips template load`() {
+        val fakeToken = "header.payload.signature"
+        coEvery { mockAuthTokenManager.currentToken() } returns validatedToken(fakeToken)
+
+        val client = KlaviyoWebViewClient()
+        var firstUiDispatch = true
+        every { mockThreadHelper.runOnUiThread(any()) } answers {
+            val runnable = firstArg<() -> Unit>()
+            if (firstUiDispatch) {
+                firstUiDispatch = false
+                client.destroyWebView()
+            }
+            runnable.invoke()
+        }
+
+        client.initializeWebView()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        verify(inverse = true) { anyConstructed<KlaviyoWebView>().loadTemplate(any(), any(), any()) }
+        verify {
+            spyLog.debug(
+                match { it.contains("Skipping IAF template load: WebView no longer current") }
+            )
+        }
+        verify(inverse = true) { spyLog.debug(match { it.contains("Auth token injected at load") }) }
+    }
+
+    @Test
     fun `initializeWebView logs debug and proceeds without token when no provider is registered`() {
         // Default mock throws NoProviderRegistered — the expected state for apps not using JWT
         // auth. Should be a quiet diagnostic, not a warning.

--- a/sdk/forms/src/test/java/com/klaviyo/forms/webview/KlaviyoWebViewClientTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/webview/KlaviyoWebViewClientTest.kt
@@ -15,6 +15,7 @@ import androidx.webkit.WebViewCompat
 import androidx.webkit.WebViewFeature
 import com.klaviyo.core.Registry
 import com.klaviyo.core.auth.AuthTokenManager
+import com.klaviyo.core.auth.ValidatedToken
 import com.klaviyo.fixtures.BaseTest
 import com.klaviyo.fixtures.MockIntent
 import com.klaviyo.fixtures.mockDeviceProperties
@@ -82,6 +83,11 @@ class KlaviyoWebViewClientTest : BaseTest() {
     }
 
     private val mockAuthTokenManager = mockk<AuthTokenManager>()
+
+    // exp/iat are read by production logging in [KlaviyoAuthTokenManager] but not by the WebView
+    // injection path under test — any non-zero placeholder is fine for these tests.
+    private fun validatedToken(rawToken: String): ValidatedToken =
+        ValidatedToken(rawToken = rawToken, expiresAtEpochSeconds = 0L, issuedAtEpochSeconds = 0L)
 
     private val stubKlaviyoJs = "stubKlaviyoJs"
     private val mockKlaviyoJsUri = mockk<Uri>(relaxed = true).also {
@@ -265,6 +271,7 @@ class KlaviyoWebViewClientTest : BaseTest() {
 
         val client = KlaviyoWebViewClient()
         client.initializeWebView()
+        dispatcher.scheduler.advanceUntilIdle()
 
         verify {
             spyLog.debug(
@@ -510,7 +517,7 @@ class KlaviyoWebViewClientTest : BaseTest() {
     @Test
     fun `initializeWebView injects auth token into data-klaviyo-jwt when token is available`() {
         val fakeToken = "header.payload.signature"
-        coEvery { mockAuthTokenManager.currentToken() } returns fakeToken
+        coEvery { mockAuthTokenManager.currentToken() } returns validatedToken(fakeToken)
 
         val client = KlaviyoWebViewClient()
         client.initializeWebView()
@@ -546,7 +553,7 @@ class KlaviyoWebViewClientTest : BaseTest() {
     @Test
     fun `initializeWebView HTML-escapes special characters in auth token value`() {
         val mischievousToken = "a&b'c<d"
-        coEvery { mockAuthTokenManager.currentToken() } returns mischievousToken
+        coEvery { mockAuthTokenManager.currentToken() } returns validatedToken(mischievousToken)
 
         val client = KlaviyoWebViewClient()
         client.initializeWebView()
@@ -566,7 +573,7 @@ class KlaviyoWebViewClientTest : BaseTest() {
 
     @Test
     fun `destroyWebView cancels in-flight initJob during auth token fetch`() {
-        val tokenCompletion = CompletableDeferred<String>()
+        val tokenCompletion = CompletableDeferred<ValidatedToken>()
         coEvery { mockAuthTokenManager.currentToken() } coAnswers { tokenCompletion.await() }
 
         val client = KlaviyoWebViewClient()
@@ -575,7 +582,7 @@ class KlaviyoWebViewClientTest : BaseTest() {
         coVerify(exactly = 1) { mockAuthTokenManager.currentToken() }
 
         client.destroyWebView()
-        tokenCompletion.complete("would-be-token")
+        tokenCompletion.complete(validatedToken("would-be-token"))
         dispatcher.scheduler.advanceUntilIdle()
 
         verify(inverse = true) { anyConstructed<KlaviyoWebView>().loadTemplate(any(), any(), any()) }

--- a/sdk/forms/src/test/java/com/klaviyo/forms/webview/KlaviyoWebViewClientTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/webview/KlaviyoWebViewClientTest.kt
@@ -14,6 +14,7 @@ import androidx.core.view.ViewCompat
 import androidx.webkit.WebViewCompat
 import androidx.webkit.WebViewFeature
 import com.klaviyo.core.Registry
+import com.klaviyo.core.auth.AuthTokenException
 import com.klaviyo.core.auth.AuthTokenManager
 import com.klaviyo.core.auth.ValidatedToken
 import com.klaviyo.fixtures.BaseTest
@@ -129,9 +130,9 @@ class KlaviyoWebViewClientTest : BaseTest() {
         Registry.register<JsBridge>(mockJsBridge)
         Registry.register<JsBridgeObserverCollection>(mockObserverCollection)
         Registry.register<NativeBridge>(mockBridge)
-        // Default: no token available — form loads without auth token (JWT_TOKEN → "").
-        coEvery { mockAuthTokenManager.currentToken() } throws
-            RuntimeException("No auth token provider registered")
+        // Default: no provider registered — form loads without auth token (JWT_TOKEN → "").
+        // Tests that need a fetch-failure outcome override this with a different exception type.
+        coEvery { mockAuthTokenManager.currentToken() } throws AuthTokenException.NoProviderRegistered
         Registry.register<AuthTokenManager>(mockAuthTokenManager)
         mockDeviceProperties()
         every { mockConfig.isDebugBuild } returns false
@@ -534,8 +535,9 @@ class KlaviyoWebViewClientTest : BaseTest() {
     }
 
     @Test
-    fun `initializeWebView proceeds with empty data-klaviyo-jwt when auth token unavailable`() {
-        // Default setup has currentToken() throwing — form must still load without a token.
+    fun `initializeWebView logs debug and proceeds without token when no provider is registered`() {
+        // Default mock throws NoProviderRegistered — the expected state for apps not using JWT
+        // auth. Should be a quiet diagnostic, not a warning.
         val client = KlaviyoWebViewClient()
         client.initializeWebView()
         dispatcher.scheduler.advanceUntilIdle()
@@ -547,7 +549,31 @@ class KlaviyoWebViewClientTest : BaseTest() {
                 mockBridge
             )
         }
-        verify { spyLog.warning(match { it.contains("Auth token unavailable") }) }
+        verify { spyLog.debug(match { it.contains("Auth not enabled") }) }
+        verify(inverse = true) { spyLog.warning(match { it.contains("Auth token fetch failed") }) }
+    }
+
+    @Test
+    fun `initializeWebView logs warning and proceeds without token when provider fetch fails`() {
+        // Provider IS registered but its fetch fails — degraded functionality with fallback,
+        // appropriate for a warning. ValidationFailed stands in for any non-NoProviderRegistered
+        // AuthTokenException; a plain RuntimeException would hit the same branch.
+        coEvery { mockAuthTokenManager.currentToken() } throws
+            AuthTokenException.ValidationFailed("Malformed")
+
+        val client = KlaviyoWebViewClient()
+        client.initializeWebView()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        verify {
+            anyConstructed<KlaviyoWebView>().loadTemplate(
+                match { it.contains("data-klaviyo-jwt=''") },
+                client,
+                mockBridge
+            )
+        }
+        verify { spyLog.warning(match { it.contains("Auth token fetch failed") }) }
+        verify(inverse = true) { spyLog.debug(match { it.contains("Auth not enabled") }) }
     }
 
     @Test

--- a/sdk/forms/src/test/java/com/klaviyo/forms/webview/KlaviyoWebViewClientTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/webview/KlaviyoWebViewClientTest.kt
@@ -523,7 +523,7 @@ class KlaviyoWebViewClientTest : BaseTest() {
                 mockBridge
             )
         }
-        verify { spyLog.info(match { it.contains("Auth token injected") }) }
+        verify { spyLog.debug(match { it.contains("Auth token injected") }) }
     }
 
     @Test
@@ -540,7 +540,7 @@ class KlaviyoWebViewClientTest : BaseTest() {
                 mockBridge
             )
         }
-        verify { spyLog.info(match { it.contains("Auth token unavailable") }) }
+        verify { spyLog.warning(match { it.contains("Auth token unavailable") }) }
     }
 
     @Test

--- a/sdk/forms/src/test/java/com/klaviyo/forms/webview/KlaviyoWebViewClientTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/webview/KlaviyoWebViewClientTest.kt
@@ -27,6 +27,7 @@ import com.klaviyo.forms.bridge.compileJson
 import com.klaviyo.forms.presentation.PresentationManager
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -35,6 +36,7 @@ import io.mockk.mockkStatic
 import io.mockk.runs
 import io.mockk.verify
 import java.io.ByteArrayInputStream
+import kotlinx.coroutines.CompletableDeferred
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -521,7 +523,7 @@ class KlaviyoWebViewClientTest : BaseTest() {
                 mockBridge
             )
         }
-        verify { spyLog.debug(match { it.contains("Auth token injected") }) }
+        verify { spyLog.info(match { it.contains("Auth token injected") }) }
     }
 
     @Test
@@ -538,17 +540,58 @@ class KlaviyoWebViewClientTest : BaseTest() {
                 mockBridge
             )
         }
-        verify { spyLog.warning(match { it.contains("Auth token unavailable") }) }
+        verify { spyLog.info(match { it.contains("Auth token unavailable") }) }
     }
 
     @Test
-    fun `initializeWebView skips stale load when webview is destroyed before auth token resolves`() {
+    fun `initializeWebView HTML-escapes special characters in auth token value`() {
+        val mischievousToken = "a&b'c<d"
+        coEvery { mockAuthTokenManager.currentToken() } returns mischievousToken
+
         val client = KlaviyoWebViewClient()
         client.initializeWebView()
-        // Destroy before the coroutine runs — cancels initJob, so loadTemplate must not be called.
+        dispatcher.scheduler.advanceUntilIdle()
+
+        verify {
+            anyConstructed<KlaviyoWebView>().loadTemplate(
+                match { html ->
+                    html.contains("data-klaviyo-jwt='a&amp;b&#x27;c&lt;d'") &&
+                        !html.contains("data-klaviyo-jwt='a&b'c<d'")
+                },
+                client,
+                mockBridge
+            )
+        }
+    }
+
+    @Test
+    fun `destroyWebView cancels in-flight initJob during auth token fetch`() {
+        val tokenCompletion = CompletableDeferred<String>()
+        coEvery { mockAuthTokenManager.currentToken() } coAnswers { tokenCompletion.await() }
+
+        val client = KlaviyoWebViewClient()
+        client.initializeWebView()
+        dispatcher.scheduler.runCurrent()
+        coVerify(exactly = 1) { mockAuthTokenManager.currentToken() }
+
+        client.destroyWebView()
+        tokenCompletion.complete("would-be-token")
+        dispatcher.scheduler.advanceUntilIdle()
+
+        verify(inverse = true) { anyConstructed<KlaviyoWebView>().loadTemplate(any(), any(), any()) }
+        // Stale-ref log absence proves cancellation killed the coroutine at the suspension point
+        // rather than the guard catching a non-cancelled stale completion.
+        verify(inverse = true) { spyLog.debug(match { it.contains("no longer current") }) }
+    }
+
+    @Test
+    fun `destroyWebView before coroutine starts cancels initJob and prevents loadTemplate`() {
+        val client = KlaviyoWebViewClient()
+        client.initializeWebView()
         client.destroyWebView()
         dispatcher.scheduler.advanceUntilIdle()
 
         verify(inverse = true) { anyConstructed<KlaviyoWebView>().loadTemplate(any(), any(), any()) }
+        coVerify(exactly = 0) { mockAuthTokenManager.currentToken() }
     }
 }

--- a/sdk/forms/src/test/java/com/klaviyo/forms/webview/KlaviyoWebViewClientTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/webview/KlaviyoWebViewClientTest.kt
@@ -14,6 +14,7 @@ import androidx.core.view.ViewCompat
 import androidx.webkit.WebViewCompat
 import androidx.webkit.WebViewFeature
 import com.klaviyo.core.Registry
+import com.klaviyo.core.auth.AuthTokenManager
 import com.klaviyo.fixtures.BaseTest
 import com.klaviyo.fixtures.MockIntent
 import com.klaviyo.fixtures.mockDeviceProperties
@@ -25,6 +26,7 @@ import com.klaviyo.forms.bridge.NativeBridgeMessage
 import com.klaviyo.forms.bridge.compileJson
 import com.klaviyo.forms.presentation.PresentationManager
 import io.mockk.clearAllMocks
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -51,6 +53,7 @@ class KlaviyoWebViewClientTest : BaseTest() {
                   data-forms-data-environment='FORMS_ENVIRONMENT'
                   data-klaviyo-local-tracking="1"
                   data-klaviyo-profile="{}"
+                  data-klaviyo-jwt='JWT_TOKEN'
             >
                 <meta charset="UTF-8">
                 <meta name="viewport"
@@ -75,6 +78,8 @@ class KlaviyoWebViewClientTest : BaseTest() {
             </html>
         """.trimIndent()
     }
+
+    private val mockAuthTokenManager = mockk<AuthTokenManager>()
 
     private val stubKlaviyoJs = "stubKlaviyoJs"
     private val mockKlaviyoJsUri = mockk<Uri>(relaxed = true).also {
@@ -116,6 +121,10 @@ class KlaviyoWebViewClientTest : BaseTest() {
         Registry.register<JsBridge>(mockJsBridge)
         Registry.register<JsBridgeObserverCollection>(mockObserverCollection)
         Registry.register<NativeBridge>(mockBridge)
+        // Default: no token available — form loads without auth token (JWT_TOKEN → "").
+        coEvery { mockAuthTokenManager.currentToken() } throws
+            RuntimeException("No auth token provider registered")
+        Registry.register<AuthTokenManager>(mockAuthTokenManager)
         mockDeviceProperties()
         every { mockConfig.isDebugBuild } returns false
         every { mockContext.assets } returns mockAssets
@@ -160,6 +169,7 @@ class KlaviyoWebViewClientTest : BaseTest() {
     override fun cleanup() {
         Registry.unregister<NativeBridge>()
         Registry.unregister<JsBridgeObserverCollection>()
+        Registry.unregister<AuthTokenManager>()
         clearAllMocks()
         super.cleanup()
     }
@@ -200,6 +210,7 @@ class KlaviyoWebViewClientTest : BaseTest() {
                   data-forms-data-environment='in-app'
                   data-klaviyo-local-tracking="1"
                   data-klaviyo-profile="{}"
+                  data-klaviyo-jwt=''
             >
                 <meta charset="UTF-8">
                 <meta name="viewport"
@@ -226,6 +237,7 @@ class KlaviyoWebViewClientTest : BaseTest() {
 
         val client = KlaviyoWebViewClient()
         client.initializeWebView()
+        dispatcher.scheduler.advanceUntilIdle()
 
         verify { mockAssets.open("InAppFormsTemplate.html") }
         verify { anyConstructed<KlaviyoWebView>().loadTemplate(expectedHtml, client, mockBridge) }
@@ -240,6 +252,7 @@ class KlaviyoWebViewClientTest : BaseTest() {
         val client = KlaviyoWebViewClient()
         client.initializeWebView()
         client.initializeWebView()
+        dispatcher.scheduler.advanceUntilIdle()
         // Verify that loadTemplate was only called once (which means WebView was only constructed once)
         verify(exactly = 1) { anyConstructed<KlaviyoWebView>().loadTemplate(any(), any(), any()) }
     }
@@ -282,6 +295,7 @@ class KlaviyoWebViewClientTest : BaseTest() {
 
         val client = KlaviyoWebViewClient()
         client.initializeWebView()
+        dispatcher.scheduler.advanceUntilIdle()
 
         verify { mockSettings.javaScriptEnabled = true }
         verify { mockSettings.userAgentString = "Mock User Agent" }
@@ -299,6 +313,7 @@ class KlaviyoWebViewClientTest : BaseTest() {
     fun `timeout cancels on handshake`() {
         val client = KlaviyoWebViewClient()
         client.initializeWebView()
+        dispatcher.scheduler.advanceUntilIdle()
 
         client.onJsHandshakeCompleted()
         staticClock.execute(10_000)
@@ -314,6 +329,7 @@ class KlaviyoWebViewClientTest : BaseTest() {
     fun `closes webview on timeout`() {
         val client = KlaviyoWebViewClient()
         client.initializeWebView()
+        dispatcher.scheduler.advanceUntilIdle()
         // notably no handshake
         staticClock.execute(10_000)
 
@@ -487,5 +503,52 @@ class KlaviyoWebViewClientTest : BaseTest() {
         every { mockConfig.assetSource } returns "test-asset-source"
         KlaviyoWebViewClient().onPageFinished(mockWebview, "https://example.com")
         verify { spyLog.debug(any()) }
+    }
+
+    @Test
+    fun `initializeWebView injects auth token into data-klaviyo-jwt when token is available`() {
+        val fakeToken = "header.payload.signature"
+        coEvery { mockAuthTokenManager.currentToken() } returns fakeToken
+
+        val client = KlaviyoWebViewClient()
+        client.initializeWebView()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        verify {
+            anyConstructed<KlaviyoWebView>().loadTemplate(
+                match { it.contains("data-klaviyo-jwt='$fakeToken'") },
+                client,
+                mockBridge
+            )
+        }
+        verify { spyLog.debug(match { it.contains("Auth token injected") }) }
+    }
+
+    @Test
+    fun `initializeWebView proceeds with empty data-klaviyo-jwt when auth token unavailable`() {
+        // Default setup has currentToken() throwing — form must still load without a token.
+        val client = KlaviyoWebViewClient()
+        client.initializeWebView()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        verify {
+            anyConstructed<KlaviyoWebView>().loadTemplate(
+                match { it.contains("data-klaviyo-jwt=''") },
+                client,
+                mockBridge
+            )
+        }
+        verify { spyLog.warning(match { it.contains("Auth token unavailable") }) }
+    }
+
+    @Test
+    fun `initializeWebView skips stale load when webview is destroyed before auth token resolves`() {
+        val client = KlaviyoWebViewClient()
+        client.initializeWebView()
+        // Destroy before the coroutine runs — cancels initJob, so loadTemplate must not be called.
+        client.destroyWebView()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        verify(inverse = true) { anyConstructed<KlaviyoWebView>().loadTemplate(any(), any(), any()) }
     }
 }


### PR DESCRIPTION
## Summary

Phase 1 of MAGE-619: inject the JWT auth token into the In-App Forms WebView's HTML `<head>` at template load time so fender's `data-klaviyo-jwt` MutationObserver (MAGE-553, already merged) can serve personalized content on first render.

- Adds `data-klaviyo-jwt='JWT_TOKEN'` placeholder to `InAppFormsTemplate.html`, following the existing `data-klaviyo-*` substitution convention.
- Refactors `KlaviyoWebViewClient.initializeWebView()` to fetch the auth token asynchronously via `Registry.get<AuthTokenManager>().currentToken()` before loading the WebView template. Synchronous substitutions (SDK metadata, bridge config, device info) still run on the calling (UI) thread; only the auth token requires the async hop.
- Adds `initJob` cancellation in `destroyWebView()` and a stale-ref guard in the `runOnUiThread` block to handle the race where the WebView is destroyed while the token fetch is in flight.
- Logging: `debug` on success, `warning` on unavailability — token contents are never logged.
- Three new tests: token injected, no-token fallback, stale-WebView cancellation. Existing tests updated with `dispatcher.scheduler.advanceUntilIdle()` where `loadTemplate` is now deferred.

**Attribute name:** `data-klaviyo-jwt` — aligned with fender's `JWT_ATTRIBUTE` constant per Daniel's comment on the prior PR.

**iOS counterpart:** https://github.com/klaviyo/klaviyo-swift-sdk/pull/577

**Supersedes:** https://github.com/klaviyo/klaviyo-android-sdk/pull/454 (rebased on `feat/jwts-for-personalized-forms` with logic moved to `forms` module per updated spec; auth module import is now from `core` not `analytics`)

**Blocked portions (TODO comments in code):**
- Best-effort 500ms timeout at form-display time — waiting on **MAGE-628**
- Live-form token refresh via `onTokenRefresh` observer — waiting on **MAGE-630**

## Test plan

- [ ] All `KlaviyoWebViewClientTest` tests pass (`./gradlew :sdk:forms:testDebugUnitTest`)
- [ ] ktlint clean (`./gradlew :sdk:forms:ktlintCheck`)
- [ ] Manual: register an `AuthTokenProvider` in the sample app, trigger an IAF form, confirm `data-klaviyo-jwt` is present in the WebView head with the expected token value
- [ ] Manual: trigger a form without a registered provider; confirm form loads normally (no-token fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)