### PR TITLE
Fix scheduled refresh dropping cached auth token on failure

### DIFF
--- a/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
@@ -94,20 +94,32 @@ internal class KlaviyoAuthTokenManager(
     }
 
     override suspend fun currentToken(timeoutMs: Long): ValidatedToken {
+        return currentTokenInternal(timeoutMs = timeoutMs, allowCachedToken = true)
+    }
+
+    private suspend fun currentTokenInternal(
+        timeoutMs: Long,
+        allowCachedToken: Boolean
+    ): ValidatedToken {
         require(timeoutMs > 0L) { "timeoutMs must be positive, but was $timeoutMs" }
         if (provider == null) throw AuthTokenException.NoProviderRegistered
 
-        // Optimistic read of @Volatile field — no lock needed for the fast path.
-        val cached = cachedToken
-        if (cached != null && isStillValid(cached)) return cached
+        if (allowCachedToken) {
+            // Optimistic read of @Volatile field — no lock needed for the fast path.
+            val cached = cachedToken
+            if (cached != null && isStillValid(cached)) return cached
+        }
 
         // Atomic read-or-create of the in-flight deferred. The mutex ensures exactly one
         // scope.async { } is launched when multiple callers miss the cache simultaneously.
         val deferred: Deferred<ValidatedToken> = mutex.withLock {
             // Re-check under the lock; a concurrent caller may have populated the cache while
-            // we waited. Non-local return from this inline lambda exits currentToken() directly.
+            // we waited. Non-local return from this inline lambda exits currentTokenInternal()
+            // directly.
             val freshenedCache = cachedToken
-            if (freshenedCache != null && isStillValid(freshenedCache)) return freshenedCache
+            if (allowCachedToken && freshenedCache != null && isStillValid(freshenedCache)) {
+                return freshenedCache
+            }
 
             inFlightFetch ?: scope.async { doFetch() }.also { d ->
                 inFlightFetch = d
@@ -132,7 +144,7 @@ internal class KlaviyoAuthTokenManager(
                 deferred.await()
             } catch (e: CancellationException) {
                 currentCoroutineContext().ensureActive()
-                currentToken(timeoutMs)
+                currentTokenInternal(timeoutMs = timeoutMs, allowCachedToken = allowCachedToken)
             }
         } ?: run {
             val error = AuthTokenException.TimedOut
@@ -210,9 +222,9 @@ internal class KlaviyoAuthTokenManager(
     }
 
     // Forces a fresh provider invocation and routes through the standard dedup + timeout path.
-    // Clears the cache first so currentToken()'s optimistic read falls through to the mutex
-    // block, where it either joins an existing in-flight fetch or starts a new one. Any
-    // concurrent caller that arrives between the clear and the fetch completion shares the
+    // Leaves the existing cache intact so callers can keep using it while refresh is in-flight,
+    // even if the refresh attempt fails. Any
+    // concurrent caller that arrives while refresh is in-flight shares the
     // single in-flight Deferred automatically.
     // Logs at WARNING on failure — the still-valid cached token remains for live consumers.
     // On failure does NOT reschedule; one foreground-transition retry is possible if
@@ -221,9 +233,11 @@ internal class KlaviyoAuthTokenManager(
     private suspend fun performScheduledRefresh() {
         if (provider == null) return
         Registry.log.info("Proactive token refresh fired")
-        mutex.withLock { cachedToken = null }
         try {
-            currentToken(AuthTokenManager.BACKGROUND_FETCH_TIMEOUT_MS)
+            currentTokenInternal(
+                timeoutMs = AuthTokenManager.BACKGROUND_FETCH_TIMEOUT_MS,
+                allowCachedToken = false
+            )
             Registry.log.info("Proactive token refresh succeeded")
         } catch (e: CancellationException) {
             throw e

--- a/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerRefreshTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerRefreshTest.kt
@@ -108,6 +108,37 @@ class KlaviyoAuthTokenManagerRefreshTest : BaseTest() {
     }
 
     @Test
+    fun `failed scheduled refresh keeps prior cached token for callers`() = runTest(dispatcher) {
+        val token = makeJwt()
+        val provider = ScriptedProvider(
+            ArrayDeque(
+                listOf(
+                    Result.success(token),
+                    Result.failure(RuntimeException("refresh failed"))
+                )
+            )
+        )
+        val manager = KlaviyoAuthTokenManager()
+
+        manager.registerProvider(provider)
+        dispatcher.scheduler.advanceUntilIdle()
+        assertEquals(1, provider.callCount)
+
+        val timerTask = staticClock.scheduledTasks.first()
+        staticClock.execute(timerTask.time - staticClock.time)
+        dispatcher.scheduler.advanceUntilIdle()
+        assertEquals("scheduled refresh should attempt one additional provider call", 2, provider.callCount)
+
+        val cached = manager.currentToken()
+        assertEquals(token, cached.rawToken)
+        assertEquals(
+            "callers should keep using the prior cached token after refresh failure",
+            2,
+            provider.callCount
+        )
+    }
+
+    @Test
     fun `registerProvider cancels pending refresh job`() = runTest(dispatcher) {
         val tokenA = makeJwt()
         val tokenB = makeJwt(EXP_SECONDS + 1, IAT_SECONDS + 1)
@@ -220,6 +251,23 @@ class KlaviyoAuthTokenManagerRefreshTest : BaseTest() {
         override fun fetchToken(callback: AuthTokenProvider.Callback) {
             callCount++
             callback.onSuccess(jwt)
+        }
+    }
+
+    private class ScriptedProvider(
+        private val results: ArrayDeque<Result<String>>
+    ) : AuthTokenProvider {
+        var callCount = 0
+            private set
+
+        override fun fetchToken(callback: AuthTokenProvider.Callback) {
+            callCount++
+            val result = results.removeFirstOrNull()
+                ?: error("No scripted provider result for call #$callCount")
+            result.fold(
+                onSuccess = callback::onSuccess,
+                onFailure = callback::onFailure
+            )
         }
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Description
Keep the previously cached JWT available when proactive refresh fails. `performScheduledRefresh` now forces a provider fetch without clearing `cachedToken`, so consumers can still use a still-valid token through the fast cache path.

## Due Diligence
- [ ] I have tested this on an emulator and/or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all Android versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API. 
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [ ] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.

## Changelog / Code Overview
- Added `currentTokenInternal(timeoutMs, allowCachedToken)` so scheduled refresh can bypass cached reads without evicting the cached token.
- Updated `performScheduledRefresh` to force a provider fetch via the new internal path while preserving the existing cached token on refresh failure.
- Added regression test `failed scheduled refresh keeps prior cached token for callers`.

## Test Plan
- Added unit regression coverage in `KlaviyoAuthTokenManagerRefreshTest`.
- Attempted local run:
  - `./gradlew :sdk:core:testDebugUnitTest --tests "com.klaviyo.core.auth.KlaviyoAuthTokenManagerRefreshTest"`
  - Blocked in cloud env: `SDK location not found` (missing `ANDROID_HOME`/`sdk.dir`).

## Related Issues/Tickets
- Issue reported in cloud task: `performScheduledRefresh` clears `cachedToken` and can strand callers after refresh failure.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-78f7d092-0d5a-4c0c-a272-50cf7edfb138"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-78f7d092-0d5a-4c0c-a272-50cf7edfb138"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

