### PR TITLE
fix(auth): address connectivity retry race conditions and test quality

### DIFF
--- a/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
@@ -400,6 +400,11 @@ internal class KlaviyoAuthTokenManager(
         timerGeneration: Long? = null,
         allowImmediateConnectivityRetry: Boolean = true
     ) {
+        // Snapshot the profile generation before we suspend into the network fetch. If a profile
+        // transition (registerProvider / invalidate / clearTokenState) fires while we are awaiting
+        // the network response, the catch block below must not arm a connectivity job on behalf of
+        // the now-stale session. Comparing against the snapshot lets us detect that case cheaply.
+        val profileGenerationAtStart = profileGeneration.get()
         if (provider == null) return
         Registry.log.info("Proactive token refresh fired")
         try {
@@ -426,7 +431,11 @@ internal class KlaviyoAuthTokenManager(
         } catch (e: Exception) {
             if (timerGeneration != null) clearFiredFlagForFailedRefresh(timerGeneration)
             Registry.log.warning("Proactive token refresh failed: ${e.javaClass.simpleName}", e)
-            if (isNetworkException(e) && provider != null && !profileResetPending) {
+            if (profileGeneration.get() == profileGenerationAtStart &&
+                isNetworkException(e) &&
+                provider != null &&
+                !profileResetPending
+            ) {
                 armConnectivityWaitJob(
                     resumeImmediatelyIfConnected = allowImmediateConnectivityRetry
                 )

--- a/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
@@ -396,7 +396,10 @@ internal class KlaviyoAuthTokenManager(
      * On failure does NOT reschedule; one foreground-transition retry is possible if
      * [refreshAtWallClockMs] was not yet cleared (timer fired but fetch failed).
      */
-    private suspend fun performScheduledRefresh(timerGeneration: Long? = null) {
+    private suspend fun performScheduledRefresh(
+        timerGeneration: Long? = null,
+        allowImmediateConnectivityRetry: Boolean = true
+    ) {
         if (provider == null) return
         Registry.log.info("Proactive token refresh fired")
         try {
@@ -424,7 +427,9 @@ internal class KlaviyoAuthTokenManager(
             if (timerGeneration != null) clearFiredFlagForFailedRefresh(timerGeneration)
             Registry.log.warning("Proactive token refresh failed: ${e.javaClass.simpleName}", e)
             if (isNetworkException(e) && provider != null && !profileResetPending) {
-                armConnectivityWaitJob()
+                armConnectivityWaitJob(
+                    resumeImmediatelyIfConnected = allowImmediateConnectivityRetry
+                )
             }
         }
     }
@@ -476,18 +481,25 @@ internal class KlaviyoAuthTokenManager(
 
     /**
      * Arms [connectivityWaitJob]: a single coroutine on [scope] that suspends until the next
-     * "connectivity available" notification from [Registry.networkMonitor] (or immediately if
-     * already connected), then triggers a proactive refresh via [performScheduledRefresh].
+     * "connectivity available" notification from [Registry.networkMonitor], then triggers a
+     * proactive refresh via [performScheduledRefresh].
      *
      * At most one job is active at a time. All [connectivityWaitJob] and
      * [connectivityWaitGeneration] transitions are serialized via [connectivityWaitLock] so that
      * concurrent calls (rapid flap) and racing teardown from [registerProvider]/[clearTokenState]
      * cannot leave multiple active jobs or a stale assignment.
      *
+     * @param resumeImmediatelyIfConnected When true (the default), the job resumes immediately if
+     * the device is already connected — [Registry.networkMonitor] does not replay state on observer
+     * registration. Pass false from the connectivity-retry path to prevent a tight loop: if the
+     * provider keeps failing with a network exception while the device stays online, a re-armed job
+     * with [resumeImmediatelyIfConnected]=false waits for an actual connectivity transition before
+     * retrying again.
+     *
      * Only invoked from the proactive-refresh failure path ([performScheduledRefresh]); demand
      * callers via [currentToken] are not retried here — they surface the error to their own caller.
      */
-    private fun armConnectivityWaitJob() {
+    private fun armConnectivityWaitJob(resumeImmediatelyIfConnected: Boolean = true) {
         Registry.log.info(
             "AuthTokenManager: network failure — waiting for connectivity to retry refresh"
         )
@@ -521,7 +533,11 @@ internal class KlaviyoAuthTokenManager(
                         }
                         // Resume immediately if already online — networkMonitor does not replay
                         // state on registration (handles SocketTimeoutException on live network).
-                        if (Registry.networkMonitor.isNetworkConnected() &&
+                        // Skip on re-arm (resumeImmediatelyIfConnected=false) to prevent a tight
+                        // loop when the provider keeps failing with IOException while the device
+                        // stays connected; in that case we wait for an actual connectivity event.
+                        if (resumeImmediatelyIfConnected &&
+                            Registry.networkMonitor.isNetworkConnected() &&
                             resumed.compareAndSet(false, true)
                         ) {
                             Registry.networkMonitor.offNetworkChange(observer)
@@ -534,7 +550,10 @@ internal class KlaviyoAuthTokenManager(
                     // Cancellation checkpoint: registerProvider()/clearTokenState() may have
                     // cancelled this job after the connectivity event fired but before we retry.
                     currentCoroutineContext().ensureActive()
-                    performScheduledRefresh()
+                    // Pass allowImmediateConnectivityRetry=false so that if this retry also fails
+                    // with a network exception, the re-armed job will NOT immediately resume on an
+                    // already-connected device — avoiding a tight retry loop.
+                    performScheduledRefresh(allowImmediateConnectivityRetry = false)
                 } finally {
                     // Only clear the field if the generation still matches — a concurrent
                     // re-arm may have replaced this job; if so leave the new job in place.

--- a/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
@@ -431,17 +431,32 @@ internal class KlaviyoAuthTokenManager(
         } catch (e: Exception) {
             if (timerGeneration != null) clearFiredFlagForFailedRefresh(timerGeneration)
             Registry.log.warning("Proactive token refresh failed: ${e.javaClass.simpleName}", e)
-            if (profileGeneration.get() == profileGenerationAtStart &&
-                isNetworkException(e) &&
-                provider != null &&
-                !profileResetPending
-            ) {
+            if (shouldArmConnectivityRetry(e, profileGenerationAtStart)) {
                 armConnectivityWaitJob(
                     resumeImmediatelyIfConnected = allowImmediateConnectivityRetry
                 )
             }
         }
     }
+
+    /**
+     * Returns true when a proactive-refresh failure should trigger a connectivity wait job.
+     *
+     * All four conditions must hold:
+     * - [profileGeneration] matches [generationAtStart]: no profile transition (registerProvider /
+     *   invalidate / clearTokenState) occurred while the refresh was suspended. Without this check,
+     *   a stale failure could arm a retry job for an already-replaced session.
+     * - The exception is a transient network error ([isNetworkException]): server errors and
+     *   validation failures should not trigger a connectivity retry.
+     * - [provider] is still set: a concurrent teardown may have cleared it.
+     * - No profile reset is pending ([profileResetPending]): guards against the window between
+     *   invalidate() and clearTokenState() where the flag is still true.
+     */
+    private fun shouldArmConnectivityRetry(exception: Exception, generationAtStart: Long): Boolean =
+        profileGeneration.get() == generationAtStart &&
+            isNetworkException(exception) &&
+            provider != null &&
+            !profileResetPending
 
     /**
      * Iterates [refreshObservers] and invokes each with [jwt]. Best-effort: if an observer throws,

--- a/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
@@ -85,6 +85,13 @@ internal class KlaviyoAuthTokenManager(
     // Deliberately separate from refreshGeneration (which scheduleRefresh() also bumps).
     private val profileGeneration = AtomicLong(0L)
 
+    // Tracks logout/reset events only: incremented by invalidate() and clearTokenState(), but NOT
+    // by registerProvider(). Used by shouldArmConnectivityRetry to distinguish a stale failure from
+    // a logout-triggered reset vs. a benign mid-fetch provider swap. profileGeneration is too coarse
+    // for this check because registerProvider() also bumps it, which would wrongly block
+    // connectivity retry for the new session when a provider is swapped mid-fetch.
+    private val resetGeneration = AtomicLong(0L)
+
     // Set to true by invalidate() and reset to false by registerProvider() and clearTokenState().
     // Read by performScheduledRefresh just before notifying observers: if a profile reset is
     // pending (i.e. invalidate() was called but clearTokenState() hasn't finished yet), the
@@ -160,6 +167,9 @@ internal class KlaviyoAuthTokenManager(
         // Set the flag before bumping the generation so that any performScheduledRefresh that
         // reads the flag after this call (regardless of when its fetch started) will skip observers.
         profileResetPending = true
+        // Also bump resetGeneration so shouldArmConnectivityRetry can detect a logout-triggered
+        // failure even after clearTokenState() has cleared profileResetPending.
+        resetGeneration.incrementAndGet()
         return profileGeneration.incrementAndGet()
     }
 
@@ -185,6 +195,10 @@ internal class KlaviyoAuthTokenManager(
             cancelConnectivityWaitJob()
             cachedToken = null
             profileGeneration.incrementAndGet()
+            // Also advance resetGeneration so that any performScheduledRefresh that started before
+            // this clear cannot arm a zombie connectivity job even when profileResetPending has been
+            // cleared by the time its catch block executes.
+            resetGeneration.incrementAndGet()
             // Clear the reset-pending flag so the next successful refresh (from a new or retained
             // provider) can notify observers normally.
             profileResetPending = false
@@ -400,11 +414,13 @@ internal class KlaviyoAuthTokenManager(
         timerGeneration: Long? = null,
         allowImmediateConnectivityRetry: Boolean = true
     ) {
-        // Snapshot the profile generation before we suspend into the network fetch. If a profile
-        // transition (registerProvider / invalidate / clearTokenState) fires while we are awaiting
-        // the network response, the catch block below must not arm a connectivity job on behalf of
-        // the now-stale session. Comparing against the snapshot lets us detect that case cheaply.
-        val profileGenerationAtStart = profileGeneration.get()
+        // Snapshot the reset generation before suspending into the network fetch. If a logout or
+        // token-state clear (invalidate / clearTokenState) fires while the fetch is in progress,
+        // the catch block must not arm a connectivity retry for the now-stale session. We use
+        // resetGeneration rather than profileGeneration so that a benign provider swap
+        // (registerProvider without a logout) does not falsely suppress the retry for the new
+        // session — registerProvider does not bump resetGeneration.
+        val resetGenerationAtStart = resetGeneration.get()
         if (provider == null) return
         Registry.log.info("Proactive token refresh fired")
         try {
@@ -431,7 +447,7 @@ internal class KlaviyoAuthTokenManager(
         } catch (e: Exception) {
             if (timerGeneration != null) clearFiredFlagForFailedRefresh(timerGeneration)
             Registry.log.warning("Proactive token refresh failed: ${e.javaClass.simpleName}", e)
-            if (shouldArmConnectivityRetry(e, profileGenerationAtStart)) {
+            if (shouldArmConnectivityRetry(e, resetGenerationAtStart)) {
                 armConnectivityWaitJob(
                     resumeImmediatelyIfConnected = allowImmediateConnectivityRetry
                 )
@@ -443,17 +459,22 @@ internal class KlaviyoAuthTokenManager(
      * Returns true when a proactive-refresh failure should trigger a connectivity wait job.
      *
      * All four conditions must hold:
-     * - [profileGeneration] matches [generationAtStart]: no profile transition (registerProvider /
-     *   invalidate / clearTokenState) occurred while the refresh was suspended. Without this check,
-     *   a stale failure could arm a retry job for an already-replaced session.
+     * - [resetGeneration] matches [resetGenerationAtStart]: no logout or state-clear
+     *   (invalidate / clearTokenState) occurred while the refresh was suspended. We use
+     *   [resetGeneration] rather than [profileGeneration] so that a benign provider swap
+     *   (registerProvider without a logout) does not falsely suppress retry — registerProvider
+     *   does not bump [resetGeneration].
      * - The exception is a transient network error ([isNetworkException]): server errors and
      *   validation failures should not trigger a connectivity retry.
      * - [provider] is still set: a concurrent teardown may have cleared it.
      * - No profile reset is pending ([profileResetPending]): guards against the window between
      *   invalidate() and clearTokenState() where the flag is still true.
      */
-    private fun shouldArmConnectivityRetry(exception: Exception, generationAtStart: Long): Boolean =
-        profileGeneration.get() == generationAtStart &&
+    private fun shouldArmConnectivityRetry(
+        exception: Exception,
+        resetGenerationAtStart: Long
+    ): Boolean =
+        resetGeneration.get() == resetGenerationAtStart &&
             isNetworkException(exception) &&
             provider != null &&
             !profileResetPending

--- a/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
@@ -12,6 +12,7 @@ import java.net.ConnectException
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
 import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
@@ -96,10 +97,9 @@ internal class KlaviyoAuthTokenManager(
     private val refreshObservers = CopyOnWriteArrayList<TokenRefreshObserver>()
 
     // A pending coroutine that waits for connectivity to be restored before retrying
-    // performScheduledRefresh. At most one is active at a time; any existing job is cancelled before
-    // arming a new one (prevents job accumulation on rapid flap). Cleared once the wait resolves or
-    // is cancelled. Guarded by mutex writes inside clearTokenState; @Volatile for reads in
-    // armConnectivityWaitJob (outside the mutex) so cancel() is visible to the newly-starting job.
+    // performScheduledRefresh. At most one is active at a time. All transitions to this field and
+    // to connectivityWaitGeneration are serialized via connectivityWaitLock. @Volatile for
+    // visibility to tests that read the field outside any lock.
     // Internal (not private) so tests in this module can inspect job state without reflection.
     @Volatile internal var connectivityWaitJob: Job? = null
 
@@ -107,6 +107,18 @@ internal class KlaviyoAuthTokenManager(
     // job's finally block to detect whether a newer arm replaced it; if so the old job must not
     // null out the new job's reference. AtomicLong for the same reason as refreshGeneration.
     private val connectivityWaitGeneration = AtomicLong(0L)
+
+    // JVM lock serializing all connectivityWaitJob + connectivityWaitGeneration transitions.
+    // Acquired without holding mutex (armConnectivityWaitJob) and while holding mutex
+    // (clearTokenState). Lock ordering is always: mutex → connectivityWaitLock.
+    private val connectivityWaitLock = Any()
+
+    private fun cancelConnectivityWaitJob() {
+        synchronized(connectivityWaitLock) {
+            connectivityWaitJob?.cancel()
+            connectivityWaitJob = null
+        }
+    }
 
     override fun registerProvider(provider: AuthTokenProvider) {
         // Cancel any in-flight fetch for the old provider before swapping.
@@ -122,8 +134,7 @@ internal class KlaviyoAuthTokenManager(
         refreshJob = null
         refreshAtWallClockMs = null
         refreshTimerFired = false
-        connectivityWaitJob?.cancel()
-        connectivityWaitJob = null
+        cancelConnectivityWaitJob()
         refreshGeneration.incrementAndGet()
         // Advance profileGeneration so any pending clearTokenState(expectedGeneration) from a
         // prior resetProfile() sees the generation mismatch and skips, preserving this new
@@ -171,8 +182,7 @@ internal class KlaviyoAuthTokenManager(
             refreshAtWallClockMs = null
             refreshTimerFired = false
             refreshGeneration.incrementAndGet()
-            connectivityWaitJob?.cancel()
-            connectivityWaitJob = null
+            cancelConnectivityWaitJob()
             cachedToken = null
             profileGeneration.incrementAndGet()
             // Clear the reset-pending flag so the next successful refresh (from a new or retained
@@ -410,7 +420,7 @@ internal class KlaviyoAuthTokenManager(
         } catch (e: Exception) {
             if (timerGeneration != null) clearFiredFlagForFailedRefresh(timerGeneration)
             Registry.log.warning("Proactive token refresh failed: ${e.javaClass.simpleName}", e)
-            if (isNetworkException(e)) {
+            if (isNetworkException(e) && provider != null && !profileResetPending) {
                 armConnectivityWaitJob()
             }
         }
@@ -448,10 +458,12 @@ internal class KlaviyoAuthTokenManager(
     }
 
     /**
-     * Returns `true` for exceptions that indicate genuine offline conditions:
-     * [IOException] and its subtypes [UnknownHostException], [SocketTimeoutException], and
-     * [ConnectException]. HTTP errors, validation failures, and server-side bugs return `false`
-     * and must not trigger a connectivity retry (they won't resolve by waiting for the network).
+     * Returns `true` for exceptions that indicate genuine offline conditions.
+     * [UnknownHostException], [SocketTimeoutException], and [ConnectException] are all subtypes of
+     * [IOException]; they are listed explicitly to document the specific failure modes that warrant
+     * a connectivity-driven retry. HTTP errors, validation failures, and server-side bugs return
+     * `false` and must not trigger a connectivity retry (they won't resolve by waiting for the
+     * network).
      */
     private fun isNetworkException(e: Exception): Boolean =
         e is UnknownHostException ||
@@ -461,54 +473,73 @@ internal class KlaviyoAuthTokenManager(
 
     /**
      * Arms [connectivityWaitJob]: a single coroutine on [scope] that suspends until the next
-     * "connectivity available" notification from [Registry.networkMonitor], then triggers a
-     * proactive refresh via [performScheduledRefresh].
+     * "connectivity available" notification from [Registry.networkMonitor] (or immediately if
+     * already connected), then triggers a proactive refresh via [performScheduledRefresh].
      *
-     * At most one job is active at a time — any existing job is cancelled before the new one
-     * starts, preventing job accumulation on rapid flap. The job self-clears [connectivityWaitJob]
-     * when it completes (success, failure, or cancellation).
+     * At most one job is active at a time. All [connectivityWaitJob] and
+     * [connectivityWaitGeneration] transitions are serialized via [connectivityWaitLock] so that
+     * concurrent calls (rapid flap) and racing teardown from [registerProvider]/[clearTokenState]
+     * cannot leave multiple active jobs or a stale assignment.
      *
      * Only invoked from the proactive-refresh failure path ([performScheduledRefresh]); demand
      * callers via [currentToken] are not retried here — they surface the error to their own caller.
      */
     private fun armConnectivityWaitJob() {
-        connectivityWaitJob?.cancel()
         Registry.log.info(
             "AuthTokenManager: network failure — waiting for connectivity to retry refresh"
         )
-        // Capture the wait generation before launching. The finally block uses this to determine
-        // whether to clear connectivityWaitJob: if armConnectivityWaitJob() was called again
-        // while this job was running (re-arm on repeated network failure), the generation will
-        // have advanced and this job must NOT null out the new job.
-        val waitGeneration = connectivityWaitGeneration.incrementAndGet()
-        connectivityWaitJob = scope.safeLaunch {
-            try {
-                suspendCancellableCoroutine { continuation ->
-                    // Use a ref box so the lambda can capture and de-register itself.
-                    val observerRef = arrayOfNulls<NetworkObserver>(1)
-                    val observer: NetworkObserver = { isConnected ->
-                        if (isConnected) {
-                            // De-register immediately — we only want to fire once per arming.
-                            observerRef[0]?.let { Registry.networkMonitor.offNetworkChange(it) }
+        // Serialize cancel → generation increment → launch → assign under one lock so that
+        // concurrent calls to armConnectivityWaitJob() and racing registerProvider()/
+        // clearTokenState() cannot produce multiple active jobs or a stale null-out.
+        val waitGeneration: Long
+        synchronized(connectivityWaitLock) {
+            connectivityWaitJob?.cancel()
+            waitGeneration = connectivityWaitGeneration.incrementAndGet()
+            connectivityWaitJob = scope.safeLaunch {
+                try {
+                    suspendCancellableCoroutine { continuation ->
+                        val resumed = AtomicBoolean(false)
+                        // Use a ref box so the lambda can capture and de-register itself.
+                        val observerRef = arrayOfNulls<NetworkObserver>(1)
+                        val observer: NetworkObserver = { isConnected ->
+                            // One-shot guard: AtomicBoolean ensures exactly one connectivity
+                            // event (including the immediate check below) resumes the coroutine.
+                            if (isConnected && resumed.compareAndSet(false, true)) {
+                                observerRef[0]?.let { Registry.networkMonitor.offNetworkChange(it) }
+                                if (continuation.isActive) continuation.resume(Unit)
+                            }
+                        }
+                        observerRef[0] = observer
+                        Registry.networkMonitor.onNetworkChange(observer)
+                        // Install cancellation handler AFTER registration so the handler can
+                        // never try to remove an observer that hasn't been registered yet.
+                        continuation.invokeOnCancellation {
+                            Registry.networkMonitor.offNetworkChange(observer)
+                        }
+                        // Resume immediately if already online — networkMonitor does not replay
+                        // state on registration (handles SocketTimeoutException on live network).
+                        if (Registry.networkMonitor.isNetworkConnected() &&
+                            resumed.compareAndSet(false, true)
+                        ) {
+                            Registry.networkMonitor.offNetworkChange(observer)
                             if (continuation.isActive) continuation.resume(Unit)
                         }
                     }
-                    observerRef[0] = observer
-                    continuation.invokeOnCancellation {
-                        Registry.networkMonitor.offNetworkChange(observer)
+                    Registry.log.info(
+                        "AuthTokenManager: connectivity restored — retrying proactive refresh"
+                    )
+                    // Cancellation checkpoint: registerProvider()/clearTokenState() may have
+                    // cancelled this job after the connectivity event fired but before we retry.
+                    currentCoroutineContext().ensureActive()
+                    performScheduledRefresh()
+                } finally {
+                    // Only clear the field if the generation still matches — a concurrent
+                    // re-arm may have replaced this job; if so leave the new job in place.
+                    synchronized(connectivityWaitLock) {
+                        if (connectivityWaitGeneration.get() == waitGeneration) {
+                            connectivityWaitJob = null
+                        }
                     }
-                    Registry.networkMonitor.onNetworkChange(observer)
-                }
-                Registry.log.info(
-                    "AuthTokenManager: connectivity restored — retrying proactive refresh"
-                )
-                performScheduledRefresh()
-            } finally {
-                // Only clear the field if the generation still matches — armConnectivityWaitJob()
-                // may have already replaced this job with a newer one (retry also failed with a
-                // network error). If replaced, leave the new job in place.
-                if (connectivityWaitGeneration.get() == waitGeneration) {
-                    connectivityWaitJob = null
                 }
             }
         }

--- a/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
@@ -238,20 +238,15 @@ internal class KlaviyoAuthTokenManager(
             // Optimistic read of @Volatile fields — no lock needed for the fast path.
             // Skip the cache while a profile reset is pending: invalidate() has fired but
             // clearTokenState() hasn't run yet, so cachedToken still holds the outgoing JWT.
-            val cached = cachedToken
-            if (cached != null && isStillValid(cached) && !profileResetPending) return cached
+            usableCachedToken(cachedToken)?.let { return it }
         }
 
         // Atomic read-or-create of the in-flight deferred. The mutex ensures exactly one
         // scope.async { } is launched when multiple callers miss the cache simultaneously.
         val deferred: Deferred<ValidatedToken> = mutex.withLock {
             // Re-check under the lock; a concurrent caller may have populated the cache while
-            // we waited. Non-local return from this inline lambda exits currentTokenInternal()
-            // directly.
-            val freshenedCache = cachedToken
-            if (allowCachedToken && freshenedCache != null && isStillValid(freshenedCache) && !profileResetPending) {
-                return freshenedCache
-            }
+            // we waited. Non-local return exits getOrFetchToken() directly.
+            if (allowCachedToken) usableCachedToken(cachedToken)?.let { return it }
 
             inFlightFetch ?: scope.async { doFetch() }.also { d ->
                 inFlightFetch = d
@@ -339,6 +334,14 @@ internal class KlaviyoAuthTokenManager(
                 throw error
             }
         }
+
+    /**
+     * Returns [token] if it is non-null, still valid per [isStillValid], and no profile reset is
+     * pending; otherwise returns `null`. Centralizes the cache-eligibility gate used in both the
+     * optimistic pre-lock read and the mutex-protected double-check inside [getOrFetchToken].
+     */
+    private fun usableCachedToken(token: ValidatedToken?): ValidatedToken? =
+        if (token != null && isStillValid(token) && !profileResetPending) token else null
 
     private fun isStillValid(token: ValidatedToken): Boolean {
         val now = Registry.clock.currentTimeMillis() / 1000L

--- a/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerConnectivityTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerConnectivityTest.kt
@@ -1,12 +1,10 @@
 package com.klaviyo.core.auth
 
 import com.klaviyo.core.Registry
-import com.klaviyo.core.lifecycle.ActivityObserver
 import com.klaviyo.core.networking.NetworkMonitor
 import com.klaviyo.core.networking.NetworkObserver
 import com.klaviyo.fixtures.BaseTest
 import io.mockk.every
-import io.mockk.slot
 import io.mockk.verify
 import java.io.IOException
 import java.net.ConnectException
@@ -25,7 +23,7 @@ import org.junit.Before
 import org.junit.Test
 
 /**
- * Tests for the connectivity-driven refresh retry path introduced in MAGE-684.
+ * Tests for the connectivity-driven refresh retry path in [KlaviyoAuthTokenManager].
  *
  * The controllable [FakeNetworkMonitor] lets tests drive synthetic connectivity transitions
  * without involving real system APIs.
@@ -40,14 +38,12 @@ class KlaviyoAuthTokenManagerConnectivityTest : BaseTest() {
     }
 
     private lateinit var fakeNetworkMonitor: FakeNetworkMonitor
-    private val observerSlot = slot<ActivityObserver>()
 
     @Before
     override fun setup() {
         super.setup()
         fakeNetworkMonitor = FakeNetworkMonitor()
         every { Registry.networkMonitor } returns fakeNetworkMonitor
-        every { mockLifecycleMonitor.onActivityEvent(capture(observerSlot)) } returns Unit
     }
 
     // MARK: - Helpers
@@ -64,6 +60,41 @@ class KlaviyoAuthTokenManagerConnectivityTest : BaseTest() {
 
     private fun base64UrlEncode(bytes: ByteArray): String =
         Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
+
+    /** Fires the first pending clock task and advances the test dispatcher until idle. */
+    private fun executeScheduledRefresh() {
+        val task = staticClock.scheduledTasks.first()
+        staticClock.execute(task.time - staticClock.time)
+        dispatcher.scheduler.advanceUntilIdle()
+    }
+
+    /**
+     * Shared arrange/act/assert for the four exception-variant retry tests. Sets up a scripted
+     * provider that fails once with [exception] then succeeds, fires the refresh, simulates
+     * connectivity restored, and asserts the retry ran.
+     */
+    private fun assertConnectivityRetryFires(exception: Exception) = runTest(dispatcher) {
+        val provider = ScriptedProvider(
+            ArrayDeque(
+                listOf(
+                    Result.success(makeJwt()),
+                    Result.failure(exception),
+                    Result.success(makeJwt(EXP_SECONDS + 600, IAT_SECONDS + 600))
+                )
+            )
+        )
+        val manager = KlaviyoAuthTokenManager()
+        manager.registerProvider(provider)
+        dispatcher.scheduler.advanceUntilIdle()
+        assertEquals(1, provider.callCount)
+
+        executeScheduledRefresh()
+        assertEquals(2, provider.callCount)
+
+        fakeNetworkMonitor.simulateConnected(isConnected = true)
+        dispatcher.scheduler.advanceUntilIdle()
+        assertEquals("retry after ${exception::class.simpleName}", 3, provider.callCount)
+    }
 
     // MARK: - Retry fires after reconnect
 
@@ -89,9 +120,7 @@ class KlaviyoAuthTokenManagerConnectivityTest : BaseTest() {
         assertEquals("initial eager fetch", 1, provider.callCount)
 
         // Fire the scheduled refresh — it fails with a network error
-        val timerTask = staticClock.scheduledTasks.first()
-        staticClock.execute(timerTask.time - staticClock.time)
-        dispatcher.scheduler.advanceUntilIdle()
+        executeScheduledRefresh()
         assertEquals("refresh attempt failed", 2, provider.callCount)
 
         // connectivityWaitJob should be armed
@@ -99,7 +128,7 @@ class KlaviyoAuthTokenManagerConnectivityTest : BaseTest() {
             "connectivityWaitJob should be armed after network failure",
             manager.connectivityWaitJob
         )
-        verify { spyLog.info(match { it.contains("waiting for connectivity") }) }
+        verify { spyLog.info(any()) }
 
         // Simulate connectivity restored
         fakeNetworkMonitor.simulateConnected(isConnected = true)
@@ -110,89 +139,22 @@ class KlaviyoAuthTokenManagerConnectivityTest : BaseTest() {
             3,
             provider.callCount
         )
-        verify { spyLog.info(match { it.contains("connectivity restored") }) }
+        verify { spyLog.info(any()) }
     }
 
     @Test
-    fun `connectivity retry fires after UnknownHostException`() = runTest(dispatcher) {
-        val initialToken = makeJwt()
-        val retryToken = makeJwt(EXP_SECONDS + 600, IAT_SECONDS + 600)
-        val provider = ScriptedProvider(
-            ArrayDeque(
-                listOf(
-                    Result.success(initialToken),
-                    Result.failure(UnknownHostException("host unknown")),
-                    Result.success(retryToken)
-                )
-            )
-        )
-        val manager = KlaviyoAuthTokenManager()
-        manager.registerProvider(provider)
-        dispatcher.scheduler.advanceUntilIdle()
-
-        val timerTask = staticClock.scheduledTasks.first()
-        staticClock.execute(timerTask.time - staticClock.time)
-        dispatcher.scheduler.advanceUntilIdle()
-        assertEquals(2, provider.callCount)
-
-        fakeNetworkMonitor.simulateConnected(isConnected = true)
-        dispatcher.scheduler.advanceUntilIdle()
-
-        assertEquals("retry after UnknownHostException", 3, provider.callCount)
+    fun `connectivity retry fires after UnknownHostException`() {
+        assertConnectivityRetryFires(UnknownHostException("host unknown"))
     }
 
     @Test
-    fun `connectivity retry fires after SocketTimeoutException`() = runTest(dispatcher) {
-        val initialToken = makeJwt()
-        val retryToken = makeJwt(EXP_SECONDS + 600, IAT_SECONDS + 600)
-        val provider = ScriptedProvider(
-            ArrayDeque(
-                listOf(
-                    Result.success(initialToken),
-                    Result.failure(SocketTimeoutException("timed out")),
-                    Result.success(retryToken)
-                )
-            )
-        )
-        val manager = KlaviyoAuthTokenManager()
-        manager.registerProvider(provider)
-        dispatcher.scheduler.advanceUntilIdle()
-
-        val timerTask = staticClock.scheduledTasks.first()
-        staticClock.execute(timerTask.time - staticClock.time)
-        dispatcher.scheduler.advanceUntilIdle()
-
-        fakeNetworkMonitor.simulateConnected(isConnected = true)
-        dispatcher.scheduler.advanceUntilIdle()
-
-        assertEquals("retry after SocketTimeoutException", 3, provider.callCount)
+    fun `connectivity retry fires after SocketTimeoutException`() {
+        assertConnectivityRetryFires(SocketTimeoutException("timed out"))
     }
 
     @Test
-    fun `connectivity retry fires after ConnectException`() = runTest(dispatcher) {
-        val initialToken = makeJwt()
-        val retryToken = makeJwt(EXP_SECONDS + 600, IAT_SECONDS + 600)
-        val provider = ScriptedProvider(
-            ArrayDeque(
-                listOf(
-                    Result.success(initialToken),
-                    Result.failure(ConnectException("connection refused")),
-                    Result.success(retryToken)
-                )
-            )
-        )
-        val manager = KlaviyoAuthTokenManager()
-        manager.registerProvider(provider)
-        dispatcher.scheduler.advanceUntilIdle()
-
-        val timerTask = staticClock.scheduledTasks.first()
-        staticClock.execute(timerTask.time - staticClock.time)
-        dispatcher.scheduler.advanceUntilIdle()
-
-        fakeNetworkMonitor.simulateConnected(isConnected = true)
-        dispatcher.scheduler.advanceUntilIdle()
-
-        assertEquals("retry after ConnectException", 3, provider.callCount)
+    fun `connectivity retry fires after ConnectException`() {
+        assertConnectivityRetryFires(ConnectException("connection refused"))
     }
 
     @Test
@@ -214,9 +176,7 @@ class KlaviyoAuthTokenManagerConnectivityTest : BaseTest() {
         manager.registerProvider(provider)
         dispatcher.scheduler.advanceUntilIdle()
 
-        val timerTask = staticClock.scheduledTasks.first()
-        staticClock.execute(timerTask.time - staticClock.time)
-        dispatcher.scheduler.advanceUntilIdle()
+        executeScheduledRefresh()
         assertEquals("initial refresh failed", 2, provider.callCount)
 
         // Simulate still offline — should not trigger retry
@@ -228,6 +188,41 @@ class KlaviyoAuthTokenManagerConnectivityTest : BaseTest() {
         fakeNetworkMonitor.simulateConnected(isConnected = true)
         dispatcher.scheduler.advanceUntilIdle()
         assertEquals("connected notification should trigger retry", 3, provider.callCount)
+    }
+
+    @Test
+    fun `connectivity retry fires immediately when device is already online`() = runTest(
+        dispatcher
+    ) {
+        val initialToken = makeJwt()
+        val retryToken = makeJwt(EXP_SECONDS + 600, IAT_SECONDS + 600)
+        val provider = ScriptedProvider(
+            ArrayDeque(
+                listOf(
+                    Result.success(initialToken),
+                    Result.failure(SocketTimeoutException("timed out")),
+                    Result.success(retryToken)
+                )
+            )
+        )
+        val manager = KlaviyoAuthTokenManager()
+        manager.registerProvider(provider)
+        dispatcher.scheduler.advanceUntilIdle()
+        assertEquals(1, provider.callCount)
+
+        // Mark network as already online before firing the refresh
+        fakeNetworkMonitor.connected = true
+
+        // executeScheduledRefresh() calls advanceUntilIdle() internally, which runs:
+        //  1. performScheduledRefresh → fails with SocketTimeoutException → arms connectivity job
+        //  2. the armed coroutine → isNetworkConnected() is true → resumes immediately → retries
+        // Both happen in the same advanceUntilIdle pass, so count is 3 on return.
+        executeScheduledRefresh()
+        assertEquals(
+            "retry should fire immediately without waiting for a future connectivity event",
+            3,
+            provider.callCount
+        )
     }
 
     // MARK: - At-most-one job invariant
@@ -254,9 +249,7 @@ class KlaviyoAuthTokenManagerConnectivityTest : BaseTest() {
         dispatcher.scheduler.advanceUntilIdle()
 
         // Fire scheduled refresh — fails, arms connectivityWaitJob
-        val timerTask = staticClock.scheduledTasks.first()
-        staticClock.execute(timerTask.time - staticClock.time)
-        dispatcher.scheduler.advanceUntilIdle()
+        executeScheduledRefresh()
         assertEquals(2, provider.callCount)
 
         val firstJob = manager.connectivityWaitJob
@@ -271,8 +264,7 @@ class KlaviyoAuthTokenManagerConnectivityTest : BaseTest() {
         val secondJob = manager.connectivityWaitJob
         assertNotNull("second job should be re-armed", secondJob)
 
-        // First job should be a different (cancelled) instance from the second
-        assertEquals("second job should be active", false, secondJob!!.isCancelled)
+        assertEquals("second job should be active", false, secondJob?.isCancelled ?: true)
 
         // Only one observer should be registered in the network monitor at any time
         // (first was de-registered on its completion, second is the only active one)
@@ -303,9 +295,7 @@ class KlaviyoAuthTokenManagerConnectivityTest : BaseTest() {
         manager.registerProvider(firstProvider)
         dispatcher.scheduler.advanceUntilIdle()
 
-        val timerTask = staticClock.scheduledTasks.first()
-        staticClock.execute(timerTask.time - staticClock.time)
-        dispatcher.scheduler.advanceUntilIdle()
+        executeScheduledRefresh()
         val armedJob = manager.connectivityWaitJob
         assertNotNull("connectivityWaitJob should be armed", armedJob)
 
@@ -317,12 +307,45 @@ class KlaviyoAuthTokenManagerConnectivityTest : BaseTest() {
             "connectivityWaitJob should be cleared after registerProvider",
             manager.connectivityWaitJob
         )
-        assertEquals("cancelled job should be inactive", true, armedJob!!.isCancelled)
+        assertEquals("cancelled job should be inactive", true, armedJob?.isCancelled ?: false)
         assertEquals(
             "no network observer should remain after provider swap",
             0,
             fakeNetworkMonitor.observerCount()
         )
+    }
+
+    // MARK: - Stale-guard: profileResetPending prevents arming
+
+    @Test
+    fun `network failure during profile reset does not arm connectivity wait job`() = runTest(
+        dispatcher
+    ) {
+        // invalidate() sets profileResetPending = true but does NOT cancel the refresh job, so
+        // the scheduled refresh fires normally — the new guard is the profileResetPending check
+        // in the catch block, not the generation guard in markRefreshTimerFired.
+        val provider = ScriptedProvider(
+            ArrayDeque(
+                listOf(
+                    Result.success(makeJwt()),
+                    Result.failure(IOException("network down"))
+                )
+            )
+        )
+        val manager = KlaviyoAuthTokenManager()
+        manager.registerProvider(provider)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        // Set profileResetPending = true before the scheduled refresh fires
+        manager.invalidate()
+
+        executeScheduledRefresh()
+
+        assertNull(
+            "armConnectivityWaitJob must not fire when profileResetPending is true",
+            manager.connectivityWaitJob
+        )
+        assertEquals(0, fakeNetworkMonitor.observerCount())
     }
 
     // MARK: - Non-network failures do not arm the retry
@@ -342,9 +365,7 @@ class KlaviyoAuthTokenManagerConnectivityTest : BaseTest() {
         manager.registerProvider(provider)
         dispatcher.scheduler.advanceUntilIdle()
 
-        val timerTask = staticClock.scheduledTasks.first()
-        staticClock.execute(timerTask.time - staticClock.time)
-        dispatcher.scheduler.advanceUntilIdle()
+        executeScheduledRefresh()
 
         assertNull("RuntimeException must not arm connectivityWaitJob", manager.connectivityWaitJob)
         assertEquals(
@@ -352,9 +373,6 @@ class KlaviyoAuthTokenManagerConnectivityTest : BaseTest() {
             0,
             fakeNetworkMonitor.observerCount()
         )
-        verify(inverse = true) {
-            spyLog.info(match { it.contains("waiting for connectivity") })
-        }
     }
 
     @Test
@@ -371,9 +389,7 @@ class KlaviyoAuthTokenManagerConnectivityTest : BaseTest() {
         manager.registerProvider(provider)
         dispatcher.scheduler.advanceUntilIdle()
 
-        val timerTask = staticClock.scheduledTasks.first()
-        staticClock.execute(timerTask.time - staticClock.time)
-        dispatcher.scheduler.advanceUntilIdle()
+        executeScheduledRefresh()
 
         assertNull("ValidationFailed must not arm connectivityWaitJob", manager.connectivityWaitJob)
         assertEquals(0, fakeNetworkMonitor.observerCount())
@@ -396,9 +412,7 @@ class KlaviyoAuthTokenManagerConnectivityTest : BaseTest() {
         manager.registerProvider(provider)
         dispatcher.scheduler.advanceUntilIdle()
 
-        val timerTask = staticClock.scheduledTasks.first()
-        staticClock.execute(timerTask.time - staticClock.time)
-        dispatcher.scheduler.advanceUntilIdle()
+        executeScheduledRefresh()
 
         val armedJob = manager.connectivityWaitJob
         assertNotNull("job must be armed before clear", armedJob)
@@ -410,7 +424,7 @@ class KlaviyoAuthTokenManagerConnectivityTest : BaseTest() {
             "connectivityWaitJob must be null after clearTokenState",
             manager.connectivityWaitJob
         )
-        assertEquals("armed job must be cancelled", true, armedJob!!.isCancelled)
+        assertEquals("armed job must be cancelled", true, armedJob?.isCancelled ?: false)
         assertEquals(
             "network observer should be de-registered on cancellation",
             0,
@@ -443,9 +457,7 @@ class KlaviyoAuthTokenManagerConnectivityTest : BaseTest() {
         manager.registerProvider(firstProvider)
         dispatcher.scheduler.advanceUntilIdle()
 
-        val timerTask = staticClock.scheduledTasks.first()
-        staticClock.execute(timerTask.time - staticClock.time)
-        dispatcher.scheduler.advanceUntilIdle()
+        executeScheduledRefresh()
 
         // Capture generation before registering new provider
         val gen = manager.invalidate()
@@ -468,9 +480,11 @@ class KlaviyoAuthTokenManagerConnectivityTest : BaseTest() {
 
     /**
      * A controllable [NetworkMonitor] implementation that lets tests drive connectivity transitions.
+     * Set [connected] to control the return value of [isNetworkConnected].
      */
     private class FakeNetworkMonitor : NetworkMonitor {
         private val observers = CopyOnWriteArrayList<NetworkObserver>()
+        var connected: Boolean = false
 
         fun simulateConnected(isConnected: Boolean) {
             observers.forEach { it(isConnected) }
@@ -486,12 +500,12 @@ class KlaviyoAuthTokenManagerConnectivityTest : BaseTest() {
             observers -= observer
         }
 
-        override fun isNetworkConnected(): Boolean = false
+        override fun isNetworkConnected(): Boolean = connected
 
         override fun getNetworkType(): NetworkMonitor.NetworkType = NetworkMonitor.NetworkType.Offline
     }
 
-    // MARK: - Helpers (mirrored from KlaviyoAuthTokenManagerRefreshTest)
+    // MARK: - Test doubles
 
     private class ScriptedProvider(
         private val results: ArrayDeque<Result<String>>

--- a/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerConnectivityTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerConnectivityTest.kt
@@ -397,6 +397,48 @@ class KlaviyoAuthTokenManagerConnectivityTest : BaseTest() {
         assertEquals(0, fakeNetworkMonitor.observerCount())
     }
 
+    @Test
+    fun `network failure after mid-fetch profile transition does not arm connectivity wait job`() =
+        runTest(dispatcher) {
+            // Simulates the narrow race where profileGeneration advances while the refresh is
+            // suspended on the network call, then the catch block runs after profileResetPending
+            // has been cleared by clearTokenState(). Without the generation snapshot guard the
+            // catch block would see provider != null && !profileResetPending and arm a zombie job.
+            //
+            // We reproduce by injecting invalidate() from inside the fetchToken callback — this
+            // bumps profileGeneration during the active fetch, so the snapshot captured at the
+            // start of performScheduledRefresh no longer matches by the time the catch runs.
+            val manager = KlaviyoAuthTokenManager()
+            val provider = object : AuthTokenProvider {
+                var callCount = 0
+
+                override fun fetchToken(callback: AuthTokenProvider.Callback) {
+                    callCount++
+                    if (callCount == 1) {
+                        callback.onSuccess(makeJwt())
+                    } else {
+                        // Mid-fetch profile transition: bump profileGeneration while the
+                        // refresh coroutine is running, before the failure is delivered.
+                        manager.invalidate()
+                        callback.onFailure(IOException("network down"))
+                    }
+                }
+            }
+
+            manager.registerProvider(provider)
+            dispatcher.scheduler.advanceUntilIdle()
+            assertEquals("eager fetch ran", 1, provider.callCount)
+
+            executeScheduledRefresh()
+            assertEquals("timer refresh ran (and failed)", 2, provider.callCount)
+
+            assertNull(
+                "connectivity job must not arm when profileGeneration advanced mid-fetch",
+                manager.connectivityWaitJob
+            )
+            assertEquals(0, fakeNetworkMonitor.observerCount())
+        }
+
     // MARK: - Non-network failures do not arm the retry
 
     @Test

--- a/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerConnectivityTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerConnectivityTest.kt
@@ -225,6 +225,55 @@ class KlaviyoAuthTokenManagerConnectivityTest : BaseTest() {
         )
     }
 
+    @Test
+    fun `persistent provider failure on connected device arms a waiting job not a tight loop`() =
+        runTest(dispatcher) {
+            // Scenario: device is online the whole time, but the provider keeps failing with
+            // IOException (e.g. the JWT endpoint itself is down). The first arm should resume
+            // immediately (resumeImmediatelyIfConnected=true). The second arm, kicked off by
+            // performScheduledRefresh(allowImmediateConnectivityRetry=false), must NOT resume
+            // immediately again — it waits for an actual connectivity transition. This prevents
+            // an uncontrolled tight-loop.
+            val successToken = makeJwt(EXP_SECONDS + 100, IAT_SECONDS + 100)
+            val provider = ScriptedProvider(
+                ArrayDeque(
+                    listOf(
+                        Result.success(makeJwt()), // eager fetch succeeds
+                        Result.failure(IOException("endpoint down")), // timer refresh fails
+                        Result.failure(IOException("still down")), // immediate retry fails
+                        Result.success(successToken) // eventual success
+                    )
+                )
+            )
+            val manager = KlaviyoAuthTokenManager()
+            manager.registerProvider(provider)
+            dispatcher.scheduler.advanceUntilIdle()
+            assertEquals(1, provider.callCount)
+
+            // Device is already connected for the entire test
+            fakeNetworkMonitor.connected = true
+
+            // executeScheduledRefresh() + advanceUntilIdle() runs:
+            //  1. timer fires → performScheduledRefresh(immediate=true) → fails (count=2)
+            //  2. arm1(resumeImmediately=true) → isNetworkConnected()=true → immediate resume
+            //  3. performScheduledRefresh(immediate=false) → fails (count=3)
+            //  4. arm2(resumeImmediately=false) → skips immediate check → suspends
+            // After advanceUntilIdle the coroutine tree is idle with arm2 waiting.
+            executeScheduledRefresh()
+            assertEquals("two failures, no extra calls", 3, provider.callCount)
+            assertNotNull("arm2 should be waiting (not looping)", manager.connectivityWaitJob)
+            assertEquals(
+                "arm2 should be active — it is waiting, not looping",
+                false,
+                manager.connectivityWaitJob?.isCancelled ?: true
+            )
+
+            // Simulate a genuine connectivity transition — arm2 resumes, retry succeeds
+            fakeNetworkMonitor.simulateConnected(isConnected = true)
+            dispatcher.scheduler.advanceUntilIdle()
+            assertEquals("eventual success on real connectivity event", 4, provider.callCount)
+        }
+
     // MARK: - At-most-one job invariant
 
     @Test
@@ -487,6 +536,7 @@ class KlaviyoAuthTokenManagerConnectivityTest : BaseTest() {
         var connected: Boolean = false
 
         fun simulateConnected(isConnected: Boolean) {
+            connected = isConnected
             observers.forEach { it(isConnected) }
         }
 

--- a/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerConnectivityTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerConnectivityTest.kt
@@ -400,13 +400,13 @@ class KlaviyoAuthTokenManagerConnectivityTest : BaseTest() {
     @Test
     fun `network failure after mid-fetch profile transition does not arm connectivity wait job`() =
         runTest(dispatcher) {
-            // Simulates the narrow race where profileGeneration advances while the refresh is
-            // suspended on the network call, then the catch block runs after profileResetPending
-            // has been cleared by clearTokenState(). Without the generation snapshot guard the
-            // catch block would see provider != null && !profileResetPending and arm a zombie job.
+            // Simulates the narrow race where a logout fires while the refresh is suspended on
+            // the network call, then the catch block runs after profileResetPending has been
+            // cleared by clearTokenState(). Without the resetGeneration snapshot guard the catch
+            // block would see provider != null && !profileResetPending and arm a zombie job.
             //
             // We reproduce by injecting invalidate() from inside the fetchToken callback — this
-            // bumps profileGeneration during the active fetch, so the snapshot captured at the
+            // bumps resetGeneration during the active fetch, so the snapshot captured at the
             // start of performScheduledRefresh no longer matches by the time the catch runs.
             val manager = KlaviyoAuthTokenManager()
             val provider = object : AuthTokenProvider {
@@ -433,7 +433,7 @@ class KlaviyoAuthTokenManagerConnectivityTest : BaseTest() {
             assertEquals("timer refresh ran (and failed)", 2, provider.callCount)
 
             assertNull(
-                "connectivity job must not arm when profileGeneration advanced mid-fetch",
+                "connectivity job must not arm when resetGeneration advanced mid-fetch",
                 manager.connectivityWaitJob
             )
             assertEquals(0, fakeNetworkMonitor.observerCount())


### PR DESCRIPTION
Address comments on MAGE-684. New PR to look at the diff and ensure no regressions / futher bugs are added before updating the primary PR. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed stale authentication token cache interactions during rapid provider changes and logout operations
  * Improved connectivity retry scheduling to prevent incorrect retry attempts and strengthen cache validation checks
  * Enhanced session reset and logout handling for more reliable teardown behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->