### PR TITLE
refactor(forms): deliver JWT via window.jwtMutation JS bridge (MAGE-724)

### DIFF
--- a/sdk/forms/src/main/assets/InAppFormsTemplate.html
+++ b/sdk/forms/src/main/assets/InAppFormsTemplate.html
@@ -8,7 +8,7 @@
       data-klaviyo-local-tracking="1"
       data-klaviyo-profile="{}"
       data-klaviyo-device='DEVICE_INFO'
-      data-klaviyo-jwt='JWT_TOKEN'
+      data-klaviyo-jwt=''
 >
     <meta charset="UTF-8">
     <meta name="viewport"

--- a/sdk/forms/src/main/assets/klaviyo-js-bridge.js
+++ b/sdk/forms/src/main/assets/klaviyo-js-bridge.js
@@ -117,6 +117,21 @@ window.setSafeArea = function(left, top, right, bottom) {
     return true;
  }
 
+/**
+ * Updates the data-klaviyo-jwt attribute on the document head.
+ *
+ * Delivered via the JS bridge (rather than a static HTML attribute) so the SDK controls
+ * ordering: the JWT is set at jsReady, before profile identifiers are injected at handshake,
+ * which is what the onsite personalization module needs to trigger the authenticated fetch.
+ *
+ * @param token - JWT string, or null if auth is not enabled / token fetch failed
+ * @returns {boolean}
+ */
+window.jwtMutation = function (token) {
+    document.head.setAttribute("data-klaviyo-jwt", token)
+    return true
+}
+
 // Notify the SDK over the native bridge that these local JS scripts are initialized
 var bridgeName = document.head.getAttribute("data-native-bridge-name") || ""
 

--- a/sdk/forms/src/main/assets/klaviyo-js-bridge.js
+++ b/sdk/forms/src/main/assets/klaviyo-js-bridge.js
@@ -124,7 +124,7 @@ window.setSafeArea = function(left, top, right, bottom) {
  * ordering: the JWT is set at jsReady, before profile identifiers are injected at handshake,
  * which is what the onsite personalization module needs to trigger the authenticated fetch.
  *
- * @param token - JWT string, or null if auth is not enabled / token fetch failed
+ * @param token - JWT string, or empty string if auth is not enabled / token fetch failed
  * @returns {boolean}
  */
 window.jwtMutation = function (token) {

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/JsBridge.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/JsBridge.kt
@@ -59,8 +59,8 @@ internal interface JsBridge {
     /**
      * Inject the auth token into the webview as a data attribute.
      *
-     * A null [token] indicates auth is not enabled or the token fetch failed; the onsite JS
+     * An empty [token] indicates auth is not enabled or the token fetch failed; the onsite JS
      * module treats a missing/empty token as "unauthenticated" and skips the authenticated fetch.
      */
-    fun jwtMutation(token: String?)
+    fun jwtMutation(token: String)
 }

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/JsBridge.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/JsBridge.kt
@@ -55,4 +55,12 @@ internal interface JsBridge {
      *
      */
     fun profileEvent(event: Event)
+
+    /**
+     * Inject the auth token into the webview as a data attribute.
+     *
+     * A null [token] indicates auth is not enabled or the token fetch failed; the onsite JS
+     * module treats a missing/empty token as "unauthenticated" and skips the authenticated fetch.
+     */
+    fun jwtMutation(token: String?)
 }

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/JwtObserver.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/JwtObserver.kt
@@ -5,6 +5,7 @@ import com.klaviyo.core.auth.AuthTokenException
 import com.klaviyo.core.auth.AuthTokenManager
 import com.klaviyo.core.safeLaunch
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
@@ -18,9 +19,15 @@ import kotlinx.coroutines.SupervisorJob
  * fetch when both a JWT and profile identifiers are present. Delivering the JWT at JsReady (before
  * profile at HandShook) guarantees the token is in place when identifiers arrive.
  *
+ * [jwtReady] is completed after the JWT is injected (or cancelled on [stopObserver]) so that
+ * [ProfileMutationObserver] can await it before injecting profile identifiers, eliminating the
+ * residual race where a slow async token fetch outlasts the JsReady→HandShook window.
+ *
  * Live token refresh delivery on rotation is tracked in MAGE-630.
  */
-internal class JwtObserver : JsBridgeObserver {
+internal class JwtObserver(
+    internal val jwtReady: CompletableDeferred<Unit> = CompletableDeferred()
+) : JsBridgeObserver {
     // startOn defaults to NativeBridgeMessage.JsReady — intentionally earlier than
     // ProfileMutationObserver (HandShook) so the JWT is set before profile identifiers.
 
@@ -46,6 +53,7 @@ internal class JwtObserver : JsBridgeObserver {
 
             Registry.threadHelper.runOnUiThread {
                 Registry.get<JsBridge>().jwtMutation(token ?: "")
+                jwtReady.complete(Unit)
             }
         }
     }
@@ -53,5 +61,8 @@ internal class JwtObserver : JsBridgeObserver {
     override fun stopObserver() {
         fetchJob?.cancel()
         fetchJob = null
+        // Cancel the deferred so ProfileMutationObserver doesn't hang if the WebView is
+        // destroyed before the token fetch completes.
+        jwtReady.cancel()
     }
 }

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/JwtObserver.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/JwtObserver.kt
@@ -11,58 +11,48 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 
 /**
- * Delivers the auth token to the webview via [JsBridge.jwtMutation] as soon as the JS bridge
- * script is ready ([NativeBridgeMessage.JsReady]), which fires before the handshake phase where
- * [ProfileMutationObserver] injects profile identifiers.
+ * Delivers the auth token to the webview via [JsBridge.jwtMutation] at [NativeBridgeMessage.JsReady],
+ * before [ProfileMutationObserver] injects profile identifiers at HandShook.
  *
- * Ordering matters: the onsite personalization module only triggers the authenticated profile
- * fetch when both a JWT and profile identifiers are present. Delivering the JWT at JsReady (before
- * profile at HandShook) guarantees the token is in place when identifiers arrive.
- *
- * [jwtReady] is a fresh [CompletableDeferred] created on each [startObserver] call. It is
- * completed after the JWT is injected so that [ProfileMutationObserver] can await it before
- * injecting profile identifiers, eliminating the residual race where a slow async token fetch
- * outlasts the JsReady→HandShook window. A new deferred is created each session so that reinit
- * after [stopObserver] always starts from a clean state.
- *
- * Live token refresh delivery on rotation is tracked in MAGE-630.
+ * The onsite personalization module only triggers the authenticated profile fetch when both a JWT
+ * and profile identifiers are present, so the JWT must land first.
  */
 internal class JwtObserver : JsBridgeObserver {
-    // startOn defaults to NativeBridgeMessage.JsReady — intentionally earlier than
-    // ProfileMutationObserver (HandShook) so the JWT is set before profile identifiers.
 
     /**
-     * Deferred that completes once the JWT has been delivered for the current WebView session.
-     * Replaced with a fresh instance on every [startObserver] call, so [ProfileMutationObserver]
-     * always awaits the deferred that corresponds to the active session.
+     * Completes once the JWT has been delivered. [ProfileMutationObserver] awaits this before
+     * injecting profile identifiers. Reused while still pending so a re-entrant start does not
+     * orphan a waiter that captured the previous reference.
      */
     @Volatile
     internal var jwtReady: CompletableDeferred<Unit> = CompletableDeferred()
         private set
 
-    // Guards against a queued runOnUiThread callback from a previous session delivering a stale
-    // JWT after stopObserver. Cooperative cancellation of fetchJob only works at suspension
-    // points; the post-suspension path (after currentToken returns) needs this explicit flag.
     @Volatile private var stopped = false
+
+    @Volatile private var latestFetch: Any? = null
 
     private val scope = CoroutineScope(SupervisorJob() + Registry.dispatcher)
     private var fetchJob: Job? = null
 
     override fun startObserver() {
         stopped = false
-        // Fresh deferred for this WebView session. ProfileMutationObserver reads jwtReady via
-        // its JwtObserver reference in its own startObserver, so it always gets this new instance.
-        val currentJwtReady = CompletableDeferred<Unit>()
-        jwtReady = currentJwtReady
+        val thisFetch = Any()
+        latestFetch = thisFetch
+        val currentJwtReady = if (jwtReady.isCompleted) {
+            CompletableDeferred<Unit>().also { jwtReady = it }
+        } else {
+            jwtReady
+        }
 
-        fetchJob?.cancel() // guard against double-start without an intervening stopObserver
+        fetchJob?.cancel()
         fetchJob = scope.safeLaunch {
             val token = try {
                 Registry.get<AuthTokenManager>()
                     .currentToken(AuthTokenManager.INTERACTIVE_FETCH_TIMEOUT_MS)
                     .rawToken
             } catch (e: CancellationException) {
-                throw e // Propagate coroutine cancellation
+                throw e
             } catch (_: AuthTokenException.NoProviderRegistered) {
                 Registry.log.debug("Auth not enabled — injecting empty JWT")
                 null
@@ -72,11 +62,7 @@ internal class JwtObserver : JsBridgeObserver {
             }
 
             Registry.threadHelper.runOnUiThread {
-                // Double-guard: check both that this session's deferred is still current (i.e.
-                // startObserver hasn't been called again) and that stop wasn't requested. This
-                // prevents a stale runOnUiThread callback — queued after currentToken returned
-                // but before stopObserver ran — from injecting into a destroyed or new WebView.
-                if (jwtReady === currentJwtReady && !stopped) {
+                if (latestFetch === thisFetch && !stopped) {
                     Registry.get<JsBridge>().jwtMutation(token ?: "")
                     currentJwtReady.complete(Unit)
                 }
@@ -88,8 +74,5 @@ internal class JwtObserver : JsBridgeObserver {
         stopped = true
         fetchJob?.cancel()
         fetchJob = null
-        // Do NOT cancel jwtReady here — ProfileMutationObserver cancels its own initJob in
-        // stopObserver, which unblocks any await on jwtReady without poisoning the deferred
-        // for a potential subsequent session.
     }
 }

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/JwtObserver.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/JwtObserver.kt
@@ -1,0 +1,56 @@
+package com.klaviyo.forms.bridge
+
+import com.klaviyo.core.Registry
+import com.klaviyo.core.auth.AuthTokenException
+import com.klaviyo.core.auth.AuthTokenManager
+import com.klaviyo.core.safeLaunch
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+
+/**
+ * Delivers the auth token to the webview via [JsBridge.jwtMutation] as soon as the JS bridge
+ * script is ready ([NativeBridgeMessage.JsReady]), which fires before the handshake phase where
+ * [ProfileMutationObserver] injects profile identifiers.
+ *
+ * Ordering matters: the onsite personalization module only triggers the authenticated profile
+ * fetch when both a JWT and profile identifiers are present. Delivering the JWT at JsReady (before
+ * profile at HandShook) guarantees the token is in place when identifiers arrive.
+ *
+ * Live token refresh delivery on rotation is tracked in MAGE-630.
+ */
+internal class JwtObserver : JsBridgeObserver {
+    // startOn defaults to NativeBridgeMessage.JsReady — intentionally earlier than
+    // ProfileMutationObserver (HandShook) so the JWT is set before profile identifiers.
+
+    private val scope = CoroutineScope(SupervisorJob() + Registry.dispatcher)
+    private var fetchJob: Job? = null
+
+    override fun startObserver() {
+        fetchJob = scope.safeLaunch {
+            val token = try {
+                Registry.get<AuthTokenManager>()
+                    .currentToken(AuthTokenManager.INTERACTIVE_FETCH_TIMEOUT_MS)
+                    .rawToken
+            } catch (e: CancellationException) {
+                throw e // Propagate coroutine cancellation
+            } catch (_: AuthTokenException.NoProviderRegistered) {
+                Registry.log.debug("Auth not enabled — injecting null JWT")
+                null
+            } catch (_: Exception) {
+                Registry.log.warning("Auth token fetch failed — injecting null JWT")
+                null
+            }
+
+            Registry.threadHelper.runOnUiThread {
+                Registry.get<JsBridge>().jwtMutation(token)
+            }
+        }
+    }
+
+    override fun stopObserver() {
+        fetchJob?.cancel()
+        fetchJob = null
+    }
+}

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/JwtObserver.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/JwtObserver.kt
@@ -19,22 +19,42 @@ import kotlinx.coroutines.SupervisorJob
  * fetch when both a JWT and profile identifiers are present. Delivering the JWT at JsReady (before
  * profile at HandShook) guarantees the token is in place when identifiers arrive.
  *
- * [jwtReady] is completed after the JWT is injected (or cancelled on [stopObserver]) so that
- * [ProfileMutationObserver] can await it before injecting profile identifiers, eliminating the
- * residual race where a slow async token fetch outlasts the JsReady→HandShook window.
+ * [jwtReady] is a fresh [CompletableDeferred] created on each [startObserver] call. It is
+ * completed after the JWT is injected so that [ProfileMutationObserver] can await it before
+ * injecting profile identifiers, eliminating the residual race where a slow async token fetch
+ * outlasts the JsReady→HandShook window. A new deferred is created each session so that reinit
+ * after [stopObserver] always starts from a clean state.
  *
  * Live token refresh delivery on rotation is tracked in MAGE-630.
  */
-internal class JwtObserver(
-    internal val jwtReady: CompletableDeferred<Unit> = CompletableDeferred()
-) : JsBridgeObserver {
+internal class JwtObserver : JsBridgeObserver {
     // startOn defaults to NativeBridgeMessage.JsReady — intentionally earlier than
     // ProfileMutationObserver (HandShook) so the JWT is set before profile identifiers.
+
+    /**
+     * Deferred that completes once the JWT has been delivered for the current WebView session.
+     * Replaced with a fresh instance on every [startObserver] call, so [ProfileMutationObserver]
+     * always awaits the deferred that corresponds to the active session.
+     */
+    @Volatile
+    internal var jwtReady: CompletableDeferred<Unit> = CompletableDeferred()
+        private set
+
+    // Guards against a queued runOnUiThread callback from a previous session delivering a stale
+    // JWT after stopObserver. Cooperative cancellation of fetchJob only works at suspension
+    // points; the post-suspension path (after currentToken returns) needs this explicit flag.
+    @Volatile private var stopped = false
 
     private val scope = CoroutineScope(SupervisorJob() + Registry.dispatcher)
     private var fetchJob: Job? = null
 
     override fun startObserver() {
+        stopped = false
+        // Fresh deferred for this WebView session. ProfileMutationObserver reads jwtReady via
+        // its JwtObserver reference in its own startObserver, so it always gets this new instance.
+        val currentJwtReady = CompletableDeferred<Unit>()
+        jwtReady = currentJwtReady
+
         fetchJob?.cancel() // guard against double-start without an intervening stopObserver
         fetchJob = scope.safeLaunch {
             val token = try {
@@ -52,17 +72,24 @@ internal class JwtObserver(
             }
 
             Registry.threadHelper.runOnUiThread {
-                Registry.get<JsBridge>().jwtMutation(token ?: "")
-                jwtReady.complete(Unit)
+                // Double-guard: check both that this session's deferred is still current (i.e.
+                // startObserver hasn't been called again) and that stop wasn't requested. This
+                // prevents a stale runOnUiThread callback — queued after currentToken returned
+                // but before stopObserver ran — from injecting into a destroyed or new WebView.
+                if (jwtReady === currentJwtReady && !stopped) {
+                    Registry.get<JsBridge>().jwtMutation(token ?: "")
+                    currentJwtReady.complete(Unit)
+                }
             }
         }
     }
 
     override fun stopObserver() {
+        stopped = true
         fetchJob?.cancel()
         fetchJob = null
-        // Cancel the deferred so ProfileMutationObserver doesn't hang if the WebView is
-        // destroyed before the token fetch completes.
-        jwtReady.cancel()
+        // Do NOT cancel jwtReady here — ProfileMutationObserver cancels its own initJob in
+        // stopObserver, which unblocks any await on jwtReady without poisoning the deferred
+        // for a potential subsequent session.
     }
 }

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/JwtObserver.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/JwtObserver.kt
@@ -28,6 +28,7 @@ internal class JwtObserver : JsBridgeObserver {
     private var fetchJob: Job? = null
 
     override fun startObserver() {
+        fetchJob?.cancel() // guard against double-start without an intervening stopObserver
         fetchJob = scope.safeLaunch {
             val token = try {
                 Registry.get<AuthTokenManager>()
@@ -36,15 +37,15 @@ internal class JwtObserver : JsBridgeObserver {
             } catch (e: CancellationException) {
                 throw e // Propagate coroutine cancellation
             } catch (_: AuthTokenException.NoProviderRegistered) {
-                Registry.log.debug("Auth not enabled — injecting null JWT")
+                Registry.log.debug("Auth not enabled — injecting empty JWT")
                 null
             } catch (_: Exception) {
-                Registry.log.warning("Auth token fetch failed — injecting null JWT")
+                Registry.log.warning("Auth token fetch failed — injecting empty JWT")
                 null
             }
 
             Registry.threadHelper.runOnUiThread {
-                Registry.get<JsBridge>().jwtMutation(token)
+                Registry.get<JsBridge>().jwtMutation(token ?: "")
             }
         }
     }

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/KlaviyoJsBridge.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/KlaviyoJsBridge.kt
@@ -86,6 +86,11 @@ internal class KlaviyoJsBridge : JsBridge {
             bottom.toString()
         )
 
+    override fun jwtMutation(token: String?) = evaluateJavascript(
+        HelperFunction.jwtMutation,
+        token
+    )
+
     /**
      * Evaluates a JS function in the webview with the given arguments
      */

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/KlaviyoJsBridge.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/KlaviyoJsBridge.kt
@@ -86,7 +86,7 @@ internal class KlaviyoJsBridge : JsBridge {
             bottom.toString()
         )
 
-    override fun jwtMutation(token: String?) = evaluateJavascript(
+    override fun jwtMutation(token: String) = evaluateJavascript(
         HelperFunction.jwtMutation,
         token
     )

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/KlaviyoObserverCollection.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/KlaviyoObserverCollection.kt
@@ -4,9 +4,6 @@ package com.klaviyo.forms.bridge
  * Manages the collection of observers that inject data into the webview
  */
 internal class KlaviyoObserverCollection : JsBridgeObserverCollection {
-    // JwtObserver owns its jwtReady deferred and creates a fresh one on each startObserver call.
-    // ProfileMutationObserver reads jwtReady from this reference at its own startObserver time,
-    // so it always awaits the deferred for the current WebView session rather than a stale one.
     private val jwtObserver = JwtObserver()
 
     override val observers: List<JsBridgeObserver> by lazy {

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/KlaviyoObserverCollection.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/KlaviyoObserverCollection.kt
@@ -1,22 +1,20 @@
 package com.klaviyo.forms.bridge
 
-import kotlinx.coroutines.CompletableDeferred
-
 /**
  * Manages the collection of observers that inject data into the webview
  */
 internal class KlaviyoObserverCollection : JsBridgeObserverCollection {
-    // Shared deferred that JwtObserver completes (or cancels) after delivering the JWT.
-    // ProfileMutationObserver awaits it before its initial profile injection, ensuring the
-    // JWT attribute is set before profile identifiers arrive in the onsite JS module.
-    private val jwtReady = CompletableDeferred<Unit>()
+    // JwtObserver owns its jwtReady deferred and creates a fresh one on each startObserver call.
+    // ProfileMutationObserver reads jwtReady from this reference at its own startObserver time,
+    // so it always awaits the deferred for the current WebView session rather than a stale one.
+    private val jwtObserver = JwtObserver()
 
     override val observers: List<JsBridgeObserver> by lazy {
         listOf(
             CompanyObserver(),
             LifecycleObserver(),
-            JwtObserver(jwtReady),
-            ProfileMutationObserver(jwtReady),
+            jwtObserver,
+            ProfileMutationObserver(jwtObserver),
             ProfileEventObserver()
         )
     }

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/KlaviyoObserverCollection.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/KlaviyoObserverCollection.kt
@@ -8,6 +8,7 @@ internal class KlaviyoObserverCollection : JsBridgeObserverCollection {
         listOf(
             CompanyObserver(),
             LifecycleObserver(),
+            JwtObserver(),
             ProfileMutationObserver(),
             ProfileEventObserver()
         )

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/KlaviyoObserverCollection.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/KlaviyoObserverCollection.kt
@@ -1,15 +1,22 @@
 package com.klaviyo.forms.bridge
 
+import kotlinx.coroutines.CompletableDeferred
+
 /**
  * Manages the collection of observers that inject data into the webview
  */
 internal class KlaviyoObserverCollection : JsBridgeObserverCollection {
+    // Shared deferred that JwtObserver completes (or cancels) after delivering the JWT.
+    // ProfileMutationObserver awaits it before its initial profile injection, ensuring the
+    // JWT attribute is set before profile identifiers arrive in the onsite JS module.
+    private val jwtReady = CompletableDeferred<Unit>()
+
     override val observers: List<JsBridgeObserver> by lazy {
         listOf(
             CompanyObserver(),
             LifecycleObserver(),
-            JwtObserver(),
-            ProfileMutationObserver(),
+            JwtObserver(jwtReady),
+            ProfileMutationObserver(jwtReady),
             ProfileEventObserver()
         )
     }

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/ProfileMutationObserver.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/ProfileMutationObserver.kt
@@ -10,6 +10,16 @@ import com.klaviyo.core.Registry
  */
 internal class ProfileMutationObserver : JsBridgeObserver, StateChangeObserver {
 
+    /**
+     * Start on [NativeBridgeMessage.HandShook] rather than the default [NativeBridgeMessage.JsReady]
+     * so the initial profile injection fires *after* [JwtObserver] has delivered the JWT at JsReady.
+     *
+     * The onsite personalization module only triggers the authenticated profile fetch when both a
+     * JWT and profile identifiers are present. If profile is injected before the JWT, the module
+     * sees identifiers with no token and never makes the authenticated fetch.
+     */
+    override val startOn: NativeBridgeMessage get() = NativeBridgeMessage.HandShook
+
     override fun startObserver() {
         // Set initial profile identifiers on startup
         injectProfile()

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/ProfileMutationObserver.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/ProfileMutationObserver.kt
@@ -7,18 +7,21 @@ import com.klaviyo.core.Registry
 import com.klaviyo.core.safeLaunch
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 
 /**
  * Observe [State] in the analytics package to synchronize profile identifiers with the webview
  */
 internal class ProfileMutationObserver(
-    private val jwtReady: Deferred<Unit>? = null
+    private val jwtObserver: JwtObserver? = null
 ) : JsBridgeObserver, StateChangeObserver {
 
+    // Scope is intentionally long-lived and never cancelled — cancelling the scope permanently
+    // prevents future startObserver calls from launching coroutines. Per-session cleanup is done
+    // by cancelling initJob in stopObserver instead.
     private val scope = CoroutineScope(SupervisorJob() + Registry.dispatcher)
+    private var initJob: Job? = null
 
     /**
      * Start on [NativeBridgeMessage.HandShook] rather than the default [NativeBridgeMessage.JsReady]
@@ -28,16 +31,19 @@ internal class ProfileMutationObserver(
      * JWT and profile identifiers are present. If profile is injected before the JWT, the module
      * sees identifiers with no token and never makes the authenticated fetch.
      *
-     * When [jwtReady] is provided, the initial [injectProfile] call additionally awaits that
-     * deferred before injecting, eliminating the residual race where a slow async token fetch
-     * completes after [NativeBridgeMessage.HandShook] fires.
+     * When [jwtObserver] is provided, the initial [injectProfile] call additionally awaits
+     * [JwtObserver.jwtReady] before injecting, eliminating the residual race where a slow async
+     * token fetch completes after [NativeBridgeMessage.HandShook] fires. Reading [jwtReady] from
+     * the observer (rather than capturing it at construction) ensures we always await the deferred
+     * that [JwtObserver.startObserver] created for the current WebView session.
      */
     override val startOn: NativeBridgeMessage get() = NativeBridgeMessage.HandShook
 
     override fun startObserver() {
-        val deferred = jwtReady
+        val deferred = jwtObserver?.jwtReady
         if (deferred != null) {
-            scope.safeLaunch {
+            initJob?.cancel()
+            initJob = scope.safeLaunch {
                 try {
                     deferred.await()
                 } catch (e: CancellationException) {
@@ -51,7 +57,8 @@ internal class ProfileMutationObserver(
     }
 
     override fun stopObserver() {
-        scope.cancel()
+        initJob?.cancel()
+        initJob = null
         Registry.get<State>().offStateChange(this)
     }
 

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/ProfileMutationObserver.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/ProfileMutationObserver.kt
@@ -4,11 +4,21 @@ import com.klaviyo.analytics.state.State
 import com.klaviyo.analytics.state.StateChange
 import com.klaviyo.analytics.state.StateChangeObserver
 import com.klaviyo.core.Registry
+import com.klaviyo.core.safeLaunch
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 
 /**
  * Observe [State] in the analytics package to synchronize profile identifiers with the webview
  */
-internal class ProfileMutationObserver : JsBridgeObserver, StateChangeObserver {
+internal class ProfileMutationObserver(
+    private val jwtReady: Deferred<Unit>? = null
+) : JsBridgeObserver, StateChangeObserver {
+
+    private val scope = CoroutineScope(SupervisorJob() + Registry.dispatcher)
 
     /**
      * Start on [NativeBridgeMessage.HandShook] rather than the default [NativeBridgeMessage.JsReady]
@@ -17,16 +27,33 @@ internal class ProfileMutationObserver : JsBridgeObserver, StateChangeObserver {
      * The onsite personalization module only triggers the authenticated profile fetch when both a
      * JWT and profile identifiers are present. If profile is injected before the JWT, the module
      * sees identifiers with no token and never makes the authenticated fetch.
+     *
+     * When [jwtReady] is provided, the initial [injectProfile] call additionally awaits that
+     * deferred before injecting, eliminating the residual race where a slow async token fetch
+     * completes after [NativeBridgeMessage.HandShook] fires.
      */
     override val startOn: NativeBridgeMessage get() = NativeBridgeMessage.HandShook
 
     override fun startObserver() {
-        // Set initial profile identifiers on startup
-        injectProfile()
-        Registry.get<State>().onStateChange(this)
+        val deferred = jwtReady
+        if (deferred != null) {
+            scope.safeLaunch {
+                try {
+                    deferred.await()
+                } catch (e: CancellationException) {
+                    throw e // WebView is being torn down — do not inject
+                }
+                injectAndSubscribe()
+            }
+        } else {
+            injectAndSubscribe()
+        }
     }
 
-    override fun stopObserver() = Registry.get<State>().offStateChange(this)
+    override fun stopObserver() {
+        scope.cancel()
+        Registry.get<State>().offStateChange(this)
+    }
 
     /**
      * Update profile in webview whenever an identifier changes, or profile is reset
@@ -36,6 +63,11 @@ internal class ProfileMutationObserver : JsBridgeObserver, StateChangeObserver {
             is StateChange.ProfileIdentifier, is StateChange.ProfileReset -> injectProfile()
             else -> Unit
         }
+    }
+
+    private fun injectAndSubscribe() {
+        injectProfile()
+        Registry.get<State>().onStateChange(this)
     }
 
     private fun injectProfile() = Registry.get<JsBridge>().profileMutation(

--- a/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
@@ -22,6 +22,7 @@ import com.klaviyo.forms.bridge.DeviceInfoProvider
 import com.klaviyo.forms.bridge.HandshakeSpec
 import com.klaviyo.forms.bridge.JsBridge
 import com.klaviyo.forms.bridge.JsBridgeObserverCollection
+import com.klaviyo.forms.bridge.JwtObserver
 import com.klaviyo.forms.bridge.NativeBridge
 import com.klaviyo.forms.bridge.NativeBridgeMessage
 import com.klaviyo.forms.bridge.compileJson
@@ -51,7 +52,7 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
      *
      * All template substitutions (SDK metadata, bridge config, device info) run synchronously on
      * the calling (UI) thread. The auth token is no longer injected into the template here — it is
-     * delivered after load via [com.klaviyo.forms.bridge.JwtObserver] over the JS bridge, so the
+     * delivered after load via [JwtObserver] over the JS bridge, so the
      * SDK can control JWT/profile ordering and push live token refreshes (MAGE-630).
      */
     override fun initializeWebView() {

--- a/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
@@ -52,8 +52,8 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
      *
      * All template substitutions (SDK metadata, bridge config, device info) run synchronously on
      * the calling (UI) thread. The auth token is no longer injected into the template here — it is
-     * delivered after load via [JwtObserver] over the JS bridge, so the
-     * SDK can control JWT/profile ordering and push live token refreshes (MAGE-630).
+     * delivered after load via [JwtObserver] over the JS bridge so the SDK can control
+     * JWT/profile ordering. Live token refresh remains out of scope here.
      */
     override fun initializeWebView() {
         if (webView != null) {

--- a/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
@@ -15,11 +15,7 @@ import androidx.webkit.WebViewCompat
 import androidx.webkit.WebViewFeature.WEB_MESSAGE_LISTENER
 import androidx.webkit.WebViewFeature.isFeatureSupported
 import com.klaviyo.core.Registry
-import com.klaviyo.core.auth.AuthTokenException
-import com.klaviyo.core.auth.AuthTokenManager
-import com.klaviyo.core.auth.ValidatedToken
 import com.klaviyo.core.config.Clock
-import com.klaviyo.core.safeLaunch
 import com.klaviyo.core.utils.WeakReferenceDelegate
 import com.klaviyo.core.utils.startActivityIfResolved
 import com.klaviyo.forms.bridge.DeviceInfoProvider
@@ -31,10 +27,6 @@ import com.klaviyo.forms.bridge.NativeBridgeMessage
 import com.klaviyo.forms.bridge.compileJson
 import com.klaviyo.forms.presentation.PresentationManager
 import java.io.BufferedReader
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
 
 /**
  * Manages the [KlaviyoWebView] instance that powers In-App Forms behavior, triggering, rendering and display,
@@ -54,27 +46,13 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
     private var webView: KlaviyoWebView? by WeakReferenceDelegate()
 
     /**
-     * Retained across [destroyWebView] so the client can be reinitialized. Individual jobs
-     * (currently [initJob]) are cancelled in [destroyWebView]; future `safeLaunch` callers must
-     * track their own [Job] or migrate to `scope.coroutineContext.cancelChildren()`.
-     */
-    private val scope = CoroutineScope(SupervisorJob() + Registry.dispatcher)
-
-    private var initJob: Job? = null
-
-    private companion object {
-        const val JWT_TOKEN_PLACEHOLDER = "JWT_TOKEN"
-    }
-
-    /**
      * Initialize a webview instance, with protection against duplication
      * and initialize klaviyo.js for In-App Forms with handshake data injected in the document head.
      *
-     * Template substitutions that don't require async work (SDK metadata, bridge config, device
-     * info) are applied synchronously on the calling (UI) thread. Auth token injection requires
-     * an async provider call, so the final [KlaviyoWebView.loadTemplate] invocation is deferred
-     * to a background coroutine that calls [AuthTokenManager.currentToken] and then dispatches
-     * back to the UI thread.
+     * All template substitutions (SDK metadata, bridge config, device info) run synchronously on
+     * the calling (UI) thread. The auth token is no longer injected into the template here — it is
+     * delivered after load via [com.klaviyo.forms.bridge.JwtObserver] over the JS bridge, so the
+     * SDK can control JWT/profile ordering and push live token refreshes (MAGE-630).
      */
     override fun initializeWebView() {
         if (webView != null) {
@@ -112,86 +90,12 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
             // double-quoted strings.
             .replace("DEVICE_INFO", DeviceInfoProvider.current().toJson())
 
-        initJob = scope.safeLaunch {
-            loadTemplateWithAuthToken(webView, partialHtml, nativeBridge)
-        }
-    }
-
-    /**
-     * Fetch the auth token, then dispatch back to the UI thread to inject the (escaped) JWT into
-     * [partialHtml], load it, and log the auth outcome. [webView] is the locally-captured
-     * reference from [initializeWebView]; the body re-checks `this.webView !== webView` after the
-     * dispatch because the field is held weakly and may be cleared by destroy or GC mid-fetch.
-     */
-    private suspend fun loadTemplateWithAuthToken(
-        webView: KlaviyoWebView,
-        partialHtml: String,
-        nativeBridge: NativeBridge
-    ) {
-        // TODO: [MAGE-630] Subscribe to AuthTokenManager.onTokenRefresh for live updates.
-        // NoProviderRegistered is split out from generic fetch failures: the former is the
-        // expected state for apps not using JWT auth (logged at debug), the latter is degraded
-        // functionality with a fallback (logged at warning). Matches the AuthTokenException
-        // KDoc intent — "treat NoProviderRegistered as 'auth is not enabled' rather than 'auth
-        // failed.'"
-        val outcome: AuthOutcome = try {
-            AuthOutcome.Success(
-                Registry.get<AuthTokenManager>()
-                    .currentToken(AuthTokenManager.INTERACTIVE_FETCH_TIMEOUT_MS)
-            )
-        } catch (e: CancellationException) {
-            throw e
-        } catch (_: AuthTokenException.NoProviderRegistered) {
-            AuthOutcome.NotEnabled
-        } catch (_: Exception) {
-            AuthOutcome.FetchFailed
-        }
-
-        Registry.threadHelper.runOnUiThread {
-            if (this.webView !== webView) {
-                Registry.log.debug("Skipping IAF template load: WebView no longer current")
-                return@runOnUiThread
-            }
-            val token = (outcome as? AuthOutcome.Success)?.token
-            val jwtValue = token?.rawToken?.let(::escapeForHtmlAttribute).orEmpty()
-            partialHtml.replace(JWT_TOKEN_PLACEHOLDER, jwtValue).let { html ->
-                webView.loadTemplate(html, this, nativeBridge)
-                when (outcome) {
-                    is AuthOutcome.Success ->
-                        Registry.log.debug("Auth token injected at load")
-                    AuthOutcome.NotEnabled ->
-                        Registry.log.debug("Auth not enabled — proceeding without token")
-                    AuthOutcome.FetchFailed ->
-                        Registry.log.warning("Auth token fetch failed — proceeding without token")
-                }
-                handshakeTimer?.cancel()
-                handshakeTimer = Registry.clock.schedule(
-                    Registry.config.networkTimeout.toLong(),
-                    ::onJsHandshakeTimeout
-                )
-            }
-        }
-    }
-
-    /**
-     * Defense-in-depth escape for the single-quoted `data-klaviyo-jwt` attribute. Valid JWTs
-     * cannot contain these characters, but a custom `AuthTokenProvider` could bypass validation.
-     */
-    private fun escapeForHtmlAttribute(value: String): String =
-        value
-            .replace("&", "&amp;") // must escape first to avoid double-encoding entities below
-            .replace("'", "&#x27;")
-            .replace("<", "&lt;")
-
-    /**
-     * Three-way result of the auth-token fetch in [loadTemplateWithAuthToken]. Lets the call site
-     * differentiate "auth not enabled" (debug-level log) from "auth fetch failed" (warning-level
-     * log) without re-throwing or re-checking exception types after the catch block.
-     */
-    private sealed interface AuthOutcome {
-        data class Success(val token: ValidatedToken) : AuthOutcome
-        data object NotEnabled : AuthOutcome
-        data object FetchFailed : AuthOutcome
+        webView.loadTemplate(partialHtml, this, nativeBridge)
+        handshakeTimer?.cancel()
+        handshakeTimer = Registry.clock.schedule(
+            Registry.config.networkTimeout.toLong(),
+            ::onJsHandshakeTimeout
+        )
     }
 
     override fun onLocalJsReady() {
@@ -254,8 +158,6 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
      */
     override fun destroyWebView() = apply {
         handshakeTimer?.cancel()
-        initJob?.cancel()
-        initJob = null
         Registry.get<JsBridgeObserverCollection>().stopObservers()
         webView?.let { webView ->
             Registry.threadHelper.runOnUiThread {

--- a/sdk/forms/src/test/java/com/klaviyo/forms/bridge/JsBridgeObserverTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/bridge/JsBridgeObserverTest.kt
@@ -63,6 +63,8 @@ class JsBridgeObserverTest {
         val observers = KlaviyoObserverCollection().observers
         val jwtIndex = observers.indexOfFirst { it is JwtObserver }
         val profileIndex = observers.indexOfFirst { it is ProfileMutationObserver }
+        assert(jwtIndex >= 0) { "JwtObserver not found in collection" }
+        assert(profileIndex >= 0) { "ProfileMutationObserver not found in collection" }
         assert(jwtIndex < profileIndex) {
             "JwtObserver ($jwtIndex) must precede ProfileMutationObserver ($profileIndex)"
         }

--- a/sdk/forms/src/test/java/com/klaviyo/forms/bridge/JsBridgeObserverTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/bridge/JsBridgeObserverTest.kt
@@ -50,10 +50,21 @@ class JsBridgeObserverTest {
         val klaviyoObserverCollection = KlaviyoObserverCollection()
         val observers = klaviyoObserverCollection.observers
 
-        assertEquals(4, klaviyoObserverCollection.observers.size)
+        assertEquals(5, klaviyoObserverCollection.observers.size)
         assert(observers.any { it is CompanyObserver }) { "Expected CompanyObserver in the collection" }
+        assert(observers.any { it is JwtObserver }) { "Expected JwtObserver in the collection" }
         assert(observers.any { it is ProfileMutationObserver }) { "Expected ProfileObserver in the collection" }
         assert(observers.any { it is LifecycleObserver }) { "Expected LifecycleObserver in the collection" }
         assert(observers.any { it is ProfileEventObserver }) { "Expected FormsProfileEventObserver in the collection" }
+    }
+
+    @Test
+    fun `JwtObserver is ordered before ProfileMutationObserver`() {
+        val observers = KlaviyoObserverCollection().observers
+        val jwtIndex = observers.indexOfFirst { it is JwtObserver }
+        val profileIndex = observers.indexOfFirst { it is ProfileMutationObserver }
+        assert(jwtIndex < profileIndex) {
+            "JwtObserver ($jwtIndex) must precede ProfileMutationObserver ($profileIndex)"
+        }
     }
 }

--- a/sdk/forms/src/test/java/com/klaviyo/forms/bridge/JwtObserverTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/bridge/JwtObserverTest.kt
@@ -1,0 +1,96 @@
+package com.klaviyo.forms.bridge
+
+import com.klaviyo.core.Registry
+import com.klaviyo.core.auth.AuthTokenException
+import com.klaviyo.core.auth.AuthTokenManager
+import com.klaviyo.core.auth.ValidatedToken
+import com.klaviyo.fixtures.BaseTest
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.CompletableDeferred
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class JwtObserverTest : BaseTest() {
+
+    private val mockAuthTokenManager = mockk<AuthTokenManager>()
+    private val mockJsBridge = mockk<JsBridge>(relaxed = true)
+
+    private fun validatedToken(rawToken: String): ValidatedToken =
+        ValidatedToken(rawToken = rawToken, expiresAtEpochSeconds = 0L, issuedAtEpochSeconds = 0L)
+
+    @Before
+    override fun setup() {
+        super.setup()
+        Registry.register<AuthTokenManager>(mockAuthTokenManager)
+        Registry.register<JsBridge>(mockJsBridge)
+    }
+
+    @After
+    override fun cleanup() {
+        Registry.unregister<AuthTokenManager>()
+        Registry.unregister<JsBridge>()
+        super.cleanup()
+    }
+
+    @Test
+    fun `startOn defaults to JsReady so JWT is delivered before profile`() {
+        assertEquals(NativeBridgeMessage.JsReady, JwtObserver().startOn)
+    }
+
+    @Test
+    fun `startObserver injects token when fetch succeeds`() {
+        val token = "header.payload.signature"
+        coEvery { mockAuthTokenManager.currentToken(any()) } returns validatedToken(token)
+
+        JwtObserver().startObserver()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        verify { mockJsBridge.jwtMutation(token) }
+    }
+
+    @Test
+    fun `startObserver injects null and logs debug when no provider registered`() {
+        coEvery { mockAuthTokenManager.currentToken(any()) } throws
+            AuthTokenException.NoProviderRegistered
+
+        JwtObserver().startObserver()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        verify { mockJsBridge.jwtMutation(null) }
+        verify { spyLog.debug(match { it.contains("Auth not enabled") }) }
+    }
+
+    @Test
+    fun `startObserver injects null and logs warning when fetch fails`() {
+        coEvery { mockAuthTokenManager.currentToken(any()) } throws
+            AuthTokenException.ValidationFailed("Malformed")
+
+        JwtObserver().startObserver()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        verify { mockJsBridge.jwtMutation(null) }
+        verify { spyLog.warning(match { it.contains("Auth token fetch failed") }) }
+    }
+
+    @Test
+    fun `stopObserver cancels in-flight fetch before injection`() {
+        val tokenCompletion = CompletableDeferred<ValidatedToken>()
+        coEvery { mockAuthTokenManager.currentToken(any()) } coAnswers { tokenCompletion.await() }
+
+        val observer = JwtObserver()
+        observer.startObserver()
+        dispatcher.scheduler.runCurrent()
+        coVerify(exactly = 1) { mockAuthTokenManager.currentToken(any()) }
+
+        observer.stopObserver()
+        tokenCompletion.complete(validatedToken("would-be-token"))
+        dispatcher.scheduler.advanceUntilIdle()
+
+        verify(inverse = true) { mockJsBridge.jwtMutation(any()) }
+    }
+}

--- a/sdk/forms/src/test/java/com/klaviyo/forms/bridge/JwtObserverTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/bridge/JwtObserverTest.kt
@@ -12,6 +12,8 @@ import io.mockk.verify
 import kotlinx.coroutines.CompletableDeferred
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
@@ -92,6 +94,40 @@ class JwtObserverTest : BaseTest() {
         dispatcher.scheduler.advanceUntilIdle()
 
         verify(inverse = true) { mockJsBridge.jwtMutation(any()) }
+    }
+
+    @Test
+    fun `startObserver completes jwtReady after successful injection`() {
+        val jwtReady = CompletableDeferred<Unit>()
+        coEvery { mockAuthTokenManager.currentToken(any()) } returns validatedToken("token")
+
+        JwtObserver(jwtReady).startObserver()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertTrue(jwtReady.isCompleted)
+        assertFalse(jwtReady.isCancelled)
+    }
+
+    @Test
+    fun `startObserver completes jwtReady even when auth is not enabled`() {
+        val jwtReady = CompletableDeferred<Unit>()
+        coEvery { mockAuthTokenManager.currentToken(any()) } throws
+            AuthTokenException.NoProviderRegistered
+
+        JwtObserver(jwtReady).startObserver()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertTrue(jwtReady.isCompleted)
+        assertFalse(jwtReady.isCancelled)
+    }
+
+    @Test
+    fun `stopObserver cancels jwtReady so ProfileMutationObserver awaiter is unblocked`() {
+        val jwtReady = CompletableDeferred<Unit>()
+
+        JwtObserver(jwtReady).stopObserver()
+
+        assertTrue(jwtReady.isCancelled)
     }
 
     @Test

--- a/sdk/forms/src/test/java/com/klaviyo/forms/bridge/JwtObserverTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/bridge/JwtObserverTest.kt
@@ -54,26 +54,26 @@ class JwtObserverTest : BaseTest() {
     }
 
     @Test
-    fun `startObserver injects null and logs debug when no provider registered`() {
+    fun `startObserver injects empty string and logs debug when no provider registered`() {
         coEvery { mockAuthTokenManager.currentToken(any()) } throws
             AuthTokenException.NoProviderRegistered
 
         JwtObserver().startObserver()
         dispatcher.scheduler.advanceUntilIdle()
 
-        verify { mockJsBridge.jwtMutation(null) }
+        verify { mockJsBridge.jwtMutation("") }
         verify { spyLog.debug(match { it.contains("Auth not enabled") }) }
     }
 
     @Test
-    fun `startObserver injects null and logs warning when fetch fails`() {
+    fun `startObserver injects empty string and logs warning when fetch fails`() {
         coEvery { mockAuthTokenManager.currentToken(any()) } throws
             AuthTokenException.ValidationFailed("Malformed")
 
         JwtObserver().startObserver()
         dispatcher.scheduler.advanceUntilIdle()
 
-        verify { mockJsBridge.jwtMutation(null) }
+        verify { mockJsBridge.jwtMutation("") }
         verify { spyLog.warning(match { it.contains("Auth token fetch failed") }) }
     }
 
@@ -92,5 +92,26 @@ class JwtObserverTest : BaseTest() {
         dispatcher.scheduler.advanceUntilIdle()
 
         verify(inverse = true) { mockJsBridge.jwtMutation(any()) }
+    }
+
+    @Test
+    fun `double startObserver cancels previous in-flight fetch`() {
+        val firstCompletion = CompletableDeferred<ValidatedToken>()
+        val secondToken = "second.token.value"
+        coEvery { mockAuthTokenManager.currentToken(any()) } coAnswers { firstCompletion.await() }
+
+        val observer = JwtObserver()
+        observer.startObserver()
+        dispatcher.scheduler.runCurrent()
+
+        // Second start before first fetch completes — should cancel the first job
+        coEvery { mockAuthTokenManager.currentToken(any()) } returns validatedToken(secondToken)
+        observer.startObserver()
+        firstCompletion.complete(validatedToken("first.token.value"))
+        dispatcher.scheduler.advanceUntilIdle()
+
+        // Only the second token should be injected
+        verify(exactly = 1) { mockJsBridge.jwtMutation(secondToken) }
+        verify(inverse = true) { mockJsBridge.jwtMutation("first.token.value") }
     }
 }

--- a/sdk/forms/src/test/java/com/klaviyo/forms/bridge/JwtObserverTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/bridge/JwtObserverTest.kt
@@ -11,8 +11,8 @@ import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.CompletableDeferred
 import org.junit.After
-import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotSame
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -41,7 +41,7 @@ class JwtObserverTest : BaseTest() {
 
     @Test
     fun `startOn defaults to JsReady so JWT is delivered before profile`() {
-        assertEquals(NativeBridgeMessage.JsReady, JwtObserver().startOn)
+        assert(JwtObserver().startOn == NativeBridgeMessage.JsReady)
     }
 
     @Test
@@ -98,36 +98,62 @@ class JwtObserverTest : BaseTest() {
 
     @Test
     fun `startObserver completes jwtReady after successful injection`() {
-        val jwtReady = CompletableDeferred<Unit>()
         coEvery { mockAuthTokenManager.currentToken(any()) } returns validatedToken("token")
 
-        JwtObserver(jwtReady).startObserver()
+        val observer = JwtObserver()
+        observer.startObserver()
         dispatcher.scheduler.advanceUntilIdle()
 
-        assertTrue(jwtReady.isCompleted)
-        assertFalse(jwtReady.isCancelled)
+        assertTrue(observer.jwtReady.isCompleted)
+        assertFalse(observer.jwtReady.isCancelled)
     }
 
     @Test
     fun `startObserver completes jwtReady even when auth is not enabled`() {
-        val jwtReady = CompletableDeferred<Unit>()
         coEvery { mockAuthTokenManager.currentToken(any()) } throws
             AuthTokenException.NoProviderRegistered
 
-        JwtObserver(jwtReady).startObserver()
+        val observer = JwtObserver()
+        observer.startObserver()
         dispatcher.scheduler.advanceUntilIdle()
 
-        assertTrue(jwtReady.isCompleted)
-        assertFalse(jwtReady.isCancelled)
+        assertTrue(observer.jwtReady.isCompleted)
+        assertFalse(observer.jwtReady.isCancelled)
     }
 
     @Test
-    fun `stopObserver cancels jwtReady so ProfileMutationObserver awaiter is unblocked`() {
-        val jwtReady = CompletableDeferred<Unit>()
+    fun `startObserver creates a fresh jwtReady each session so reinit is not broken`() {
+        coEvery { mockAuthTokenManager.currentToken(any()) } returns validatedToken("session-1")
+        val observer = JwtObserver()
+        val initialDeferred = observer.jwtReady
 
-        JwtObserver(jwtReady).stopObserver()
+        // First session
+        observer.startObserver()
+        dispatcher.scheduler.advanceUntilIdle()
+        val firstSessionDeferred = observer.jwtReady
+        assertNotSame(
+            "startObserver must replace jwtReady with a new deferred",
+            initialDeferred,
+            firstSessionDeferred
+        )
+        assertTrue(firstSessionDeferred.isCompleted)
 
-        assertTrue(jwtReady.isCancelled)
+        observer.stopObserver()
+
+        // Second session — must get a fresh, non-cancelled deferred
+        coEvery { mockAuthTokenManager.currentToken(any()) } returns validatedToken("session-2")
+        observer.startObserver()
+        dispatcher.scheduler.advanceUntilIdle()
+        val secondSessionDeferred = observer.jwtReady
+        assertNotSame(
+            "second startObserver must replace jwtReady again",
+            firstSessionDeferred,
+            secondSessionDeferred
+        )
+        assertTrue(secondSessionDeferred.isCompleted)
+        assertFalse(secondSessionDeferred.isCancelled)
+        verify(exactly = 1) { mockJsBridge.jwtMutation("session-1") }
+        verify(exactly = 1) { mockJsBridge.jwtMutation("session-2") }
     }
 
     @Test

--- a/sdk/forms/src/test/java/com/klaviyo/forms/bridge/JwtObserverTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/bridge/JwtObserverTest.kt
@@ -7,12 +7,14 @@ import com.klaviyo.core.auth.ValidatedToken
 import com.klaviyo.fixtures.BaseTest
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.CompletableDeferred
 import org.junit.After
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -122,38 +124,47 @@ class JwtObserverTest : BaseTest() {
     }
 
     @Test
-    fun `startObserver creates a fresh jwtReady each session so reinit is not broken`() {
+    fun `startObserver allocates a fresh jwtReady on reinit after the previous completed`() {
         coEvery { mockAuthTokenManager.currentToken(any()) } returns validatedToken("session-1")
         val observer = JwtObserver()
-        val initialDeferred = observer.jwtReady
 
-        // First session
         observer.startObserver()
         dispatcher.scheduler.advanceUntilIdle()
         val firstSessionDeferred = observer.jwtReady
-        assertNotSame(
-            "startObserver must replace jwtReady with a new deferred",
-            initialDeferred,
-            firstSessionDeferred
-        )
         assertTrue(firstSessionDeferred.isCompleted)
 
         observer.stopObserver()
 
-        // Second session — must get a fresh, non-cancelled deferred
         coEvery { mockAuthTokenManager.currentToken(any()) } returns validatedToken("session-2")
         observer.startObserver()
         dispatcher.scheduler.advanceUntilIdle()
         val secondSessionDeferred = observer.jwtReady
-        assertNotSame(
-            "second startObserver must replace jwtReady again",
-            firstSessionDeferred,
-            secondSessionDeferred
-        )
+        assertNotSame(firstSessionDeferred, secondSessionDeferred)
         assertTrue(secondSessionDeferred.isCompleted)
         assertFalse(secondSessionDeferred.isCancelled)
         verify(exactly = 1) { mockJsBridge.jwtMutation("session-1") }
         verify(exactly = 1) { mockJsBridge.jwtMutation("session-2") }
+    }
+
+    @Test
+    fun `startObserver reuses jwtReady when previous session is still in flight`() {
+        val firstCompletion = CompletableDeferred<ValidatedToken>()
+        coEvery { mockAuthTokenManager.currentToken(any()) } coAnswers { firstCompletion.await() }
+
+        val observer = JwtObserver()
+        val initialDeferred = observer.jwtReady
+
+        observer.startObserver()
+        dispatcher.scheduler.runCurrent()
+        assertSame(initialDeferred, observer.jwtReady)
+
+        coEvery { mockAuthTokenManager.currentToken(any()) } returns validatedToken("second")
+        observer.startObserver()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertSame(initialDeferred, observer.jwtReady)
+        assertTrue(observer.jwtReady.isCompleted)
+        verify(exactly = 1) { mockJsBridge.jwtMutation("second") }
     }
 
     @Test
@@ -175,5 +186,31 @@ class JwtObserverTest : BaseTest() {
         // Only the second token should be injected
         verify(exactly = 1) { mockJsBridge.jwtMutation(secondToken) }
         verify(inverse = true) { mockJsBridge.jwtMutation("first.token.value") }
+    }
+
+    @Test
+    fun `queued ui callback from a superseded fetch does not inject its stale token`() {
+        // In prod, runOnUiThread posts to the real UI thread. If currentToken returns synchronously
+        // (cached) the first fetch can queue its UI callback before the second startObserver runs.
+        // Override the relaxed runOnUiThread answer with a manual queue so the test can observe the
+        // queued ordering.
+        val uiQueue = mutableListOf<() -> Unit>()
+        every { mockThreadHelper.runOnUiThread(any()) } answers {
+            uiQueue.add(firstArg())
+        }
+
+        coEvery { mockAuthTokenManager.currentToken(any()) } returns validatedToken("stale")
+        val observer = JwtObserver()
+        observer.startObserver()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        coEvery { mockAuthTokenManager.currentToken(any()) } returns validatedToken("fresh")
+        observer.startObserver()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        uiQueue.forEach { it.invoke() }
+
+        verify(inverse = true) { mockJsBridge.jwtMutation("stale") }
+        verify(exactly = 1) { mockJsBridge.jwtMutation("fresh") }
     }
 }

--- a/sdk/forms/src/test/java/com/klaviyo/forms/bridge/KlaviyoJsBridgeTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/bridge/KlaviyoJsBridgeTest.kt
@@ -255,16 +255,16 @@ class KlaviyoJsBridgeTest : BaseTest() {
     }
 
     @Test
-    fun `jwtMutation with null token calls JS evaluator with null`() {
+    fun `jwtMutation with empty token calls JS evaluator with empty string`() {
         every { jsEvaluator.evaluateJavascript(any(), any()) } answers {
             secondArg<(Boolean) -> Unit>().invoke(true)
         }
 
-        bridge.jwtMutation(null)
+        bridge.jwtMutation("")
 
         verify {
             jsEvaluator.evaluateJavascript(
-                eq("""window.jwtMutation(null)"""),
+                eq("""window.jwtMutation("")"""),
                 any()
             )
         }

--- a/sdk/forms/src/test/java/com/klaviyo/forms/bridge/KlaviyoJsBridgeTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/bridge/KlaviyoJsBridgeTest.kt
@@ -237,4 +237,36 @@ class KlaviyoJsBridgeTest : BaseTest() {
             )
         }
     }
+
+    @Test
+    fun `jwtMutation calls JS evaluator with correct JS`() {
+        every { jsEvaluator.evaluateJavascript(any(), any()) } answers {
+            secondArg<(Boolean) -> Unit>().invoke(true)
+        }
+
+        bridge.jwtMutation("jwt.token.value")
+
+        verify {
+            jsEvaluator.evaluateJavascript(
+                eq("""window.jwtMutation("jwt.token.value")"""),
+                any()
+            )
+        }
+    }
+
+    @Test
+    fun `jwtMutation with null token calls JS evaluator with null`() {
+        every { jsEvaluator.evaluateJavascript(any(), any()) } answers {
+            secondArg<(Boolean) -> Unit>().invoke(true)
+        }
+
+        bridge.jwtMutation(null)
+
+        verify {
+            jsEvaluator.evaluateJavascript(
+                eq("""window.jwtMutation(null)"""),
+                any()
+            )
+        }
+    }
 }

--- a/sdk/forms/src/test/java/com/klaviyo/forms/bridge/ProfileMutationObserverAsyncTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/bridge/ProfileMutationObserverAsyncTest.kt
@@ -7,13 +7,12 @@ import com.klaviyo.fixtures.BaseTest
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import kotlinx.coroutines.CompletableDeferred
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
 
 /**
- * Tests for [ProfileMutationObserver] behaviour when a [jwtReady] deferred is provided —
+ * Tests for [ProfileMutationObserver] behaviour when a [JwtObserver] is provided —
  * i.e. the coordination path used by [KlaviyoObserverCollection] to prevent profile injection
  * from racing ahead of JWT delivery.
  */
@@ -41,15 +40,17 @@ class ProfileMutationObserverAsyncTest : BaseTest() {
 
     @Test
     fun `startObserver awaits jwtReady before injecting profile`() {
-        val jwtReady = CompletableDeferred<Unit>()
-        ProfileMutationObserver(jwtReady).startObserver()
+        // JwtObserver created but not started — jwtReady is the initial incomplete deferred,
+        // which we complete manually below to simulate JWT delivery.
+        val jwtObserver = JwtObserver()
+        ProfileMutationObserver(jwtObserver).startObserver()
         dispatcher.scheduler.runCurrent()
 
         // JWT not yet delivered — profile must not have been injected
         verify(inverse = true) { mockBridge.profileMutation(any()) }
 
         // JWT arrives — profile injection should now proceed
-        jwtReady.complete(Unit)
+        jwtObserver.jwtReady.complete(Unit)
         dispatcher.scheduler.advanceUntilIdle()
 
         verify(exactly = 1) { mockBridge.profileMutation(stubProfile) }
@@ -57,15 +58,34 @@ class ProfileMutationObserverAsyncTest : BaseTest() {
 
     @Test
     fun `startObserver does not inject profile if jwtReady is cancelled`() {
-        val jwtReady = CompletableDeferred<Unit>()
-        val observer = ProfileMutationObserver(jwtReady)
+        val jwtObserver = JwtObserver()
+        val observer = ProfileMutationObserver(jwtObserver)
         observer.startObserver()
         dispatcher.scheduler.runCurrent()
 
         // WebView destroyed before JWT delivered — deferred is cancelled
-        jwtReady.cancel()
+        jwtObserver.jwtReady.cancel()
         dispatcher.scheduler.advanceUntilIdle()
 
         verify(inverse = true) { mockBridge.profileMutation(any()) }
+    }
+
+    @Test
+    fun `startObserver works on reinit after stop — scope must not be permanently cancelled`() {
+        // Regression test: the old implementation called scope.cancel() in stopObserver(),
+        // which permanently destroyed the scope and made subsequent startObserver calls a no-op.
+        val jwtObserver = JwtObserver()
+        val observer = ProfileMutationObserver(jwtObserver)
+
+        // First session: start and immediately stop
+        observer.startObserver()
+        observer.stopObserver()
+
+        // Second session: should work even though stopObserver was previously called
+        observer.startObserver()
+        jwtObserver.jwtReady.complete(Unit)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        verify(exactly = 1) { mockBridge.profileMutation(stubProfile) }
     }
 }

--- a/sdk/forms/src/test/java/com/klaviyo/forms/bridge/ProfileMutationObserverAsyncTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/bridge/ProfileMutationObserverAsyncTest.kt
@@ -1,0 +1,71 @@
+package com.klaviyo.forms.bridge
+
+import com.klaviyo.analytics.model.Profile
+import com.klaviyo.analytics.state.State
+import com.klaviyo.core.Registry
+import com.klaviyo.fixtures.BaseTest
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.CompletableDeferred
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Tests for [ProfileMutationObserver] behaviour when a [jwtReady] deferred is provided —
+ * i.e. the coordination path used by [KlaviyoObserverCollection] to prevent profile injection
+ * from racing ahead of JWT delivery.
+ */
+class ProfileMutationObserverAsyncTest : BaseTest() {
+
+    private val stubProfile = Profile()
+    private val stateMock = mockk<State>(relaxed = true).apply {
+        every { getAsProfile() } returns stubProfile
+    }
+    private val mockBridge = mockk<JsBridge>(relaxed = true)
+
+    @Before
+    override fun setup() {
+        super.setup()
+        Registry.register<State>(stateMock)
+        Registry.register<JsBridge>(mockBridge)
+    }
+
+    @After
+    override fun cleanup() {
+        Registry.unregister<State>()
+        Registry.unregister<JsBridge>()
+        super.cleanup()
+    }
+
+    @Test
+    fun `startObserver awaits jwtReady before injecting profile`() {
+        val jwtReady = CompletableDeferred<Unit>()
+        ProfileMutationObserver(jwtReady).startObserver()
+        dispatcher.scheduler.runCurrent()
+
+        // JWT not yet delivered — profile must not have been injected
+        verify(inverse = true) { mockBridge.profileMutation(any()) }
+
+        // JWT arrives — profile injection should now proceed
+        jwtReady.complete(Unit)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        verify(exactly = 1) { mockBridge.profileMutation(stubProfile) }
+    }
+
+    @Test
+    fun `startObserver does not inject profile if jwtReady is cancelled`() {
+        val jwtReady = CompletableDeferred<Unit>()
+        val observer = ProfileMutationObserver(jwtReady)
+        observer.startObserver()
+        dispatcher.scheduler.runCurrent()
+
+        // WebView destroyed before JWT delivered — deferred is cancelled
+        jwtReady.cancel()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        verify(inverse = true) { mockBridge.profileMutation(any()) }
+    }
+}

--- a/sdk/forms/src/test/java/com/klaviyo/forms/bridge/ProfileMutationObserverAsyncTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/bridge/ProfileMutationObserverAsyncTest.kt
@@ -3,11 +3,15 @@ package com.klaviyo.forms.bridge
 import com.klaviyo.analytics.model.Profile
 import com.klaviyo.analytics.state.State
 import com.klaviyo.core.Registry
+import com.klaviyo.core.auth.AuthTokenManager
+import com.klaviyo.core.auth.ValidatedToken
 import com.klaviyo.fixtures.BaseTest
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.After
+import org.junit.Assert.assertNotSame
 import org.junit.Before
 import org.junit.Test
 
@@ -87,5 +91,38 @@ class ProfileMutationObserverAsyncTest : BaseTest() {
         dispatcher.scheduler.advanceUntilIdle()
 
         verify(exactly = 1) { mockBridge.profileMutation(stubProfile) }
+    }
+
+    @Test
+    fun `startObserver reads jwtReady fresh each session — regression for capture-at-construction`() {
+        val jwtObserver = JwtObserver()
+        val observer = ProfileMutationObserver(jwtObserver)
+        val sessionOneDeferred = jwtObserver.jwtReady
+
+        observer.startObserver()
+        sessionOneDeferred.cancel()
+        dispatcher.scheduler.advanceUntilIdle()
+        verify(inverse = true) { mockBridge.profileMutation(any()) }
+        observer.stopObserver()
+
+        val mockAuth = mockk<AuthTokenManager>()
+        coEvery { mockAuth.currentToken(any()) } returns ValidatedToken(
+            rawToken = "tok",
+            expiresAtEpochSeconds = 0L,
+            issuedAtEpochSeconds = 0L
+        )
+        Registry.register<AuthTokenManager>(mockAuth)
+        try {
+            jwtObserver.startObserver()
+            dispatcher.scheduler.advanceUntilIdle()
+            assertNotSame(sessionOneDeferred, jwtObserver.jwtReady)
+
+            observer.startObserver()
+            dispatcher.scheduler.advanceUntilIdle()
+
+            verify(exactly = 1) { mockBridge.profileMutation(stubProfile) }
+        } finally {
+            Registry.unregister<AuthTokenManager>()
+        }
     }
 }

--- a/sdk/forms/src/test/java/com/klaviyo/forms/bridge/ProfileObserverTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/bridge/ProfileObserverTest.kt
@@ -12,6 +12,7 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 
@@ -40,6 +41,11 @@ class ProfileObserverTest {
         Registry.register<JsBridge>(mockBridge)
         ProfileMutationObserver().startObserver()
         return mockBridge
+    }
+
+    @Test
+    fun `observer starts on HandShook so JWT is injected before profile`() {
+        assertEquals(NativeBridgeMessage.HandShook, ProfileMutationObserver().startOn)
     }
 
     @Test

--- a/sdk/forms/src/test/java/com/klaviyo/forms/webview/KlaviyoWebViewClientTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/webview/KlaviyoWebViewClientTest.kt
@@ -14,9 +14,6 @@ import androidx.core.view.ViewCompat
 import androidx.webkit.WebViewCompat
 import androidx.webkit.WebViewFeature
 import com.klaviyo.core.Registry
-import com.klaviyo.core.auth.AuthTokenException
-import com.klaviyo.core.auth.AuthTokenManager
-import com.klaviyo.core.auth.ValidatedToken
 import com.klaviyo.fixtures.BaseTest
 import com.klaviyo.fixtures.MockIntent
 import com.klaviyo.fixtures.mockDeviceProperties
@@ -28,8 +25,6 @@ import com.klaviyo.forms.bridge.NativeBridgeMessage
 import com.klaviyo.forms.bridge.compileJson
 import com.klaviyo.forms.presentation.PresentationManager
 import io.mockk.clearAllMocks
-import io.mockk.coEvery
-import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -38,7 +33,6 @@ import io.mockk.mockkStatic
 import io.mockk.runs
 import io.mockk.verify
 import java.io.ByteArrayInputStream
-import kotlinx.coroutines.CompletableDeferred
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -57,24 +51,24 @@ class KlaviyoWebViewClientTest : BaseTest() {
                   data-forms-data-environment='FORMS_ENVIRONMENT'
                   data-klaviyo-local-tracking="1"
                   data-klaviyo-profile="{}"
-                  data-klaviyo-jwt='JWT_TOKEN'
+                  data-klaviyo-jwt=''
             >
                 <meta charset="UTF-8">
                 <meta name="viewport"
                       content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0, viewport-fit=cover"/>
-            
+
                 <!--  This meta tag protects @imported fonts from being blocked by CORS  -->
                 <meta name="referrer" content="same-origin"/>
-            
+
                 <title>Klaviyo In-App Form Template</title>
-            
+
                 <!-- Load in JS helper functions from assets directory -->
                 <script type="text/javascript" src="file:///android_asset/onsite-bridge.js"></script>
-            
+
                 <!-- Static stylesheet for "websafe" fonts that may be unavailable or inconsistent from the system -->
                 <link rel="stylesheet" type="text/css"
                       href="https://static-forms.klaviyo.com/fonts/api/v1/in-app-web-fonts/websafe_fonts.css" crossorigin/>
-            
+
                 <!-- Placeholder script to load klaviyo.js -->
                 <script type="text/javascript" src="KLAVIYO_JS_URL"></script>
             </head>
@@ -82,13 +76,6 @@ class KlaviyoWebViewClientTest : BaseTest() {
             </html>
         """.trimIndent()
     }
-
-    private val mockAuthTokenManager = mockk<AuthTokenManager>()
-
-    // exp/iat are read by production logging in [KlaviyoAuthTokenManager] but not by the WebView
-    // injection path under test — any non-zero placeholder is fine for these tests.
-    private fun validatedToken(rawToken: String): ValidatedToken =
-        ValidatedToken(rawToken = rawToken, expiresAtEpochSeconds = 0L, issuedAtEpochSeconds = 0L)
 
     private val stubKlaviyoJs = "stubKlaviyoJs"
     private val mockKlaviyoJsUri = mockk<Uri>(relaxed = true).also {
@@ -130,10 +117,6 @@ class KlaviyoWebViewClientTest : BaseTest() {
         Registry.register<JsBridge>(mockJsBridge)
         Registry.register<JsBridgeObserverCollection>(mockObserverCollection)
         Registry.register<NativeBridge>(mockBridge)
-        // Default: no provider registered — form loads without auth token (JWT_TOKEN → "").
-        // Tests that need a fetch-failure outcome override this with a different exception type.
-        coEvery { mockAuthTokenManager.currentToken(any()) } throws AuthTokenException.NoProviderRegistered
-        Registry.register<AuthTokenManager>(mockAuthTokenManager)
         mockDeviceProperties()
         every { mockConfig.isDebugBuild } returns false
         every { mockContext.assets } returns mockAssets
@@ -178,7 +161,6 @@ class KlaviyoWebViewClientTest : BaseTest() {
     override fun cleanup() {
         Registry.unregister<NativeBridge>()
         Registry.unregister<JsBridgeObserverCollection>()
-        Registry.unregister<AuthTokenManager>()
         clearAllMocks()
         super.cleanup()
     }
@@ -513,148 +495,5 @@ class KlaviyoWebViewClientTest : BaseTest() {
         every { mockConfig.assetSource } returns "test-asset-source"
         KlaviyoWebViewClient().onPageFinished(mockWebview, "https://example.com")
         verify { spyLog.debug(any()) }
-    }
-
-    @Test
-    fun `initializeWebView injects auth token into data-klaviyo-jwt when token is available`() {
-        val fakeToken = "header.payload.signature"
-        coEvery { mockAuthTokenManager.currentToken(any()) } returns validatedToken(fakeToken)
-
-        val client = KlaviyoWebViewClient()
-        client.initializeWebView()
-        dispatcher.scheduler.advanceUntilIdle()
-
-        verify {
-            anyConstructed<KlaviyoWebView>().loadTemplate(
-                match { it.contains("data-klaviyo-jwt='$fakeToken'") },
-                client,
-                mockBridge
-            )
-        }
-        verify { spyLog.debug(match { it.contains("Auth token injected") }) }
-    }
-
-    @Test
-    fun `initializeWebView does not log injected token when stale webview skips template load`() {
-        val fakeToken = "header.payload.signature"
-        coEvery { mockAuthTokenManager.currentToken(any()) } returns validatedToken(fakeToken)
-
-        val client = KlaviyoWebViewClient()
-        var firstUiDispatch = true
-        every { mockThreadHelper.runOnUiThread(any()) } answers {
-            val runnable = firstArg<() -> Unit>()
-            if (firstUiDispatch) {
-                firstUiDispatch = false
-                client.destroyWebView()
-            }
-            runnable.invoke()
-        }
-
-        client.initializeWebView()
-        dispatcher.scheduler.advanceUntilIdle()
-
-        verify(inverse = true) { anyConstructed<KlaviyoWebView>().loadTemplate(any(), any(), any()) }
-        verify {
-            spyLog.debug(
-                match { it.contains("Skipping IAF template load: WebView no longer current") }
-            )
-        }
-        verify(inverse = true) { spyLog.debug(match { it.contains("Auth token injected at load") }) }
-    }
-
-    @Test
-    fun `initializeWebView logs debug and proceeds without token when no provider is registered`() {
-        // Default mock throws NoProviderRegistered — the expected state for apps not using JWT
-        // auth. Should be a quiet diagnostic, not a warning.
-        val client = KlaviyoWebViewClient()
-        client.initializeWebView()
-        dispatcher.scheduler.advanceUntilIdle()
-
-        verify {
-            anyConstructed<KlaviyoWebView>().loadTemplate(
-                match { it.contains("data-klaviyo-jwt=''") },
-                client,
-                mockBridge
-            )
-        }
-        verify { spyLog.debug(match { it.contains("Auth not enabled") }) }
-        verify(inverse = true) { spyLog.warning(match { it.contains("Auth token fetch failed") }) }
-    }
-
-    @Test
-    fun `initializeWebView logs warning and proceeds without token when provider fetch fails`() {
-        // Provider IS registered but its fetch fails — degraded functionality with fallback,
-        // appropriate for a warning. ValidationFailed stands in for any non-NoProviderRegistered
-        // AuthTokenException; a plain RuntimeException would hit the same branch.
-        coEvery { mockAuthTokenManager.currentToken(any()) } throws
-            AuthTokenException.ValidationFailed("Malformed")
-
-        val client = KlaviyoWebViewClient()
-        client.initializeWebView()
-        dispatcher.scheduler.advanceUntilIdle()
-
-        verify {
-            anyConstructed<KlaviyoWebView>().loadTemplate(
-                match { it.contains("data-klaviyo-jwt=''") },
-                client,
-                mockBridge
-            )
-        }
-        verify { spyLog.warning(match { it.contains("Auth token fetch failed") }) }
-        verify(inverse = true) { spyLog.debug(match { it.contains("Auth not enabled") }) }
-    }
-
-    @Test
-    fun `initializeWebView HTML-escapes special characters in auth token value`() {
-        val mischievousToken = "a&b'c<d"
-        coEvery { mockAuthTokenManager.currentToken(any()) } returns validatedToken(
-            mischievousToken
-        )
-
-        val client = KlaviyoWebViewClient()
-        client.initializeWebView()
-        dispatcher.scheduler.advanceUntilIdle()
-
-        verify {
-            anyConstructed<KlaviyoWebView>().loadTemplate(
-                match { html ->
-                    html.contains("data-klaviyo-jwt='a&amp;b&#x27;c&lt;d'") &&
-                        !html.contains("data-klaviyo-jwt='a&b'c<d'")
-                },
-                client,
-                mockBridge
-            )
-        }
-    }
-
-    @Test
-    fun `destroyWebView cancels in-flight initJob during auth token fetch`() {
-        val tokenCompletion = CompletableDeferred<ValidatedToken>()
-        coEvery { mockAuthTokenManager.currentToken(any()) } coAnswers { tokenCompletion.await() }
-
-        val client = KlaviyoWebViewClient()
-        client.initializeWebView()
-        dispatcher.scheduler.runCurrent()
-        coVerify(exactly = 1) { mockAuthTokenManager.currentToken(any()) }
-
-        client.destroyWebView()
-        tokenCompletion.complete(validatedToken("would-be-token"))
-        dispatcher.scheduler.advanceUntilIdle()
-
-        verify(inverse = true) { anyConstructed<KlaviyoWebView>().loadTemplate(any(), any(), any()) }
-        // Stale-ref log absence proves cancellation killed the coroutine at the suspension point
-        // rather than the guard catching a non-cancelled stale completion.
-        verify(inverse = true) { spyLog.debug(match { it.contains("no longer current") }) }
-    }
-
-    @Test
-    fun `destroyWebView before coroutine starts cancels initJob and prevents loadTemplate`() {
-        val client = KlaviyoWebViewClient()
-        client.initializeWebView()
-        client.destroyWebView()
-        dispatcher.scheduler.advanceUntilIdle()
-
-        verify(inverse = true) { anyConstructed<KlaviyoWebView>().loadTemplate(any(), any(), any()) }
-        coVerify(exactly = 0) { mockAuthTokenManager.currentToken(any()) }
     }
 }


### PR DESCRIPTION
## Summary

Delivers the JWT to the In-App Forms WebView over the JS bridge (`window.jwtMutation`) at an explicit, ordered trigger point, instead of injecting it as a static `data-klaviyo-jwt` HTML attribute before load.

### Root cause this fixes
The old approach set `data-klaviyo-jwt` statically before the page loaded. Fender's `startJwtMutationObserver` reads that attribute at module init and calls `setJWT(token)` — but `profileIdentifiers` is still null at that point, so the authenticated `GET /api/profiles/` fetch never fires. Profile is delivered dynamically at `HandShook` while JWT was delivered statically, and the mismatched ordering broke personalization.

### Approach
Deliver JWT and profile through the same `evaluateJavascript` mechanism, ordered so JWT lands first:
1. **JsReady** → `JwtObserver` calls `window.jwtMutation(token)` → sets `data-klaviyo-jwt`
2. **HandShook** → `ProfileMutationObserver` calls `window.profileMutation(...)` → onsite sees the JWT already present → triggers the fetch

## Changes
- **`klaviyo-js-bridge.js`**: add `window.jwtMutation(token)` (mirrors `window.profileMutation`)
- **`JsBridge` / `KlaviyoJsBridge`**: add `jwtMutation(token: String?)` using the existing `HelperFunction.jwtMutation` enum entry
- **`JwtObserver`** (new): `startOn = JsReady`; fetches from `AuthTokenManager.currentToken(INTERACTIVE_FETCH_TIMEOUT_MS)` and injects on the UI thread. `NoProviderRegistered` → null/debug; other failures → null/warning; cancellation propagated
- **`KlaviyoObserverCollection`**: `JwtObserver` ordered before `ProfileMutationObserver`
- **`ProfileMutationObserver`**: `startOn = HandShook` (documented rationale)
- **`KlaviyoWebViewClient`**: removed the async JWT-at-load path (`loadTemplateWithAuthToken`, `scope`, `initJob`, `JWT_TOKEN_PLACEHOLDER`, `escapeForHtmlAttribute`, `AuthOutcome`); template loads synchronously again
- **`InAppFormsTemplate.html`**: `data-klaviyo-jwt='JWT_TOKEN'` → `data-klaviyo-jwt=''`

### Re: PR #466 discussion
- Kept the `<script src="file:///android_asset/klaviyo-js-bridge.js">` tag — **not** inlined
- The `ProfileMutationObserver.startOn = HandShook` move is the justified version this ticket exists to land; basic form display was never broken, only the JWT-gated personalization fetch

Live JWT refresh on token rotation is out of scope (MAGE-630).

## Test plan
- [x] `./gradlew :sdk:forms:testDebugUnitTest` — all pass
- [x] `./gradlew :sdk:forms:ktlintCheck` — clean
- [ ] Manual (Chrome DevTools): set email before opening a form, confirm `data-klaviyo-jwt` set at JsReady, `data-klaviyo-profile` at HandShook, and `GET /api/profiles/?filter=equals(email,...)` fires; confirm no fetch when no profile / no provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Asynchronous JWT delivery via the JS bridge so the JWT is applied before profile injection.

* **Refactor**
  * Streamlined webview initialization and switched rendered templates to include an explicit empty-JWT placeholder by default.

* **Tests**
  * Added comprehensive tests for JWT delivery, observer ordering, and profile-injection coordination; removed legacy JWT-fetch tests tied to the previous init flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->