### PR TITLE
feat(forms): add jwtMutation to JsBridge handshake spec

### DIFF
--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/KlaviyoJsBridge.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/KlaviyoJsBridge.kt
@@ -19,7 +19,8 @@ internal class KlaviyoJsBridge : JsBridge {
         openForm,
         closeForm,
         profileEvent,
-        setSafeArea
+        setSafeArea,
+        jwtMutation
     }
 
     override val handshake: List<HandshakeSpec> = listOf(
@@ -37,6 +38,10 @@ internal class KlaviyoJsBridge : JsBridge {
         ),
         HandshakeSpec(
             type = HelperFunction.profileEvent.name,
+            version = 1
+        ),
+        HandshakeSpec(
+            type = HelperFunction.jwtMutation.name,
             version = 1
         )
     )

--- a/sdk/forms/src/test/java/com/klaviyo/forms/bridge/KlaviyoJsBridgeTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/bridge/KlaviyoJsBridgeTest.kt
@@ -35,7 +35,7 @@ class KlaviyoJsBridgeTest : BaseTest() {
     fun `compileJson returns correct JSON for supported functions`() {
         val expectedJson = KlaviyoJsBridge().handshake.compileJson()
         val actualJson = """
-           [{"type":"profileMutation","version":1},{"type":"lifecycleEvent","version":1},{"type":"closeForm","version":1},{"type":"profileEvent","version":1}]
+           [{"type":"profileMutation","version":1},{"type":"lifecycleEvent","version":1},{"type":"closeForm","version":1},{"type":"profileEvent","version":1},{"type":"jwtMutation","version":1}]
         """.trimIndent()
         assertEquals(actualJson, expectedJson)
     }


### PR DESCRIPTION
## Summary

- Adds `jwtMutation` to the `HelperFunction` enum in `KlaviyoJsBridge`
- Adds `HandshakeSpec(type = "jwtMutation", version = 1)` to the handshake list
- Updates `KlaviyoJsBridgeTest` expected JSON accordingly

The handshake is the capability advertisement the native SDK sends to the fender JS layer at WebView init. Without `jwtMutation` in the spec, fender doesn't know the SDK supports pushing token updates and won't wire up that path. 

The full live-refresh implementation (`window.jwtMutation(newToken)` called on token refresh via the observer) is tracked in MAGE-630 and is out of scope here.

## Test plan

- [x] `./gradlew :sdk:forms:testDebugUnitTest` — all pass
- [x] `./gradlew :sdk:forms:ktlintCheck` — clean

Addresses: https://github.com/klaviyo/klaviyo-android-sdk/pull/460#issuecomment-4578797038

🤖 Generated with [Claude Code](https://claude.com/claude-code)