### PR TITLE
Fix auth refresh foreground race

### DIFF
--- a/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
@@ -56,6 +56,14 @@ internal class KlaviyoAuthTokenManager(
 
     @Volatile private var refreshAtWallClockMs: Long? = null
 
+    // Set synchronously by the timer callback before refresh work is dispatched. This prevents a
+    // foreground transition from treating an already-fired timer as a Doze-style miss while the
+    // scheduled refresh coroutine is still queued or in-flight.
+    @Volatile private var refreshTimerFired = false
+
+    // Monotonic token used to ignore callbacks from refresh jobs cancelled by a later schedule.
+    @Volatile private var refreshGeneration = 0L
+
     // Reserved for MAGE-630 (onTokenRefresh/offTokenRefresh observers). Matches the established
     // SDK observer-collection pattern (CopyOnWriteArrayList for thread-safe iteration while
     // observers add/remove themselves on arbitrary threads).
@@ -75,6 +83,8 @@ internal class KlaviyoAuthTokenManager(
         refreshJob?.cancel()
         refreshJob = null
         refreshAtWallClockMs = null
+        refreshTimerFired = false
+        refreshGeneration += 1
         cachedToken = null
         this.provider = provider
         Registry.log.info("AuthTokenProvider registered")
@@ -211,14 +221,25 @@ internal class KlaviyoAuthTokenManager(
     private fun scheduleRefresh(token: ValidatedToken) {
         val nowMs = Registry.clock.currentTimeMillis()
         val targetMs = computeRefreshTarget(token, nowMs)
+        val generation = refreshGeneration + 1
         refreshJob?.cancel()
+        refreshGeneration = generation
+        refreshTimerFired = false
         refreshAtWallClockMs = targetMs
         refreshJob = Registry.clock.schedule((targetMs - nowMs).coerceAtLeast(0)) {
-            scope.safeLaunch { performScheduledRefresh() }
+            if (markRefreshTimerFired(generation)) {
+                scope.safeLaunch { performScheduledRefresh(generation) }
+            }
         }
         Registry.log.info(
             "Proactive token refresh scheduled (target=${Registry.clock.isoTime(targetMs)})"
         )
+    }
+
+    private fun markRefreshTimerFired(generation: Long): Boolean {
+        if (refreshGeneration != generation) return false
+        refreshTimerFired = true
+        return true
     }
 
     // Forces a fresh provider invocation and routes through the standard dedup + timeout path.
@@ -230,7 +251,7 @@ internal class KlaviyoAuthTokenManager(
     // On failure does NOT reschedule; one foreground-transition retry is possible if
     // refreshAtWallClockMs was not yet cleared (timer fired but fetch failed).
     // TODO (MAGE-630): emit onTokenRefresh notification to observers on success.
-    private suspend fun performScheduledRefresh() {
+    private suspend fun performScheduledRefresh(timerGeneration: Long? = null) {
         if (provider == null) return
         Registry.log.info("Proactive token refresh fired")
         try {
@@ -242,6 +263,9 @@ internal class KlaviyoAuthTokenManager(
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
+            if (timerGeneration != null && refreshGeneration == timerGeneration) {
+                refreshTimerFired = false
+            }
             Registry.log.warning("Proactive token refresh failed: ${e.javaClass.simpleName}", e)
         }
     }
@@ -262,14 +286,22 @@ internal class KlaviyoAuthTokenManager(
             when {
                 cached != null && !isStillValid(cached) -> {
                     cachedToken = null
-                    refreshJob?.cancel(); refreshJob = null; refreshAtWallClockMs = null
+                    refreshJob?.cancel()
+                    refreshJob = null
+                    refreshAtWallClockMs = null
+                    refreshTimerFired = false
+                    refreshGeneration += 1
                     Registry.log.info(
                         "AuthTokenManager: foreground transition (case=expired-cached-token)"
                     )
                     scope.safeLaunch { tryEagerFetch() }
                 }
-                targetMs != null && nowMs >= targetMs -> {
-                    refreshJob?.cancel(); refreshJob = null; refreshAtWallClockMs = null
+                targetMs != null && nowMs >= targetMs && !refreshTimerFired -> {
+                    refreshJob?.cancel()
+                    refreshJob = null
+                    refreshAtWallClockMs = null
+                    refreshTimerFired = false
+                    refreshGeneration += 1
                     Registry.log.info(
                         "AuthTokenManager: foreground transition (case=missed-refresh)"
                     )

--- a/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
@@ -56,7 +56,7 @@ internal class KlaviyoAuthTokenManager(
 
     @Volatile private var refreshAtWallClockMs: Long? = null
 
-    // Set synchronously by the timer callback before refresh work is dispatched. This prevents a
+    // Set by the timer callback while holding [mutex] before refresh work begins. This prevents a
     // foreground transition from treating an already-fired timer as a Doze-style miss while the
     // scheduled refresh coroutine is still queued or in-flight.
     @Volatile private var refreshTimerFired = false
@@ -227,8 +227,10 @@ internal class KlaviyoAuthTokenManager(
         refreshTimerFired = false
         refreshAtWallClockMs = targetMs
         refreshJob = Registry.clock.schedule((targetMs - nowMs).coerceAtLeast(0)) {
-            if (markRefreshTimerFired(generation)) {
-                scope.safeLaunch { performScheduledRefresh(generation) }
+            scope.safeLaunch {
+                if (markRefreshTimerFired(generation)) {
+                    performScheduledRefresh(generation)
+                }
             }
         }
         Registry.log.info(
@@ -236,11 +238,12 @@ internal class KlaviyoAuthTokenManager(
         )
     }
 
-    private fun markRefreshTimerFired(generation: Long): Boolean {
-        if (refreshGeneration != generation) return false
-        refreshTimerFired = true
-        return true
-    }
+    private suspend fun markRefreshTimerFired(generation: Long): Boolean =
+        mutex.withLock {
+            if (refreshGeneration != generation) return@withLock false
+            refreshTimerFired = true
+            true
+        }
 
     // Forces a fresh provider invocation and routes through the standard dedup + timeout path.
     // Leaves the existing cache intact so callers can keep using it while refresh is in-flight,
@@ -263,10 +266,16 @@ internal class KlaviyoAuthTokenManager(
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            if (timerGeneration != null && refreshGeneration == timerGeneration) {
+            if (timerGeneration != null) clearFiredFlagForFailedRefresh(timerGeneration)
+            Registry.log.warning("Proactive token refresh failed: ${e.javaClass.simpleName}", e)
+        }
+    }
+
+    private suspend fun clearFiredFlagForFailedRefresh(timerGeneration: Long) {
+        mutex.withLock {
+            if (refreshGeneration == timerGeneration) {
                 refreshTimerFired = false
             }
-            Registry.log.warning("Proactive token refresh failed: ${e.javaClass.simpleName}", e)
         }
     }
 

--- a/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerRefreshTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerRefreshTest.kt
@@ -5,6 +5,7 @@ import com.klaviyo.core.lifecycle.ActivityObserver
 import com.klaviyo.fixtures.BaseTest
 import io.mockk.every
 import io.mockk.slot
+import io.mockk.verify
 import java.util.Base64
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -225,6 +226,74 @@ class KlaviyoAuthTokenManagerRefreshTest : BaseTest() {
     }
 
     @Test
+    fun `foreground after timer fires while refresh is in-flight is not treated as missed`() = runTest(
+        dispatcher
+    ) {
+        val initialToken = makeJwt()
+        val refreshedToken = makeJwt(EXP_SECONDS + 600, IAT_SECONDS + 600)
+        val provider = InitialThenResolvableProvider(initialToken)
+        val manager = KlaviyoAuthTokenManager()
+
+        manager.registerProvider(provider)
+        dispatcher.scheduler.advanceUntilIdle()
+        assertEquals(1, provider.callCount)
+
+        val timerTask = staticClock.scheduledTasks.first()
+        staticClock.execute(timerTask.time - staticClock.time)
+        dispatcher.scheduler.runCurrent()
+        assertEquals("scheduled refresh should be in-flight", 2, provider.callCount)
+
+        observerSlot.captured.invoke(ActivityEvent.FirstStarted(mockActivity))
+        dispatcher.scheduler.runCurrent()
+
+        verify(inverse = true) {
+            spyLog.info(match { it.contains("case=missed-refresh") })
+        }
+
+        provider.resolve(refreshedToken)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(
+            "foreground should not enqueue another forced provider fetch after timer success",
+            2,
+            provider.callCount
+        )
+    }
+
+    @Test
+    fun `foreground retries after scheduled timer refresh fails`() = runTest(dispatcher) {
+        val initialToken = makeJwt()
+        val retryToken = makeJwt(EXP_SECONDS + 600, IAT_SECONDS + 600)
+        val provider = ScriptedProvider(
+            ArrayDeque(
+                listOf(
+                    Result.success(initialToken),
+                    Result.failure(RuntimeException("refresh failed")),
+                    Result.success(retryToken)
+                )
+            )
+        )
+        val manager = KlaviyoAuthTokenManager()
+
+        manager.registerProvider(provider)
+        dispatcher.scheduler.advanceUntilIdle()
+        assertEquals(1, provider.callCount)
+
+        val timerTask = staticClock.scheduledTasks.first()
+        staticClock.execute(timerTask.time - staticClock.time)
+        dispatcher.scheduler.advanceUntilIdle()
+        assertEquals("scheduled refresh should have failed", 2, provider.callCount)
+
+        manager.fireFirstStarted()
+
+        assertEquals(
+            "failed scheduled refresh should leave one foreground retry available",
+            3,
+            provider.callCount
+        )
+    }
+
+    @Test
     fun `foreground with expired token clears cache and eager-fetches`() = runTest(dispatcher) {
         val provider = CountingSuccessProvider(makeJwt())
         val manager = KlaviyoAuthTokenManager()
@@ -252,6 +321,24 @@ class KlaviyoAuthTokenManagerRefreshTest : BaseTest() {
             callCount++
             callback.onSuccess(jwt)
         }
+    }
+
+    private class InitialThenResolvableProvider(private val initialJwt: String) : AuthTokenProvider {
+        var callCount = 0
+            private set
+
+        private val pendingCallbacks = ArrayDeque<AuthTokenProvider.Callback>()
+
+        override fun fetchToken(callback: AuthTokenProvider.Callback) {
+            callCount++
+            if (callCount == 1) {
+                callback.onSuccess(initialJwt)
+            } else {
+                pendingCallbacks.addLast(callback)
+            }
+        }
+
+        fun resolve(jwt: String) = pendingCallbacks.removeFirstOrNull()?.onSuccess(jwt)
     }
 
     private class ScriptedProvider(

--- a/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerRefreshTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerRefreshTest.kt
@@ -1,5 +1,7 @@
 package com.klaviyo.core.auth
 
+import com.klaviyo.core.Registry
+import com.klaviyo.core.config.Clock
 import com.klaviyo.core.lifecycle.ActivityEvent
 import com.klaviyo.core.lifecycle.ActivityObserver
 import com.klaviyo.fixtures.BaseTest
@@ -265,6 +267,35 @@ class KlaviyoAuthTokenManagerRefreshTest : BaseTest() {
     }
 
     @Test
+    fun `foreground racing with fired timer only launches one scheduled refresh`() = runTest(
+        dispatcher
+    ) {
+        val racingClock = CancelRunsTaskClock(TIME, ISO_TIME)
+        every { Registry.clock } returns racingClock
+        val provider = CountingSuccessProvider(makeJwt())
+        val manager = KlaviyoAuthTokenManager()
+
+        manager.registerProvider(provider)
+        dispatcher.scheduler.advanceUntilIdle()
+        assertEquals(1, provider.callCount)
+
+        val timerTask = racingClock.scheduledTasks.first()
+        racingClock.time = timerTask.time + 1_000L
+
+        manager.fireFirstStarted()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(
+            "racing timer and foreground handlers should share one provider fetch",
+            2,
+            provider.callCount
+        )
+        verify(exactly = 1) {
+            spyLog.info("Proactive token refresh fired")
+        }
+    }
+
+    @Test
     fun `foreground retries after scheduled timer refresh fails`() = runTest(dispatcher) {
         val initialToken = makeJwt()
         val retryToken = makeJwt(EXP_SECONDS + 600, IAT_SECONDS + 600)
@@ -316,6 +347,39 @@ class KlaviyoAuthTokenManagerRefreshTest : BaseTest() {
     }
 
     // MARK: - Helpers
+
+    private class CancelRunsTaskClock(
+        var time: Long,
+        private val formatted: String
+    ) : Clock {
+        val scheduledTasks = mutableListOf<ScheduledTask>()
+
+        override fun currentTimeMillis(): Long = time
+
+        override fun isoTime(milliseconds: Long): String = formatted
+
+        override fun schedule(delay: Long, task: () -> Unit): Clock.Cancellable {
+            val scheduledTask = ScheduledTask(currentTimeMillis() + delay, task)
+            scheduledTasks.add(scheduledTask)
+            return object : Clock.Cancellable {
+                override fun runNow() {
+                    if (scheduledTasks.remove(scheduledTask)) {
+                        task()
+                    }
+                }
+
+                override fun cancel(): Boolean {
+                    val removed = scheduledTasks.remove(scheduledTask)
+                    if (removed) {
+                        task()
+                    }
+                    return removed
+                }
+            }
+        }
+
+        class ScheduledTask(val time: Long, val task: () -> Unit)
+    }
 
     private class CountingSuccessProvider(private val jwt: String) : AuthTokenProvider {
         var callCount = 0

--- a/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerRefreshTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerRefreshTest.kt
@@ -128,7 +128,11 @@ class KlaviyoAuthTokenManagerRefreshTest : BaseTest() {
         val timerTask = staticClock.scheduledTasks.first()
         staticClock.execute(timerTask.time - staticClock.time)
         dispatcher.scheduler.advanceUntilIdle()
-        assertEquals("scheduled refresh should attempt one additional provider call", 2, provider.callCount)
+        assertEquals(
+            "scheduled refresh should attempt one additional provider call",
+            2,
+            provider.callCount
+        )
 
         val cached = manager.currentToken()
         assertEquals(token, cached.rawToken)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Description
Fixes a proactive auth-token refresh race where foreground missed-refresh handling could treat an already-fired timer as a Doze-style miss and enqueue another forced provider fetch.

## Due Diligence
- [ ] I have tested this on an emulator and/or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all Android versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API. 
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [x] This is planned work for an upcoming release.

## Changelog / Code Overview
- Tracks when a scheduled refresh timer has actually fired so foreground transitions do not classify an in-flight or completed timer refresh as missed.
- Invalidates stale scheduled callbacks across provider swaps and foreground-clearing paths.
- Adds regression coverage for fired-timer foreground handling and foreground retry after timer refresh failure.

## Test Plan
- [x] `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 ANDROID_HOME=/opt/android-sdk ANDROID_SDK_ROOT=/opt/android-sdk ./gradlew --no-daemon :sdk:core:testDebugUnitTest --tests "com.klaviyo.core.auth.KlaviyoAuthTokenManagerRefreshTest"`
- [x] `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 ANDROID_HOME=/opt/android-sdk ANDROID_SDK_ROOT=/opt/android-sdk ./gradlew --no-daemon :sdk:core:ktlintCheck`

## Related Issues/Tickets
- MAGE-629
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-26515ede-61cf-4c02-aba4-c3120203612b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-26515ede-61cf-4c02-aba4-c3120203612b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

