### PR TITLE
fix(auth): CodeRabbit review fixes for AuthTokenManager

### DIFF
--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -305,25 +305,14 @@ object Klaviyo {
      */
     @JvmStatic
     fun resetProfile() = safeApply {
-        Registry.get<State>().reset()
-        // Two-step auth cleanup for the outgoing profile:
-        //
-        // Step 1 — invalidate() is SYNCHRONOUS. It immediately bumps the auth manager's profile
-        // generation, causing any in-flight proactive refresh to skip its observer notification
-        // even before the async clear has had a chance to run. This closes the race where a
-        // scheduled refresh completes in the window between State.reset() and clearTokenState().
-        //
-        // Step 2 — clearTokenState(gen) is ASYNC (fire-and-forget). It discards the cached token
-        // and cancels the scheduled refresh job. Passing the generation captured from invalidate()
-        // makes the clear conditional: if registerAuthTokenProvider() is called before the
-        // coroutine runs, profileGeneration advances past gen and the clear is skipped, preserving
-        // the new session's token state (registerProvider does its own full reset).
-        //
-        // Scope: KlaviyoAuthTokenManager.scope is internal and unreachable from this module, so
-        // we create a short-lived scope (matching the pattern in KlaviyoApiClient / DeepLinking).
-        // clearTokenState() is fast (mutex + cancellations), so the scope is GC'd promptly.
+        // invalidate() runs first (synchronous) so any in-flight proactive refresh completing in
+        // the gap before State.reset() sees profileResetPending=true and skips observer dispatch.
         val auth = Registry.get<AuthTokenManager>()
         val gen = auth.invalidate()
+        Registry.get<State>().reset()
+        // clearTokenState(gen) is fire-and-forget. Passing the captured generation makes it
+        // conditional: if registerAuthTokenProvider() runs first, profileGeneration has advanced
+        // and the clear is skipped, preserving the new session's token state.
         CoroutineScope(Registry.dispatcher).safeLaunch {
             auth.clearTokenState(expectedGeneration = gen)
         }

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
@@ -505,7 +505,7 @@ internal class KlaviyoTest : BaseTest() {
         Klaviyo.resetProfile()
         dispatcher.scheduler.advanceUntilIdle()
         verify(exactly = 1) { mockAuthTokenManager.invalidate() }
-        coVerify(exactly = 1) { mockAuthTokenManager.clearTokenState(any()) }
+        coVerify(exactly = 1) { mockAuthTokenManager.clearTokenState(expectedGeneration = 1L) }
     }
 
     @Test

--- a/sdk/core/src/main/java/com/klaviyo/core/auth/AuthTokenManager.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/AuthTokenManager.kt
@@ -73,8 +73,9 @@ interface AuthTokenManager {
      *
      * Multiple observers are supported. Each is invoked on the manager's internal dispatcher
      * (IO); the observer is responsible for any thread handoff it needs (e.g. hopping to the UI
-     * thread for WebView calls). Dispatch is best-effort: if an observer throws, the exception is
-     * logged at WARNING and remaining observers are still called.
+     * thread for WebView calls). Dispatch is best-effort: if an observer throws an [Exception], it
+     * is logged at WARNING and remaining observers are still called.
+     * [kotlinx.coroutines.CancellationException] is rethrown per structured-concurrency contract.
      *
      * Registration is by reference — pass the same lambda instance to [offTokenRefresh] to
      * unregister. Duplicate registrations (same instance) add the observer twice.

--- a/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
@@ -400,10 +400,10 @@ internal class KlaviyoAuthTokenManager(
             } catch (e: CancellationException) {
                 // Structured-concurrency contract: CancellationException must never be swallowed.
                 throw e
-            } catch (e: Throwable) {
+            } catch (e: Exception) {
                 // Best-effort dispatch: log and continue so a misbehaving observer cannot block
-                // others from receiving the token. Catching Throwable (not just Exception) ensures
-                // an observer throwing an Error (e.g. AssertionError) also doesn't escape the loop.
+                // others from receiving the token. JVM-fatal Errors (OOM, StackOverflowError, etc.)
+                // are intentionally NOT caught here — they should propagate.
                 Registry.log.warning(
                     "TokenRefreshObserver threw ${e.javaClass.simpleName} — skipping",
                     e

--- a/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerRefreshTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerRefreshTest.kt
@@ -632,7 +632,7 @@ class KlaviyoAuthTokenManagerRefreshTest : BaseTest() {
         staticClock.execute(timerTask.time - staticClock.time)
         dispatcher.scheduler.advanceUntilIdle()
 
-        verify { spyLog.warning(match { it.contains("TokenRefreshObserver threw") }, any()) }
+        verify { spyLog.warning(any(), any()) }
         assertEquals("second observer should still receive jwt", 1, receivedBySecond.size)
     }
 
@@ -721,16 +721,14 @@ class KlaviyoAuthTokenManagerRefreshTest : BaseTest() {
         assertEquals("retained provider should serve the next fetch", 2, provider.callCount)
 
         // Observer is retained: fire a new proactive refresh and verify it fires
-        val timerTask = staticClock.scheduledTasks.firstOrNull()
-        if (timerTask != null) {
-            staticClock.execute(timerTask.time - staticClock.time)
-            dispatcher.scheduler.advanceUntilIdle()
-            assertEquals(
-                "retained observer should receive jwt from post-reset refresh",
-                1,
-                received.size
-            )
-        }
+        val timerTask = staticClock.scheduledTasks.first()
+        staticClock.execute(timerTask.time - staticClock.time)
+        dispatcher.scheduler.advanceUntilIdle()
+        assertEquals(
+            "retained observer should receive jwt from post-reset refresh",
+            1,
+            received.size
+        )
     }
 
     @Test


### PR DESCRIPTION
## Summary

Addresses 6 CodeRabbit findings on the `AuthTokenManager` PR:

1. **Race fix in `resetProfile()`** — `auth.invalidate()` now runs before `State.reset()`. Previously a proactive refresh completing between `State.reset()` and `auth.invalidate()` would see `profileResetPending=false` and dispatch the outgoing profile's JWT to observers. The reordering ensures the flag is set before state is cleared.

2. **`catch (Throwable)` → `catch (Exception)` in `notifyRefreshObservers`** — JVM-fatal errors (OOM, StackOverflowError) should propagate rather than being logged and swallowed. `CancellationException` already has its own rethrow guard above.

3. **KDoc for `onTokenRefresh`** — Clarifies that `CancellationException` is rethrown per structured-concurrency contract, not just "any exception is caught."

4. **Pin `expectedGeneration=1L` in `KlaviyoTest`** — The `invalidate()` stub returns `1L`; asserting the specific value rather than `any()` makes the test catch a regression if the stub or production call changes.

5. **`firstOrNull()` → `first()` in retain-observers test** — A timer task is guaranteed to exist at that point in the test (the fetch just completed and `doFetch` schedules a refresh). Using `first()` lets the test fail with a clear `NoSuchElementException` rather than silently skipping the assertion.

6. **Relax warning-log assertion** — Drops the `match { it.contains("TokenRefreshObserver threw") }` substring pin in favour of `any()`, consistent with the project guideline of verifying log level rather than exact message content.

## Test plan

- [x] `./gradlew :sdk:core:testDebugUnitTest --tests "com.klaviyo.core.auth.KlaviyoAuthTokenManagerRefreshTest"`
- [x] `./gradlew :sdk:analytics:testDebugUnitTest --tests "com.klaviyo.analytics.KlaviyoTest"`
- [x] `./gradlew :sdk:core:ktlintCheck :sdk:analytics:ktlintCheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved auth token cleanup sequence during profile reset to prevent race conditions.
  * Enhanced exception handling in token refresh observer notifications for better resilience.

* **Documentation**
  * Clarified token refresh observer behavior and exception handling policies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->