### PR TITLE
Fix cancellation check gap before auth token cache write

### DIFF
--- a/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
@@ -6,11 +6,13 @@ import com.klaviyo.core.safeLaunch
 import java.util.concurrent.CopyOnWriteArrayList
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
+import kotlin.coroutines.coroutineContext
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -56,9 +58,9 @@ internal class KlaviyoAuthTokenManager(
         // Two complementary guards prevent a stale token from reaching the cache:
         //   1. If the cancelled coroutine is still inside invokeProvider(), the isActive check in
         //      suspendCancellableCoroutine drops any late onSuccess/onFailure callback.
-        //   2. If the callback already fired and doFetch() is past invokeProvider() but hasn't
-        //      written the cache yet, the next suspension point (mutex.withLock in doFetch)
-        //      will observe the cancellation and throw CancellationException before the write.
+        //   2. If the callback already fired and doFetch() is past invokeProvider(), an explicit
+        //      ensureActive check runs immediately before acquiring mutex.withLock so cancellation
+        //      is observed even when lock acquisition takes the uncontended fast path.
         inFlightFetch?.cancel()
         inFlightFetch = null
         cachedToken = null
@@ -119,6 +121,7 @@ internal class KlaviyoAuthTokenManager(
     private suspend fun doFetch(): ValidatedToken {
         val jwt = invokeProvider()
         val token = validateOrThrow(jwt)
+        coroutineContext.ensureActive()
         mutex.withLock { cachedToken = token }
         Registry.log.info(
             "Auth token acquired (exp=${token.expiresAtEpochSeconds}, iat=${token.issuedAtEpochSeconds})"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Description
Fixes a stale-token race in `KlaviyoAuthTokenManager.doFetch()` by checking coroutine cancellation immediately before the cache write lock. Also updates the `registerProvider` guard comment to reflect the actual cancellation behavior.

## Due Diligence
- [ ] I have tested this on an emulator and/or a physical device.
- [ ] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all Android versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API. 
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [ ] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.

## Changelog / Code Overview
- Added `coroutineContext.ensureActive()` in `doFetch()` after JWT validation and before `mutex.withLock { cachedToken = token }`.
- Corrected the in-code guard explanation in `registerProvider()` to describe the explicit cancellation check, including uncontended mutex acquisition behavior.

## Test Plan
- Attempted: `./gradlew :sdk:core:testDebugUnitTest --tests "com.klaviyo.core.auth.KlaviyoAuthTokenManagerTest"`
- Result in cloud environment: blocked by missing Android SDK configuration (`ANDROID_HOME`/`local.properties sdk.dir`).

## Related Issues/Tickets
- MAGE-628
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6a46727a-8a49-48f5-8292-1fe8c8093c5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a46727a-8a49-48f5-8292-1fe8c8093c5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

