### PR TITLE
ci: drop path_instructions from CodeRabbit config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -8,28 +8,3 @@ reviews:
     drafts: false
     base_branches:
       - ".*"
-
-  path_instructions:
-    - path: "**"
-      instructions: |
-        # Bugbot Configuration
-        
-        ## Primary Instructions
-        
-        **Read the main AI agent guidelines in `/AGENTS.md`** - this file contains comprehensive guidance on:
-        - Project architecture and module structure
-        - Build, test, and lint commands
-        - Code style and conventions
-        - Testing best practices
-        
-        ## Additional Bugbot-Specific Rules
-        - The pull request description should use the repository's PR template
-        - Avoid wildcard imports
-        - Avoid fully qualified names inline
-        - Avoid lateinit unless absolutely necessary
-        - Do not use `!!` to get around nullability checks
-        - Extract duplicated logic into shared utilities
-        - Proper exception handling in public API surfaces
-        - Verify log statements use the correct severity level per AGENTS.md guidelines
-        - Tests should generally verify log level, not exact message strings to avoid brittle tests
-        - Verify public APIs are callable from Java (see Java Interoperability section in AGENTS.md)


### PR DESCRIPTION
The BugBot instructions folded into `.coderabbit.yaml` were a verbatim copy and added no value, so this removes the whole `reviews.path_instructions` block. The rest of the CodeRabbit config is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration settings to streamline development processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->