### PR TITLE
refactor(forms): split auth no-provider from fetch failure in IAF log levels (MAGE-619)

### DIFF
--- a/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
@@ -15,6 +15,7 @@ import androidx.webkit.WebViewCompat
 import androidx.webkit.WebViewFeature.WEB_MESSAGE_LISTENER
 import androidx.webkit.WebViewFeature.isFeatureSupported
 import com.klaviyo.core.Registry
+import com.klaviyo.core.auth.AuthTokenException
 import com.klaviyo.core.auth.AuthTokenManager
 import com.klaviyo.core.auth.ValidatedToken
 import com.klaviyo.core.config.Clock
@@ -129,18 +130,28 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
     ) {
         // TODO: [MAGE-628] AuthTokenManager will enforce its own 500ms best-effort deadline.
         // TODO: [MAGE-630] Subscribe to AuthTokenManager.onTokenRefresh for live updates.
-        val token: ValidatedToken? = try {
-            Registry.get<AuthTokenManager>().currentToken()
+        // NoProviderRegistered is split out from generic fetch failures: the former is the
+        // expected state for apps not using JWT auth (logged at debug), the latter is degraded
+        // functionality with a fallback (logged at warning). Matches the AuthTokenException
+        // KDoc intent — "treat NoProviderRegistered as 'auth is not enabled' rather than 'auth
+        // failed.'"
+        val outcome: AuthOutcome = try {
+            AuthOutcome.Success(Registry.get<AuthTokenManager>().currentToken())
         } catch (e: CancellationException) {
             throw e
+        } catch (_: AuthTokenException.NoProviderRegistered) {
+            AuthOutcome.NotEnabled
         } catch (_: Exception) {
-            null
+            AuthOutcome.FetchFailed
         }
 
-        if (token != null) {
-            Registry.log.debug("Auth token injected at load")
-        } else {
-            Registry.log.warning("Auth token unavailable at load — proceeding without token")
+        when (outcome) {
+            is AuthOutcome.Success ->
+                Registry.log.debug("Auth token injected at load")
+            AuthOutcome.NotEnabled ->
+                Registry.log.debug("Auth not enabled — proceeding without token")
+            AuthOutcome.FetchFailed ->
+                Registry.log.warning("Auth token fetch failed — proceeding without token")
         }
 
         Registry.threadHelper.runOnUiThread {
@@ -148,6 +159,7 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
                 Registry.log.debug("Skipping IAF template load: WebView no longer current")
                 return@runOnUiThread
             }
+            val token = (outcome as? AuthOutcome.Success)?.token
             val jwtValue = token?.rawToken?.let(::escapeForHtmlAttribute).orEmpty()
             partialHtml.replace(JWT_TOKEN_PLACEHOLDER, jwtValue).let { html ->
                 webView.loadTemplate(html, this, nativeBridge)
@@ -169,6 +181,17 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
             .replace("&", "&amp;") // must escape first to avoid double-encoding entities below
             .replace("'", "&#x27;")
             .replace("<", "&lt;")
+
+    /**
+     * Three-way result of the auth-token fetch in [loadTemplateWithAuthToken]. Lets the call site
+     * differentiate "auth not enabled" (debug-level log) from "auth fetch failed" (warning-level
+     * log) without re-throwing or re-checking exception types after the catch block.
+     */
+    private sealed interface AuthOutcome {
+        data class Success(val token: ValidatedToken) : AuthOutcome
+        data object NotEnabled : AuthOutcome
+        data object FetchFailed : AuthOutcome
+    }
 
     override fun onLocalJsReady() {
         Registry.get<JsBridgeObserverCollection>().startObservers(NativeBridgeMessage.JsReady)

--- a/sdk/forms/src/test/java/com/klaviyo/forms/webview/KlaviyoWebViewClientTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/webview/KlaviyoWebViewClientTest.kt
@@ -14,6 +14,7 @@ import androidx.core.view.ViewCompat
 import androidx.webkit.WebViewCompat
 import androidx.webkit.WebViewFeature
 import com.klaviyo.core.Registry
+import com.klaviyo.core.auth.AuthTokenException
 import com.klaviyo.core.auth.AuthTokenManager
 import com.klaviyo.core.auth.ValidatedToken
 import com.klaviyo.fixtures.BaseTest
@@ -129,9 +130,9 @@ class KlaviyoWebViewClientTest : BaseTest() {
         Registry.register<JsBridge>(mockJsBridge)
         Registry.register<JsBridgeObserverCollection>(mockObserverCollection)
         Registry.register<NativeBridge>(mockBridge)
-        // Default: no token available — form loads without auth token (JWT_TOKEN → "").
-        coEvery { mockAuthTokenManager.currentToken() } throws
-            RuntimeException("No auth token provider registered")
+        // Default: no provider registered — form loads without auth token (JWT_TOKEN → "").
+        // Tests that need a fetch-failure outcome override this with a different exception type.
+        coEvery { mockAuthTokenManager.currentToken() } throws AuthTokenException.NoProviderRegistered
         Registry.register<AuthTokenManager>(mockAuthTokenManager)
         mockDeviceProperties()
         every { mockConfig.isDebugBuild } returns false
@@ -534,8 +535,9 @@ class KlaviyoWebViewClientTest : BaseTest() {
     }
 
     @Test
-    fun `initializeWebView proceeds with empty data-klaviyo-jwt when auth token unavailable`() {
-        // Default setup has currentToken() throwing — form must still load without a token.
+    fun `initializeWebView logs debug and proceeds without token when no provider is registered`() {
+        // Default mock throws NoProviderRegistered — the expected state for apps not using JWT
+        // auth. Should be a quiet diagnostic, not a warning.
         val client = KlaviyoWebViewClient()
         client.initializeWebView()
         dispatcher.scheduler.advanceUntilIdle()
@@ -547,7 +549,31 @@ class KlaviyoWebViewClientTest : BaseTest() {
                 mockBridge
             )
         }
-        verify { spyLog.warning(match { it.contains("Auth token unavailable") }) }
+        verify { spyLog.debug(match { it.contains("Auth not enabled") }) }
+        verify(inverse = true) { spyLog.warning(match { it.contains("Auth token fetch failed") }) }
+    }
+
+    @Test
+    fun `initializeWebView logs warning and proceeds without token when provider fetch fails`() {
+        // Provider IS registered but its fetch fails — degraded functionality with fallback,
+        // appropriate for a warning. ValidationFailed stands in for any non-NoProviderRegistered
+        // AuthTokenException; a plain RuntimeException would hit the same branch.
+        coEvery { mockAuthTokenManager.currentToken() } throws
+            AuthTokenException.ValidationFailed("Malformed")
+
+        val client = KlaviyoWebViewClient()
+        client.initializeWebView()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        verify {
+            anyConstructed<KlaviyoWebView>().loadTemplate(
+                match { it.contains("data-klaviyo-jwt=''") },
+                client,
+                mockBridge
+            )
+        }
+        verify { spyLog.warning(match { it.contains("Auth token fetch failed") }) }
+        verify(inverse = true) { spyLog.debug(match { it.contains("Auth not enabled") }) }
     }
 
     @Test


### PR DESCRIPTION
## Summary

Stacked on [#460](https://github.com/klaviyo/klaviyo-android-sdk/pull/460) (Phase 1 of MAGE-619). Addresses Cursor Bugbot's open finding ([thread](https://github.com/klaviyo/klaviyo-android-sdk/pull/460#discussion_r3318456933)): *\"Warning log fires on every form load without JWT.\"*

## Problem

After [#462](https://github.com/klaviyo/klaviyo-android-sdk/pull/462) brought the log levels back to `debug`/`warning`, the catch in `KlaviyoWebViewClient.loadTemplateWithAuthToken` collapses **every** exception — including `AuthTokenException.NoProviderRegistered`, the expected state for apps that don't use JWT auth — to a single `warning`.

In debug builds (default threshold is `warning+`), apps that never register an `AuthTokenProvider` would see this warning on every IAF form load. That's noise, not signal.

The `AuthTokenException` sealed hierarchy was already designed for this distinction. From [`AuthTokenException.NoProviderRegistered`'s KDoc](https://github.com/klaviyo/klaviyo-android-sdk/blob/MAGE-619-refactor/sdk/core/src/main/java/com/klaviyo/core/auth/AuthTokenException.kt#L17-L18):

> *Callers should treat this as \"auth is not enabled\" rather than \"auth failed.\"*

Only the call site needed to use it.

## Change

`sdk/forms/.../KlaviyoWebViewClient.kt`:

- Introduces a small file-private `AuthOutcome` sealed interface (`Success` / `NotEnabled` / `FetchFailed`).
- `NoProviderRegistered` → `debug` (\"Auth not enabled — proceeding without token\")
- Any other thrown exception → `warning` (\"Auth token fetch failed — proceeding without token\")
- Success log unchanged at `debug`.

`sdk/forms/.../KlaviyoWebViewClientTest.kt`:

- Default mock now throws the real `AuthTokenException.NoProviderRegistered` data object (was a generic `RuntimeException` with a matching message — wrong type for the new specific catch).
- Single previous miss-path test split into two:
  - `logs debug and proceeds without token when no provider is registered`
  - `logs warning and proceeds without token when provider fetch fails` (mock overridden to throw `AuthTokenException.ValidationFailed`)

No public API change.

## Test plan

- [x] `./gradlew :sdk:forms:ktlintCheck` — clean
- [x] `./gradlew :sdk:forms:testDebugUnitTest` — passes (both new tests + all existing)
- [x] `./gradlew assembleDebug` — full repo compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)