### PR TITLE
Fix stale WebView auth-injection logging order

### DIFF
--- a/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
@@ -118,10 +118,10 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
     }
 
     /**
-     * Fetch the auth token, log the outcome, then dispatch back to the UI thread to inject the
-     * (escaped) JWT into [partialHtml] and load it. [webView] is the locally-captured reference
-     * from [initializeWebView]; the body re-checks `this.webView !== webView` after the dispatch
-     * because the field is held weakly and may be cleared by destroy or GC mid-fetch.
+     * Fetch the auth token, then dispatch back to the UI thread to inject the (escaped) JWT into
+     * [partialHtml], load it, and log the auth outcome. [webView] is the locally-captured
+     * reference from [initializeWebView]; the body re-checks `this.webView !== webView` after the
+     * dispatch because the field is held weakly and may be cleared by destroy or GC mid-fetch.
      */
     private suspend fun loadTemplateWithAuthToken(
         webView: KlaviyoWebView,
@@ -145,15 +145,6 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
             AuthOutcome.FetchFailed
         }
 
-        when (outcome) {
-            is AuthOutcome.Success ->
-                Registry.log.debug("Auth token injected at load")
-            AuthOutcome.NotEnabled ->
-                Registry.log.debug("Auth not enabled — proceeding without token")
-            AuthOutcome.FetchFailed ->
-                Registry.log.warning("Auth token fetch failed — proceeding without token")
-        }
-
         Registry.threadHelper.runOnUiThread {
             if (this.webView !== webView) {
                 Registry.log.debug("Skipping IAF template load: WebView no longer current")
@@ -163,6 +154,14 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
             val jwtValue = token?.rawToken?.let(::escapeForHtmlAttribute).orEmpty()
             partialHtml.replace(JWT_TOKEN_PLACEHOLDER, jwtValue).let { html ->
                 webView.loadTemplate(html, this, nativeBridge)
+                when (outcome) {
+                    is AuthOutcome.Success ->
+                        Registry.log.debug("Auth token injected at load")
+                    AuthOutcome.NotEnabled ->
+                        Registry.log.debug("Auth not enabled — proceeding without token")
+                    AuthOutcome.FetchFailed ->
+                        Registry.log.warning("Auth token fetch failed — proceeding without token")
+                }
                 handshakeTimer?.cancel()
                 handshakeTimer = Registry.clock.schedule(
                     Registry.config.networkTimeout.toLong(),

--- a/sdk/forms/src/test/java/com/klaviyo/forms/webview/KlaviyoWebViewClientTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/webview/KlaviyoWebViewClientTest.kt
@@ -554,7 +554,11 @@ class KlaviyoWebViewClientTest : BaseTest() {
         dispatcher.scheduler.advanceUntilIdle()
 
         verify(inverse = true) { anyConstructed<KlaviyoWebView>().loadTemplate(any(), any(), any()) }
-        verify { spyLog.debug(match { it.contains("Skipping IAF template load: WebView no longer current") }) }
+        verify {
+            spyLog.debug(
+                match { it.contains("Skipping IAF template load: WebView no longer current") }
+            )
+        }
         verify(inverse = true) { spyLog.debug(match { it.contains("Auth token injected at load") }) }
     }
 

--- a/sdk/forms/src/test/java/com/klaviyo/forms/webview/KlaviyoWebViewClientTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/webview/KlaviyoWebViewClientTest.kt
@@ -535,6 +535,30 @@ class KlaviyoWebViewClientTest : BaseTest() {
     }
 
     @Test
+    fun `initializeWebView does not log injected token when stale webview skips template load`() {
+        val fakeToken = "header.payload.signature"
+        coEvery { mockAuthTokenManager.currentToken() } returns validatedToken(fakeToken)
+
+        val client = KlaviyoWebViewClient()
+        var firstUiDispatch = true
+        every { mockThreadHelper.runOnUiThread(any()) } answers {
+            val runnable = firstArg<() -> Unit>()
+            if (firstUiDispatch) {
+                firstUiDispatch = false
+                client.destroyWebView()
+            }
+            runnable.invoke()
+        }
+
+        client.initializeWebView()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        verify(inverse = true) { anyConstructed<KlaviyoWebView>().loadTemplate(any(), any(), any()) }
+        verify { spyLog.debug(match { it.contains("Skipping IAF template load: WebView no longer current") }) }
+        verify(inverse = true) { spyLog.debug(match { it.contains("Auth token injected at load") }) }
+    }
+
+    @Test
     fun `initializeWebView logs debug and proceeds without token when no provider is registered`() {
         // Default mock throws NoProviderRegistered — the expected state for apps not using JWT
         // auth. Should be a quiet diagnostic, not a warning.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Description
Fixes a forms WebView logging race where `"Auth token injected at load"` could be emitted before the UI-thread stale-reference guard ran. Auth outcome logs are now emitted only after the stale guard passes and template load is invoked, preventing contradictory diagnostics.

## Due Diligence
- [ ] I have tested this on an emulator and/or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all Android versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API. 
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [ ] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.

## Changelog / Code Overview
- Moved auth outcome logging in `KlaviyoWebViewClient.loadTemplateWithAuthToken` from the background coroutine section into the UI runnable after `this.webView !== webView` guard.
- Ensures `"Auth token injected at load"` is only logged when the current WebView proceeds through template load.
- Added regression test `initializeWebView does not log injected token when stale webview skips template load` to cover the race path.

## Test Plan
1. Run: `./gradlew :sdk:forms:testDebugUnitTest --tests "com.klaviyo.forms.webview.KlaviyoWebViewClientTest"`
2. Expected: tests pass and stale-guard logging behavior is validated.

Note: In this cloud environment the Gradle task fails before test execution because Android SDK is unavailable (`SDK location not found; set ANDROID_HOME or local.properties sdk.dir`).

## Related Issues/Tickets
- User-reported race in `KlaviyoWebViewClient` auth-injection logging order (`sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt:147-161`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b88d02df-c7dc-46e0-b199-8a5c90d3dd89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b88d02df-c7dc-46e0-b199-8a5c90d3dd89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

