### PR TITLE
refactor: address second-round PR #460 review feedback (MAGE-619)

### DIFF
--- a/sdk/core/src/main/java/com/klaviyo/core/auth/AuthTokenManager.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/AuthTokenManager.kt
@@ -27,12 +27,16 @@ interface AuthTokenManager {
     fun registerProvider(provider: AuthTokenProvider)
 
     /**
-     * Return a currently-valid JWT, fetching from the registered provider if no cached token is
-     * available or the cached token has expired.
+     * Return a currently-valid [ValidatedToken], fetching from the registered provider if no
+     * cached token is available or the cached token has expired. Callers that only need the raw
+     * JWT string should read [ValidatedToken.rawToken]; consumers that benefit from the parsed
+     * `exp`/`iat` metadata (e.g. cache-aware short-circuiting, refresh scheduling) read it
+     * directly. [ValidatedToken.toString] is redacted, so the wrapper is safer to handle than
+     * the raw string.
      *
      * @throws [AuthTokenException.NoProviderRegistered] if no provider has been registered.
      * @throws [AuthTokenException.ValidationFailed] if the returned token fails validation.
      * @throws Throwable whatever error the provider passed to [AuthTokenProvider.Callback.onFailure].
      */
-    suspend fun currentToken(): String
+    suspend fun currentToken(): ValidatedToken
 }

--- a/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
@@ -66,10 +66,10 @@ internal class KlaviyoAuthTokenManager(
         }
     }
 
-    override suspend fun currentToken(): String {
+    override suspend fun currentToken(): ValidatedToken {
         val cached = cachedToken
         if (cached != null && isStillValid(cached)) {
-            return cached.rawToken
+            return cached
         }
 
         val jwt = invokeProvider()
@@ -79,7 +79,7 @@ internal class KlaviyoAuthTokenManager(
         Registry.log.info(
             "Auth token acquired (exp=${token.expiresAtEpochSeconds}, iat=${token.issuedAtEpochSeconds})"
         )
-        return token.rawToken
+        return token
     }
 
     private suspend fun invokeProvider(): String = suspendCancellableCoroutine { continuation ->

--- a/sdk/core/src/main/java/com/klaviyo/core/auth/ValidatedToken.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/ValidatedToken.kt
@@ -1,6 +1,14 @@
 package com.klaviyo.core.auth
 
-internal data class ValidatedToken(
+/**
+ * A JWT that has been parsed and validated by [JWTParser]. Returned by
+ * [AuthTokenManager.currentToken] so consumers get both the raw token (for transport/injection)
+ * and the parsed claim metadata (`exp`, `iat`) without re-parsing.
+ *
+ * Public so cross-module consumers (e.g. the forms module's WebView injection layer) can read
+ * the metadata; [toString] is redacted to keep the raw token out of accidental log statements.
+ */
+data class ValidatedToken(
     val rawToken: String,
     val expiresAtEpochSeconds: Long,
     val issuedAtEpochSeconds: Long

--- a/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerTest.kt
@@ -44,7 +44,9 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
 
         val result = manager.currentToken()
 
-        assertEquals(token, result)
+        assertEquals(token, result.rawToken)
+        assertEquals(EXP_SECONDS, result.expiresAtEpochSeconds)
+        assertEquals(IAT_SECONDS, result.issuedAtEpochSeconds)
     }
 
     @Test
@@ -59,7 +61,7 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
 
         val result = manager.currentToken()
 
-        assertEquals(token, result)
+        assertEquals(token, result.rawToken)
         assertEquals(callsAfterRegister, provider.callCount)
     }
 
@@ -79,7 +81,7 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
         dispatcher.scheduler.advanceUntilIdle()
 
         val result = manager.currentToken()
-        assertEquals(secondToken, result)
+        assertEquals(secondToken, result.rawToken)
     }
 
     @Test
@@ -187,7 +189,7 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
         dispatcher.scheduler.advanceUntilIdle()
 
         val result = manager.currentToken()
-        assertEquals(token, result)
+        assertEquals(token, result.rawToken)
     }
 
     // MARK: - Helpers

--- a/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
@@ -16,6 +16,7 @@ import androidx.webkit.WebViewFeature.WEB_MESSAGE_LISTENER
 import androidx.webkit.WebViewFeature.isFeatureSupported
 import com.klaviyo.core.Registry
 import com.klaviyo.core.auth.AuthTokenManager
+import com.klaviyo.core.auth.ValidatedToken
 import com.klaviyo.core.config.Clock
 import com.klaviyo.core.safeLaunch
 import com.klaviyo.core.utils.WeakReferenceDelegate
@@ -111,44 +112,57 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
             .replace("DEVICE_INFO", DeviceInfoProvider.current().toJson())
 
         initJob = scope.safeLaunch {
-            // TODO: [MAGE-628] AuthTokenManager will enforce its own 500ms best-effort deadline.
-            // TODO: [MAGE-630] Subscribe to AuthTokenManager.onTokenRefresh for live updates.
-            val authToken: String? = try {
-                Registry.get<AuthTokenManager>().currentToken()
-            } catch (e: CancellationException) {
-                throw e
-            } catch (_: Exception) {
-                null
-            }
+            loadTemplateWithAuthToken(webView, partialHtml, nativeBridge)
+        }
+    }
 
-            if (authToken != null) {
-                Registry.log.debug("Auth token injected at load")
-            } else {
-                Registry.log.warning("Auth token unavailable at load — proceeding without token")
-            }
+    /**
+     * Fetch the auth token, log the outcome, then dispatch back to the UI thread to inject the
+     * (escaped) JWT into [partialHtml] and load it. [webView] is the locally-captured reference
+     * from [initializeWebView]; the body re-checks `this.webView !== webView` after the dispatch
+     * because the field is held weakly and may be cleared by destroy or GC mid-fetch.
+     */
+    private suspend fun loadTemplateWithAuthToken(
+        webView: KlaviyoWebView,
+        partialHtml: String,
+        nativeBridge: NativeBridge
+    ) {
+        // TODO: [MAGE-628] AuthTokenManager will enforce its own 500ms best-effort deadline.
+        // TODO: [MAGE-630] Subscribe to AuthTokenManager.onTokenRefresh for live updates.
+        val token: ValidatedToken? = try {
+            Registry.get<AuthTokenManager>().currentToken()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            null
+        }
 
-            Registry.threadHelper.runOnUiThread {
-                // webView is held weakly; may be cleared by destroy or GC mid-fetch.
-                if (this@KlaviyoWebViewClient.webView !== webView) {
-                    Registry.log.debug("Skipping IAF template load: WebView no longer current")
-                    return@runOnUiThread
-                }
-                val jwtValue = authToken?.let(::escapeForHtmlAttribute).orEmpty()
-                partialHtml.replace(JWT_TOKEN_PLACEHOLDER, jwtValue).let { html ->
-                    webView.loadTemplate(html, this@KlaviyoWebViewClient, nativeBridge)
-                    handshakeTimer?.cancel()
-                    handshakeTimer = Registry.clock.schedule(
-                        Registry.config.networkTimeout.toLong(),
-                        ::onJsHandshakeTimeout
-                    )
-                }
+        if (token != null) {
+            Registry.log.debug("Auth token injected at load")
+        } else {
+            Registry.log.warning("Auth token unavailable at load — proceeding without token")
+        }
+
+        Registry.threadHelper.runOnUiThread {
+            if (this.webView !== webView) {
+                Registry.log.debug("Skipping IAF template load: WebView no longer current")
+                return@runOnUiThread
+            }
+            val jwtValue = token?.rawToken?.let(::escapeForHtmlAttribute).orEmpty()
+            partialHtml.replace(JWT_TOKEN_PLACEHOLDER, jwtValue).let { html ->
+                webView.loadTemplate(html, this, nativeBridge)
+                handshakeTimer?.cancel()
+                handshakeTimer = Registry.clock.schedule(
+                    Registry.config.networkTimeout.toLong(),
+                    ::onJsHandshakeTimeout
+                )
             }
         }
     }
 
     /**
      * Defense-in-depth escape for the single-quoted `data-klaviyo-jwt` attribute. Valid JWTs
-     * cannot contain these characters, but a custom [AuthTokenProvider] could bypass validation.
+     * cannot contain these characters, but a custom `AuthTokenProvider` could bypass validation.
      */
     private fun escapeForHtmlAttribute(value: String): String =
         value

--- a/sdk/forms/src/test/java/com/klaviyo/forms/webview/KlaviyoWebViewClientTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/webview/KlaviyoWebViewClientTest.kt
@@ -15,6 +15,7 @@ import androidx.webkit.WebViewCompat
 import androidx.webkit.WebViewFeature
 import com.klaviyo.core.Registry
 import com.klaviyo.core.auth.AuthTokenManager
+import com.klaviyo.core.auth.ValidatedToken
 import com.klaviyo.fixtures.BaseTest
 import com.klaviyo.fixtures.MockIntent
 import com.klaviyo.fixtures.mockDeviceProperties
@@ -82,6 +83,11 @@ class KlaviyoWebViewClientTest : BaseTest() {
     }
 
     private val mockAuthTokenManager = mockk<AuthTokenManager>()
+
+    // exp/iat are read by production logging in [KlaviyoAuthTokenManager] but not by the WebView
+    // injection path under test — any non-zero placeholder is fine for these tests.
+    private fun validatedToken(rawToken: String): ValidatedToken =
+        ValidatedToken(rawToken = rawToken, expiresAtEpochSeconds = 0L, issuedAtEpochSeconds = 0L)
 
     private val stubKlaviyoJs = "stubKlaviyoJs"
     private val mockKlaviyoJsUri = mockk<Uri>(relaxed = true).also {
@@ -265,6 +271,7 @@ class KlaviyoWebViewClientTest : BaseTest() {
 
         val client = KlaviyoWebViewClient()
         client.initializeWebView()
+        dispatcher.scheduler.advanceUntilIdle()
 
         verify {
             spyLog.debug(
@@ -510,7 +517,7 @@ class KlaviyoWebViewClientTest : BaseTest() {
     @Test
     fun `initializeWebView injects auth token into data-klaviyo-jwt when token is available`() {
         val fakeToken = "header.payload.signature"
-        coEvery { mockAuthTokenManager.currentToken() } returns fakeToken
+        coEvery { mockAuthTokenManager.currentToken() } returns validatedToken(fakeToken)
 
         val client = KlaviyoWebViewClient()
         client.initializeWebView()
@@ -546,7 +553,7 @@ class KlaviyoWebViewClientTest : BaseTest() {
     @Test
     fun `initializeWebView HTML-escapes special characters in auth token value`() {
         val mischievousToken = "a&b'c<d"
-        coEvery { mockAuthTokenManager.currentToken() } returns mischievousToken
+        coEvery { mockAuthTokenManager.currentToken() } returns validatedToken(mischievousToken)
 
         val client = KlaviyoWebViewClient()
         client.initializeWebView()
@@ -566,7 +573,7 @@ class KlaviyoWebViewClientTest : BaseTest() {
 
     @Test
     fun `destroyWebView cancels in-flight initJob during auth token fetch`() {
-        val tokenCompletion = CompletableDeferred<String>()
+        val tokenCompletion = CompletableDeferred<ValidatedToken>()
         coEvery { mockAuthTokenManager.currentToken() } coAnswers { tokenCompletion.await() }
 
         val client = KlaviyoWebViewClient()
@@ -575,7 +582,7 @@ class KlaviyoWebViewClientTest : BaseTest() {
         coVerify(exactly = 1) { mockAuthTokenManager.currentToken() }
 
         client.destroyWebView()
-        tokenCompletion.complete("would-be-token")
+        tokenCompletion.complete(validatedToken("would-be-token"))
         dispatcher.scheduler.advanceUntilIdle()
 
         verify(inverse = true) { anyConstructed<KlaviyoWebView>().loadTemplate(any(), any(), any()) }


### PR DESCRIPTION
## Summary

Second round of improvements stacked on [#460](https://github.com/klaviyo/klaviyo-android-sdk/pull/460). Addresses [@evan-masseau](https://github.com/evan-masseau)'s two unresolved comments plus two carryover nits.

### Reviewer feedback addressed

1. **`nit: I'd extract the body of this to its own method`**
   `KlaviyoWebViewClient.initializeWebView` — the `safeLaunch { ... }` body is now a private suspend method, `loadTemplateWithAuthToken(webView, partialHtml, nativeBridge)`. The lambda collapses to a single call; the named method is easier to scan than an inline closure containing two TODOs, a try/catch, two log branches, and a UI dispatch.

2. **`Should currentToken() return ValidatedToken rather than String?`**
   Adopted across the board. All three of Evan's reasons hold:
   - `ValidatedToken.toString()` is already redacted — keeping the wrapped form in scope makes accidental token-logging much harder.
   - `expiresAtEpochSeconds` / `issuedAtEpochSeconds` are directly useful for MAGE-628 (cache-aware short-circuit) and MAGE-630 (proactive refresh scheduling).
   - `currentToken(): ValidatedToken` matches what's parsed, validated, and cached internally in `KlaviyoAuthTokenManager`. The previous `String` return hid the parse work.

   API cost: `ValidatedToken` promoted from `internal` to `public`. The only current call site (this PR's IAF injection layer) reads `.rawToken` at the HTML substitution point. Java interop is clean (data class with primitive/String members).

### Carryover nits from my prior self-review

3. **`appends asset source` test** — added `dispatcher.scheduler.advanceUntilIdle()` for consistency with every other `initializeWebView` test in the suite.
4. **KDoc reference fix** — `[AuthTokenProvider]` → `` `AuthTokenProvider` `` in `escapeForHtmlAttribute` doc so Dokka renders it correctly.

## Breaking change

`refactor(core)!` — `AuthTokenManager.currentToken()` signature changes from `suspend fun currentToken(): String` to `suspend fun currentToken(): ValidatedToken`. The interface was introduced last week ([#458](https://github.com/klaviyo/klaviyo-android-sdk/pull/458)); no external consumers yet. The only current internal caller (this PR's IAF injection) is updated.

## Files changed

- `sdk/core/.../ValidatedToken.kt` — `internal` → `public`, KDoc added
- `sdk/core/.../AuthTokenManager.kt` — `currentToken()` returns `ValidatedToken`
- `sdk/core/.../KlaviyoAuthTokenManager.kt` — impl returns the wrapped token
- `sdk/core/.../KlaviyoAuthTokenManagerTest.kt` — assertions unwrap via `.rawToken`; the first-fetch test additionally validates `exp`/`iat` round-trip
- `sdk/forms/.../KlaviyoWebViewClient.kt` — extracted `loadTemplateWithAuthToken`, consumes `ValidatedToken`, log levels preserved from #462 (`debug` injected / `warning` unavailable)
- `sdk/forms/.../KlaviyoWebViewClientTest.kt` — `validatedToken(rawToken)` helper, mocks now return `ValidatedToken`, asset-source test advances scheduler

## Test plan

- [x] `./gradlew :sdk:core:testDebugUnitTest :sdk:forms:testDebugUnitTest` — passes
- [x] `./gradlew :sdk:core:ktlintCheck :sdk:forms:ktlintCheck` — clean
- [x] `./gradlew assembleDebug` — full repo compiles
- [ ] Manual smoke (deferred to PR #460): trigger an IAF after registering a provider; inspect `data-klaviyo-jwt` in the WebView

🤖 Generated with [Claude Code](https://claude.com/claude-code)