### PR TITLE
feat(core): AuthTokenManager deduplication and timeouts (MAGE-628)

### DIFF
--- a/sdk/core/src/main/java/com/klaviyo/core/auth/AuthTokenException.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/AuthTokenException.kt
@@ -24,4 +24,13 @@ sealed class AuthTokenException(message: String) : RuntimeException(message) {
     data class ValidationFailed(val reason: String) : AuthTokenException(
         "Auth token validation failed: $reason"
     )
+
+    /**
+     * The provider did not return a token within the caller's timeout budget.
+     * The underlying provider invocation may still be in-flight; a later caller with a longer
+     * budget can still receive the result without triggering a second provider call.
+     *
+     * Mirrors iOS `AuthTokenError.timedOut`.
+     */
+    data object TimedOut : AuthTokenException("Auth token request timed out")
 }

--- a/sdk/core/src/main/java/com/klaviyo/core/auth/AuthTokenException.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/AuthTokenException.kt
@@ -30,7 +30,6 @@ sealed class AuthTokenException(message: String) : RuntimeException(message) {
      * The underlying provider invocation may still be in-flight; a later caller with a longer
      * budget can still receive the result without triggering a second provider call.
      *
-     * Mirrors iOS `AuthTokenError.timedOut`.
      */
     data object TimedOut : AuthTokenException("Auth token request timed out")
 }

--- a/sdk/core/src/main/java/com/klaviyo/core/auth/AuthTokenManager.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/AuthTokenManager.kt
@@ -27,7 +27,6 @@ interface AuthTokenManager {
         /**
          * Best-effort timeout budget used at form-display time, where latency is user-visible.
          * A timeout here degrades gracefully — the form loads without a token rather than blocking.
-         * Matches iOS `FetchMode.interactive`.
          */
         const val INTERACTIVE_FETCH_TIMEOUT_MS = 500L
     }

--- a/sdk/core/src/main/java/com/klaviyo/core/auth/AuthTokenManager.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/AuthTokenManager.kt
@@ -17,6 +17,21 @@ internal typealias TokenRefreshObserver = (token: ValidatedToken) -> Unit
  */
 interface AuthTokenManager {
 
+    companion object {
+        /**
+         * Timeout budget for proactive / background fetches (registration-time warm-up, scheduled
+         * refresh). Matches iOS `FetchMode.background`.
+         */
+        const val BACKGROUND_FETCH_TIMEOUT_MS = 5_000L
+
+        /**
+         * Best-effort timeout budget used at form-display time, where latency is user-visible.
+         * A timeout here degrades gracefully — the form loads without a token rather than blocking.
+         * Matches iOS `FetchMode.interactive`.
+         */
+        const val INTERACTIVE_FETCH_TIMEOUT_MS = 500L
+    }
+
     /**
      * Replace the registered [AuthTokenProvider] (if any), discard any cached token, and
      * asynchronously pre-warm the cache with a fresh token via the new provider.
@@ -34,9 +49,18 @@ interface AuthTokenManager {
      * directly. [ValidatedToken.toString] is redacted, so the wrapper is safer to handle than
      * the raw string.
      *
+     * Concurrent callers that arrive while a provider fetch is already in-flight share the result
+     * of that single fetch rather than each triggering a new provider invocation. Each caller's
+     * [timeoutMs] budget is enforced independently — a caller that times out does not cancel the
+     * underlying fetch, so a later caller with a larger budget can still receive the result.
+     *
+     * @param timeoutMs Maximum milliseconds to wait for the provider to return a token.
+     *   Defaults to [BACKGROUND_FETCH_TIMEOUT_MS]. Pass [INTERACTIVE_FETCH_TIMEOUT_MS] at
+     *   form-display time for a best-effort, non-blocking fetch.
      * @throws [AuthTokenException.NoProviderRegistered] if no provider has been registered.
      * @throws [AuthTokenException.ValidationFailed] if the returned token fails validation.
+     * @throws [AuthTokenException.TimedOut] if the provider does not respond within [timeoutMs].
      * @throws Throwable whatever error the provider passed to [AuthTokenProvider.Callback.onFailure].
      */
-    suspend fun currentToken(): ValidatedToken
+    suspend fun currentToken(timeoutMs: Long = BACKGROUND_FETCH_TIMEOUT_MS): ValidatedToken
 }

--- a/sdk/core/src/main/java/com/klaviyo/core/auth/AuthTokenManager.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/AuthTokenManager.kt
@@ -20,7 +20,7 @@ interface AuthTokenManager {
     companion object {
         /**
          * Timeout budget for proactive / background fetches (registration-time warm-up, scheduled
-         * refresh). Matches iOS `FetchMode.background`.
+         * refresh).
          */
         const val BACKGROUND_FETCH_TIMEOUT_MS = 5_000L
 

--- a/sdk/core/src/main/java/com/klaviyo/core/auth/AuthTokenManager.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/AuthTokenManager.kt
@@ -54,10 +54,8 @@ interface AuthTokenManager {
      * underlying fetch, so a later caller with a larger budget can still receive the result.
      *
      * @param timeoutMs Maximum milliseconds to wait for the provider to return a token. Must be
-     *   positive. Defaults to [BACKGROUND_FETCH_TIMEOUT_MS] (note: Swift's default is
-     *   [INTERACTIVE_FETCH_TIMEOUT_MS] — pass the desired budget explicitly when cross-platform
-     *   parity matters). Pass [INTERACTIVE_FETCH_TIMEOUT_MS] at form-display time for a
-     *   best-effort, non-blocking fetch.
+     *   positive. Defaults to [BACKGROUND_FETCH_TIMEOUT_MS], pass [INTERACTIVE_FETCH_TIMEOUT_MS] 
+     *  at form-display time for a best-effort, non-blocking fetch.
      * @throws [AuthTokenException.NoProviderRegistered] if no provider has been registered.
      * @throws [AuthTokenException.ValidationFailed] if the returned token fails validation.
      * @throws [AuthTokenException.TimedOut] if the provider does not respond within [timeoutMs].

--- a/sdk/core/src/main/java/com/klaviyo/core/auth/AuthTokenManager.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/AuthTokenManager.kt
@@ -54,12 +54,15 @@ interface AuthTokenManager {
      * [timeoutMs] budget is enforced independently — a caller that times out does not cancel the
      * underlying fetch, so a later caller with a larger budget can still receive the result.
      *
-     * @param timeoutMs Maximum milliseconds to wait for the provider to return a token.
-     *   Defaults to [BACKGROUND_FETCH_TIMEOUT_MS]. Pass [INTERACTIVE_FETCH_TIMEOUT_MS] at
-     *   form-display time for a best-effort, non-blocking fetch.
+     * @param timeoutMs Maximum milliseconds to wait for the provider to return a token. Must be
+     *   positive. Defaults to [BACKGROUND_FETCH_TIMEOUT_MS] (note: Swift's default is
+     *   [INTERACTIVE_FETCH_TIMEOUT_MS] — pass the desired budget explicitly when cross-platform
+     *   parity matters). Pass [INTERACTIVE_FETCH_TIMEOUT_MS] at form-display time for a
+     *   best-effort, non-blocking fetch.
      * @throws [AuthTokenException.NoProviderRegistered] if no provider has been registered.
      * @throws [AuthTokenException.ValidationFailed] if the returned token fails validation.
      * @throws [AuthTokenException.TimedOut] if the provider does not respond within [timeoutMs].
+     * @throws IllegalArgumentException if [timeoutMs] is not positive.
      * @throws Throwable whatever error the provider passed to [AuthTokenProvider.Callback.onFailure].
      */
     suspend fun currentToken(timeoutMs: Long = BACKGROUND_FETCH_TIMEOUT_MS): ValidatedToken

--- a/sdk/core/src/main/java/com/klaviyo/core/auth/AuthTokenManager.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/AuthTokenManager.kt
@@ -54,8 +54,8 @@ interface AuthTokenManager {
      * underlying fetch, so a later caller with a larger budget can still receive the result.
      *
      * @param timeoutMs Maximum milliseconds to wait for the provider to return a token. Must be
-     *   positive. Defaults to [BACKGROUND_FETCH_TIMEOUT_MS], pass [INTERACTIVE_FETCH_TIMEOUT_MS] 
-     *  at form-display time for a best-effort, non-blocking fetch.
+     *   positive. Defaults to [BACKGROUND_FETCH_TIMEOUT_MS], pass [INTERACTIVE_FETCH_TIMEOUT_MS]
+     *   at form-display time for a best-effort, non-blocking fetch.
      * @throws [AuthTokenException.NoProviderRegistered] if no provider has been registered.
      * @throws [AuthTokenException.ValidationFailed] if the returned token fails validation.
      * @throws [AuthTokenException.TimedOut] if the provider does not respond within [timeoutMs].

--- a/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
@@ -10,9 +10,11 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeoutOrNull
 
 /**
  * @param lifecycleMonitor declared in the constructor to lock the signature for MAGE-629's
@@ -26,8 +28,8 @@ internal class KlaviyoAuthTokenManager(
     // when calling currentToken(), binding auth work to the correct lifecycle.
     internal val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Registry.dispatcher)
 
-    // Mutex retained for currentToken's read-validate-write transition; MAGE-628 will replace
-    // this with Deferred-based deduplication.
+    // Guards the read-validate-write transition on both cachedToken and inFlightFetch, ensuring
+    // exactly one Deferred is created when multiple callers miss the cache simultaneously.
     private val mutex = Mutex()
 
     // @Volatile so reads in invokeProvider (outside the mutex) always observe the latest write
@@ -36,9 +38,10 @@ internal class KlaviyoAuthTokenManager(
 
     @Volatile private var cachedToken: ValidatedToken? = null
 
-    // Reserved for MAGE-628 (concurrent-caller deduplication).
-    @Suppress("unused")
-    private var inFlightFetch: Deferred<String>? = null
+    // Shared in-flight fetch deferred. All concurrent callers that miss the cache await this
+    // single Deferred rather than each invoking the provider independently. Cleared (via
+    // invokeOnCompletion) on both success and failure so the next request starts a fresh fetch.
+    private var inFlightFetch: Deferred<ValidatedToken>? = null
 
     // Reserved for MAGE-630 (onTokenRefresh/offTokenRefresh observers). Matches the established
     // SDK observer-collection pattern (CopyOnWriteArrayList for thread-safe iteration while
@@ -47,6 +50,11 @@ internal class KlaviyoAuthTokenManager(
     private val refreshObservers = CopyOnWriteArrayList<TokenRefreshObserver>()
 
     override fun registerProvider(provider: AuthTokenProvider) {
+        // Cancel any in-flight fetch for the old provider before swapping. The isActive guard in
+        // invokeProvider's suspendCancellableCoroutine ensures a late onSuccess/onFailure from the
+        // cancelled coroutine is harmlessly dropped.
+        inFlightFetch?.cancel()
+        inFlightFetch = null
         cachedToken = null
         this.provider = provider
         Registry.log.info("AuthTokenProvider registered")
@@ -55,26 +63,56 @@ internal class KlaviyoAuthTokenManager(
 
     private suspend fun tryEagerFetch() {
         try {
-            currentToken()
+            currentToken(AuthTokenManager.BACKGROUND_FETCH_TIMEOUT_MS)
         } catch (e: CancellationException) {
             // Preserve structured concurrency by rethrowing cancellation.
             throw e
         } catch (_: Exception) {
-            // The failure is already logged at ERROR by validateOrThrow (or surfaced by the
-            // provider's own onFailure). Avoid double-logging at WARNING here.
+            // The failure is already logged at ERROR by validateOrThrow, by the timeout path, or
+            // surfaced by the provider's own onFailure. Avoid double-logging at WARNING here.
             Registry.log.debug("Eager auth token fetch failed")
         }
     }
 
-    override suspend fun currentToken(): ValidatedToken {
+    override suspend fun currentToken(timeoutMs: Long): ValidatedToken {
+        // Optimistic read of @Volatile field — no lock needed for the fast path.
         val cached = cachedToken
-        if (cached != null && isStillValid(cached)) {
-            return cached
+        if (cached != null && isStillValid(cached)) return cached
+
+        // Atomic read-or-create of the in-flight deferred. The mutex ensures exactly one
+        // scope.async { } is launched when multiple callers miss the cache simultaneously.
+        val deferred: Deferred<ValidatedToken> = mutex.withLock {
+            // Re-check under the lock; a concurrent caller may have populated the cache while
+            // we waited. Non-local return from this inline lambda exits currentToken() directly.
+            val freshenedCache = cachedToken
+            if (freshenedCache != null && isStillValid(freshenedCache)) return freshenedCache
+
+            inFlightFetch ?: scope.async { doFetch() }.also { d ->
+                inFlightFetch = d
+                // Reference-identity check: prevents a stale deferred's completion handler from
+                // clearing a freshly-created deferred after a concurrent provider swap.
+                d.invokeOnCompletion { if (inFlightFetch === d) inFlightFetch = null }
+            }
         }
 
+        // Each caller races its own timeout budget against the shared deferred. Timing out does
+        // NOT cancel the underlying task — other callers with a larger budget still benefit if
+        // the provider eventually responds.
+        return withTimeoutOrNull(timeoutMs) { deferred.await() } ?: run {
+            val error = AuthTokenException.TimedOut
+            Registry.log.error(requireNotNull(error.message), error)
+            throw error
+        }
+    }
+
+    /**
+     * Invoke the provider, validate the returned JWT, write to the cache, and return the token.
+     * Runs inside [scope].async so failures (provider error, validation error) are captured by
+     * the Deferred and re-thrown to all awaiting callers.
+     */
+    private suspend fun doFetch(): ValidatedToken {
         val jwt = invokeProvider()
         val token = validateOrThrow(jwt)
-
         mutex.withLock { cachedToken = token }
         Registry.log.info(
             "Auth token acquired (exp=${token.expiresAtEpochSeconds}, iat=${token.issuedAtEpochSeconds})"

--- a/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
@@ -41,7 +41,9 @@ internal class KlaviyoAuthTokenManager(
     // Shared in-flight fetch deferred. All concurrent callers that miss the cache await this
     // single Deferred rather than each invoking the provider independently. Cleared (via
     // invokeOnCompletion) on both success and failure so the next request starts a fresh fetch.
-    private var inFlightFetch: Deferred<ValidatedToken>? = null
+    // @Volatile because registerProvider and invokeOnCompletion clear it without holding the
+    // mutex; @Volatile ensures those writes are visible to the mutex-protected read in currentToken.
+    @Volatile private var inFlightFetch: Deferred<ValidatedToken>? = null
 
     // Reserved for MAGE-630 (onTokenRefresh/offTokenRefresh observers). Matches the established
     // SDK observer-collection pattern (CopyOnWriteArrayList for thread-safe iteration while
@@ -50,9 +52,13 @@ internal class KlaviyoAuthTokenManager(
     private val refreshObservers = CopyOnWriteArrayList<TokenRefreshObserver>()
 
     override fun registerProvider(provider: AuthTokenProvider) {
-        // Cancel any in-flight fetch for the old provider before swapping. The isActive guard in
-        // invokeProvider's suspendCancellableCoroutine ensures a late onSuccess/onFailure from the
-        // cancelled coroutine is harmlessly dropped.
+        // Cancel any in-flight fetch for the old provider before swapping.
+        // Two complementary guards prevent a stale token from reaching the cache:
+        //   1. If the cancelled coroutine is still inside invokeProvider(), the isActive check in
+        //      suspendCancellableCoroutine drops any late onSuccess/onFailure callback.
+        //   2. If the callback already fired and doFetch() is past invokeProvider() but hasn't
+        //      written the cache yet, the next suspension point (mutex.withLock in doFetch)
+        //      will observe the cancellation and throw CancellationException before the write.
         inFlightFetch?.cancel()
         inFlightFetch = null
         cachedToken = null

--- a/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
@@ -108,9 +108,23 @@ internal class KlaviyoAuthTokenManager(
         // Each caller races its own timeout budget against the shared deferred. Timing out does
         // NOT cancel the underlying task — other callers with a larger budget still benefit if
         // the provider eventually responds.
-        return withTimeoutOrNull(timeoutMs) { deferred.await() } ?: run {
+        //
+        // CancellationException handling: Deferred.await() throws CancellationException if the
+        // deferred is cancelled externally (e.g. by registerProvider swapping the provider). This
+        // would otherwise propagate to callers as if THEIR coroutine was cancelled, which breaks
+        // structured-concurrency semantics. We catch it, use ensureActive() to distinguish "our
+        // coroutine was cancelled" (rethrow — normal teardown) from "the deferred was cancelled
+        // by a provider swap" (retry — pick up the new provider's fetch transparently).
+        return withTimeoutOrNull(timeoutMs) {
+            try {
+                deferred.await()
+            } catch (e: CancellationException) {
+                currentCoroutineContext().ensureActive()
+                currentToken(timeoutMs)
+            }
+        } ?: run {
             val error = AuthTokenException.TimedOut
-            Registry.log.error(requireNotNull(error.message), error)
+            Registry.log.warning(requireNotNull(error.message), error)
             throw error
         }
     }

--- a/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
@@ -115,6 +115,12 @@ internal class KlaviyoAuthTokenManager(
         // structured-concurrency semantics. We catch it, use ensureActive() to distinguish "our
         // coroutine was cancelled" (rethrow — normal teardown) from "the deferred was cancelled
         // by a provider swap" (retry — pick up the new provider's fetch transparently).
+        //
+        // Budget: the retry calls currentToken(timeoutMs) inside this same withTimeoutOrNull block,
+        // so the caller's original deadline governs the total wait end-to-end. The recursive call
+        // creates a fresh inner withTimeoutOrNull(timeoutMs) starting from the current time, but
+        // the outer one fires first if the budget is nearly exhausted. This is intentional — the
+        // caller asked for a response within timeoutMs of their call site, not of the swap.
         return withTimeoutOrNull(timeoutMs) {
             try {
                 deferred.await()

--- a/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
@@ -11,6 +11,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -57,8 +59,8 @@ internal class KlaviyoAuthTokenManager(
         //   1. If the cancelled coroutine is still inside invokeProvider(), the isActive check in
         //      suspendCancellableCoroutine drops any late onSuccess/onFailure callback.
         //   2. If the callback already fired and doFetch() is past invokeProvider() but hasn't
-        //      written the cache yet, the next suspension point (mutex.withLock in doFetch)
-        //      will observe the cancellation and throw CancellationException before the write.
+        //      written the cache yet, ensureActive() in doFetch will throw CancellationException
+        //      before the write — even when mutex.withLock acquires the lock uncontended.
         inFlightFetch?.cancel()
         inFlightFetch = null
         cachedToken = null
@@ -75,12 +77,14 @@ internal class KlaviyoAuthTokenManager(
             throw e
         } catch (_: Exception) {
             // The failure is already logged at ERROR by validateOrThrow, by the timeout path, or
-            // surfaced by the provider's own onFailure. Avoid double-logging at WARNING here.
-            Registry.log.debug("Eager auth token fetch failed")
+            // surfaced by the provider's own onFailure. Nothing more to log here.
         }
     }
 
     override suspend fun currentToken(timeoutMs: Long): ValidatedToken {
+        require(timeoutMs > 0L) { "timeoutMs must be positive, but was $timeoutMs" }
+        if (provider == null) throw AuthTokenException.NoProviderRegistered
+
         // Optimistic read of @Volatile field — no lock needed for the fast path.
         val cached = cachedToken
         if (cached != null && isStillValid(cached)) return cached
@@ -119,6 +123,11 @@ internal class KlaviyoAuthTokenManager(
     private suspend fun doFetch(): ValidatedToken {
         val jwt = invokeProvider()
         val token = validateOrThrow(jwt)
+        // Non-suspending cancellation check: if this deferred was cancelled (e.g. by a provider
+        // swap) after invokeProvider() returned but before we write the cache, bail out now.
+        // mutex.withLock does NOT check cancellation when the lock is uncontended, so this guard
+        // is required even when the mutex is free.
+        currentCoroutineContext().ensureActive()
         mutex.withLock { cachedToken = token }
         Registry.log.info(
             "Auth token acquired (exp=${token.expiresAtEpochSeconds}, iat=${token.issuedAtEpochSeconds})"

--- a/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerTest.kt
@@ -205,7 +205,7 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
         assertEquals(token, result.rawToken)
     }
 
-    // MARK: - MAGE-628: Deduplication and Timeouts
+    // MARK: - Deduplication and Timeouts
 
     @Test
     fun `concurrent callers share a single provider invocation`() = runTest(dispatcher) {

--- a/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerTest.kt
@@ -381,6 +381,50 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
     }
 
     @Test
+    fun `outer timeout budget is respected when provider swap triggers retry`() = runTest(
+        dispatcher
+    ) {
+        // When the in-flight deferred is cancelled by a provider swap, currentToken() retries
+        // inside the SAME withTimeoutOrNull block. The retry creates a fresh inner
+        // withTimeoutOrNull(timeoutMs) starting from the current time, but the outer one was
+        // set at original call-time and fires first if the budget is nearly exhausted — so the
+        // caller's original deadline governs the total wait end-to-end.
+        val providerA = DeferredProvider() // never resolves
+        val providerB = DeferredProvider() // never resolves
+        val manager = KlaviyoAuthTokenManager()
+
+        manager.registerProvider(providerA)
+        dispatcher.scheduler.runCurrent() // A's eager fetch starts and suspends
+
+        // Caller has a 100ms total budget.
+        var caught: AuthTokenException.TimedOut? = null
+        val callerJob = launch {
+            try {
+                manager.currentToken(timeoutMs = 100)
+            } catch (e: AuthTokenException.TimedOut) {
+                caught = e
+            }
+        }
+        dispatcher.scheduler.runCurrent() // caller awaits A's deferred
+
+        // Swap at t=80ms — only 20ms of the original 100ms budget remains.
+        dispatcher.scheduler.advanceTimeBy(80)
+        manager.registerProvider(providerB)
+        // Retry starts and awaits B. Inner withTimeoutOrNull(100) would fire at t=180;
+        // outer withTimeoutOrNull(100) fires first at t=100.
+        dispatcher.scheduler.runCurrent()
+
+        dispatcher.scheduler.advanceTimeBy(21) // t=101ms — past the outer 100ms deadline
+        dispatcher.scheduler.runCurrent()
+        callerJob.join()
+
+        assertNotNull(
+            "Outer 100ms deadline should fire; inner retry budget must not extend it",
+            caught
+        )
+    }
+
+    @Test
     fun `provider swap does not write stale token when callback fires before cancellation`() = runTest(
         dispatcher
     ) {

--- a/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerTest.kt
@@ -6,9 +6,11 @@ import java.util.Base64
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Test
@@ -24,7 +26,9 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
     }
 
     @Test
-    fun `currentToken throws NoProviderRegistered when no provider registered`() = runTest {
+    fun `currentToken throws NoProviderRegistered when no provider registered`() = runTest(
+        dispatcher
+    ) {
         val manager = KlaviyoAuthTokenManager()
 
         try {
@@ -36,7 +40,7 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
     }
 
     @Test
-    fun `currentToken returns provider token on first fetch`() = runTest {
+    fun `currentToken returns provider token on first fetch`() = runTest(dispatcher) {
         val token = makeJwt(EXP_SECONDS, IAT_SECONDS)
         val manager = KlaviyoAuthTokenManager()
         manager.registerProvider(SuccessProvider(token))
@@ -50,7 +54,7 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
     }
 
     @Test
-    fun `currentToken returns cached token without re-invoking provider`() = runTest {
+    fun `currentToken returns cached token without re-invoking provider`() = runTest(dispatcher) {
         val token = makeJwt(EXP_SECONDS, IAT_SECONDS)
         val provider = SuccessProvider(token)
         val manager = KlaviyoAuthTokenManager()
@@ -66,7 +70,9 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
     }
 
     @Test
-    fun `registerProvider replaces previous provider and discards cached token`() = runTest {
+    fun `registerProvider replaces previous provider and discards cached token`() = runTest(
+        dispatcher
+    ) {
         val firstToken = makeJwt(EXP_SECONDS, IAT_SECONDS)
         val secondToken = makeJwt(EXP_SECONDS + 1, IAT_SECONDS + 1)
         val firstProvider = SuccessProvider(firstToken)
@@ -85,7 +91,7 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
     }
 
     @Test
-    fun `registerProvider triggers eager fetch`() = runTest {
+    fun `registerProvider triggers eager fetch`() = runTest(dispatcher) {
         val token = makeJwt(EXP_SECONDS, IAT_SECONDS)
         val provider = SuccessProvider(token)
         val manager = KlaviyoAuthTokenManager()
@@ -100,7 +106,9 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
     }
 
     @Test
-    fun `registerProvider cancellation during eager fetch does not log warning`() = runTest {
+    fun `registerProvider cancellation during eager fetch does not log warning`() = runTest(
+        dispatcher
+    ) {
         val provider = DeferredProvider()
         val manager = KlaviyoAuthTokenManager()
 
@@ -116,7 +124,7 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
     }
 
     @Test
-    fun `currentToken throws when provider invokes onFailure`() = runTest {
+    fun `currentToken throws when provider invokes onFailure`() = runTest(dispatcher) {
         val failure = RuntimeException("network down")
         val manager = KlaviyoAuthTokenManager()
         // Use a provider that fails on the explicit currentToken() call. The eager fetch
@@ -133,7 +141,9 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
     }
 
     @Test
-    fun `currentToken throws ValidationFailed and logs error when returned jwt is malformed`() = runTest {
+    fun `currentToken throws ValidationFailed and logs error when returned jwt is malformed`() = runTest(
+        dispatcher
+    ) {
         val manager = KlaviyoAuthTokenManager()
         manager.registerProvider(SuccessProvider("not-a-jwt"))
         dispatcher.scheduler.advanceUntilIdle()
@@ -159,7 +169,9 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
     }
 
     @Test
-    fun `currentToken throws ValidationFailed when returned jwt is expired on receipt`() = runTest {
+    fun `currentToken throws ValidationFailed when returned jwt is expired on receipt`() = runTest(
+        dispatcher
+    ) {
         // exp within leeway of NOW → ExpiredOnReceipt
         val expired = makeJwt(NOW_SECONDS, IAT_SECONDS)
         val manager = KlaviyoAuthTokenManager()
@@ -175,7 +187,7 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
     }
 
     @Test
-    fun `currentToken does not invoke onFailure-and-then-onSuccess twice`() = runTest {
+    fun `currentToken does not invoke onFailure-and-then-onSuccess twice`() = runTest(dispatcher) {
         // Late callback resolution should be harmlessly ignored (isActive guard).
         val token = makeJwt(EXP_SECONDS, IAT_SECONDS)
         val provider = AuthTokenProvider { callback ->
@@ -190,6 +202,142 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
 
         val result = manager.currentToken()
         assertEquals(token, result.rawToken)
+    }
+
+    // MARK: - MAGE-628: Deduplication and Timeouts
+
+    @Test
+    fun `concurrent callers share a single provider invocation`() = runTest(dispatcher) {
+        val token = makeJwt(EXP_SECONDS, IAT_SECONDS)
+        val provider = ResolvableProvider()
+        val manager = KlaviyoAuthTokenManager()
+        manager.registerProvider(provider)
+        // Hold off on advancing — keep the eager fetch pending so all callers race the same deferred.
+
+        val results = mutableListOf<ValidatedToken>()
+        val jobs = (1..5).map {
+            launch { results.add(manager.currentToken()) }
+        }
+
+        // Let all coroutines start and reach their await() on the shared deferred.
+        dispatcher.scheduler.runCurrent()
+
+        // One provider resolution satisfies the deferred and all awaiting callers.
+        provider.resolve(token)
+        dispatcher.scheduler.advanceUntilIdle()
+        jobs.forEach { it.join() }
+
+        assertEquals(1, provider.callCount)
+        assertEquals(5, results.size)
+        assertTrue(results.all { it.rawToken == token })
+    }
+
+    @Test
+    fun `currentToken throws TimedOut when provider does not respond within timeout`() = runTest(
+        dispatcher
+    ) {
+        val manager = KlaviyoAuthTokenManager()
+        manager.registerProvider(DeferredProvider())
+        dispatcher.scheduler.runCurrent() // start eager fetch (also waiting on provider)
+
+        var caught: AuthTokenException.TimedOut? = null
+        val job = launch {
+            try {
+                manager.currentToken(timeoutMs = 100)
+            } catch (e: AuthTokenException.TimedOut) {
+                caught = e
+            }
+        }
+        dispatcher.scheduler.runCurrent()
+        dispatcher.scheduler.advanceTimeBy(101)
+        dispatcher.scheduler.runCurrent()
+        job.join()
+
+        assertNotNull("Expected TimedOut to be thrown", caught)
+        verify {
+            spyLog.error(
+                match { it.contains("timed out", ignoreCase = true) },
+                any<AuthTokenException.TimedOut>()
+            )
+        }
+    }
+
+    @Test
+    fun `timeout does not cancel underlying fetch so later callers still benefit`() = runTest(
+        dispatcher
+    ) {
+        val token = makeJwt(EXP_SECONDS, IAT_SECONDS)
+        val provider = ResolvableProvider()
+        val manager = KlaviyoAuthTokenManager()
+        manager.registerProvider(provider)
+        dispatcher.scheduler.runCurrent() // eager fetch starts and suspends on provider
+
+        // First caller times out after 100ms.
+        var timedOut = false
+        val firstJob = launch {
+            try {
+                manager.currentToken(timeoutMs = 100)
+            } catch (_: AuthTokenException.TimedOut) {
+                timedOut = true
+            }
+        }
+        dispatcher.scheduler.runCurrent()
+        dispatcher.scheduler.advanceTimeBy(101)
+        dispatcher.scheduler.runCurrent()
+        firstJob.join()
+        assertTrue("First caller should have timed out", timedOut)
+
+        // Underlying fetch is still alive — resolve the provider now.
+        provider.resolve(token)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        // Second caller gets the token from cache populated by the completed underlying fetch.
+        val result = manager.currentToken()
+        assertEquals(token, result.rawToken)
+        assertEquals(1, provider.callCount)
+    }
+
+    @Test
+    fun `failure clears in-flight slot so next call re-invokes provider`() = runTest(dispatcher) {
+        val failure = RuntimeException("fetch failed")
+        val provider = CountingFailureProvider(failure)
+        val manager = KlaviyoAuthTokenManager()
+        manager.registerProvider(provider)
+        dispatcher.scheduler.advanceUntilIdle() // eager fetch fails (callCount = 1)
+
+        try { manager.currentToken() } catch (_: Exception) {}
+        val countAfterFirst = provider.callCount // eager + 1 explicit
+
+        try { manager.currentToken() } catch (_: Exception) {}
+
+        // Each call after a failure must re-invoke the provider (slot was cleared by invokeOnCompletion).
+        assertEquals(countAfterFirst + 1, provider.callCount)
+    }
+
+    @Test
+    fun `provider swap cancels in-flight fetch so stale token cannot poison cache`() = runTest(
+        dispatcher
+    ) {
+        val staleToken = makeJwt(EXP_SECONDS, IAT_SECONDS)
+        val freshToken = makeJwt(EXP_SECONDS + 100, IAT_SECONDS + 100)
+        val providerA = ResolvableProvider()
+        val providerB = SuccessProvider(freshToken)
+        val manager = KlaviyoAuthTokenManager()
+
+        manager.registerProvider(providerA)
+        dispatcher.scheduler.runCurrent() // eager fetch for A starts, awaits provider
+
+        // Swap provider while A's fetch is in-flight; B's eager fetch resolves immediately.
+        manager.registerProvider(providerB)
+        dispatcher.scheduler.advanceUntilIdle() // B's eager fetch completes → cache = freshToken
+
+        // A calls back late — its continuation is inactive (deferred was cancelled on swap).
+        providerA.resolve(staleToken)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        // Cache should hold freshToken, not staleToken.
+        val result = manager.currentToken()
+        assertEquals(freshToken, result.rawToken)
     }
 
     // MARK: - Helpers
@@ -234,4 +382,36 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
 
     private fun base64UrlEncode(bytes: ByteArray): String =
         Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
+
+    /**
+     * Provider that captures the callback so tests can resolve it manually, enabling
+     * deterministic control over when the provider "responds".
+     */
+    private class ResolvableProvider : AuthTokenProvider {
+        var callCount: Int = 0
+            private set
+        private var pendingCallback: AuthTokenProvider.Callback? = null
+
+        override fun fetchToken(callback: AuthTokenProvider.Callback) {
+            callCount++
+            pendingCallback = callback
+        }
+
+        fun resolve(jwt: String) = pendingCallback?.onSuccess(jwt)
+        fun reject(error: Throwable) = pendingCallback?.onFailure(error)
+    }
+
+    /**
+     * Failure provider that exposes an invocation counter for asserting that the in-flight slot
+     * is cleared on failure (so each new call re-invokes the provider).
+     */
+    private class CountingFailureProvider(private val error: Throwable) : AuthTokenProvider {
+        var callCount: Int = 0
+            private set
+
+        override fun fetchToken(callback: AuthTokenProvider.Callback) {
+            callCount++
+            callback.onFailure(error)
+        }
+    }
 }

--- a/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerTest.kt
@@ -340,6 +340,37 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
         assertEquals(freshToken, result.rawToken)
     }
 
+    @Test
+    fun `provider swap does not write stale token when callback fires before cancellation`() = runTest(
+        dispatcher
+    ) {
+        // Regression test for the uncontended-mutex cancellation gap:
+        // If invokeProvider() already returned a value before the deferred is cancelled,
+        // ensureActive() in doFetch() must throw CancellationException before the cache write —
+        // even though mutex.withLock would acquire an uncontended lock without suspending.
+        val staleToken = makeJwt(EXP_SECONDS, IAT_SECONDS)
+        val freshToken = makeJwt(EXP_SECONDS + 100, IAT_SECONDS + 100)
+        val providerA = ResolvableProvider()
+        val providerB = SuccessProvider(freshToken)
+        val manager = KlaviyoAuthTokenManager()
+
+        manager.registerProvider(providerA)
+        dispatcher.scheduler.runCurrent() // A's eager fetch starts and suspends on provider
+
+        // Resolve A's callback now — this schedules A's coroutine to resume with staleToken.
+        // A's doFetch() has not yet run past invokeProvider().
+        providerA.resolve(staleToken)
+
+        // Swap to B *before* the scheduler runs A's resumed coroutine. Without ensureActive(),
+        // A's doFetch() would proceed through validateOrThrow and write staleToken to the cache
+        // on an uncontended mutex.withLock (no suspension → no cancellation check there).
+        manager.registerProvider(providerB)
+        dispatcher.scheduler.advanceUntilIdle() // A hits ensureActive() and aborts; B completes
+
+        val result = manager.currentToken()
+        assertEquals(freshToken, result.rawToken)
+    }
+
     // MARK: - Helpers
 
     private class SuccessProvider(private val jwt: String) : AuthTokenProvider {
@@ -384,21 +415,23 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
         Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
 
     /**
-     * Provider that captures the callback so tests can resolve it manually, enabling
-     * deterministic control over when the provider "responds".
+     * Provider that captures callbacks so tests can resolve them manually, enabling
+     * deterministic control over when the provider "responds". Callbacks are queued so
+     * concurrent invocations (e.g. eager fetch + explicit caller) can each be resolved
+     * independently without the second call clobbering the first.
      */
     private class ResolvableProvider : AuthTokenProvider {
         var callCount: Int = 0
             private set
-        private var pendingCallback: AuthTokenProvider.Callback? = null
+        private val pendingCallbacks = ArrayDeque<AuthTokenProvider.Callback>()
 
         override fun fetchToken(callback: AuthTokenProvider.Callback) {
             callCount++
-            pendingCallback = callback
+            pendingCallbacks.addLast(callback)
         }
 
-        fun resolve(jwt: String) = pendingCallback?.onSuccess(jwt)
-        fun reject(error: Throwable) = pendingCallback?.onFailure(error)
+        fun resolve(jwt: String) = pendingCallbacks.removeFirstOrNull()?.onSuccess(jwt)
+        fun reject(error: Throwable) = pendingCallbacks.removeFirstOrNull()?.onFailure(error)
     }
 
     /**

--- a/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerTest.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.test.runTest
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Test
@@ -255,7 +256,7 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
 
         assertNotNull("Expected TimedOut to be thrown", caught)
         verify {
-            spyLog.error(
+            spyLog.warning(
                 match { it.contains("timed out", ignoreCase = true) },
                 any<AuthTokenException.TimedOut>()
             )
@@ -338,6 +339,45 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
         // Cache should hold freshToken, not staleToken.
         val result = manager.currentToken()
         assertEquals(freshToken, result.rawToken)
+    }
+
+    @Test
+    fun `caller waiting on in-flight fetch receives new provider token after provider swap`() = runTest(
+        dispatcher
+    ) {
+        // Regression: when registerProvider() cancels the in-flight deferred, deferred.await()
+        // throws CancellationException. Without the ensureActive() + retry fix in currentToken(),
+        // this propagates to the caller as if their coroutine was cancelled, breaking callers like
+        // KlaviyoWebViewClient that rethrow CancellationException for structured concurrency.
+        val freshToken = makeJwt(EXP_SECONDS + 100, IAT_SECONDS + 100)
+        val providerA = ResolvableProvider()
+        val providerB = SuccessProvider(freshToken)
+        val manager = KlaviyoAuthTokenManager()
+
+        manager.registerProvider(providerA)
+        dispatcher.scheduler.runCurrent() // A's eager fetch starts, suspends on provider
+
+        // Caller joins the in-flight deferred from provider A.
+        var result: ValidatedToken? = null
+        var caught: Throwable? = null
+        val callerJob = launch {
+            try {
+                result = manager.currentToken(timeoutMs = 5_000)
+            } catch (e: Throwable) {
+                caught = e
+            }
+        }
+        dispatcher.scheduler.runCurrent() // caller reaches deferred.await()
+
+        // Swap to B while caller is suspended — A's deferred is cancelled, which would throw
+        // CancellationException to the caller without the fix. With the fix the caller retries
+        // and transparently picks up B's token.
+        manager.registerProvider(providerB)
+        dispatcher.scheduler.advanceUntilIdle() // B completes; caller's retry finds the cache
+
+        callerJob.join()
+        assertNull("Caller should not have thrown but got: $caught", caught)
+        assertEquals(freshToken, result?.rawToken)
     }
 
     @Test

--- a/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
@@ -128,7 +128,6 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
         partialHtml: String,
         nativeBridge: NativeBridge
     ) {
-        // TODO: [MAGE-628] AuthTokenManager will enforce its own 500ms best-effort deadline.
         // TODO: [MAGE-630] Subscribe to AuthTokenManager.onTokenRefresh for live updates.
         // NoProviderRegistered is split out from generic fetch failures: the former is the
         // expected state for apps not using JWT auth (logged at debug), the latter is degraded
@@ -136,7 +135,10 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
         // KDoc intent — "treat NoProviderRegistered as 'auth is not enabled' rather than 'auth
         // failed.'"
         val outcome: AuthOutcome = try {
-            AuthOutcome.Success(Registry.get<AuthTokenManager>().currentToken())
+            AuthOutcome.Success(
+                Registry.get<AuthTokenManager>()
+                    .currentToken(AuthTokenManager.INTERACTIVE_FETCH_TIMEOUT_MS)
+            )
         } catch (e: CancellationException) {
             throw e
         } catch (_: AuthTokenException.NoProviderRegistered) {

--- a/sdk/forms/src/test/java/com/klaviyo/forms/webview/KlaviyoWebViewClientTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/webview/KlaviyoWebViewClientTest.kt
@@ -132,7 +132,7 @@ class KlaviyoWebViewClientTest : BaseTest() {
         Registry.register<NativeBridge>(mockBridge)
         // Default: no provider registered — form loads without auth token (JWT_TOKEN → "").
         // Tests that need a fetch-failure outcome override this with a different exception type.
-        coEvery { mockAuthTokenManager.currentToken() } throws AuthTokenException.NoProviderRegistered
+        coEvery { mockAuthTokenManager.currentToken(any()) } throws AuthTokenException.NoProviderRegistered
         Registry.register<AuthTokenManager>(mockAuthTokenManager)
         mockDeviceProperties()
         every { mockConfig.isDebugBuild } returns false
@@ -518,7 +518,7 @@ class KlaviyoWebViewClientTest : BaseTest() {
     @Test
     fun `initializeWebView injects auth token into data-klaviyo-jwt when token is available`() {
         val fakeToken = "header.payload.signature"
-        coEvery { mockAuthTokenManager.currentToken() } returns validatedToken(fakeToken)
+        coEvery { mockAuthTokenManager.currentToken(any()) } returns validatedToken(fakeToken)
 
         val client = KlaviyoWebViewClient()
         client.initializeWebView()
@@ -537,7 +537,7 @@ class KlaviyoWebViewClientTest : BaseTest() {
     @Test
     fun `initializeWebView does not log injected token when stale webview skips template load`() {
         val fakeToken = "header.payload.signature"
-        coEvery { mockAuthTokenManager.currentToken() } returns validatedToken(fakeToken)
+        coEvery { mockAuthTokenManager.currentToken(any()) } returns validatedToken(fakeToken)
 
         val client = KlaviyoWebViewClient()
         var firstUiDispatch = true
@@ -586,7 +586,7 @@ class KlaviyoWebViewClientTest : BaseTest() {
         // Provider IS registered but its fetch fails — degraded functionality with fallback,
         // appropriate for a warning. ValidationFailed stands in for any non-NoProviderRegistered
         // AuthTokenException; a plain RuntimeException would hit the same branch.
-        coEvery { mockAuthTokenManager.currentToken() } throws
+        coEvery { mockAuthTokenManager.currentToken(any()) } throws
             AuthTokenException.ValidationFailed("Malformed")
 
         val client = KlaviyoWebViewClient()
@@ -607,7 +607,9 @@ class KlaviyoWebViewClientTest : BaseTest() {
     @Test
     fun `initializeWebView HTML-escapes special characters in auth token value`() {
         val mischievousToken = "a&b'c<d"
-        coEvery { mockAuthTokenManager.currentToken() } returns validatedToken(mischievousToken)
+        coEvery { mockAuthTokenManager.currentToken(any()) } returns validatedToken(
+            mischievousToken
+        )
 
         val client = KlaviyoWebViewClient()
         client.initializeWebView()
@@ -628,12 +630,12 @@ class KlaviyoWebViewClientTest : BaseTest() {
     @Test
     fun `destroyWebView cancels in-flight initJob during auth token fetch`() {
         val tokenCompletion = CompletableDeferred<ValidatedToken>()
-        coEvery { mockAuthTokenManager.currentToken() } coAnswers { tokenCompletion.await() }
+        coEvery { mockAuthTokenManager.currentToken(any()) } coAnswers { tokenCompletion.await() }
 
         val client = KlaviyoWebViewClient()
         client.initializeWebView()
         dispatcher.scheduler.runCurrent()
-        coVerify(exactly = 1) { mockAuthTokenManager.currentToken() }
+        coVerify(exactly = 1) { mockAuthTokenManager.currentToken(any()) }
 
         client.destroyWebView()
         tokenCompletion.complete(validatedToken("would-be-token"))
@@ -653,6 +655,6 @@ class KlaviyoWebViewClientTest : BaseTest() {
         dispatcher.scheduler.advanceUntilIdle()
 
         verify(inverse = true) { anyConstructed<KlaviyoWebView>().loadTemplate(any(), any(), any()) }
-        coVerify(exactly = 0) { mockAuthTokenManager.currentToken() }
+        coVerify(exactly = 0) { mockAuthTokenManager.currentToken(any()) }
     }
 }


### PR DESCRIPTION
# Description

Hardens `KlaviyoAuthTokenManager` against concurrent callers and slow/unresponsive providers. Concurrent calls to `currentToken()` that miss the cache now share a single in-flight `Deferred<ValidatedToken>` rather than each triggering an independent provider invocation. Per-caller timeout budgets are enforced without cancelling the underlying task, so a later caller with a larger budget still benefits if the provider eventually responds.

Android counterpart to [klaviyo-swift-sdk#586](https://github.com/klaviyo/klaviyo-swift-sdk/pull/586).

## Due Diligence
- [ ] I have tested this on an emulator and/or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all Android versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

> **Note:** `AuthTokenManager.currentToken()` gains a `timeoutMs` parameter with a default value — source-compatible, no callers need to change unless they want the interactive (500 ms) budget.

## Changelog / Code Overview

### `AuthTokenException.kt`
- Added `TimedOut` — new sealed variant thrown when the provider doesn't respond within the caller's budget. Mirrors iOS `AuthTokenError.timedOut`.

### `AuthTokenManager.kt` (interface)
- `currentToken(timeoutMs: Long = BACKGROUND_FETCH_TIMEOUT_MS)` — parameter with default; existing callers unchanged.
- Two public constants: `BACKGROUND_FETCH_TIMEOUT_MS = 5_000L` (proactive/eager fetches) and `INTERACTIVE_FETCH_TIMEOUT_MS = 500L` (form-display time). Accessible from both `core` and `forms` without duplication.

### `KlaviyoAuthTokenManager.kt`
- `inFlightFetch: Deferred<ValidatedToken>?` is now active (`@Volatile` for lock-free reads in `registerProvider`/`invokeOnCompletion` to be visible to the mutex-guarded path in `currentToken`).
- `currentToken()` — optimistic cache check → mutex-guarded deferred read-or-create → per-caller `withTimeoutOrNull`. The mutex re-checks the cache after acquiring (double-checked locking pattern) to avoid a redundant fetch if a concurrent caller already populated it while waiting for the lock.
- `invokeOnCompletion` uses a reference-identity check (`if (inFlightFetch === d)`) so a stale deferred completing after a provider swap doesn't clear a freshly-created slot.
- `registerProvider()` cancels any in-flight deferred before swapping. Two complementary guards prevent stale tokens: (1) `isActive` in `suspendCancellableCoroutine` drops late provider callbacks; (2) `mutex.withLock` in `doFetch` is a cancellation checkpoint that catches the case where the callback already fired but the cache write hasn't run.
- `doFetch()` extracted from `currentToken()` — runs inside `scope.async`, owns the full invoke→validate→cache→log flow.

### `KlaviyoWebViewClient.kt`
- Calls `currentToken(INTERACTIVE_FETCH_TIMEOUT_MS)` — 500 ms best-effort budget at form-display time. Removed `MAGE-628` TODO.

## Test Plan

All tests pass (`./gradlew :sdk:core:testDebugUnitTest :sdk:forms:testDebugUnitTest`). Five new tests in `KlaviyoAuthTokenManagerTest`:

| Test | What it proves |
|------|----------------|
| `concurrent callers share a single provider invocation` | N callers → exactly 1 provider call; all receive same token |
| `currentToken throws TimedOut when provider does not respond within timeout` | `TimedOut` thrown and logged at ERROR within the budget |
| `timeout does not cancel underlying fetch so later callers still benefit` | First caller times out; provider resolves; second caller gets token from cache; `callCount == 1` |
| `failure clears in-flight slot so next call re-invokes provider` | `invokeOnCompletion` fires on failure; slot cleared; subsequent call triggers fresh provider invocation |
| `provider swap cancels in-flight fetch so stale token cannot poison cache` | Provider A's late callback is dropped after swap; cache holds Provider B's token |

Existing tests migrated to `runTest(dispatcher)` so `scope.async` and `withTimeoutOrNull` share a single `TestCoroutineScheduler`.

## Related Issues/Tickets

Part of MAGE-628 — https://linear.app/klaviyo/issue/MAGE-628