### PR TITLE
Fix auth token load log levels in forms webview client

### DIFF
--- a/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
@@ -122,9 +122,9 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
             }
 
             if (authToken != null) {
-                Registry.log.info("Auth token injected at load")
+                Registry.log.debug("Auth token injected at load")
             } else {
-                Registry.log.info("Auth token unavailable at load — proceeding without token")
+                Registry.log.warning("Auth token unavailable at load — proceeding without token")
             }
 
             Registry.threadHelper.runOnUiThread {

--- a/sdk/forms/src/test/java/com/klaviyo/forms/webview/KlaviyoWebViewClientTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/webview/KlaviyoWebViewClientTest.kt
@@ -523,7 +523,7 @@ class KlaviyoWebViewClientTest : BaseTest() {
                 mockBridge
             )
         }
-        verify { spyLog.info(match { it.contains("Auth token injected") }) }
+        verify { spyLog.debug(match { it.contains("Auth token injected") }) }
     }
 
     @Test
@@ -540,7 +540,7 @@ class KlaviyoWebViewClientTest : BaseTest() {
                 mockBridge
             )
         }
-        verify { spyLog.info(match { it.contains("Auth token unavailable") }) }
+        verify { spyLog.warning(match { it.contains("Auth token unavailable") }) }
     }
 
     @Test


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Description
Align auth token load logging with AGENTS.md severity guidance by logging token injection at `debug` and token unavailability at `warning`. Update unit test log verifications to match the new levels.

## Due Diligence
- [ ] I have tested this on an emulator and/or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all Android versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API. 
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [ ] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.

## Changelog / Code Overview
- Changed `KlaviyoWebViewClient.initializeWebView` auth token load logs:
  - `"Auth token injected at load"`: `info` -> `debug`
  - `"Auth token unavailable at load — proceeding without token"`: `info` -> `warning`
- Updated `KlaviyoWebViewClientTest` assertions from `spyLog.info(...)` to `spyLog.debug(...)` / `spyLog.warning(...)` for those paths.

## Test Plan
- Attempted: `./gradlew :sdk:forms:testDebugUnitTest --tests "com.klaviyo.forms.webview.KlaviyoWebViewClientTest"`
- Result in this cloud environment: failed before test execution because Android SDK is unavailable (`SDK location not found`, missing `ANDROID_HOME`/`sdk.dir`).

## Related Issues/Tickets
- N/A

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5a620e64-749f-40af-aaa9-6682a18cb197"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5a620e64-749f-40af-aaa9-6682a18cb197"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

