### PR TITLE
refactor(forms): address PR #460 review feedback (MAGE-619)

### DIFF
--- a/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
@@ -52,28 +52,15 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
     private var webView: KlaviyoWebView? by WeakReferenceDelegate()
 
     /**
-     * Coroutine scope for asynchronous work bound to this client's lifecycle.
-     * Uses [Registry.dispatcher] so tests can substitute a [kotlinx.coroutines.test.TestCoroutineDispatcher].
-     *
-     * Intentionally retained across [destroyWebView] so the client can be reinitialized without
-     * recreating the scope. Individual jobs (currently [initJob]) are cancelled in [destroyWebView];
-     * any future `scope.safeLaunch { … }` additions must track their own [Job] and cancel
-     * accordingly, or migrate to `scope.coroutineContext.cancelChildren()` on teardown.
+     * Retained across [destroyWebView] so the client can be reinitialized. Individual jobs
+     * (currently [initJob]) are cancelled in [destroyWebView]; future `safeLaunch` callers must
+     * track their own [Job] or migrate to `scope.coroutineContext.cancelChildren()`.
      */
     private val scope = CoroutineScope(SupervisorJob() + Registry.dispatcher)
 
-    /**
-     * Tracks the in-flight initialization coroutine so it can be cancelled if the WebView is
-     * destroyed before the auth token resolves.
-     */
     private var initJob: Job? = null
 
     private companion object {
-        /**
-         * Placeholder in `InAppFormsTemplate.html` for the `data-klaviyo-jwt` attribute value.
-         * Substituted at load time with the (HTML-attribute-escaped) JWT from [AuthTokenManager],
-         * or with an empty string when no token is available.
-         */
         const val JWT_TOKEN_PLACEHOLDER = "JWT_TOKEN"
     }
 
@@ -124,11 +111,8 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
             .replace("DEVICE_INFO", DeviceInfoProvider.current().toJson())
 
         initJob = scope.safeLaunch {
-            // TODO: [MAGE-628] AuthTokenManager will enforce its own 500ms best-effort deadline
-            // internally. No external timeout is needed here; once MAGE-628 lands, this call site
-            // is correct as-is.
-            // TODO: [MAGE-630] Subscribe to AuthTokenManager.onTokenRefresh here (or wire a
-            // dedicated observer) so live forms can update `data-klaviyo-jwt` without a reload.
+            // TODO: [MAGE-628] AuthTokenManager will enforce its own 500ms best-effort deadline.
+            // TODO: [MAGE-630] Subscribe to AuthTokenManager.onTokenRefresh for live updates.
             val authToken: String? = try {
                 Registry.get<AuthTokenManager>().currentToken()
             } catch (e: CancellationException) {
@@ -137,10 +121,6 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
                 null
             }
 
-            // Logged at info on both branches to mirror the iOS counterpart (PR #577) — a missing
-            // token is an expected state for apps without an AuthTokenProvider, not a degraded one.
-            // Provider-side failures are logged separately by [KlaviyoAuthTokenManager] at error
-            // level, so info here is not a regression in observability.
             if (authToken != null) {
                 Registry.log.info("Auth token injected at load")
             } else {
@@ -148,11 +128,7 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
             }
 
             Registry.threadHelper.runOnUiThread {
-                // Guard against the captured WebView no longer matching the client's current
-                // reference. Two paths reach here: (1) [destroyWebView] ran after the coroutine
-                // completed but before this UI-thread block dispatched, nulling [webView]; or
-                // (2) GC cleared the [WeakReferenceDelegate]-held field independently. Either way,
-                // the load is no longer safe — skip it.
+                // webView is held weakly; may be cleared by destroy or GC mid-fetch.
                 if (this@KlaviyoWebViewClient.webView !== webView) {
                     Registry.log.debug("Skipping IAF template load: WebView no longer current")
                     return@runOnUiThread
@@ -171,20 +147,12 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
     }
 
     /**
-     * Escape a string for safe interpolation into a single-quoted HTML attribute value.
-     *
-     * Defense-in-depth only: [KlaviyoAuthTokenManager.currentToken] returns tokens that have
-     * already passed [com.klaviyo.core.auth.JWTParser] validation, and a well-formed JWT
-     * (`base64url(header).base64url(payload).base64url(signature)`) cannot contain any of the
-     * escaped characters. This guards against host-supplied [com.klaviyo.core.auth.AuthTokenProvider]
-     * implementations that bypass validation (e.g. test doubles, or future code paths that surface
-     * raw provider strings before validation).
-     *
-     * Order matters: `&` is escaped first so subsequent entity introductions are not double-encoded.
+     * Defense-in-depth escape for the single-quoted `data-klaviyo-jwt` attribute. Valid JWTs
+     * cannot contain these characters, but a custom [AuthTokenProvider] could bypass validation.
      */
     private fun escapeForHtmlAttribute(value: String): String =
         value
-            .replace("&", "&amp;")
+            .replace("&", "&amp;") // must escape first to avoid double-encoding entities below
             .replace("'", "&#x27;")
             .replace("<", "&lt;")
 

--- a/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
@@ -54,6 +54,11 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
     /**
      * Coroutine scope for asynchronous work bound to this client's lifecycle.
      * Uses [Registry.dispatcher] so tests can substitute a [kotlinx.coroutines.test.TestCoroutineDispatcher].
+     *
+     * Intentionally retained across [destroyWebView] so the client can be reinitialized without
+     * recreating the scope. Individual jobs (currently [initJob]) are cancelled in [destroyWebView];
+     * any future `scope.safeLaunch { … }` additions must track their own [Job] and cancel
+     * accordingly, or migrate to `scope.coroutineContext.cancelChildren()` on teardown.
      */
     private val scope = CoroutineScope(SupervisorJob() + Registry.dispatcher)
 
@@ -62,6 +67,15 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
      * destroyed before the auth token resolves.
      */
     private var initJob: Job? = null
+
+    private companion object {
+        /**
+         * Placeholder in `InAppFormsTemplate.html` for the `data-klaviyo-jwt` attribute value.
+         * Substituted at load time with the (HTML-attribute-escaped) JWT from [AuthTokenManager],
+         * or with an empty string when no token is available.
+         */
+        const val JWT_TOKEN_PLACEHOLDER = "JWT_TOKEN"
+    }
 
     /**
      * Initialize a webview instance, with protection against duplication
@@ -113,6 +127,8 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
             // TODO: [MAGE-628] AuthTokenManager will enforce its own 500ms best-effort deadline
             // internally. No external timeout is needed here; once MAGE-628 lands, this call site
             // is correct as-is.
+            // TODO: [MAGE-630] Subscribe to AuthTokenManager.onTokenRefresh here (or wire a
+            // dedicated observer) so live forms can update `data-klaviyo-jwt` without a reload.
             val authToken: String? = try {
                 Registry.get<AuthTokenManager>().currentToken()
             } catch (e: CancellationException) {
@@ -121,19 +137,28 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
                 null
             }
 
+            // Logged at info on both branches to mirror the iOS counterpart (PR #577) — a missing
+            // token is an expected state for apps without an AuthTokenProvider, not a degraded one.
+            // Provider-side failures are logged separately by [KlaviyoAuthTokenManager] at error
+            // level, so info here is not a regression in observability.
             if (authToken != null) {
-                Registry.log.debug("Auth token injected at load")
+                Registry.log.info("Auth token injected at load")
             } else {
-                Registry.log.warning("Auth token unavailable at load — proceeding without token")
+                Registry.log.info("Auth token unavailable at load — proceeding without token")
             }
 
             Registry.threadHelper.runOnUiThread {
-                // Guard against the WebView being destroyed while the token fetch was in flight.
+                // Guard against the captured WebView no longer matching the client's current
+                // reference. Two paths reach here: (1) [destroyWebView] ran after the coroutine
+                // completed but before this UI-thread block dispatched, nulling [webView]; or
+                // (2) GC cleared the [WeakReferenceDelegate]-held field independently. Either way,
+                // the load is no longer safe — skip it.
                 if (this@KlaviyoWebViewClient.webView !== webView) {
-                    Registry.log.debug("Skipping IAF template load on stale WebView reference")
+                    Registry.log.debug("Skipping IAF template load: WebView no longer current")
                     return@runOnUiThread
                 }
-                partialHtml.replace("JWT_TOKEN", authToken ?: "").let { html ->
+                val jwtValue = authToken?.let(::escapeForHtmlAttribute).orEmpty()
+                partialHtml.replace(JWT_TOKEN_PLACEHOLDER, jwtValue).let { html ->
                     webView.loadTemplate(html, this@KlaviyoWebViewClient, nativeBridge)
                     handshakeTimer?.cancel()
                     handshakeTimer = Registry.clock.schedule(
@@ -144,6 +169,24 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
             }
         }
     }
+
+    /**
+     * Escape a string for safe interpolation into a single-quoted HTML attribute value.
+     *
+     * Defense-in-depth only: [KlaviyoAuthTokenManager.currentToken] returns tokens that have
+     * already passed [com.klaviyo.core.auth.JWTParser] validation, and a well-formed JWT
+     * (`base64url(header).base64url(payload).base64url(signature)`) cannot contain any of the
+     * escaped characters. This guards against host-supplied [com.klaviyo.core.auth.AuthTokenProvider]
+     * implementations that bypass validation (e.g. test doubles, or future code paths that surface
+     * raw provider strings before validation).
+     *
+     * Order matters: `&` is escaped first so subsequent entity introductions are not double-encoded.
+     */
+    private fun escapeForHtmlAttribute(value: String): String =
+        value
+            .replace("&", "&amp;")
+            .replace("'", "&#x27;")
+            .replace("<", "&lt;")
 
     override fun onLocalJsReady() {
         Registry.get<JsBridgeObserverCollection>().startObservers(NativeBridgeMessage.JsReady)

--- a/sdk/forms/src/test/java/com/klaviyo/forms/webview/KlaviyoWebViewClientTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/webview/KlaviyoWebViewClientTest.kt
@@ -545,9 +545,6 @@ class KlaviyoWebViewClientTest : BaseTest() {
 
     @Test
     fun `initializeWebView HTML-escapes special characters in auth token value`() {
-        // Defense-in-depth: real JWTs (base64url segments + '.') cannot contain these chars, but
-        // a misbehaving AuthTokenProvider implementation could. The token must be escaped before
-        // it lands in the single-quoted `data-klaviyo-jwt` attribute.
         val mischievousToken = "a&b'c<d"
         coEvery { mockAuthTokenManager.currentToken() } returns mischievousToken
 
@@ -559,7 +556,6 @@ class KlaviyoWebViewClientTest : BaseTest() {
             anyConstructed<KlaviyoWebView>().loadTemplate(
                 match { html ->
                     html.contains("data-klaviyo-jwt='a&amp;b&#x27;c&lt;d'") &&
-                        // Raw unescaped form must NOT appear — would break the attribute.
                         !html.contains("data-klaviyo-jwt='a&b'c<d'")
                 },
                 client,
@@ -570,27 +566,21 @@ class KlaviyoWebViewClientTest : BaseTest() {
 
     @Test
     fun `destroyWebView cancels in-flight initJob during auth token fetch`() {
-        // Arrange: currentToken() suspends until we explicitly complete it, so the coroutine is
-        // mid-flight when destroyWebView runs.
         val tokenCompletion = CompletableDeferred<String>()
         coEvery { mockAuthTokenManager.currentToken() } coAnswers { tokenCompletion.await() }
 
         val client = KlaviyoWebViewClient()
         client.initializeWebView()
-        // Start the coroutine and let it suspend at currentToken().
         dispatcher.scheduler.runCurrent()
         coVerify(exactly = 1) { mockAuthTokenManager.currentToken() }
 
         client.destroyWebView()
-        // Completing the deferred AFTER cancellation must be a no-op: the cancelled coroutine
-        // resumes only to propagate CancellationException, never reaching the post-token code.
         tokenCompletion.complete("would-be-token")
         dispatcher.scheduler.advanceUntilIdle()
 
         verify(inverse = true) { anyConstructed<KlaviyoWebView>().loadTemplate(any(), any(), any()) }
-        // The stale-ref guard would log this only if the coroutine reached the post-token UI
-        // block. Asserting it did NOT fire proves cancellation killed the coroutine at the
-        // suspension point — not that the guard caught a non-cancelled stale completion.
+        // Stale-ref log absence proves cancellation killed the coroutine at the suspension point
+        // rather than the guard catching a non-cancelled stale completion.
         verify(inverse = true) { spyLog.debug(match { it.contains("no longer current") }) }
     }
 
@@ -598,12 +588,10 @@ class KlaviyoWebViewClientTest : BaseTest() {
     fun `destroyWebView before coroutine starts cancels initJob and prevents loadTemplate`() {
         val client = KlaviyoWebViewClient()
         client.initializeWebView()
-        // Destroy before scheduler advance — initJob is cancelled before its body ever runs.
         client.destroyWebView()
         dispatcher.scheduler.advanceUntilIdle()
 
         verify(inverse = true) { anyConstructed<KlaviyoWebView>().loadTemplate(any(), any(), any()) }
-        // currentToken() should never be invoked because the job was cancelled pre-start.
         coVerify(exactly = 0) { mockAuthTokenManager.currentToken() }
     }
 }

--- a/sdk/forms/src/test/java/com/klaviyo/forms/webview/KlaviyoWebViewClientTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/webview/KlaviyoWebViewClientTest.kt
@@ -27,6 +27,7 @@ import com.klaviyo.forms.bridge.compileJson
 import com.klaviyo.forms.presentation.PresentationManager
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -35,6 +36,7 @@ import io.mockk.mockkStatic
 import io.mockk.runs
 import io.mockk.verify
 import java.io.ByteArrayInputStream
+import kotlinx.coroutines.CompletableDeferred
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -521,7 +523,7 @@ class KlaviyoWebViewClientTest : BaseTest() {
                 mockBridge
             )
         }
-        verify { spyLog.debug(match { it.contains("Auth token injected") }) }
+        verify { spyLog.info(match { it.contains("Auth token injected") }) }
     }
 
     @Test
@@ -538,17 +540,70 @@ class KlaviyoWebViewClientTest : BaseTest() {
                 mockBridge
             )
         }
-        verify { spyLog.warning(match { it.contains("Auth token unavailable") }) }
+        verify { spyLog.info(match { it.contains("Auth token unavailable") }) }
     }
 
     @Test
-    fun `initializeWebView skips stale load when webview is destroyed before auth token resolves`() {
+    fun `initializeWebView HTML-escapes special characters in auth token value`() {
+        // Defense-in-depth: real JWTs (base64url segments + '.') cannot contain these chars, but
+        // a misbehaving AuthTokenProvider implementation could. The token must be escaped before
+        // it lands in the single-quoted `data-klaviyo-jwt` attribute.
+        val mischievousToken = "a&b'c<d"
+        coEvery { mockAuthTokenManager.currentToken() } returns mischievousToken
+
         val client = KlaviyoWebViewClient()
         client.initializeWebView()
-        // Destroy before the coroutine runs — cancels initJob, so loadTemplate must not be called.
+        dispatcher.scheduler.advanceUntilIdle()
+
+        verify {
+            anyConstructed<KlaviyoWebView>().loadTemplate(
+                match { html ->
+                    html.contains("data-klaviyo-jwt='a&amp;b&#x27;c&lt;d'") &&
+                        // Raw unescaped form must NOT appear — would break the attribute.
+                        !html.contains("data-klaviyo-jwt='a&b'c<d'")
+                },
+                client,
+                mockBridge
+            )
+        }
+    }
+
+    @Test
+    fun `destroyWebView cancels in-flight initJob during auth token fetch`() {
+        // Arrange: currentToken() suspends until we explicitly complete it, so the coroutine is
+        // mid-flight when destroyWebView runs.
+        val tokenCompletion = CompletableDeferred<String>()
+        coEvery { mockAuthTokenManager.currentToken() } coAnswers { tokenCompletion.await() }
+
+        val client = KlaviyoWebViewClient()
+        client.initializeWebView()
+        // Start the coroutine and let it suspend at currentToken().
+        dispatcher.scheduler.runCurrent()
+        coVerify(exactly = 1) { mockAuthTokenManager.currentToken() }
+
+        client.destroyWebView()
+        // Completing the deferred AFTER cancellation must be a no-op: the cancelled coroutine
+        // resumes only to propagate CancellationException, never reaching the post-token code.
+        tokenCompletion.complete("would-be-token")
+        dispatcher.scheduler.advanceUntilIdle()
+
+        verify(inverse = true) { anyConstructed<KlaviyoWebView>().loadTemplate(any(), any(), any()) }
+        // The stale-ref guard would log this only if the coroutine reached the post-token UI
+        // block. Asserting it did NOT fire proves cancellation killed the coroutine at the
+        // suspension point — not that the guard caught a non-cancelled stale completion.
+        verify(inverse = true) { spyLog.debug(match { it.contains("no longer current") }) }
+    }
+
+    @Test
+    fun `destroyWebView before coroutine starts cancels initJob and prevents loadTemplate`() {
+        val client = KlaviyoWebViewClient()
+        client.initializeWebView()
+        // Destroy before scheduler advance — initJob is cancelled before its body ever runs.
         client.destroyWebView()
         dispatcher.scheduler.advanceUntilIdle()
 
         verify(inverse = true) { anyConstructed<KlaviyoWebView>().loadTemplate(any(), any(), any()) }
+        // currentToken() should never be invoked because the job was cancelled pre-start.
+        coVerify(exactly = 0) { mockAuthTokenManager.currentToken() }
     }
 }


### PR DESCRIPTION
## Summary

Stacked on top of [#460](https://github.com/klaviyo/klaviyo-android-sdk/pull/460) (MAGE-619 Phase 1). Implements all the actionable review feedback on that PR. Merge into `MAGE-619-refactor` to roll the improvements into the parent.

### Must-fix
- **HTML-escape the JWT** before substituting into the single-quoted `data-klaviyo-jwt` attribute. Defense-in-depth — `KlaviyoAuthTokenManager.currentToken()` already JWT-validates, and a well-formed JWT (`base64url(header).base64url(payload).base64url(sig)`) cannot contain `'`, `&`, or `<` — but this guards against test doubles or future code paths that bypass validation. Order matters: `&` escaped first so subsequent entity introductions aren't double-encoded.

### Should-fix
- **Align log levels with iOS PR #577.** Both the success and miss branches now log at `info` (was `debug` / `warning`). The miss case is an expected state for apps without an `AuthTokenProvider`, not a degraded one. Provider-side failures are still logged at `error` inside `KlaviyoAuthTokenManager.validateOrThrow`, so observability of true errors is unchanged.
- **Rigorously assert `initJob` cancellation** on `destroyWebView()`. The previous test (`skips stale load when webview is destroyed before auth token resolves`) only verified `loadTemplate` wasn't called — which the stale-ref guard would also satisfy without cancellation. Replaced with a `CompletableDeferred`-driven test that suspends `currentToken()` mid-flight, calls `destroyWebView()`, then asserts both `loadTemplate` was not invoked *and* the stale-ref guard log was not emitted (proving cancellation killed the coroutine at the suspension point rather than the guard catching a non-cancelled stale completion). Kept a separate pre-start cancellation test that also asserts `currentToken()` is never invoked.

### Nice-to-have
- **Hoist `JWT_TOKEN` to a `private companion object const val`** — first step toward addressing the broader magic-string footprint of the `*_PLACEHOLDER` substitutions in `initializeWebView`.
- **Add a `MAGE-630` TODO** next to the existing `MAGE-628` one at the fetch site so the live-refresh follow-up is discoverable via grep alongside the timeout follow-up.
- **Document scope lifecycle.** Added a doc comment on `scope` clarifying that retention across `destroyWebView` is intentional, with guidance that future `scope.safeLaunch { … }` additions must track their own `Job` (or migrate to `cancelChildren()` on teardown).
- **Rephrase the stale-ref log message** to cover both reach paths: the field is held by `WeakReferenceDelegate`, so `this.webView` can become `null` from GC alone, not just from an explicit `destroyWebView()` call. New message: `"Skipping IAF template load: WebView no longer current"`.

## Diff scope
- `sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt`: new private `escapeForHtmlAttribute` helper, `JWT_TOKEN_PLACEHOLDER` const, log-level changes, doc/TODO additions, neutral stale-ref message.
- `sdk/forms/src/test/java/com/klaviyo/forms/webview/KlaviyoWebViewClientTest.kt`: log-level test updates, new HTML-escape test, replacement cancellation test (mid-fetch via `CompletableDeferred` + `coVerify`), retained pre-start cancellation test.

## Test plan

- [x] `./gradlew :sdk:forms:testDebugUnitTest` — all `KlaviyoWebViewClientTest` tests pass, including the three new/replaced tests
- [x] `./gradlew :sdk:forms:ktlintCheck` — clean
- [ ] Manual smoke (deferred to parent PR #460): register an `AuthTokenProvider`, trigger an IAF form, inspect `document.head.getAttribute('data-klaviyo-jwt')` in the WebView

## Out of scope (still tracked as TODOs in code)
- `MAGE-628` — 500ms best-effort timeout (`AuthTokenManager` will own this internally)
- `MAGE-630` — live-form token refresh observer

🤖 Generated with [Claude Code](https://claude.com/claude-code)