### PR TITLE
refactor(auth): actor-style refactor of KlaviyoAuthTokenManager

### DIFF
--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -24,6 +24,8 @@ import com.klaviyo.core.Constants.PACKAGE_PREFIX
 import com.klaviyo.core.Constants.TRACKING_PARAMETER
 import com.klaviyo.core.Operation
 import com.klaviyo.core.Registry
+import com.klaviyo.core.auth.AuthTokenManager
+import com.klaviyo.core.auth.AuthTokenProvider
 import com.klaviyo.core.config.Config
 import com.klaviyo.core.config.LifecycleException
 import com.klaviyo.core.safeApply
@@ -139,6 +141,20 @@ object Klaviyo {
     @JvmStatic
     fun unregisterDeepLinkHandler() = safeApply {
         Registry.unregister<DeepLinkHandler>()
+    }
+
+    /**
+     * Register an [AuthTokenProvider] that supplies JWTs to authenticate personalized Klaviyo
+     * features (such as in-app forms that target a known profile).
+     *
+     * Re-registering replaces the previously registered provider and discards any cached token.
+     * The SDK will invoke [AuthTokenProvider.fetchToken] whenever a fresh token is needed; the
+     * host MUST invoke exactly one of [AuthTokenProvider.Callback.onSuccess] or
+     * [AuthTokenProvider.Callback.onFailure] per call.
+     */
+    @JvmStatic
+    fun registerAuthTokenProvider(provider: AuthTokenProvider) = safeApply {
+        Registry.get<AuthTokenManager>().registerProvider(provider)
     }
 
     /**

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -30,11 +30,13 @@ import com.klaviyo.core.config.Config
 import com.klaviyo.core.config.LifecycleException
 import com.klaviyo.core.safeApply
 import com.klaviyo.core.safeCall
+import com.klaviyo.core.safeLaunch
 import com.klaviyo.core.utils.JSONUtil.toHashMap
 import com.klaviyo.core.utils.takeIf
 import java.io.Serializable
 import java.util.LinkedList
 import java.util.Queue
+import kotlinx.coroutines.CoroutineScope
 import org.json.JSONObject
 
 /**
@@ -302,7 +304,19 @@ object Klaviyo {
      * (e.g. after a logout)
      */
     @JvmStatic
-    fun resetProfile() = safeApply { Registry.get<State>().reset() }
+    fun resetProfile() = safeApply {
+        // invalidate() runs first (synchronous) so any in-flight proactive refresh completing in
+        // the gap before State.reset() sees profileResetPending=true and skips observer dispatch.
+        val auth = Registry.get<AuthTokenManager>()
+        val gen = auth.invalidate()
+        Registry.get<State>().reset()
+        // clearTokenState(gen) is fire-and-forget. Passing the captured generation makes it
+        // conditional: if registerAuthTokenProvider() runs first, profileGeneration has advanced
+        // and the clear is skipped, preserving the new session's token state.
+        CoroutineScope(Registry.dispatcher).safeLaunch {
+            auth.clearTokenState(expectedGeneration = gen)
+        }
+    }
 
     /**
      * Creates an [Event] associated with the currently tracked profile

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -308,13 +308,13 @@ object Klaviyo {
         // invalidate() runs first (synchronous) so any in-flight proactive refresh completing in
         // the gap before State.reset() sees profileResetPending=true and skips observer dispatch.
         val auth = Registry.get<AuthTokenManager>()
-        val gen = auth.invalidate()
+        auth.invalidate()
         Registry.get<State>().reset()
-        // clearTokenState(gen) is fire-and-forget. Passing the captured generation makes it
-        // conditional: if registerAuthTokenProvider() runs first, profileGeneration has advanced
-        // and the clear is skipped, preserving the new session's token state.
+        // clearTokenState() is fire-and-forget. It is conditional on profileResetPending: if
+        // registerAuthTokenProvider() runs first it clears that flag, and the clear is skipped,
+        // preserving the new session's token state.
         CoroutineScope(Registry.dispatcher).safeLaunch {
-            auth.clearTokenState(expectedGeneration = gen)
+            auth.clearTokenState()
         }
     }
 

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoJavaApiTest.java
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoJavaApiTest.java
@@ -10,6 +10,7 @@ import com.klaviyo.analytics.model.EventKey;
 import com.klaviyo.analytics.model.EventMetric;
 import com.klaviyo.analytics.model.Profile;
 import com.klaviyo.analytics.model.ProfileKey;
+import com.klaviyo.core.auth.AuthTokenProvider;
 import com.klaviyo.fixtures.KlaviyoMock;
 
 import java.io.Serializable;
@@ -307,6 +308,19 @@ public class KlaviyoJavaApiTest {
         assertEquals(Klaviyo.INSTANCE, result2);
 
         KlaviyoMock.verifyUnregisterDeepLinkHandlerCalled(2);
+    }
+
+    @Test
+    public void testRegisterAuthTokenProvider() {
+        AuthTokenProvider provider = callback -> callback.onSuccess("eyJ.eyJ.sig");
+
+        Klaviyo result1 = Klaviyo.INSTANCE.registerAuthTokenProvider(provider);
+        assertEquals(Klaviyo.INSTANCE, result1);
+
+        Klaviyo result2 = Klaviyo.registerAuthTokenProvider(provider);
+        assertEquals(Klaviyo.INSTANCE, result2);
+
+        KlaviyoMock.verifyRegisterAuthTokenProviderCalled(2);
     }
 
     @Test

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
@@ -20,6 +20,7 @@ import com.klaviyo.analytics.state.State
 import com.klaviyo.analytics.state.StateSideEffects
 import com.klaviyo.core.DeviceProperties
 import com.klaviyo.core.Registry
+import com.klaviyo.core.auth.AuthTokenManager
 import com.klaviyo.core.config.Config
 import com.klaviyo.core.config.MissingAPIKey
 import com.klaviyo.fixtures.BaseTest
@@ -27,6 +28,7 @@ import com.klaviyo.fixtures.MockIntent
 import com.klaviyo.fixtures.mockDeviceProperties
 import com.klaviyo.fixtures.unmockDeviceProperties
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkConstructor
@@ -126,6 +128,11 @@ internal class KlaviyoTest : BaseTest() {
         }
     }
 
+    private val mockAuthTokenManager = mockk<AuthTokenManager>().apply {
+        every { invalidate() } returns 1L
+        coEvery { clearTokenState(any()) } returns Unit
+    }
+
     private val capturedProfile = slot<Profile>()
     private val mockApiClient: ApiClient = mockk<ApiClient>().apply {
         every { startService() } returns Unit
@@ -159,6 +166,7 @@ internal class KlaviyoTest : BaseTest() {
 
         every { Registry.configBuilder } returns mockBuilder
         Registry.register<ApiClient>(mockApiClient)
+        Registry.register<AuthTokenManager>(mockAuthTokenManager)
         mockDeviceProperties()
         mockkConstructor(StateSideEffects::class)
         mockkStatic(Uri::class)
@@ -181,6 +189,7 @@ internal class KlaviyoTest : BaseTest() {
         Registry.unregister<State>()
         Registry.unregister<StateSideEffects>()
         Registry.unregister<ApiClient>()
+        Registry.unregister<AuthTokenManager>()
         super.cleanup()
         Registry.unregister<Config>()
         unmockDeviceProperties()
@@ -489,6 +498,14 @@ internal class KlaviyoTest : BaseTest() {
         Klaviyo.resetProfile()
 
         assertNull(null, Registry.get<State>().email)
+    }
+
+    @Test
+    fun `resetProfile clears auth token state`() = runTest(dispatcher) {
+        Klaviyo.resetProfile()
+        dispatcher.scheduler.advanceUntilIdle()
+        verify(exactly = 1) { mockAuthTokenManager.invalidate() }
+        coVerify(exactly = 1) { mockAuthTokenManager.clearTokenState(expectedGeneration = 1L) }
     }
 
     @Test

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
@@ -129,8 +129,8 @@ internal class KlaviyoTest : BaseTest() {
     }
 
     private val mockAuthTokenManager = mockk<AuthTokenManager>().apply {
-        every { invalidate() } returns 1L
-        coEvery { clearTokenState(any()) } returns Unit
+        every { invalidate() } returns Unit
+        coEvery { clearTokenState() } returns Unit
     }
 
     private val capturedProfile = slot<Profile>()
@@ -505,7 +505,7 @@ internal class KlaviyoTest : BaseTest() {
         Klaviyo.resetProfile()
         dispatcher.scheduler.advanceUntilIdle()
         verify(exactly = 1) { mockAuthTokenManager.invalidate() }
-        coVerify(exactly = 1) { mockAuthTokenManager.clearTokenState(expectedGeneration = 1L) }
+        coVerify(exactly = 1) { mockAuthTokenManager.clearTokenState() }
     }
 
     @Test

--- a/sdk/core/consumer-rules.pro
+++ b/sdk/core/consumer-rules.pro
@@ -1,2 +1,5 @@
 # Keep only class names for stack traces, allow member obfuscation
 -keepnames class com.klaviyo.core.**
+
+# Keep ContentProvider for auto-registration
+-keep class com.klaviyo.core.CoreInitProvider

--- a/sdk/core/src/main/AndroidManifest.xml
+++ b/sdk/core/src/main/AndroidManifest.xml
@@ -15,4 +15,11 @@
             <data android:scheme="http" />
         </intent>
     </queries>
+
+    <application>
+        <provider
+            android:name="com.klaviyo.core.CoreInitProvider"
+            android:authorities="${applicationId}.klaviyo.core.init"
+            android:exported="false" />
+    </application>
 </manifest>

--- a/sdk/core/src/main/java/com/klaviyo/core/CoreInitProvider.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/CoreInitProvider.kt
@@ -1,0 +1,21 @@
+package com.klaviyo.core
+
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.database.Cursor
+import android.net.Uri
+import com.klaviyo.core.auth.AuthTokenManager
+import com.klaviyo.core.auth.KlaviyoAuthTokenManager
+
+internal class CoreInitProvider : ContentProvider() {
+    override fun onCreate(): Boolean {
+        Registry.registerOnce<AuthTokenManager> { KlaviyoAuthTokenManager() }
+        return true
+    }
+
+    override fun query(u: Uri, p: Array<String>?, s: String?, a: Array<String>?, o: String?): Cursor? = null
+    override fun getType(uri: Uri): String? = null
+    override fun insert(uri: Uri, values: ContentValues?): Uri? = null
+    override fun delete(uri: Uri, s: String?, a: Array<String>?): Int = 0
+    override fun update(uri: Uri, v: ContentValues?, s: String?, a: Array<String>?): Int = 0
+}

--- a/sdk/core/src/main/java/com/klaviyo/core/auth/AuthTokenException.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/AuthTokenException.kt
@@ -1,0 +1,27 @@
+package com.klaviyo.core.auth
+
+/**
+ * Errors thrown by [AuthTokenManager] when an auth-token request cannot be satisfied.
+ *
+ * SDK modules that consume [AuthTokenManager] (e.g. the forms WebView injection layer) can branch
+ * on these cases to distinguish "no provider has been registered yet" from "the provider returned
+ * an invalid token" when shaping their fallback behavior.
+ *
+ * Mirrors iOS `AuthTokenError`.
+ */
+sealed class AuthTokenException(message: String) : RuntimeException(message) {
+
+    /**
+     * [AuthTokenManager.currentToken] was called before any [AuthTokenProvider] was registered.
+     * Callers should treat this as "auth is not enabled" rather than "auth failed."
+     */
+    data object NoProviderRegistered : AuthTokenException("No auth token provider registered")
+
+    /**
+     * The provider returned a token that did not pass [JWTParser] validation.
+     * The [reason] is the name of the failing [JWTValidationResult] variant.
+     */
+    data class ValidationFailed(val reason: String) : AuthTokenException(
+        "Auth token validation failed: $reason"
+    )
+}

--- a/sdk/core/src/main/java/com/klaviyo/core/auth/AuthTokenException.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/AuthTokenException.kt
@@ -24,4 +24,12 @@ sealed class AuthTokenException(message: String) : RuntimeException(message) {
     data class ValidationFailed(val reason: String) : AuthTokenException(
         "Auth token validation failed: $reason"
     )
+
+    /**
+     * The provider did not return a token within the caller's timeout budget.
+     * The underlying provider invocation may still be in-flight; a later caller with a longer
+     * budget can still receive the result without triggering a second provider call.
+     *
+     */
+    data object TimedOut : AuthTokenException("Auth token request timed out")
 }

--- a/sdk/core/src/main/java/com/klaviyo/core/auth/AuthTokenManager.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/AuthTokenManager.kt
@@ -27,12 +27,16 @@ interface AuthTokenManager {
     fun registerProvider(provider: AuthTokenProvider)
 
     /**
-     * Return a currently-valid JWT, fetching from the registered provider if no cached token is
-     * available or the cached token has expired.
+     * Return a currently-valid [ValidatedToken], fetching from the registered provider if no
+     * cached token is available or the cached token has expired. Callers that only need the raw
+     * JWT string should read [ValidatedToken.rawToken]; consumers that benefit from the parsed
+     * `exp`/`iat` metadata (e.g. cache-aware short-circuiting, refresh scheduling) read it
+     * directly. [ValidatedToken.toString] is redacted, so the wrapper is safer to handle than
+     * the raw string.
      *
      * @throws [AuthTokenException.NoProviderRegistered] if no provider has been registered.
      * @throws [AuthTokenException.ValidationFailed] if the returned token fails validation.
      * @throws Throwable whatever error the provider passed to [AuthTokenProvider.Callback.onFailure].
      */
-    suspend fun currentToken(): String
+    suspend fun currentToken(): ValidatedToken
 }

--- a/sdk/core/src/main/java/com/klaviyo/core/auth/AuthTokenManager.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/AuthTokenManager.kt
@@ -1,0 +1,38 @@
+package com.klaviyo.core.auth
+
+/**
+ * Callback invoked whenever the cached auth token is refreshed.
+ *
+ * Internal for now — the public `Klaviyo.onTokenRefresh` / `offTokenRefresh` surface lands with
+ * MAGE-630, at which point this typealias and its parameter type will be promoted as needed.
+ */
+internal typealias TokenRefreshObserver = (token: ValidatedToken) -> Unit
+
+/**
+ * Manages the lifecycle of the host-supplied [AuthTokenProvider] and the resulting JWTs used by
+ * personalized Klaviyo features.
+ *
+ * Public for [com.klaviyo.core.Registry] lookup from outside the analytics module (e.g. the forms
+ * module's WebView injection layer). Implementation is internal.
+ */
+interface AuthTokenManager {
+
+    /**
+     * Replace the registered [AuthTokenProvider] (if any), discard any cached token, and
+     * asynchronously pre-warm the cache with a fresh token via the new provider.
+     *
+     * This method returns immediately — provider registration is synchronous; the eager fetch
+     * runs fire-and-forget on the manager's internal scope.
+     */
+    fun registerProvider(provider: AuthTokenProvider)
+
+    /**
+     * Return a currently-valid JWT, fetching from the registered provider if no cached token is
+     * available or the cached token has expired.
+     *
+     * @throws [AuthTokenException.NoProviderRegistered] if no provider has been registered.
+     * @throws [AuthTokenException.ValidationFailed] if the returned token fails validation.
+     * @throws Throwable whatever error the provider passed to [AuthTokenProvider.Callback.onFailure].
+     */
+    suspend fun currentToken(): String
+}

--- a/sdk/core/src/main/java/com/klaviyo/core/auth/AuthTokenManager.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/AuthTokenManager.kt
@@ -1,12 +1,16 @@
 package com.klaviyo.core.auth
 
 /**
- * Callback invoked whenever the cached auth token is refreshed.
+ * Callback invoked whenever the auth token is proactively refreshed.
  *
- * Internal for now — the public `Klaviyo.onTokenRefresh` / `offTokenRefresh` surface lands with
- * MAGE-630, at which point this typealias and its parameter type will be promoted as needed.
+ * Receives the raw JWT string. Observers must not retain the string beyond their immediate use —
+ * for the full [ValidatedToken] wrapper (exp/iat metadata) callers should use
+ * [AuthTokenManager.currentToken].
+ *
+ * Observers are invoked on the manager's internal dispatcher (IO). If a thread handoff is needed
+ * (e.g. for a WebView call that must run on the UI thread), the observer is responsible for it.
  */
-internal typealias TokenRefreshObserver = (token: ValidatedToken) -> Unit
+typealias TokenRefreshObserver = (jwt: String) -> Unit
 
 /**
  * Manages the lifecycle of the host-supplied [AuthTokenProvider] and the resulting JWTs used by
@@ -63,4 +67,68 @@ interface AuthTokenManager {
      * @throws Throwable whatever error the provider passed to [AuthTokenProvider.Callback.onFailure].
      */
     suspend fun currentToken(timeoutMs: Long = BACKGROUND_FETCH_TIMEOUT_MS): ValidatedToken
+
+    /**
+     * Register an observer that will be invoked each time the auth token is proactively refreshed.
+     *
+     * Multiple observers are supported. Each is invoked on the manager's internal dispatcher
+     * (IO); the observer is responsible for any thread handoff it needs (e.g. hopping to the UI
+     * thread for WebView calls). Dispatch is best-effort: if an observer throws an [Exception], it
+     * is logged at WARNING and remaining observers are still called.
+     * [kotlinx.coroutines.CancellationException] is rethrown per structured-concurrency contract.
+     *
+     * Registration is by reference — pass the same lambda instance to [offTokenRefresh] to
+     * unregister. Duplicate registrations (same instance) add the observer twice.
+     */
+    fun onTokenRefresh(observer: TokenRefreshObserver)
+
+    /**
+     * Remove a previously registered [TokenRefreshObserver]. The [observer] must be the same
+     * instance (by reference) as the one passed to [onTokenRefresh]. Has no effect if the observer
+     * is not currently registered.
+     */
+    fun offTokenRefresh(observer: TokenRefreshObserver)
+
+    /**
+     * Synchronously mark the current profile as stale, preventing any in-flight proactive refresh
+     * from dispatching its result to registered [TokenRefreshObserver]s.
+     *
+     * This method is intentionally non-suspending so it can be called on any thread (including the
+     * main thread from `Klaviyo.resetProfile()`) without blocking. The actual token-state cleanup
+     * is deferred to [clearTokenState], which callers should dispatch asynchronously after calling
+     * this method.
+     *
+     * @return The new profile generation value, which should be passed to [clearTokenState] as
+     *   [clearTokenState]'s `expectedGeneration` argument. If a new provider is registered before
+     *   [clearTokenState] runs, the generation will have advanced and [clearTokenState] will skip
+     *   the clear to preserve the new session's state.
+     */
+    fun invalidate(): Long
+
+    /**
+     * Clear all token-acquisition state tied to the current user, called from
+     * `Klaviyo.resetProfile()` on logout. Discards the cached token, cancels the scheduled
+     * proactive refresh and its wall-clock target, and cancels any in-flight fetch. Does **not**
+     * eagerly re-invoke the provider — the next call to [currentToken] drives the next acquisition.
+     *
+     * Deliberately retains:
+     * - The registered [AuthTokenProvider] — it is host integration code ("how to ask my auth
+     *   system for a token"), not user identity. The provider is expected to read the current user
+     *   fresh on each invocation, so the same provider correctly serves the next identified profile.
+     * - The lifecycle observer — safe to leave running across profile resets; its handler is a
+     *   no-op when no cached token or scheduled refresh exists.
+     * - Registered [TokenRefreshObserver]s — active form displays should keep their subscriptions
+     *   alive across a reset; the stream simply goes quiet until the next successful refresh.
+     *
+     * @param expectedGeneration When non-negative, the clear is skipped if the profile generation
+     *   has advanced past this value (indicating a new provider was registered between [invalidate]
+     *   and this call). Pass the value returned by [invalidate], or omit / pass `-1` for an
+     *   unconditional clear. Callers that do not use [invalidate] should always use the default.
+     *
+     * NOTE: This method's behavior may change in a future revision. The current design ("Option B")
+     * retains the provider across resets. An alternative ("Option A") would fully unregister the
+     * provider on reset, requiring the host to re-register after each login. If we switch to
+     * Option A, this method's name and behavior will change.
+     */
+    suspend fun clearTokenState(expectedGeneration: Long = -1L)
 }

--- a/sdk/core/src/main/java/com/klaviyo/core/auth/AuthTokenManager.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/AuthTokenManager.kt
@@ -17,6 +17,20 @@ internal typealias TokenRefreshObserver = (token: ValidatedToken) -> Unit
  */
 interface AuthTokenManager {
 
+    companion object {
+        /**
+         * Timeout budget for proactive / background fetches (registration-time warm-up, scheduled
+         * refresh).
+         */
+        const val BACKGROUND_FETCH_TIMEOUT_MS = 5_000L
+
+        /**
+         * Best-effort timeout budget used at form-display time, where latency is user-visible.
+         * A timeout here degrades gracefully — the form loads without a token rather than blocking.
+         */
+        const val INTERACTIVE_FETCH_TIMEOUT_MS = 500L
+    }
+
     /**
      * Replace the registered [AuthTokenProvider] (if any), discard any cached token, and
      * asynchronously pre-warm the cache with a fresh token via the new provider.
@@ -34,9 +48,19 @@ interface AuthTokenManager {
      * directly. [ValidatedToken.toString] is redacted, so the wrapper is safer to handle than
      * the raw string.
      *
+     * Concurrent callers that arrive while a provider fetch is already in-flight share the result
+     * of that single fetch rather than each triggering a new provider invocation. Each caller's
+     * [timeoutMs] budget is enforced independently — a caller that times out does not cancel the
+     * underlying fetch, so a later caller with a larger budget can still receive the result.
+     *
+     * @param timeoutMs Maximum milliseconds to wait for the provider to return a token. Must be
+     *   positive. Defaults to [BACKGROUND_FETCH_TIMEOUT_MS], pass [INTERACTIVE_FETCH_TIMEOUT_MS]
+     *   at form-display time for a best-effort, non-blocking fetch.
      * @throws [AuthTokenException.NoProviderRegistered] if no provider has been registered.
      * @throws [AuthTokenException.ValidationFailed] if the returned token fails validation.
+     * @throws [AuthTokenException.TimedOut] if the provider does not respond within [timeoutMs].
+     * @throws IllegalArgumentException if [timeoutMs] is not positive.
      * @throws Throwable whatever error the provider passed to [AuthTokenProvider.Callback.onFailure].
      */
-    suspend fun currentToken(): ValidatedToken
+    suspend fun currentToken(timeoutMs: Long = BACKGROUND_FETCH_TIMEOUT_MS): ValidatedToken
 }

--- a/sdk/core/src/main/java/com/klaviyo/core/auth/AuthTokenManager.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/AuthTokenManager.kt
@@ -98,12 +98,11 @@ interface AuthTokenManager {
      * is deferred to [clearTokenState], which callers should dispatch asynchronously after calling
      * this method.
      *
-     * @return The new profile generation value, which should be passed to [clearTokenState] as
-     *   [clearTokenState]'s `expectedGeneration` argument. If a new provider is registered before
-     *   [clearTokenState] runs, the generation will have advanced and [clearTokenState] will skip
-     *   the clear to preserve the new session's state.
+     * Sets a `profileResetPending` flag that suppresses observer dispatch and cache hits until
+     * either [clearTokenState] completes the reset or [registerProvider] supersedes it with a new
+     * session.
      */
-    fun invalidate(): Long
+    fun invalidate()
 
     /**
      * Clear all token-acquisition state tied to the current user, called from
@@ -120,15 +119,14 @@ interface AuthTokenManager {
      * - Registered [TokenRefreshObserver]s — active form displays should keep their subscriptions
      *   alive across a reset; the stream simply goes quiet until the next successful refresh.
      *
-     * @param expectedGeneration When non-negative, the clear is skipped if the profile generation
-     *   has advanced past this value (indicating a new provider was registered between [invalidate]
-     *   and this call). Pass the value returned by [invalidate], or omit / pass `-1` for an
-     *   unconditional clear. Callers that do not use [invalidate] should always use the default.
+     * The clear is skipped if [registerProvider] ran between [invalidate] and this call, because
+     * [registerProvider] clears the `profileResetPending` flag this method checks; that preserves
+     * the new session's token state.
      *
      * NOTE: This method's behavior may change in a future revision. The current design ("Option B")
      * retains the provider across resets. An alternative ("Option A") would fully unregister the
      * provider on reset, requiring the host to re-register after each login. If we switch to
      * Option A, this method's name and behavior will change.
      */
-    suspend fun clearTokenState(expectedGeneration: Long = -1L)
+    suspend fun clearTokenState()
 }

--- a/sdk/core/src/main/java/com/klaviyo/core/auth/AuthTokenProvider.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/AuthTokenProvider.kt
@@ -1,0 +1,17 @@
+package com.klaviyo.core.auth
+
+/**
+ * Host-app-supplied source of authentication tokens (JWTs) for personalized Klaviyo features.
+ *
+ * Implementations are invoked by the SDK when a fresh token is required. The host MUST invoke
+ * exactly one of [Callback.onSuccess] or [Callback.onFailure] for each call to [fetchToken].
+ */
+fun interface AuthTokenProvider {
+    fun fetchToken(callback: Callback)
+
+    interface Callback {
+        fun onSuccess(jwt: String)
+
+        fun onFailure(error: Throwable)
+    }
+}

--- a/sdk/core/src/main/java/com/klaviyo/core/auth/JWTParser.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/JWTParser.kt
@@ -1,0 +1,89 @@
+package com.klaviyo.core.auth
+
+import android.util.Base64
+import com.klaviyo.core.Registry
+import org.json.JSONException
+import org.json.JSONObject
+
+internal object JWTParser {
+    const val DEFAULT_LEEWAY_SECONDS: Long = 30L
+
+    fun parseAndValidate(
+        token: String,
+        nowEpochSeconds: Long = Registry.clock.currentTimeMillis() / 1000L,
+        leewaySeconds: Long = DEFAULT_LEEWAY_SECONDS
+    ): JWTValidationResult {
+        val segments = token.split('.')
+        if (segments.size != 3) {
+            Registry.log.warning("JWT validation failed: malformed structure")
+            return JWTValidationResult.MalformedStructure
+        }
+
+        val payloadBytes = base64UrlDecode(segments[1]) ?: run {
+            Registry.log.warning("JWT validation failed: malformed base64URL payload")
+            return JWTValidationResult.MalformedBase64
+        }
+
+        val claims = try {
+            JSONObject(String(payloadBytes, Charsets.UTF_8))
+        } catch (e: JSONException) {
+            Registry.log.warning("JWT validation failed: malformed JSON payload")
+            return JWTValidationResult.MalformedJson
+        }
+
+        val expRaw = claims.numericClaim("exp")
+        if (expRaw == null) {
+            Registry.log.warning("JWT validation failed: missing exp claim")
+            return JWTValidationResult.MissingExpClaim
+        }
+        if (expRaw.isNaN()) {
+            Registry.log.warning("JWT validation failed: exp claim non-numeric")
+            return JWTValidationResult.MalformedJson
+        }
+
+        val iatRaw = claims.numericClaim("iat")
+        if (iatRaw == null) {
+            Registry.log.warning("JWT validation failed: missing iat claim")
+            return JWTValidationResult.MissingIatClaim
+        }
+        if (iatRaw.isNaN()) {
+            Registry.log.warning("JWT validation failed: iat claim non-numeric")
+            return JWTValidationResult.MalformedJson
+        }
+
+        if (nowEpochSeconds.toDouble() >= expRaw - leewaySeconds.toDouble()) {
+            Registry.log.warning("JWT validation failed: expired on receipt")
+            return JWTValidationResult.ExpiredOnReceipt
+        }
+
+        return JWTValidationResult.Valid(
+            ValidatedToken(
+                rawToken = token,
+                expiresAtEpochSeconds = expRaw.toLong(),
+                issuedAtEpochSeconds = iatRaw.toLong()
+            )
+        )
+    }
+
+    private fun base64UrlDecode(value: String): ByteArray? {
+        val normalized = value
+            .replace('-', '+')
+            .replace('_', '/')
+        val paddingNeeded = (4 - normalized.length % 4) % 4
+        val padded = normalized + "=".repeat(paddingNeeded)
+        return try {
+            Base64.decode(padded, Base64.DEFAULT)
+        } catch (e: IllegalArgumentException) {
+            null
+        }
+    }
+
+    private fun JSONObject.numericClaim(key: String): Double? {
+        if (!has(key) || isNull(key)) return null
+        val raw = get(key)
+        return when (raw) {
+            is Number -> raw.toDouble()
+            else -> Double.NaN
+        }
+    }
+}

--- a/sdk/core/src/main/java/com/klaviyo/core/auth/JWTValidationResult.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/JWTValidationResult.kt
@@ -1,0 +1,11 @@
+package com.klaviyo.core.auth
+
+internal sealed interface JWTValidationResult {
+    data class Valid(val token: ValidatedToken) : JWTValidationResult
+    data object MalformedStructure : JWTValidationResult
+    data object MalformedBase64 : JWTValidationResult
+    data object MalformedJson : JWTValidationResult
+    data object MissingExpClaim : JWTValidationResult
+    data object MissingIatClaim : JWTValidationResult
+    data object ExpiredOnReceipt : JWTValidationResult
+}

--- a/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
@@ -1,0 +1,115 @@
+package com.klaviyo.core.auth
+
+import com.klaviyo.core.Registry
+import com.klaviyo.core.lifecycle.LifecycleMonitor
+import com.klaviyo.core.safeLaunch
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * @param lifecycleMonitor declared in the constructor to lock the signature for MAGE-629's
+ *   lifecycle-aware refresh work; unused by code in this PR.
+ */
+internal class KlaviyoAuthTokenManager(
+    @Suppress("unused") private val lifecycleMonitor: LifecycleMonitor = Registry.lifecycleMonitor
+) : AuthTokenManager {
+
+    // Internal (not on the interface) so MAGE-619 consumers are forced to use their own scope
+    // when calling currentToken(), binding auth work to the correct lifecycle.
+    internal val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Registry.dispatcher)
+
+    // Mutex retained for currentToken's read-validate-write transition; MAGE-628 will replace
+    // this with Deferred-based deduplication.
+    private val mutex = Mutex()
+
+    // @Volatile so reads in invokeProvider (outside the mutex) always observe the latest write
+    // from registerProvider. Single-write-wins semantics are acceptable for the happy path.
+    @Volatile private var provider: AuthTokenProvider? = null
+
+    @Volatile private var cachedToken: ValidatedToken? = null
+
+    // Reserved for MAGE-628 (concurrent-caller deduplication).
+    @Suppress("unused")
+    private var inFlightFetch: Deferred<String>? = null
+
+    // Reserved for MAGE-630 (onTokenRefresh/offTokenRefresh observers). Matches the established
+    // SDK observer-collection pattern (CopyOnWriteArrayList for thread-safe iteration while
+    // observers add/remove themselves on arbitrary threads).
+    @Suppress("unused")
+    private val refreshObservers = CopyOnWriteArrayList<TokenRefreshObserver>()
+
+    override fun registerProvider(provider: AuthTokenProvider) {
+        cachedToken = null
+        this.provider = provider
+        Registry.log.info("AuthTokenProvider registered")
+        scope.safeLaunch { tryEagerFetch() }
+    }
+
+    private suspend fun tryEagerFetch() {
+        try {
+            currentToken()
+        } catch (e: CancellationException) {
+            // Preserve structured concurrency by rethrowing cancellation.
+            throw e
+        } catch (_: Exception) {
+            // The failure is already logged at ERROR by validateOrThrow (or surfaced by the
+            // provider's own onFailure). Avoid double-logging at WARNING here.
+            Registry.log.debug("Eager auth token fetch failed")
+        }
+    }
+
+    override suspend fun currentToken(): String {
+        val cached = cachedToken
+        if (cached != null && isStillValid(cached)) {
+            return cached.rawToken
+        }
+
+        val jwt = invokeProvider()
+        val token = validateOrThrow(jwt)
+
+        mutex.withLock { cachedToken = token }
+        Registry.log.info(
+            "Auth token acquired (exp=${token.expiresAtEpochSeconds}, iat=${token.issuedAtEpochSeconds})"
+        )
+        return token.rawToken
+    }
+
+    private suspend fun invokeProvider(): String = suspendCancellableCoroutine { continuation ->
+        val callback = object : AuthTokenProvider.Callback {
+            override fun onSuccess(jwt: String) {
+                if (continuation.isActive) continuation.resume(jwt)
+            }
+
+            override fun onFailure(error: Throwable) {
+                if (continuation.isActive) continuation.resumeWithException(error)
+            }
+        }
+        provider?.fetchToken(callback) ?: continuation.resumeWithException(
+            AuthTokenException.NoProviderRegistered
+        )
+    }
+
+    private fun validateOrThrow(jwt: String): ValidatedToken =
+        when (val result = JWTParser.parseAndValidate(jwt)) {
+            is JWTValidationResult.Valid -> result.token
+            else -> {
+                val reason = result::class.simpleName ?: "Unknown"
+                val error = AuthTokenException.ValidationFailed(reason)
+                Registry.log.error(requireNotNull(error.message), error)
+                throw error
+            }
+        }
+
+    private fun isStillValid(token: ValidatedToken): Boolean {
+        val now = Registry.clock.currentTimeMillis() / 1000L
+        return now < token.expiresAtEpochSeconds - JWTParser.DEFAULT_LEEWAY_SECONDS
+    }
+}

--- a/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
@@ -10,9 +10,13 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeoutOrNull
 
 /**
  * @param lifecycleMonitor declared in the constructor to lock the signature for MAGE-629's
@@ -26,8 +30,8 @@ internal class KlaviyoAuthTokenManager(
     // when calling currentToken(), binding auth work to the correct lifecycle.
     internal val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Registry.dispatcher)
 
-    // Mutex retained for currentToken's read-validate-write transition; MAGE-628 will replace
-    // this with Deferred-based deduplication.
+    // Guards the read-validate-write transition on both cachedToken and inFlightFetch, ensuring
+    // exactly one Deferred is created when multiple callers miss the cache simultaneously.
     private val mutex = Mutex()
 
     // @Volatile so reads in invokeProvider (outside the mutex) always observe the latest write
@@ -36,9 +40,12 @@ internal class KlaviyoAuthTokenManager(
 
     @Volatile private var cachedToken: ValidatedToken? = null
 
-    // Reserved for MAGE-628 (concurrent-caller deduplication).
-    @Suppress("unused")
-    private var inFlightFetch: Deferred<String>? = null
+    // Shared in-flight fetch deferred. All concurrent callers that miss the cache await this
+    // single Deferred rather than each invoking the provider independently. Cleared (via
+    // invokeOnCompletion) on both success and failure so the next request starts a fresh fetch.
+    // @Volatile because registerProvider and invokeOnCompletion clear it without holding the
+    // mutex; @Volatile ensures those writes are visible to the mutex-protected read in currentToken.
+    @Volatile private var inFlightFetch: Deferred<ValidatedToken>? = null
 
     // Reserved for MAGE-630 (onTokenRefresh/offTokenRefresh observers). Matches the established
     // SDK observer-collection pattern (CopyOnWriteArrayList for thread-safe iteration while
@@ -47,6 +54,15 @@ internal class KlaviyoAuthTokenManager(
     private val refreshObservers = CopyOnWriteArrayList<TokenRefreshObserver>()
 
     override fun registerProvider(provider: AuthTokenProvider) {
+        // Cancel any in-flight fetch for the old provider before swapping.
+        // Two complementary guards prevent a stale token from reaching the cache:
+        //   1. If the cancelled coroutine is still inside invokeProvider(), the isActive check in
+        //      suspendCancellableCoroutine drops any late onSuccess/onFailure callback.
+        //   2. If the callback already fired and doFetch() is past invokeProvider() but hasn't
+        //      written the cache yet, ensureActive() in doFetch will throw CancellationException
+        //      before the write — even when mutex.withLock acquires the lock uncontended.
+        inFlightFetch?.cancel()
+        inFlightFetch = null
         cachedToken = null
         this.provider = provider
         Registry.log.info("AuthTokenProvider registered")
@@ -55,26 +71,83 @@ internal class KlaviyoAuthTokenManager(
 
     private suspend fun tryEagerFetch() {
         try {
-            currentToken()
+            currentToken(AuthTokenManager.BACKGROUND_FETCH_TIMEOUT_MS)
         } catch (e: CancellationException) {
             // Preserve structured concurrency by rethrowing cancellation.
             throw e
         } catch (_: Exception) {
-            // The failure is already logged at ERROR by validateOrThrow (or surfaced by the
-            // provider's own onFailure). Avoid double-logging at WARNING here.
-            Registry.log.debug("Eager auth token fetch failed")
+            // The failure is already logged at ERROR by validateOrThrow, by the timeout path, or
+            // surfaced by the provider's own onFailure. Nothing more to log here.
         }
     }
 
-    override suspend fun currentToken(): ValidatedToken {
+    override suspend fun currentToken(timeoutMs: Long): ValidatedToken {
+        require(timeoutMs > 0L) { "timeoutMs must be positive, but was $timeoutMs" }
+        if (provider == null) throw AuthTokenException.NoProviderRegistered
+
+        // Optimistic read of @Volatile field — no lock needed for the fast path.
         val cached = cachedToken
-        if (cached != null && isStillValid(cached)) {
-            return cached
+        if (cached != null && isStillValid(cached)) return cached
+
+        // Atomic read-or-create of the in-flight deferred. The mutex ensures exactly one
+        // scope.async { } is launched when multiple callers miss the cache simultaneously.
+        val deferred: Deferred<ValidatedToken> = mutex.withLock {
+            // Re-check under the lock; a concurrent caller may have populated the cache while
+            // we waited. Non-local return from this inline lambda exits currentToken() directly.
+            val freshenedCache = cachedToken
+            if (freshenedCache != null && isStillValid(freshenedCache)) return freshenedCache
+
+            inFlightFetch ?: scope.async { doFetch() }.also { d ->
+                inFlightFetch = d
+                // Reference-identity check: prevents a stale deferred's completion handler from
+                // clearing a freshly-created deferred after a concurrent provider swap.
+                d.invokeOnCompletion { if (inFlightFetch === d) inFlightFetch = null }
+            }
         }
 
+        // Each caller races its own timeout budget against the shared deferred. Timing out does
+        // NOT cancel the underlying task — other callers with a larger budget still benefit if
+        // the provider eventually responds.
+        //
+        // CancellationException handling: Deferred.await() throws CancellationException if the
+        // deferred is cancelled externally (e.g. by registerProvider swapping the provider). This
+        // would otherwise propagate to callers as if THEIR coroutine was cancelled, which breaks
+        // structured-concurrency semantics. We catch it, use ensureActive() to distinguish "our
+        // coroutine was cancelled" (rethrow — normal teardown) from "the deferred was cancelled
+        // by a provider swap" (retry — pick up the new provider's fetch transparently).
+        //
+        // Budget: the retry calls currentToken(timeoutMs) inside this same withTimeoutOrNull block,
+        // so the caller's original deadline governs the total wait end-to-end. The recursive call
+        // creates a fresh inner withTimeoutOrNull(timeoutMs) starting from the current time, but
+        // the outer one fires first if the budget is nearly exhausted. This is intentional — the
+        // caller asked for a response within timeoutMs of their call site, not of the swap.
+        return withTimeoutOrNull(timeoutMs) {
+            try {
+                deferred.await()
+            } catch (e: CancellationException) {
+                currentCoroutineContext().ensureActive()
+                currentToken(timeoutMs)
+            }
+        } ?: run {
+            val error = AuthTokenException.TimedOut
+            Registry.log.warning(requireNotNull(error.message), error)
+            throw error
+        }
+    }
+
+    /**
+     * Invoke the provider, validate the returned JWT, write to the cache, and return the token.
+     * Runs inside [scope].async so failures (provider error, validation error) are captured by
+     * the Deferred and re-thrown to all awaiting callers.
+     */
+    private suspend fun doFetch(): ValidatedToken {
         val jwt = invokeProvider()
         val token = validateOrThrow(jwt)
-
+        // Non-suspending cancellation check: if this deferred was cancelled (e.g. by a provider
+        // swap) after invokeProvider() returned but before we write the cache, bail out now.
+        // mutex.withLock does NOT check cancellation when the lock is uncontended, so this guard
+        // is required even when the mutex is free.
+        currentCoroutineContext().ensureActive()
         mutex.withLock { cachedToken = token }
         Registry.log.info(
             "Auth token acquired (exp=${token.expiresAtEpochSeconds}, iat=${token.issuedAtEpochSeconds})"

--- a/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
@@ -66,10 +66,10 @@ internal class KlaviyoAuthTokenManager(
         }
     }
 
-    override suspend fun currentToken(): String {
+    override suspend fun currentToken(): ValidatedToken {
         val cached = cachedToken
         if (cached != null && isStillValid(cached)) {
-            return cached.rawToken
+            return cached
         }
 
         val jwt = invokeProvider()
@@ -79,7 +79,7 @@ internal class KlaviyoAuthTokenManager(
         Registry.log.info(
             "Auth token acquired (exp=${token.expiresAtEpochSeconds}, iat=${token.issuedAtEpochSeconds})"
         )
-        return token.rawToken
+        return token
     }
 
     private suspend fun invokeProvider(): String = suspendCancellableCoroutine { continuation ->

--- a/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
@@ -1,9 +1,13 @@
 package com.klaviyo.core.auth
 
 import com.klaviyo.core.Registry
+import com.klaviyo.core.config.Clock
+import com.klaviyo.core.lifecycle.ActivityEvent
 import com.klaviyo.core.lifecycle.LifecycleMonitor
 import com.klaviyo.core.safeLaunch
+import com.klaviyo.core.utils.takeIf
 import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicLong
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlinx.coroutines.CancellationException
@@ -18,17 +22,17 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeoutOrNull
 
-/**
- * @param lifecycleMonitor declared in the constructor to lock the signature for MAGE-629's
- *   lifecycle-aware refresh work; unused by code in this PR.
- */
 internal class KlaviyoAuthTokenManager(
-    @Suppress("unused") private val lifecycleMonitor: LifecycleMonitor = Registry.lifecycleMonitor
+    private val lifecycleMonitor: LifecycleMonitor = Registry.lifecycleMonitor
 ) : AuthTokenManager {
 
     // Internal (not on the interface) so MAGE-619 consumers are forced to use their own scope
     // when calling currentToken(), binding auth work to the correct lifecycle.
     internal val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Registry.dispatcher)
+
+    init {
+        lifecycleMonitor.onActivityEvent(::onLifecycleEvent)
+    }
 
     // Guards the read-validate-write transition on both cachedToken and inFlightFetch, ensuring
     // exactly one Deferred is created when multiple callers miss the cache simultaneously.
@@ -47,6 +51,27 @@ internal class KlaviyoAuthTokenManager(
     // mutex; @Volatile ensures those writes are visible to the mutex-protected read in currentToken.
     @Volatile private var inFlightFetch: Deferred<ValidatedToken>? = null
 
+    // NOT cleared in the timer callback on firing — a failed refresh leaves this pointing at a
+    // past target so handleForegroundTransition() case 2 can detect the miss and retry once.
+    // @Volatile because registerProvider writes without holding the mutex; @Volatile ensures those
+    // writes are visible to subsequent mutex-protected reads in handleForegroundTransition().
+    @Volatile private var refreshJob: Clock.Cancellable? = null
+
+    // @Volatile for the same reason as refreshJob: registerProvider clears without holding mutex.
+    @Volatile private var refreshAtWallClockMs: Long? = null
+
+    // Set by the timer callback while holding mutex before refresh work begins. This prevents a
+    // foreground transition from treating an already-fired timer as a Doze-style miss while the
+    // scheduled refresh coroutine is still queued or in-flight.
+    // @Volatile because registerProvider resets without holding the mutex.
+    @Volatile private var refreshTimerFired = false
+
+    // Monotonic token used to ignore callbacks from refresh jobs cancelled by a later schedule.
+    // AtomicLong rather than @Volatile Long so that registerProvider's non-mutex increment
+    // (refreshGeneration.incrementAndGet()) is truly atomic and cannot race with scheduleRefresh's
+    // mutex-held increment to produce a lost update.
+    private val refreshGeneration = AtomicLong(0L)
+
     // Reserved for MAGE-630 (onTokenRefresh/offTokenRefresh observers). Matches the established
     // SDK observer-collection pattern (CopyOnWriteArrayList for thread-safe iteration while
     // observers add/remove themselves on arbitrary threads).
@@ -63,6 +88,11 @@ internal class KlaviyoAuthTokenManager(
         //      before the write — even when mutex.withLock acquires the lock uncontended.
         inFlightFetch?.cancel()
         inFlightFetch = null
+        refreshJob?.cancel()
+        refreshJob = null
+        refreshAtWallClockMs = null
+        refreshTimerFired = false
+        refreshGeneration.incrementAndGet()
         cachedToken = null
         this.provider = provider
         Registry.log.info("AuthTokenProvider registered")
@@ -82,20 +112,50 @@ internal class KlaviyoAuthTokenManager(
     }
 
     override suspend fun currentToken(timeoutMs: Long): ValidatedToken {
+        return getOrFetchToken(timeoutMs = timeoutMs, allowCachedToken = true)
+    }
+
+    /**
+     * Shared implementation behind [currentToken]. Split out so the
+     * `allowCachedToken` knob stays off the public [AuthTokenManager] interface —
+     * external callers always get the cache-honoring behavior.
+     *
+     * @param allowCachedToken When `true` (the [currentToken] path), a still-valid
+     *   cached token short-circuits both the optimistic pre-lock read and the
+     *   double-checked read under the mutex. When `false`, both reads are skipped
+     *   and the call always resolves through the in-flight fetch, forcing a fresh
+     *   provider invocation even if the cache is currently valid.
+     *
+     *   Only the proactive-refresh path ([performScheduledRefresh]) passes `false`:
+     *   a refresh fires *because* the cached token is aging, so returning that
+     *   still-valid token would make the refresh a no-op. Note this only bypasses
+     *   the *read* — dedup still applies (a concurrent fetch is joined, not
+     *   duplicated, via [inFlightFetch]), and the existing cache is left intact so
+     *   demand callers keep getting the valid token while the refresh runs.
+     */
+    private suspend fun getOrFetchToken(
+        timeoutMs: Long,
+        allowCachedToken: Boolean
+    ): ValidatedToken {
         require(timeoutMs > 0L) { "timeoutMs must be positive, but was $timeoutMs" }
         if (provider == null) throw AuthTokenException.NoProviderRegistered
 
-        // Optimistic read of @Volatile field — no lock needed for the fast path.
-        val cached = cachedToken
-        if (cached != null && isStillValid(cached)) return cached
+        if (allowCachedToken) {
+            // Optimistic read of @Volatile field — no lock needed for the fast path.
+            val cached = cachedToken
+            if (cached != null && isStillValid(cached)) return cached
+        }
 
         // Atomic read-or-create of the in-flight deferred. The mutex ensures exactly one
         // scope.async { } is launched when multiple callers miss the cache simultaneously.
         val deferred: Deferred<ValidatedToken> = mutex.withLock {
             // Re-check under the lock; a concurrent caller may have populated the cache while
-            // we waited. Non-local return from this inline lambda exits currentToken() directly.
+            // we waited. Non-local return from this inline lambda exits currentTokenInternal()
+            // directly.
             val freshenedCache = cachedToken
-            if (freshenedCache != null && isStillValid(freshenedCache)) return freshenedCache
+            if (allowCachedToken && freshenedCache != null && isStillValid(freshenedCache)) {
+                return freshenedCache
+            }
 
             inFlightFetch ?: scope.async { doFetch() }.also { d ->
                 inFlightFetch = d
@@ -126,7 +186,7 @@ internal class KlaviyoAuthTokenManager(
                 deferred.await()
             } catch (e: CancellationException) {
                 currentCoroutineContext().ensureActive()
-                currentToken(timeoutMs)
+                getOrFetchToken(timeoutMs = timeoutMs, allowCachedToken = allowCachedToken)
             }
         } ?: run {
             val error = AuthTokenException.TimedOut
@@ -148,7 +208,10 @@ internal class KlaviyoAuthTokenManager(
         // mutex.withLock does NOT check cancellation when the lock is uncontended, so this guard
         // is required even when the mutex is free.
         currentCoroutineContext().ensureActive()
-        mutex.withLock { cachedToken = token }
+        mutex.withLock {
+            cachedToken = token
+            scheduleRefresh(token)
+        }
         Registry.log.info(
             "Auth token acquired (exp=${token.expiresAtEpochSeconds}, iat=${token.issuedAtEpochSeconds})"
         )
@@ -184,5 +247,142 @@ internal class KlaviyoAuthTokenManager(
     private fun isStillValid(token: ValidatedToken): Boolean {
         val now = Registry.clock.currentTimeMillis() / 1000L
         return now < token.expiresAtEpochSeconds - JWTParser.DEFAULT_LEEWAY_SECONDS
+    }
+
+    /**
+     * Called under mutex (from [doFetch]). Non-suspending; safe inside withLock.
+     */
+    private fun scheduleRefresh(token: ValidatedToken) {
+        val nowMs = Registry.clock.currentTimeMillis()
+        val targetMs = computeRefreshTarget(token, nowMs)
+        // Bump the generation before cancelling so that if cancel() synchronously fires the old
+        // task (e.g. FireOnCancelClock in tests), the task sees a stale generation and self-aborts.
+        val generation = refreshGeneration.incrementAndGet()
+        refreshJob?.cancel()
+        refreshTimerFired = false
+        refreshAtWallClockMs = targetMs
+        refreshJob = Registry.clock.schedule((targetMs - nowMs).coerceAtLeast(0)) {
+            scope.safeLaunch {
+                if (markRefreshTimerFired(generation)) {
+                    performScheduledRefresh(generation)
+                }
+            }
+        }
+        Registry.log.info(
+            "Proactive token refresh scheduled (target=${Registry.clock.isoTime(targetMs)})"
+        )
+    }
+
+    private suspend fun markRefreshTimerFired(generation: Long): Boolean =
+        mutex.withLock {
+            if (refreshGeneration.get() != generation) return@withLock false
+            refreshTimerFired = true
+            true
+        }
+
+    /**
+     * Forces a fresh provider invocation and routes through the standard dedup + timeout path.
+     * Leaves the existing cache intact so callers can keep using it while refresh is in-flight,
+     * even if the refresh attempt fails; any concurrent caller that arrives while refresh is
+     * in-flight shares the single in-flight Deferred automatically.
+     *
+     * Logs at WARNING on failure — the still-valid cached token remains for live consumers.
+     * On failure does NOT reschedule; one foreground-transition retry is possible if
+     * [refreshAtWallClockMs] was not yet cleared (timer fired but fetch failed).
+     *
+     * TODO (MAGE-630): emit onTokenRefresh notification to observers on success.
+     */
+    private suspend fun performScheduledRefresh(timerGeneration: Long? = null) {
+        if (provider == null) return
+        Registry.log.info("Proactive token refresh fired")
+        try {
+            getOrFetchToken(
+                timeoutMs = AuthTokenManager.BACKGROUND_FETCH_TIMEOUT_MS,
+                allowCachedToken = false
+            )
+            Registry.log.info("Proactive token refresh succeeded")
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            if (timerGeneration != null) clearFiredFlagForFailedRefresh(timerGeneration)
+            Registry.log.warning("Proactive token refresh failed: ${e.javaClass.simpleName}", e)
+        }
+    }
+
+    private suspend fun clearFiredFlagForFailedRefresh(timerGeneration: Long) {
+        mutex.withLock {
+            if (refreshGeneration.get() == timerGeneration) {
+                refreshTimerFired = false
+            }
+        }
+    }
+
+    private fun onLifecycleEvent(event: ActivityEvent) {
+        event.takeIf<ActivityEvent.FirstStarted>() ?: return
+        scope.safeLaunch { handleForegroundTransition() }
+    }
+
+    /**
+     * Reconciles cache and scheduled-refresh state on foreground transition.
+     * [safeLaunch] is non-suspending, so the mutex is released before any launched
+     * coroutine runs — no re-entrancy risk with [currentToken]'s own withLock call.
+     *
+     * Case 1 uses [tryEagerFetch] (`allowCachedToken = true`) because [cachedToken] is explicitly
+     * nulled before the launch, guaranteeing a cache miss without needing to bypass the cache.
+     * Case 2 uses [performScheduledRefresh] (`allowCachedToken = false`) because the cached token
+     * is still valid and must NOT be returned — we need a fresh provider call despite the hit.
+     */
+    private suspend fun handleForegroundTransition() {
+        val nowMs = Registry.clock.currentTimeMillis()
+        mutex.withLock {
+            val cached = cachedToken
+            val targetMs = refreshAtWallClockMs
+            when {
+                cached != null && !isStillValid(cached) -> {
+                    cachedToken = null
+                    refreshJob?.cancel()
+                    refreshJob = null
+                    refreshAtWallClockMs = null
+                    refreshTimerFired = false
+                    refreshGeneration.incrementAndGet()
+                    Registry.log.info(
+                        "AuthTokenManager: foreground transition (case=expired-cached-token)"
+                    )
+                    scope.safeLaunch { tryEagerFetch() }
+                }
+                targetMs != null && nowMs >= targetMs && !refreshTimerFired -> {
+                    refreshJob?.cancel()
+                    refreshJob = null
+                    refreshAtWallClockMs = null
+                    refreshTimerFired = false
+                    refreshGeneration.incrementAndGet()
+                    Registry.log.info(
+                        "AuthTokenManager: foreground transition (case=missed-refresh)"
+                    )
+                    scope.safeLaunch { performScheduledRefresh() }
+                }
+                else -> Registry.log.info(
+                    "AuthTokenManager: foreground transition (case=still-valid)"
+                )
+            }
+        }
+    }
+
+    companion object {
+        /**
+         * Computes the absolute wall-clock target (epoch ms) for the next proactive refresh.
+         *
+         * Ideal: iat + 0.9 * (exp - iat). Clamped to [now + 5s, exp - leeway]:
+         * - Upper bound: refresh fires before the token is considered stale.
+         * - Lower bound: prevents tight loops for tokens issued near their own expiry.
+         */
+        internal fun computeRefreshTarget(token: ValidatedToken, nowMs: Long): Long {
+            val iatMs = token.issuedAtEpochSeconds * 1000L
+            val expMs = token.expiresAtEpochSeconds * 1000L
+            val idealMs = iatMs + (0.9 * (expMs - iatMs)).toLong()
+            val upperBoundMs = expMs - JWTParser.DEFAULT_LEEWAY_SECONDS * 1000L
+            val lowerBoundMs = nowMs + 5_000L
+            return maxOf(lowerBoundMs, minOf(idealMs, upperBoundMs))
+        }
     }
 }

--- a/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
@@ -72,10 +72,21 @@ internal class KlaviyoAuthTokenManager(
     // mutex-held increment to produce a lost update.
     private val refreshGeneration = AtomicLong(0L)
 
-    // Reserved for MAGE-630 (onTokenRefresh/offTokenRefresh observers). Matches the established
-    // SDK observer-collection pattern (CopyOnWriteArrayList for thread-safe iteration while
-    // observers add/remove themselves on arbitrary threads).
-    @Suppress("unused")
+    // Tracks profile lifecycle events: registerProvider(), invalidate(), and clearTokenState().
+    // Used by clearTokenState(expectedGeneration) to detect whether registerProvider() ran between
+    // the invalidate() call and the async clear, so a late clear doesn't wipe the new session.
+    // Deliberately separate from refreshGeneration (which scheduleRefresh() also bumps).
+    private val profileGeneration = AtomicLong(0L)
+
+    // Set to true by invalidate() and reset to false by registerProvider() and clearTokenState().
+    // Read by performScheduledRefresh just before notifying observers: if a profile reset is
+    // pending (i.e. invalidate() was called but clearTokenState() hasn't finished yet), the
+    // refresh must not broadcast the now-stale token. @Volatile because it is written on the
+    // calling thread (main) and read on the dispatcher (IO) with no other synchronisation.
+    @Volatile private var profileResetPending = false
+
+    // CopyOnWriteArrayList for thread-safe iteration while observers add/remove on arbitrary threads
+    // (established SDK observer-collection pattern, matches StateChangeObserver, ActivityObserver).
     private val refreshObservers = CopyOnWriteArrayList<TokenRefreshObserver>()
 
     override fun registerProvider(provider: AuthTokenProvider) {
@@ -93,10 +104,61 @@ internal class KlaviyoAuthTokenManager(
         refreshAtWallClockMs = null
         refreshTimerFired = false
         refreshGeneration.incrementAndGet()
+        // Advance profileGeneration so any pending clearTokenState(expectedGeneration) from a
+        // prior resetProfile() sees the generation mismatch and skips, preserving this new
+        // session's token state.
+        profileGeneration.incrementAndGet()
+        // Clear the reset-pending flag: the new provider supersedes any in-progress logout reset.
+        profileResetPending = false
         cachedToken = null
         this.provider = provider
         Registry.log.info("AuthTokenProvider registered")
         scope.safeLaunch { tryEagerFetch() }
+    }
+
+    override fun onTokenRefresh(observer: TokenRefreshObserver) {
+        refreshObservers.add(observer)
+    }
+
+    override fun offTokenRefresh(observer: TokenRefreshObserver) {
+        refreshObservers.remove(observer)
+    }
+
+    override fun invalidate(): Long {
+        // Set the flag before bumping the generation so that any performScheduledRefresh that
+        // reads the flag after this call (regardless of when its fetch started) will skip observers.
+        profileResetPending = true
+        return profileGeneration.incrementAndGet()
+    }
+
+    override suspend fun clearTokenState(expectedGeneration: Long) {
+        var cleared = false
+        mutex.withLock {
+            // If the caller captured a generation via invalidate() and a new provider has since
+            // been registered (profileGeneration advanced), skip the clear to avoid wiping the
+            // new session's token cache and refresh schedule.
+            if (expectedGeneration >= 0L && profileGeneration.get() != expectedGeneration) {
+                Registry.log.verbose(
+                    "clearTokenState: skipped — provider re-registered since reset"
+                )
+                return@withLock
+            }
+            inFlightFetch?.cancel()
+            inFlightFetch = null
+            refreshJob?.cancel()
+            refreshJob = null
+            refreshAtWallClockMs = null
+            refreshTimerFired = false
+            refreshGeneration.incrementAndGet()
+            // TODO (MAGE-684): connectivityWaitJob?.cancel(); connectivityWaitJob = null
+            cachedToken = null
+            profileGeneration.incrementAndGet()
+            // Clear the reset-pending flag so the next successful refresh (from a new or retained
+            // provider) can notify observers normally.
+            profileResetPending = false
+            cleared = true
+        }
+        if (cleared) Registry.log.info("Token state cleared")
     }
 
     private suspend fun tryEagerFetch() {
@@ -141,9 +203,11 @@ internal class KlaviyoAuthTokenManager(
         if (provider == null) throw AuthTokenException.NoProviderRegistered
 
         if (allowCachedToken) {
-            // Optimistic read of @Volatile field — no lock needed for the fast path.
+            // Optimistic read of @Volatile fields — no lock needed for the fast path.
+            // Skip the cache while a profile reset is pending: invalidate() has fired but
+            // clearTokenState() hasn't run yet, so cachedToken still holds the outgoing JWT.
             val cached = cachedToken
-            if (cached != null && isStillValid(cached)) return cached
+            if (cached != null && isStillValid(cached) && !profileResetPending) return cached
         }
 
         // Atomic read-or-create of the in-flight deferred. The mutex ensures exactly one
@@ -153,7 +217,7 @@ internal class KlaviyoAuthTokenManager(
             // we waited. Non-local return from this inline lambda exits currentTokenInternal()
             // directly.
             val freshenedCache = cachedToken
-            if (allowCachedToken && freshenedCache != null && isStillValid(freshenedCache)) {
+            if (allowCachedToken && freshenedCache != null && isStillValid(freshenedCache) && !profileResetPending) {
                 return freshenedCache
             }
 
@@ -286,26 +350,67 @@ internal class KlaviyoAuthTokenManager(
      * even if the refresh attempt fails; any concurrent caller that arrives while refresh is
      * in-flight shares the single in-flight Deferred automatically.
      *
+     * On success, notifies registered [TokenRefreshObserver]s with the new JWT, subject to two
+     * guards: (1) the returned token is still the live cached value (clears can null the cache
+     * mid-flight), and (2) no profile reset is pending ([profileResetPending] is false). The
+     * reset-pending flag is set synchronously by [invalidate] so that any refresh completing
+     * in the window between [invalidate] and [clearTokenState] is suppressed. Dispatch is
+     * best-effort — see [notifyRefreshObservers].
+     *
      * Logs at WARNING on failure — the still-valid cached token remains for live consumers.
      * On failure does NOT reschedule; one foreground-transition retry is possible if
      * [refreshAtWallClockMs] was not yet cleared (timer fired but fetch failed).
-     *
-     * TODO (MAGE-630): emit onTokenRefresh notification to observers on success.
      */
     private suspend fun performScheduledRefresh(timerGeneration: Long? = null) {
         if (provider == null) return
         Registry.log.info("Proactive token refresh fired")
         try {
-            getOrFetchToken(
+            val token = getOrFetchToken(
                 timeoutMs = AuthTokenManager.BACKGROUND_FETCH_TIMEOUT_MS,
                 allowCachedToken = false
             )
+            // Two-part stale guard before notifying observers:
+            // 1. Cache check (@Volatile read): clearTokenState() may have nulled cachedToken
+            //    while the fetch was suspended; skip if this token is no longer the live value.
+            // 2. Reset-pending check (@Volatile read): invalidate() sets this flag synchronously
+            //    from resetProfile() before the async clearTokenState() runs. Any refresh that
+            //    completes while a logout reset is pending must not broadcast to observers —
+            //    regardless of whether the refresh started before or after invalidate() was called.
+            //    The flag is cleared by clearTokenState() and registerProvider().
+            // Dispatch is best-effort; the small TOCTOU window on these volatile reads is
+            // acceptable (see notifyRefreshObservers KDoc).
+            if (cachedToken?.rawToken == token.rawToken && !profileResetPending) {
+                notifyRefreshObservers(token.rawToken)
+            }
             Registry.log.info("Proactive token refresh succeeded")
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
             if (timerGeneration != null) clearFiredFlagForFailedRefresh(timerGeneration)
             Registry.log.warning("Proactive token refresh failed: ${e.javaClass.simpleName}", e)
+        }
+    }
+
+    /**
+     * Iterates [refreshObservers] and invokes each with [jwt]. Best-effort: if an observer throws,
+     * the exception is logged at WARNING and the remaining observers are still called.
+     */
+    private fun notifyRefreshObservers(jwt: String) {
+        refreshObservers.forEach { observer ->
+            try {
+                observer(jwt)
+            } catch (e: CancellationException) {
+                // Structured-concurrency contract: CancellationException must never be swallowed.
+                throw e
+            } catch (e: Exception) {
+                // Best-effort dispatch: log and continue so a misbehaving observer cannot block
+                // others from receiving the token. JVM-fatal Errors (OOM, StackOverflowError, etc.)
+                // are intentionally NOT caught here — they should propagate.
+                Registry.log.warning(
+                    "TokenRefreshObserver threw ${e.javaClass.simpleName} — skipping",
+                    e
+                )
+            }
         }
     }
 

--- a/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
@@ -4,15 +4,22 @@ import com.klaviyo.core.Registry
 import com.klaviyo.core.config.Clock
 import com.klaviyo.core.lifecycle.ActivityEvent
 import com.klaviyo.core.lifecycle.LifecycleMonitor
+import com.klaviyo.core.networking.NetworkObserver
 import com.klaviyo.core.safeLaunch
 import com.klaviyo.core.utils.takeIf
+import java.io.IOException
+import java.net.ConnectException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
 import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.currentCoroutineContext
@@ -78,6 +85,13 @@ internal class KlaviyoAuthTokenManager(
     // Deliberately separate from refreshGeneration (which scheduleRefresh() also bumps).
     private val profileGeneration = AtomicLong(0L)
 
+    // Tracks logout/reset events only: incremented by invalidate() and clearTokenState(), but NOT
+    // by registerProvider(). Used by shouldArmConnectivityRetry to distinguish a stale failure from
+    // a logout-triggered reset vs. a benign mid-fetch provider swap. profileGeneration is too coarse
+    // for this check because registerProvider() also bumps it, which would wrongly block
+    // connectivity retry for the new session when a provider is swapped mid-fetch.
+    private val resetGeneration = AtomicLong(0L)
+
     // Set to true by invalidate() and reset to false by registerProvider() and clearTokenState().
     // Read by performScheduledRefresh just before notifying observers: if a profile reset is
     // pending (i.e. invalidate() was called but clearTokenState() hasn't finished yet), the
@@ -88,6 +102,30 @@ internal class KlaviyoAuthTokenManager(
     // CopyOnWriteArrayList for thread-safe iteration while observers add/remove on arbitrary threads
     // (established SDK observer-collection pattern, matches StateChangeObserver, ActivityObserver).
     private val refreshObservers = CopyOnWriteArrayList<TokenRefreshObserver>()
+
+    // A pending coroutine that waits for connectivity to be restored before retrying
+    // performScheduledRefresh. At most one is active at a time. All transitions to this field and
+    // to connectivityWaitGeneration are serialized via connectivityWaitLock. @Volatile for
+    // visibility to tests that read the field outside any lock.
+    // Internal (not private) so tests in this module can inspect job state without reflection.
+    @Volatile internal var connectivityWaitJob: Job? = null
+
+    // Monotonic counter bumped each time armConnectivityWaitJob() arms a new job. Used by the
+    // job's finally block to detect whether a newer arm replaced it; if so the old job must not
+    // null out the new job's reference. AtomicLong for the same reason as refreshGeneration.
+    private val connectivityWaitGeneration = AtomicLong(0L)
+
+    // JVM lock serializing all connectivityWaitJob + connectivityWaitGeneration transitions.
+    // Acquired without holding mutex (armConnectivityWaitJob) and while holding mutex
+    // (clearTokenState). Lock ordering is always: mutex → connectivityWaitLock.
+    private val connectivityWaitLock = Any()
+
+    private fun cancelConnectivityWaitJob() {
+        synchronized(connectivityWaitLock) {
+            connectivityWaitJob?.cancel()
+            connectivityWaitJob = null
+        }
+    }
 
     override fun registerProvider(provider: AuthTokenProvider) {
         // Cancel any in-flight fetch for the old provider before swapping.
@@ -103,6 +141,7 @@ internal class KlaviyoAuthTokenManager(
         refreshJob = null
         refreshAtWallClockMs = null
         refreshTimerFired = false
+        cancelConnectivityWaitJob()
         refreshGeneration.incrementAndGet()
         // Advance profileGeneration so any pending clearTokenState(expectedGeneration) from a
         // prior resetProfile() sees the generation mismatch and skips, preserving this new
@@ -128,6 +167,9 @@ internal class KlaviyoAuthTokenManager(
         // Set the flag before bumping the generation so that any performScheduledRefresh that
         // reads the flag after this call (regardless of when its fetch started) will skip observers.
         profileResetPending = true
+        // Also bump resetGeneration so shouldArmConnectivityRetry can detect a logout-triggered
+        // failure even after clearTokenState() has cleared profileResetPending.
+        resetGeneration.incrementAndGet()
         return profileGeneration.incrementAndGet()
     }
 
@@ -150,9 +192,13 @@ internal class KlaviyoAuthTokenManager(
             refreshAtWallClockMs = null
             refreshTimerFired = false
             refreshGeneration.incrementAndGet()
-            // TODO (MAGE-684): connectivityWaitJob?.cancel(); connectivityWaitJob = null
+            cancelConnectivityWaitJob()
             cachedToken = null
             profileGeneration.incrementAndGet()
+            // Also advance resetGeneration so that any performScheduledRefresh that started before
+            // this clear cannot arm a zombie connectivity job even when profileResetPending has been
+            // cleared by the time its catch block executes.
+            resetGeneration.incrementAndGet()
             // Clear the reset-pending flag so the next successful refresh (from a new or retained
             // provider) can notify observers normally.
             profileResetPending = false
@@ -206,20 +252,15 @@ internal class KlaviyoAuthTokenManager(
             // Optimistic read of @Volatile fields — no lock needed for the fast path.
             // Skip the cache while a profile reset is pending: invalidate() has fired but
             // clearTokenState() hasn't run yet, so cachedToken still holds the outgoing JWT.
-            val cached = cachedToken
-            if (cached != null && isStillValid(cached) && !profileResetPending) return cached
+            usableCachedToken(cachedToken)?.let { return it }
         }
 
         // Atomic read-or-create of the in-flight deferred. The mutex ensures exactly one
         // scope.async { } is launched when multiple callers miss the cache simultaneously.
         val deferred: Deferred<ValidatedToken> = mutex.withLock {
             // Re-check under the lock; a concurrent caller may have populated the cache while
-            // we waited. Non-local return from this inline lambda exits currentTokenInternal()
-            // directly.
-            val freshenedCache = cachedToken
-            if (allowCachedToken && freshenedCache != null && isStillValid(freshenedCache) && !profileResetPending) {
-                return freshenedCache
-            }
+            // we waited. Non-local return exits getOrFetchToken() directly.
+            if (allowCachedToken) usableCachedToken(cachedToken)?.let { return it }
 
             inFlightFetch ?: scope.async { doFetch() }.also { d ->
                 inFlightFetch = d
@@ -308,6 +349,14 @@ internal class KlaviyoAuthTokenManager(
             }
         }
 
+    /**
+     * Returns [token] if it is non-null, still valid per [isStillValid], and no profile reset is
+     * pending; otherwise returns `null`. Centralizes the cache-eligibility gate used in both the
+     * optimistic pre-lock read and the mutex-protected double-check inside [getOrFetchToken].
+     */
+    private fun usableCachedToken(token: ValidatedToken?): ValidatedToken? =
+        if (token != null && isStillValid(token) && !profileResetPending) token else null
+
     private fun isStillValid(token: ValidatedToken): Boolean {
         val now = Registry.clock.currentTimeMillis() / 1000L
         return now < token.expiresAtEpochSeconds - JWTParser.DEFAULT_LEEWAY_SECONDS
@@ -361,7 +410,17 @@ internal class KlaviyoAuthTokenManager(
      * On failure does NOT reschedule; one foreground-transition retry is possible if
      * [refreshAtWallClockMs] was not yet cleared (timer fired but fetch failed).
      */
-    private suspend fun performScheduledRefresh(timerGeneration: Long? = null) {
+    private suspend fun performScheduledRefresh(
+        timerGeneration: Long? = null,
+        allowImmediateConnectivityRetry: Boolean = true
+    ) {
+        // Snapshot the reset generation before suspending into the network fetch. If a logout or
+        // token-state clear (invalidate / clearTokenState) fires while the fetch is in progress,
+        // the catch block must not arm a connectivity retry for the now-stale session. We use
+        // resetGeneration rather than profileGeneration so that a benign provider swap
+        // (registerProvider without a logout) does not falsely suppress the retry for the new
+        // session — registerProvider does not bump resetGeneration.
+        val resetGenerationAtStart = resetGeneration.get()
         if (provider == null) return
         Registry.log.info("Proactive token refresh fired")
         try {
@@ -388,8 +447,37 @@ internal class KlaviyoAuthTokenManager(
         } catch (e: Exception) {
             if (timerGeneration != null) clearFiredFlagForFailedRefresh(timerGeneration)
             Registry.log.warning("Proactive token refresh failed: ${e.javaClass.simpleName}", e)
+            if (shouldArmConnectivityRetry(e, resetGenerationAtStart)) {
+                armConnectivityWaitJob(
+                    resumeImmediatelyIfConnected = allowImmediateConnectivityRetry
+                )
+            }
         }
     }
+
+    /**
+     * Returns true when a proactive-refresh failure should trigger a connectivity wait job.
+     *
+     * All four conditions must hold:
+     * - [resetGeneration] matches [resetGenerationAtStart]: no logout or state-clear
+     *   (invalidate / clearTokenState) occurred while the refresh was suspended. We use
+     *   [resetGeneration] rather than [profileGeneration] so that a benign provider swap
+     *   (registerProvider without a logout) does not falsely suppress retry — registerProvider
+     *   does not bump [resetGeneration].
+     * - The exception is a transient network error ([isNetworkException]): server errors and
+     *   validation failures should not trigger a connectivity retry.
+     * - [provider] is still set: a concurrent teardown may have cleared it.
+     * - No profile reset is pending ([profileResetPending]): guards against the window between
+     *   invalidate() and clearTokenState() where the flag is still true.
+     */
+    private fun shouldArmConnectivityRetry(
+        exception: Exception,
+        resetGenerationAtStart: Long
+    ): Boolean =
+        resetGeneration.get() == resetGenerationAtStart &&
+            isNetworkException(exception) &&
+            provider != null &&
+            !profileResetPending
 
     /**
      * Iterates [refreshObservers] and invokes each with [jwt]. Best-effort: if an observer throws,
@@ -418,6 +506,108 @@ internal class KlaviyoAuthTokenManager(
         mutex.withLock {
             if (refreshGeneration.get() == timerGeneration) {
                 refreshTimerFired = false
+            }
+        }
+    }
+
+    /**
+     * Returns `true` for exceptions that indicate genuine offline conditions.
+     * [UnknownHostException], [SocketTimeoutException], and [ConnectException] are all subtypes of
+     * [IOException]; they are listed explicitly to document the specific failure modes that warrant
+     * a connectivity-driven retry. HTTP errors, validation failures, and server-side bugs return
+     * `false` and must not trigger a connectivity retry (they won't resolve by waiting for the
+     * network).
+     */
+    private fun isNetworkException(e: Exception): Boolean =
+        e is UnknownHostException ||
+            e is SocketTimeoutException ||
+            e is ConnectException ||
+            e is IOException
+
+    /**
+     * Arms [connectivityWaitJob]: a single coroutine on [scope] that suspends until the next
+     * "connectivity available" notification from [Registry.networkMonitor], then triggers a
+     * proactive refresh via [performScheduledRefresh].
+     *
+     * At most one job is active at a time. All [connectivityWaitJob] and
+     * [connectivityWaitGeneration] transitions are serialized via [connectivityWaitLock] so that
+     * concurrent calls (rapid flap) and racing teardown from [registerProvider]/[clearTokenState]
+     * cannot leave multiple active jobs or a stale assignment.
+     *
+     * @param resumeImmediatelyIfConnected When true (the default), the job resumes immediately if
+     * the device is already connected — [Registry.networkMonitor] does not replay state on observer
+     * registration. Pass false from the connectivity-retry path to prevent a tight loop: if the
+     * provider keeps failing with a network exception while the device stays online, a re-armed job
+     * with [resumeImmediatelyIfConnected]=false waits for an actual connectivity transition before
+     * retrying again.
+     *
+     * Only invoked from the proactive-refresh failure path ([performScheduledRefresh]); demand
+     * callers via [currentToken] are not retried here — they surface the error to their own caller.
+     */
+    private fun armConnectivityWaitJob(resumeImmediatelyIfConnected: Boolean = true) {
+        Registry.log.info(
+            "AuthTokenManager: network failure — waiting for connectivity to retry refresh"
+        )
+        // Serialize cancel → generation increment → launch → assign under one lock so that
+        // concurrent calls to armConnectivityWaitJob() and racing registerProvider()/
+        // clearTokenState() cannot produce multiple active jobs or a stale null-out.
+        val waitGeneration: Long
+        synchronized(connectivityWaitLock) {
+            connectivityWaitJob?.cancel()
+            waitGeneration = connectivityWaitGeneration.incrementAndGet()
+            connectivityWaitJob = scope.safeLaunch {
+                try {
+                    suspendCancellableCoroutine { continuation ->
+                        val resumed = AtomicBoolean(false)
+                        // Use a ref box so the lambda can capture and de-register itself.
+                        val observerRef = arrayOfNulls<NetworkObserver>(1)
+                        val observer: NetworkObserver = { isConnected ->
+                            // One-shot guard: AtomicBoolean ensures exactly one connectivity
+                            // event (including the immediate check below) resumes the coroutine.
+                            if (isConnected && resumed.compareAndSet(false, true)) {
+                                observerRef[0]?.let { Registry.networkMonitor.offNetworkChange(it) }
+                                if (continuation.isActive) continuation.resume(Unit)
+                            }
+                        }
+                        observerRef[0] = observer
+                        Registry.networkMonitor.onNetworkChange(observer)
+                        // Install cancellation handler AFTER registration so the handler can
+                        // never try to remove an observer that hasn't been registered yet.
+                        continuation.invokeOnCancellation {
+                            Registry.networkMonitor.offNetworkChange(observer)
+                        }
+                        // Resume immediately if already online — networkMonitor does not replay
+                        // state on registration (handles SocketTimeoutException on live network).
+                        // Skip on re-arm (resumeImmediatelyIfConnected=false) to prevent a tight
+                        // loop when the provider keeps failing with IOException while the device
+                        // stays connected; in that case we wait for an actual connectivity event.
+                        if (resumeImmediatelyIfConnected &&
+                            Registry.networkMonitor.isNetworkConnected() &&
+                            resumed.compareAndSet(false, true)
+                        ) {
+                            Registry.networkMonitor.offNetworkChange(observer)
+                            if (continuation.isActive) continuation.resume(Unit)
+                        }
+                    }
+                    Registry.log.info(
+                        "AuthTokenManager: connectivity restored — retrying proactive refresh"
+                    )
+                    // Cancellation checkpoint: registerProvider()/clearTokenState() may have
+                    // cancelled this job after the connectivity event fired but before we retry.
+                    currentCoroutineContext().ensureActive()
+                    // Pass allowImmediateConnectivityRetry=false so that if this retry also fails
+                    // with a network exception, the re-armed job will NOT immediately resume on an
+                    // already-connected device — avoiding a tight retry loop.
+                    performScheduledRefresh(allowImmediateConnectivityRetry = false)
+                } finally {
+                    // Only clear the field if the generation still matches — a concurrent
+                    // re-arm may have replaced this job; if so leave the new job in place.
+                    synchronized(connectivityWaitLock) {
+                        if (connectivityWaitGeneration.get() == waitGeneration) {
+                            connectivityWaitJob = null
+                        }
+                    }
+                }
             }
         }
     }

--- a/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
@@ -19,84 +19,70 @@ import kotlin.coroutines.resumeWithException
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.suspendCancellableCoroutine
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 
+@OptIn(ExperimentalCoroutinesApi::class)
 internal class KlaviyoAuthTokenManager(
     private val lifecycleMonitor: LifecycleMonitor = Registry.lifecycleMonitor
 ) : AuthTokenManager {
 
+    // Single-threaded coroutine context that serializes all state mutations (the actor pattern).
+    // Routing every read-validate-write through one thread removes the need for a Mutex, JVM locks,
+    // or @Volatile on the actor-confined fields below.
+    private val actorContext = Registry.dispatcher.limitedParallelism(1)
+
     // Internal (not on the interface) so MAGE-619 consumers are forced to use their own scope
     // when calling currentToken(), binding auth work to the correct lifecycle.
-    internal val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Registry.dispatcher)
+    internal val scope: CoroutineScope = CoroutineScope(SupervisorJob() + actorContext)
 
     init {
         lifecycleMonitor.onActivityEvent(::onLifecycleEvent)
     }
 
-    // Guards the read-validate-write transition on both cachedToken and inFlightFetch, ensuring
-    // exactly one Deferred is created when multiple callers miss the cache simultaneously.
-    private val mutex = Mutex()
+    // Actor-confined: only read/written on the single-threaded actorContext, so no @Volatile needed.
+    private var provider: AuthTokenProvider? = null
 
-    // @Volatile so reads in invokeProvider (outside the mutex) always observe the latest write
-    // from registerProvider. Single-write-wins semantics are acceptable for the happy path.
-    @Volatile private var provider: AuthTokenProvider? = null
-
-    @Volatile private var cachedToken: ValidatedToken? = null
+    private var cachedToken: ValidatedToken? = null
 
     // Shared in-flight fetch deferred. All concurrent callers that miss the cache await this
     // single Deferred rather than each invoking the provider independently. Cleared (via
     // invokeOnCompletion) on both success and failure so the next request starts a fresh fetch.
-    // @Volatile because registerProvider and invokeOnCompletion clear it without holding the
-    // mutex; @Volatile ensures those writes are visible to the mutex-protected read in currentToken.
-    @Volatile private var inFlightFetch: Deferred<ValidatedToken>? = null
+    private var inFlightFetch: Deferred<ValidatedToken>? = null
 
     // NOT cleared in the timer callback on firing — a failed refresh leaves this pointing at a
     // past target so handleForegroundTransition() case 2 can detect the miss and retry once.
-    // @Volatile because registerProvider writes without holding the mutex; @Volatile ensures those
-    // writes are visible to subsequent mutex-protected reads in handleForegroundTransition().
-    @Volatile private var refreshJob: Clock.Cancellable? = null
+    private var refreshJob: Clock.Cancellable? = null
 
-    // @Volatile for the same reason as refreshJob: registerProvider clears without holding mutex.
-    @Volatile private var refreshAtWallClockMs: Long? = null
+    private var refreshAtWallClockMs: Long? = null
 
-    // Set by the timer callback while holding mutex before refresh work begins. This prevents a
-    // foreground transition from treating an already-fired timer as a Doze-style miss while the
-    // scheduled refresh coroutine is still queued or in-flight.
-    // @Volatile because registerProvider resets without holding the mutex.
-    @Volatile private var refreshTimerFired = false
+    // Set by the timer callback before refresh work begins. This prevents a foreground transition
+    // from treating an already-fired timer as a Doze-style miss while the scheduled refresh
+    // coroutine is still queued or in-flight.
+    private var refreshTimerFired = false
 
     // Monotonic token used to ignore callbacks from refresh jobs cancelled by a later schedule.
-    // AtomicLong rather than @Volatile Long so that registerProvider's non-mutex increment
-    // (refreshGeneration.incrementAndGet()) is truly atomic and cannot race with scheduleRefresh's
-    // mutex-held increment to produce a lost update.
-    private val refreshGeneration = AtomicLong(0L)
+    // Actor-confined, so a plain var suffices.
+    private var refreshGeneration = 0L
 
-    // Tracks profile lifecycle events: registerProvider(), invalidate(), and clearTokenState().
-    // Used by clearTokenState(expectedGeneration) to detect whether registerProvider() ran between
-    // the invalidate() call and the async clear, so a late clear doesn't wipe the new session.
-    // Deliberately separate from refreshGeneration (which scheduleRefresh() also bumps).
-    private val profileGeneration = AtomicLong(0L)
-
-    // Tracks logout/reset events only: incremented by invalidate() and clearTokenState(), but NOT
-    // by registerProvider(). Used by shouldArmConnectivityRetry to distinguish a stale failure from
-    // a logout-triggered reset vs. a benign mid-fetch provider swap. profileGeneration is too coarse
-    // for this check because registerProvider() also bumps it, which would wrongly block
-    // connectivity retry for the new session when a provider is swapped mid-fetch.
+    // Tracks logout/reset events only: incremented by invalidate(), but NOT by registerProvider().
+    // Used by shouldArmConnectivityRetry to distinguish a stale failure from a logout-triggered
+    // reset vs. a benign mid-fetch provider swap. AtomicLong because invalidate() runs on the
+    // caller's thread (main), outside the actorContext.
     private val resetGeneration = AtomicLong(0L)
 
     // Set to true by invalidate() and reset to false by registerProvider() and clearTokenState().
     // Read by performScheduledRefresh just before notifying observers: if a profile reset is
     // pending (i.e. invalidate() was called but clearTokenState() hasn't finished yet), the
-    // refresh must not broadcast the now-stale token. @Volatile because it is written on the
-    // calling thread (main) and read on the dispatcher (IO) with no other synchronisation.
+    // refresh must not broadcast the now-stale token. @Volatile because invalidate() writes it on
+    // the calling thread (main), outside the actorContext.
     @Volatile private var profileResetPending = false
 
     // CopyOnWriteArrayList for thread-safe iteration while observers add/remove on arbitrary threads
@@ -104,55 +90,39 @@ internal class KlaviyoAuthTokenManager(
     private val refreshObservers = CopyOnWriteArrayList<TokenRefreshObserver>()
 
     // A pending coroutine that waits for connectivity to be restored before retrying
-    // performScheduledRefresh. At most one is active at a time. All transitions to this field and
-    // to connectivityWaitGeneration are serialized via connectivityWaitLock. @Volatile for
-    // visibility to tests that read the field outside any lock.
-    // Internal (not private) so tests in this module can inspect job state without reflection.
+    // performScheduledRefresh. At most one is active at a time; an existing job is cancelled before
+    // arming a new one. @Volatile for visibility to tests that read the field outside the
+    // actorContext. Internal (not private) so tests in this module can inspect job state.
     @Volatile internal var connectivityWaitJob: Job? = null
 
-    // Monotonic counter bumped each time armConnectivityWaitJob() arms a new job. Used by the
-    // job's finally block to detect whether a newer arm replaced it; if so the old job must not
-    // null out the new job's reference. AtomicLong for the same reason as refreshGeneration.
-    private val connectivityWaitGeneration = AtomicLong(0L)
-
-    // JVM lock serializing all connectivityWaitJob + connectivityWaitGeneration transitions.
-    // Acquired without holding mutex (armConnectivityWaitJob) and while holding mutex
-    // (clearTokenState). Lock ordering is always: mutex → connectivityWaitLock.
-    private val connectivityWaitLock = Any()
-
-    private fun cancelConnectivityWaitJob() {
-        synchronized(connectivityWaitLock) {
-            connectivityWaitJob?.cancel()
-            connectivityWaitJob = null
-        }
-    }
-
     override fun registerProvider(provider: AuthTokenProvider) {
-        // Cancel any in-flight fetch for the old provider before swapping.
-        // Two complementary guards prevent a stale token from reaching the cache:
+        // Cancel any in-flight work synchronously so the old provider's deferred is torn down
+        // before this call returns. Two complementary guards prevent a stale token from reaching
+        // the cache:
         //   1. If the cancelled coroutine is still inside invokeProvider(), the isActive check in
         //      suspendCancellableCoroutine drops any late onSuccess/onFailure callback.
         //   2. If the callback already fired and doFetch() is past invokeProvider() but hasn't
         //      written the cache yet, ensureActive() in doFetch will throw CancellationException
-        //      before the write — even when mutex.withLock acquires the lock uncontended.
+        //      before the write.
         inFlightFetch?.cancel()
-        inFlightFetch = null
         refreshJob?.cancel()
-        refreshJob = null
-        refreshAtWallClockMs = null
-        refreshTimerFired = false
-        cancelConnectivityWaitJob()
-        refreshGeneration.incrementAndGet()
-        // Advance profileGeneration so any pending clearTokenState(expectedGeneration) from a
-        // prior resetProfile() sees the generation mismatch and skips, preserving this new
-        // session's token state.
-        profileGeneration.incrementAndGet()
-        // Clear the reset-pending flag: the new provider supersedes any in-progress logout reset.
-        profileResetPending = false
-        cachedToken = null
-        this.provider = provider
-        Registry.log.info("AuthTokenProvider registered")
-        scope.safeLaunch { tryEagerFetch() }
+        connectivityWaitJob?.cancel()
+        // All field mutations run on the actorContext so they are ordered relative to fetches,
+        // refreshes, and clears. Reset-pending is cleared here because the new provider supersedes
+        // any in-progress logout reset.
+        scope.safeLaunch {
+            inFlightFetch = null
+            refreshJob = null
+            refreshAtWallClockMs = null
+            refreshTimerFired = false
+            connectivityWaitJob = null
+            refreshGeneration++
+            profileResetPending = false
+            cachedToken = null
+            this@KlaviyoAuthTokenManager.provider = provider
+            Registry.log.info("AuthTokenProvider registered")
+            tryEagerFetch()
+        }
     }
 
     override fun onTokenRefresh(observer: TokenRefreshObserver) {
@@ -163,27 +133,25 @@ internal class KlaviyoAuthTokenManager(
         refreshObservers.remove(observer)
     }
 
-    override fun invalidate(): Long {
-        // Set the flag before bumping the generation so that any performScheduledRefresh that
-        // reads the flag after this call (regardless of when its fetch started) will skip observers.
+    override fun invalidate() {
+        // Set the flag so that any performScheduledRefresh that reads it after this call
+        // (regardless of when its fetch started) will skip observers.
         profileResetPending = true
         // Also bump resetGeneration so shouldArmConnectivityRetry can detect a logout-triggered
         // failure even after clearTokenState() has cleared profileResetPending.
         resetGeneration.incrementAndGet()
-        return profileGeneration.incrementAndGet()
     }
 
-    override suspend fun clearTokenState(expectedGeneration: Long) {
+    override suspend fun clearTokenState() {
         var cleared = false
-        mutex.withLock {
-            // If the caller captured a generation via invalidate() and a new provider has since
-            // been registered (profileGeneration advanced), skip the clear to avoid wiping the
-            // new session's token cache and refresh schedule.
-            if (expectedGeneration >= 0L && profileGeneration.get() != expectedGeneration) {
+        withContext(actorContext) {
+            // If registerProvider() ran between invalidate() and this call, it cleared
+            // profileResetPending — so a stale clear must not wipe the new session's state.
+            if (!profileResetPending) {
                 Registry.log.verbose(
                     "clearTokenState: skipped — provider re-registered since reset"
                 )
-                return@withLock
+                return@withContext
             }
             inFlightFetch?.cancel()
             inFlightFetch = null
@@ -191,10 +159,10 @@ internal class KlaviyoAuthTokenManager(
             refreshJob = null
             refreshAtWallClockMs = null
             refreshTimerFired = false
-            refreshGeneration.incrementAndGet()
-            cancelConnectivityWaitJob()
+            refreshGeneration++
+            connectivityWaitJob?.cancel()
+            connectivityWaitJob = null
             cachedToken = null
-            profileGeneration.incrementAndGet()
             // Also advance resetGeneration so that any performScheduledRefresh that started before
             // this clear cannot arm a zombie connectivity job even when profileResetPending has been
             // cleared by the time its catch block executes.
@@ -219,9 +187,10 @@ internal class KlaviyoAuthTokenManager(
         }
     }
 
-    override suspend fun currentToken(timeoutMs: Long): ValidatedToken {
-        return getOrFetchToken(timeoutMs = timeoutMs, allowCachedToken = true)
-    }
+    override suspend fun currentToken(timeoutMs: Long): ValidatedToken =
+        withContext(actorContext) {
+            getOrFetchToken(timeoutMs = timeoutMs, allowCachedToken = true)
+        }
 
     /**
      * Shared implementation behind [currentToken]. Split out so the
@@ -248,26 +217,17 @@ internal class KlaviyoAuthTokenManager(
         require(timeoutMs > 0L) { "timeoutMs must be positive, but was $timeoutMs" }
         if (provider == null) throw AuthTokenException.NoProviderRegistered
 
-        if (allowCachedToken) {
-            // Optimistic read of @Volatile fields — no lock needed for the fast path.
-            // Skip the cache while a profile reset is pending: invalidate() has fired but
-            // clearTokenState() hasn't run yet, so cachedToken still holds the outgoing JWT.
-            usableCachedToken(cachedToken)?.let { return it }
-        }
+        // Cache read and in-flight-deferred creation both run on the single-threaded actorContext,
+        // so exactly one scope.async { } is launched even when multiple callers miss the cache.
+        // Skip the cache while a profile reset is pending: invalidate() has fired but
+        // clearTokenState() hasn't run yet, so cachedToken still holds the outgoing JWT.
+        if (allowCachedToken) usableCachedToken(cachedToken)?.let { return it }
 
-        // Atomic read-or-create of the in-flight deferred. The mutex ensures exactly one
-        // scope.async { } is launched when multiple callers miss the cache simultaneously.
-        val deferred: Deferred<ValidatedToken> = mutex.withLock {
-            // Re-check under the lock; a concurrent caller may have populated the cache while
-            // we waited. Non-local return exits getOrFetchToken() directly.
-            if (allowCachedToken) usableCachedToken(cachedToken)?.let { return it }
-
-            inFlightFetch ?: scope.async { doFetch() }.also { d ->
-                inFlightFetch = d
-                // Reference-identity check: prevents a stale deferred's completion handler from
-                // clearing a freshly-created deferred after a concurrent provider swap.
-                d.invokeOnCompletion { if (inFlightFetch === d) inFlightFetch = null }
-            }
+        val deferred: Deferred<ValidatedToken> = inFlightFetch ?: scope.async { doFetch() }.also { d ->
+            inFlightFetch = d
+            // Reference-identity check: prevents a stale deferred's completion handler from
+            // clearing a freshly-created deferred after a concurrent provider swap.
+            d.invokeOnCompletion { if (inFlightFetch === d) inFlightFetch = null }
         }
 
         // Each caller races its own timeout budget against the shared deferred. Timing out does
@@ -309,14 +269,11 @@ internal class KlaviyoAuthTokenManager(
         val jwt = invokeProvider()
         val token = validateOrThrow(jwt)
         // Non-suspending cancellation check: if this deferred was cancelled (e.g. by a provider
-        // swap) after invokeProvider() returned but before we write the cache, bail out now.
-        // mutex.withLock does NOT check cancellation when the lock is uncontended, so this guard
-        // is required even when the mutex is free.
+        // swap) after invokeProvider() returned but before we write the cache, bail out now so a
+        // stale token can never reach the cache.
         currentCoroutineContext().ensureActive()
-        mutex.withLock {
-            cachedToken = token
-            scheduleRefresh(token)
-        }
+        cachedToken = token
+        scheduleRefresh(token)
         Registry.log.info(
             "Auth token acquired (exp=${token.expiresAtEpochSeconds}, iat=${token.issuedAtEpochSeconds})"
         )
@@ -363,14 +320,14 @@ internal class KlaviyoAuthTokenManager(
     }
 
     /**
-     * Called under mutex (from [doFetch]). Non-suspending; safe inside withLock.
+     * Called on the actorContext (from [doFetch]). Non-suspending.
      */
     private fun scheduleRefresh(token: ValidatedToken) {
         val nowMs = Registry.clock.currentTimeMillis()
         val targetMs = computeRefreshTarget(token, nowMs)
         // Bump the generation before cancelling so that if cancel() synchronously fires the old
         // task (e.g. FireOnCancelClock in tests), the task sees a stale generation and self-aborts.
-        val generation = refreshGeneration.incrementAndGet()
+        val generation = ++refreshGeneration
         refreshJob?.cancel()
         refreshTimerFired = false
         refreshAtWallClockMs = targetMs
@@ -386,12 +343,11 @@ internal class KlaviyoAuthTokenManager(
         )
     }
 
-    private suspend fun markRefreshTimerFired(generation: Long): Boolean =
-        mutex.withLock {
-            if (refreshGeneration.get() != generation) return@withLock false
-            refreshTimerFired = true
-            true
-        }
+    private fun markRefreshTimerFired(generation: Long): Boolean {
+        if (refreshGeneration != generation) return false
+        refreshTimerFired = true
+        return true
+    }
 
     /**
      * Forces a fresh provider invocation and routes through the standard dedup + timeout path.
@@ -502,11 +458,9 @@ internal class KlaviyoAuthTokenManager(
         }
     }
 
-    private suspend fun clearFiredFlagForFailedRefresh(timerGeneration: Long) {
-        mutex.withLock {
-            if (refreshGeneration.get() == timerGeneration) {
-                refreshTimerFired = false
-            }
+    private fun clearFiredFlagForFailedRefresh(timerGeneration: Long) {
+        if (refreshGeneration == timerGeneration) {
+            refreshTimerFired = false
         }
     }
 
@@ -529,10 +483,9 @@ internal class KlaviyoAuthTokenManager(
      * "connectivity available" notification from [Registry.networkMonitor], then triggers a
      * proactive refresh via [performScheduledRefresh].
      *
-     * At most one job is active at a time. All [connectivityWaitJob] and
-     * [connectivityWaitGeneration] transitions are serialized via [connectivityWaitLock] so that
-     * concurrent calls (rapid flap) and racing teardown from [registerProvider]/[clearTokenState]
-     * cannot leave multiple active jobs or a stale assignment.
+     * At most one job is active at a time: the existing job is cancelled before a new one is armed.
+     * Arming runs on the actorContext (via [performScheduledRefresh]), which serializes it against
+     * racing teardown from [registerProvider]/[clearTokenState].
      *
      * @param resumeImmediatelyIfConnected When true (the default), the job resumes immediately if
      * the device is already connected — [Registry.networkMonitor] does not replay state on observer
@@ -548,68 +501,59 @@ internal class KlaviyoAuthTokenManager(
         Registry.log.info(
             "AuthTokenManager: network failure — waiting for connectivity to retry refresh"
         )
-        // Serialize cancel → generation increment → launch → assign under one lock so that
-        // concurrent calls to armConnectivityWaitJob() and racing registerProvider()/
-        // clearTokenState() cannot produce multiple active jobs or a stale null-out.
-        val waitGeneration: Long
-        synchronized(connectivityWaitLock) {
-            connectivityWaitJob?.cancel()
-            waitGeneration = connectivityWaitGeneration.incrementAndGet()
-            connectivityWaitJob = scope.safeLaunch {
-                try {
-                    suspendCancellableCoroutine { continuation ->
-                        val resumed = AtomicBoolean(false)
-                        // Use a ref box so the lambda can capture and de-register itself.
-                        val observerRef = arrayOfNulls<NetworkObserver>(1)
-                        val observer: NetworkObserver = { isConnected ->
-                            // One-shot guard: AtomicBoolean ensures exactly one connectivity
-                            // event (including the immediate check below) resumes the coroutine.
-                            if (isConnected && resumed.compareAndSet(false, true)) {
-                                observerRef[0]?.let { Registry.networkMonitor.offNetworkChange(it) }
-                                if (continuation.isActive) continuation.resume(Unit)
-                            }
-                        }
-                        observerRef[0] = observer
-                        Registry.networkMonitor.onNetworkChange(observer)
-                        // Install cancellation handler AFTER registration so the handler can
-                        // never try to remove an observer that hasn't been registered yet.
-                        continuation.invokeOnCancellation {
-                            Registry.networkMonitor.offNetworkChange(observer)
-                        }
-                        // Resume immediately if already online — networkMonitor does not replay
-                        // state on registration (handles SocketTimeoutException on live network).
-                        // Skip on re-arm (resumeImmediatelyIfConnected=false) to prevent a tight
-                        // loop when the provider keeps failing with IOException while the device
-                        // stays connected; in that case we wait for an actual connectivity event.
-                        if (resumeImmediatelyIfConnected &&
-                            Registry.networkMonitor.isNetworkConnected() &&
-                            resumed.compareAndSet(false, true)
-                        ) {
-                            Registry.networkMonitor.offNetworkChange(observer)
+        connectivityWaitJob?.cancel()
+        var selfRef: Job? = null
+        selfRef = scope.safeLaunch {
+            try {
+                suspendCancellableCoroutine { continuation ->
+                    val resumed = AtomicBoolean(false)
+                    // Use a ref box so the lambda can capture and de-register itself.
+                    val observerRef = arrayOfNulls<NetworkObserver>(1)
+                    val observer: NetworkObserver = { isConnected ->
+                        // One-shot guard: AtomicBoolean ensures exactly one connectivity
+                        // event (including the immediate check below) resumes the coroutine.
+                        if (isConnected && resumed.compareAndSet(false, true)) {
+                            observerRef[0]?.let { Registry.networkMonitor.offNetworkChange(it) }
                             if (continuation.isActive) continuation.resume(Unit)
                         }
                     }
-                    Registry.log.info(
-                        "AuthTokenManager: connectivity restored — retrying proactive refresh"
-                    )
-                    // Cancellation checkpoint: registerProvider()/clearTokenState() may have
-                    // cancelled this job after the connectivity event fired but before we retry.
-                    currentCoroutineContext().ensureActive()
-                    // Pass allowImmediateConnectivityRetry=false so that if this retry also fails
-                    // with a network exception, the re-armed job will NOT immediately resume on an
-                    // already-connected device — avoiding a tight retry loop.
-                    performScheduledRefresh(allowImmediateConnectivityRetry = false)
-                } finally {
-                    // Only clear the field if the generation still matches — a concurrent
-                    // re-arm may have replaced this job; if so leave the new job in place.
-                    synchronized(connectivityWaitLock) {
-                        if (connectivityWaitGeneration.get() == waitGeneration) {
-                            connectivityWaitJob = null
-                        }
+                    observerRef[0] = observer
+                    Registry.networkMonitor.onNetworkChange(observer)
+                    // Install cancellation handler AFTER registration so the handler can
+                    // never try to remove an observer that hasn't been registered yet.
+                    continuation.invokeOnCancellation {
+                        Registry.networkMonitor.offNetworkChange(observer)
+                    }
+                    // Resume immediately if already online — networkMonitor does not replay
+                    // state on registration (handles SocketTimeoutException on live network).
+                    // Skip on re-arm (resumeImmediatelyIfConnected=false) to prevent a tight
+                    // loop when the provider keeps failing with IOException while the device
+                    // stays connected; in that case we wait for an actual connectivity event.
+                    if (resumeImmediatelyIfConnected &&
+                        Registry.networkMonitor.isNetworkConnected() &&
+                        resumed.compareAndSet(false, true)
+                    ) {
+                        Registry.networkMonitor.offNetworkChange(observer)
+                        if (continuation.isActive) continuation.resume(Unit)
                     }
                 }
+                Registry.log.info(
+                    "AuthTokenManager: connectivity restored — retrying proactive refresh"
+                )
+                // Cancellation checkpoint: registerProvider()/clearTokenState() may have
+                // cancelled this job after the connectivity event fired but before we retry.
+                currentCoroutineContext().ensureActive()
+                // Pass allowImmediateConnectivityRetry=false so that if this retry also fails
+                // with a network exception, the re-armed job will NOT immediately resume on an
+                // already-connected device — avoiding a tight retry loop.
+                performScheduledRefresh(allowImmediateConnectivityRetry = false)
+            } finally {
+                // Reference-identity check: only clear the field if it still points at this job —
+                // a concurrent re-arm may have replaced it, in which case leave the new job intact.
+                if (connectivityWaitJob === selfRef) connectivityWaitJob = null
             }
         }
+        connectivityWaitJob = selfRef
     }
 
     private fun onLifecycleEvent(event: ActivityEvent) {
@@ -618,48 +562,47 @@ internal class KlaviyoAuthTokenManager(
     }
 
     /**
-     * Reconciles cache and scheduled-refresh state on foreground transition.
-     * [safeLaunch] is non-suspending, so the mutex is released before any launched
-     * coroutine runs — no re-entrancy risk with [currentToken]'s own withLock call.
+     * Reconciles cache and scheduled-refresh state on foreground transition. Runs on the
+     * actorContext, so it is serialized against fetches, refreshes, and clears. The nested
+     * [safeLaunch] calls queue follow-up work on the same single-threaded actor rather than
+     * re-entering it.
      *
      * Case 1 uses [tryEagerFetch] (`allowCachedToken = true`) because [cachedToken] is explicitly
      * nulled before the launch, guaranteeing a cache miss without needing to bypass the cache.
      * Case 2 uses [performScheduledRefresh] (`allowCachedToken = false`) because the cached token
      * is still valid and must NOT be returned — we need a fresh provider call despite the hit.
      */
-    private suspend fun handleForegroundTransition() {
+    private fun handleForegroundTransition() {
         val nowMs = Registry.clock.currentTimeMillis()
-        mutex.withLock {
-            val cached = cachedToken
-            val targetMs = refreshAtWallClockMs
-            when {
-                cached != null && !isStillValid(cached) -> {
-                    cachedToken = null
-                    refreshJob?.cancel()
-                    refreshJob = null
-                    refreshAtWallClockMs = null
-                    refreshTimerFired = false
-                    refreshGeneration.incrementAndGet()
-                    Registry.log.info(
-                        "AuthTokenManager: foreground transition (case=expired-cached-token)"
-                    )
-                    scope.safeLaunch { tryEagerFetch() }
-                }
-                targetMs != null && nowMs >= targetMs && !refreshTimerFired -> {
-                    refreshJob?.cancel()
-                    refreshJob = null
-                    refreshAtWallClockMs = null
-                    refreshTimerFired = false
-                    refreshGeneration.incrementAndGet()
-                    Registry.log.info(
-                        "AuthTokenManager: foreground transition (case=missed-refresh)"
-                    )
-                    scope.safeLaunch { performScheduledRefresh() }
-                }
-                else -> Registry.log.info(
-                    "AuthTokenManager: foreground transition (case=still-valid)"
+        val cached = cachedToken
+        val targetMs = refreshAtWallClockMs
+        when {
+            cached != null && !isStillValid(cached) -> {
+                cachedToken = null
+                refreshJob?.cancel()
+                refreshJob = null
+                refreshAtWallClockMs = null
+                refreshTimerFired = false
+                refreshGeneration++
+                Registry.log.info(
+                    "AuthTokenManager: foreground transition (case=expired-cached-token)"
                 )
+                scope.safeLaunch { tryEagerFetch() }
             }
+            targetMs != null && nowMs >= targetMs && !refreshTimerFired -> {
+                refreshJob?.cancel()
+                refreshJob = null
+                refreshAtWallClockMs = null
+                refreshTimerFired = false
+                refreshGeneration++
+                Registry.log.info(
+                    "AuthTokenManager: foreground transition (case=missed-refresh)"
+                )
+                scope.safeLaunch { performScheduledRefresh() }
+            }
+            else -> Registry.log.info(
+                "AuthTokenManager: foreground transition (case=still-valid)"
+            )
         }
     }
 

--- a/sdk/core/src/main/java/com/klaviyo/core/auth/ValidatedToken.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/ValidatedToken.kt
@@ -1,6 +1,14 @@
 package com.klaviyo.core.auth
 
-internal data class ValidatedToken(
+/**
+ * A JWT that has been parsed and validated by [JWTParser]. Returned by
+ * [AuthTokenManager.currentToken] so consumers get both the raw token (for transport/injection)
+ * and the parsed claim metadata (`exp`, `iat`) without re-parsing.
+ *
+ * Public so cross-module consumers (e.g. the forms module's WebView injection layer) can read
+ * the metadata; [toString] is redacted to keep the raw token out of accidental log statements.
+ */
+data class ValidatedToken(
     val rawToken: String,
     val expiresAtEpochSeconds: Long,
     val issuedAtEpochSeconds: Long

--- a/sdk/core/src/main/java/com/klaviyo/core/auth/ValidatedToken.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/ValidatedToken.kt
@@ -1,0 +1,15 @@
+package com.klaviyo.core.auth
+
+internal data class ValidatedToken(
+    val rawToken: String,
+    val expiresAtEpochSeconds: Long,
+    val issuedAtEpochSeconds: Long
+) {
+    // Defensive redaction: prevents the JWT from being exposed if any future call
+    // site ever logs a ValidatedToken (e.g. `log.debug("got $token")`). Token
+    // contents must never be passed to the logger under any circumstances.
+    override fun toString(): String =
+        "ValidatedToken(rawToken=<redacted>, " +
+            "expiresAtEpochSeconds=$expiresAtEpochSeconds, " +
+            "issuedAtEpochSeconds=$issuedAtEpochSeconds)"
+}

--- a/sdk/core/src/test/java/com/klaviyo/core/CoreInitProviderTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/CoreInitProviderTest.kt
@@ -1,0 +1,21 @@
+package com.klaviyo.core
+
+import com.klaviyo.core.auth.AuthTokenManager
+import com.klaviyo.fixtures.BaseTest
+import org.junit.After
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+internal class CoreInitProviderTest : BaseTest() {
+    @After
+    override fun cleanup() {
+        Registry.unregister<AuthTokenManager>()
+        super.cleanup()
+    }
+
+    @Test
+    fun `onCreate registers AuthTokenManager in Registry`() {
+        CoreInitProvider().onCreate()
+        assertNotNull(Registry.getOrNull<AuthTokenManager>())
+    }
+}

--- a/sdk/core/src/test/java/com/klaviyo/core/auth/JWTParserTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/auth/JWTParserTest.kt
@@ -1,0 +1,386 @@
+package com.klaviyo.core.auth
+
+import com.klaviyo.fixtures.BaseTest
+import io.mockk.verify
+import java.util.Base64
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class JWTParserTest : BaseTest() {
+    companion object {
+        private const val NOW_SECONDS = 1_700_000_000L
+        private const val IAT_SECONDS = NOW_SECONDS - 60
+        private const val EXP_SECONDS = NOW_SECONDS + 3600
+    }
+
+    // MARK: - Happy path
+
+    @Test
+    fun defaultLeewayIs30Seconds() {
+        assertEquals(30L, JWTParser.DEFAULT_LEEWAY_SECONDS)
+    }
+
+    @Test
+    fun validTokenReturnsValidWithDecodedClaims() {
+        val token = makeJwt(mapOf("exp" to EXP_SECONDS.toDouble(), "iat" to IAT_SECONDS.toDouble()))
+
+        val result = JWTParser.parseAndValidate(token, nowEpochSeconds = NOW_SECONDS)
+
+        assertTrue(result is JWTValidationResult.Valid)
+        val valid = result as JWTValidationResult.Valid
+        assertEquals(token, valid.token.rawToken)
+        assertEquals(EXP_SECONDS, valid.token.expiresAtEpochSeconds)
+        assertEquals(IAT_SECONDS, valid.token.issuedAtEpochSeconds)
+    }
+
+    @Test
+    fun validTokenIgnoresUnknownClaims() {
+        val extraClaims = mapOf(
+            "exp" to EXP_SECONDS.toDouble(),
+            "iat" to IAT_SECONDS.toDouble(),
+            "iss" to "https://auth.example.com",
+            "sub" to "550e8400-e29b-41d4-a716-446655440000",
+            "aud" to JSONArray(listOf("klaviyo", "other-rp")),
+            "nbf" to IAT_SECONDS.toDouble(),
+            "jti" to "a8f5c1d4-3b6a-4c2e-9d1f-7e8b2a3c4d5e",
+            "auth_time" to IAT_SECONDS.toDouble(),
+            "azp" to "klaviyo-mobile-sdk",
+            "email" to "user@example.com",
+            "email_verified" to true,
+            "scope" to "openid profile email",
+            "address" to JSONObject(mapOf("country" to "US", "postal_code" to "12345"))
+        )
+        val token = makeJwt(extraClaims)
+
+        val result = JWTParser.parseAndValidate(token, nowEpochSeconds = NOW_SECONDS)
+
+        assertTrue(result is JWTValidationResult.Valid)
+        val valid = result as JWTValidationResult.Valid
+        assertEquals(EXP_SECONDS, valid.token.expiresAtEpochSeconds)
+        assertEquals(IAT_SECONDS, valid.token.issuedAtEpochSeconds)
+    }
+
+    @Test
+    fun validTokenDecodesFractionalNumericDate() {
+        val iatFractional = IAT_SECONDS.toDouble() + 0.25
+        val expFractional = EXP_SECONDS.toDouble() + 0.75
+        val token = makeJwt(mapOf("exp" to expFractional, "iat" to iatFractional))
+
+        val result = JWTParser.parseAndValidate(token, nowEpochSeconds = NOW_SECONDS)
+
+        assertTrue(result is JWTValidationResult.Valid)
+        val valid = result as JWTValidationResult.Valid
+        // Verify that the data class stores truncated Long values
+        assertEquals(EXP_SECONDS, valid.token.expiresAtEpochSeconds)
+        assertEquals(IAT_SECONDS, valid.token.issuedAtEpochSeconds)
+    }
+
+    // MARK: - Malformed structure
+
+    @Test
+    fun malformedStructureEmptyString() {
+        val result = JWTParser.parseAndValidate("", nowEpochSeconds = NOW_SECONDS)
+        assertEquals(JWTValidationResult.MalformedStructure, result)
+    }
+
+    @Test
+    fun malformedStructureSingleSegment() {
+        val result = JWTParser.parseAndValidate("only-one-segment", nowEpochSeconds = NOW_SECONDS)
+        assertEquals(JWTValidationResult.MalformedStructure, result)
+    }
+
+    @Test
+    fun malformedStructureTwoSegments() {
+        val result = JWTParser.parseAndValidate("header.payload", nowEpochSeconds = NOW_SECONDS)
+        assertEquals(JWTValidationResult.MalformedStructure, result)
+    }
+
+    @Test
+    fun malformedStructureFourSegments() {
+        val result = JWTParser.parseAndValidate("a.b.c.d", nowEpochSeconds = NOW_SECONDS)
+        assertEquals(JWTValidationResult.MalformedStructure, result)
+    }
+
+    // MARK: - Malformed Base64
+
+    @Test
+    fun malformedBase64Payload() {
+        val header = base64UrlEncode(JSONObject(mapOf("alg" to "HS256")).toString().toByteArray())
+        val token = "$header.****.$header"
+
+        val result = JWTParser.parseAndValidate(token, nowEpochSeconds = NOW_SECONDS)
+
+        assertEquals(JWTValidationResult.MalformedBase64, result)
+    }
+
+    // MARK: - Malformed JSON
+
+    @Test
+    fun nonJsonPayload() {
+        val header = base64UrlEncode(JSONObject(mapOf("alg" to "HS256")).toString().toByteArray())
+        val payload = base64UrlEncode("not-actually-json".toByteArray())
+        val token = "$header.$payload.$header"
+
+        val result = JWTParser.parseAndValidate(token, nowEpochSeconds = NOW_SECONDS)
+
+        assertEquals(JWTValidationResult.MalformedJson, result)
+    }
+
+    @Test
+    fun jsonArrayPayload() {
+        val header = base64UrlEncode(JSONObject(mapOf("alg" to "HS256")).toString().toByteArray())
+        val payload = base64UrlEncode(JSONArray(listOf(1, 2, 3)).toString().toByteArray())
+        val token = "$header.$payload.$header"
+
+        val result = JWTParser.parseAndValidate(token, nowEpochSeconds = NOW_SECONDS)
+
+        assertEquals(JWTValidationResult.MalformedJson, result)
+    }
+
+    @Test
+    fun expAsString() {
+        val token = makeJwt(mapOf("exp" to "not-a-number", "iat" to IAT_SECONDS.toDouble()))
+
+        val result = JWTParser.parseAndValidate(token, nowEpochSeconds = NOW_SECONDS)
+
+        assertEquals(JWTValidationResult.MalformedJson, result)
+    }
+
+    @Test
+    fun iatAsString() {
+        val token = makeJwt(mapOf("exp" to EXP_SECONDS.toDouble(), "iat" to "not-a-number"))
+
+        val result = JWTParser.parseAndValidate(token, nowEpochSeconds = NOW_SECONDS)
+
+        assertEquals(JWTValidationResult.MalformedJson, result)
+    }
+
+    @Test
+    fun emptyPayloadSegment() {
+        val header = base64UrlEncode(JSONObject(mapOf("alg" to "HS256")).toString().toByteArray())
+        val token = "$header..$header"
+
+        val result = JWTParser.parseAndValidate(token, nowEpochSeconds = NOW_SECONDS)
+
+        assertEquals(JWTValidationResult.MalformedJson, result)
+    }
+
+    // MARK: - Missing claims
+
+    @Test
+    fun missingExpClaim() {
+        val token = makeJwt(mapOf("iat" to IAT_SECONDS.toDouble()))
+
+        val result = JWTParser.parseAndValidate(token, nowEpochSeconds = NOW_SECONDS)
+
+        assertEquals(JWTValidationResult.MissingExpClaim, result)
+    }
+
+    @Test
+    fun missingIatClaim() {
+        val token = makeJwt(mapOf("exp" to EXP_SECONDS.toDouble()))
+
+        val result = JWTParser.parseAndValidate(token, nowEpochSeconds = NOW_SECONDS)
+
+        assertEquals(JWTValidationResult.MissingIatClaim, result)
+    }
+
+    @Test
+    fun emptyPayloadObject() {
+        val token = makeJwt(emptyMap())
+
+        val result = JWTParser.parseAndValidate(token, nowEpochSeconds = NOW_SECONDS)
+
+        assertEquals(JWTValidationResult.MissingExpClaim, result)
+    }
+
+    // MARK: - Expiration
+
+    @Test
+    fun nowEqualsExpIsExpired() {
+        val token = makeJwt(mapOf("exp" to EXP_SECONDS.toDouble(), "iat" to IAT_SECONDS.toDouble()))
+
+        val result = JWTParser.parseAndValidate(token, nowEpochSeconds = EXP_SECONDS)
+
+        assertEquals(JWTValidationResult.ExpiredOnReceipt, result)
+    }
+
+    @Test
+    fun nowGreaterThanExpIsExpired() {
+        val token = makeJwt(mapOf("exp" to EXP_SECONDS.toDouble(), "iat" to IAT_SECONDS.toDouble()))
+
+        val result = JWTParser.parseAndValidate(token, nowEpochSeconds = EXP_SECONDS + 1)
+
+        assertEquals(JWTValidationResult.ExpiredOnReceipt, result)
+    }
+
+    @Test
+    fun nowAtLeewayBoundaryIsExpired() {
+        val token = makeJwt(mapOf("exp" to EXP_SECONDS.toDouble(), "iat" to IAT_SECONDS.toDouble()))
+        val leeway = 15L
+        val nowAtBoundary = EXP_SECONDS - leeway
+
+        val result = JWTParser.parseAndValidate(
+            token,
+            nowEpochSeconds = nowAtBoundary,
+            leewaySeconds = leeway
+        )
+
+        assertEquals(JWTValidationResult.ExpiredOnReceipt, result)
+    }
+
+    @Test
+    fun nowJustInsideLeewayIsValid() {
+        val token = makeJwt(mapOf("exp" to EXP_SECONDS.toDouble(), "iat" to IAT_SECONDS.toDouble()))
+        val leeway = 15L
+        val nowJustInside = EXP_SECONDS - leeway - 1
+
+        val result = JWTParser.parseAndValidate(
+            token,
+            nowEpochSeconds = nowJustInside,
+            leewaySeconds = leeway
+        )
+
+        assertTrue(result is JWTValidationResult.Valid)
+    }
+
+    @Test
+    fun leewayZeroBoundary() {
+        val token = makeJwt(mapOf("exp" to EXP_SECONDS.toDouble(), "iat" to IAT_SECONDS.toDouble()))
+
+        // now == exp - 1 is still valid
+        val justBefore = JWTParser.parseAndValidate(
+            token,
+            nowEpochSeconds = EXP_SECONDS - 1,
+            leewaySeconds = 0L
+        )
+        assertTrue(justBefore is JWTValidationResult.Valid)
+
+        // now == exp is expired
+        val atExp = JWTParser.parseAndValidate(
+            token,
+            nowEpochSeconds = EXP_SECONDS,
+            leewaySeconds = 0L
+        )
+        assertEquals(JWTValidationResult.ExpiredOnReceipt, atExp)
+    }
+
+    @Test
+    fun iatGreaterThanExpButNotExpiredIsValid() {
+        val token = makeJwt(
+            mapOf("exp" to EXP_SECONDS.toDouble(), "iat" to EXP_SECONDS.toDouble() + 100)
+        )
+
+        val result = JWTParser.parseAndValidate(token, nowEpochSeconds = NOW_SECONDS)
+
+        assertTrue(result is JWTValidationResult.Valid)
+    }
+
+    // MARK: - Base64URL handling
+
+    @Test
+    fun payloadWithUrlSafeCharactersDecodesCorrectly() {
+        // Force URL-safe substitutions by choosing a claim value that produces
+        // bytes that would be encoded with + or / in standard base64
+        val token = makeJwt(
+            mapOf(
+                "exp" to EXP_SECONDS.toDouble(),
+                "iat" to IAT_SECONDS.toDouble(),
+                "data" to ">>>>???"
+            )
+        )
+
+        val result = JWTParser.parseAndValidate(token, nowEpochSeconds = NOW_SECONDS)
+
+        assertTrue(result is JWTValidationResult.Valid)
+        val valid = result as JWTValidationResult.Valid
+        assertEquals(EXP_SECONDS, valid.token.expiresAtEpochSeconds)
+    }
+
+    @Test
+    fun payloadWithoutPaddingDecodesCorrectly() {
+        val token = makeJwt(mapOf("exp" to EXP_SECONDS.toDouble(), "iat" to IAT_SECONDS.toDouble()))
+
+        // Verify no = padding in the JWT
+        assertFalse("JWT should not contain = padding", token.contains("="))
+
+        val result = JWTParser.parseAndValidate(token, nowEpochSeconds = NOW_SECONDS)
+
+        assertTrue(result is JWTValidationResult.Valid)
+    }
+
+    // MARK: - Android-specific: toString redaction
+
+    @Test
+    fun validatedTokenToStringRedactsRawToken() {
+        val token = makeJwt(mapOf("exp" to EXP_SECONDS.toDouble(), "iat" to IAT_SECONDS.toDouble()))
+        val result = JWTParser.parseAndValidate(token, nowEpochSeconds = NOW_SECONDS)
+
+        assertTrue(result is JWTValidationResult.Valid)
+        val validatedToken = (result as JWTValidationResult.Valid).token
+        val tokenString = validatedToken.toString()
+
+        assertFalse("toString should not contain the raw JWT", tokenString.contains(token))
+        assertTrue("toString should contain redaction marker", tokenString.contains("<redacted>"))
+    }
+
+    @Test
+    fun failureLogsDoNotContainRawToken() {
+        // Exercise every failure path and verify that no captured warning message
+        // contains the raw JWT. Belt-and-suspenders for the "token contents NEVER
+        // passed to the logger" requirement — code review alone is insufficient.
+        val expiredHeader = base64UrlEncode(
+            JSONObject(mapOf("alg" to "HS256")).toString().toByteArray()
+        )
+        val tokens = listOf(
+            makeJwt(mapOf("iat" to IAT_SECONDS.toDouble())), // MissingExpClaim
+            makeJwt(mapOf("exp" to EXP_SECONDS.toDouble())), // MissingIatClaim
+            makeJwt(mapOf("exp" to "not-a-number", "iat" to IAT_SECONDS.toDouble())), // exp non-numeric
+            makeJwt(mapOf("exp" to EXP_SECONDS.toDouble(), "iat" to "not-a-number")), // iat non-numeric
+            "$expiredHeader.****.signature", // MalformedBase64
+            "$expiredHeader.${base64UrlEncode("not-json".toByteArray())}.signature", // MalformedJson
+            makeJwt(mapOf("exp" to NOW_SECONDS.toDouble() - 1, "iat" to IAT_SECONDS.toDouble())) // ExpiredOnReceipt
+        )
+
+        tokens.forEach { token ->
+            JWTParser.parseAndValidate(token, nowEpochSeconds = NOW_SECONDS)
+        }
+
+        val messages = mutableListOf<String>()
+        verify { spyLog.warning(capture(messages), null) }
+
+        // Sanity: at least one warning per failure path.
+        assertTrue(
+            "Expected at least one warning per failure path",
+            messages.size >= tokens.size
+        )
+        // The actual guarantee: no captured message contains any raw token.
+        tokens.forEach { token ->
+            messages.forEach { msg ->
+                assertFalse(
+                    "Log message must not contain raw JWT. Message: '$msg'",
+                    msg.contains(token)
+                )
+            }
+        }
+    }
+
+    // MARK: - Fixtures
+
+    private fun makeJwt(claims: Map<String, Any>): String {
+        val header = mapOf("alg" to "HS256", "typ" to "JWT")
+        val headerSegment = base64UrlEncode(JSONObject(header).toString().toByteArray())
+        val payloadSegment = base64UrlEncode(JSONObject(claims).toString().toByteArray())
+        return "$headerSegment.$payloadSegment.signature"
+    }
+
+    private fun base64UrlEncode(bytes: ByteArray): String {
+        return Base64.getUrlEncoder()
+            .withoutPadding()
+            .encodeToString(bytes)
+    }
+}

--- a/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerConnectivityTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerConnectivityTest.kt
@@ -1,0 +1,631 @@
+package com.klaviyo.core.auth
+
+import com.klaviyo.core.Registry
+import com.klaviyo.core.networking.NetworkMonitor
+import com.klaviyo.core.networking.NetworkObserver
+import com.klaviyo.fixtures.BaseTest
+import io.mockk.every
+import io.mockk.verify
+import java.io.IOException
+import java.net.ConnectException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
+import java.util.Base64
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Tests for the connectivity-driven refresh retry path in [KlaviyoAuthTokenManager].
+ *
+ * The controllable [FakeNetworkMonitor] lets tests drive synthetic connectivity transitions
+ * without involving real system APIs.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class KlaviyoAuthTokenManagerConnectivityTest : BaseTest() {
+
+    companion object {
+        private const val NOW_SECONDS = TIME / 1000L
+        private const val IAT_SECONDS = NOW_SECONDS - 60
+        private const val EXP_SECONDS = NOW_SECONDS + 3600
+    }
+
+    private lateinit var fakeNetworkMonitor: FakeNetworkMonitor
+
+    @Before
+    override fun setup() {
+        super.setup()
+        fakeNetworkMonitor = FakeNetworkMonitor()
+        every { Registry.networkMonitor } returns fakeNetworkMonitor
+    }
+
+    // MARK: - Helpers
+
+    private fun makeJwt(expSeconds: Long = EXP_SECONDS, iatSeconds: Long = IAT_SECONDS): String {
+        val header = JSONObject(mapOf("alg" to "HS256", "typ" to "JWT"))
+        val payload = JSONObject(
+            mapOf("exp" to expSeconds.toDouble(), "iat" to iatSeconds.toDouble())
+        )
+        val h = base64UrlEncode(header.toString().toByteArray())
+        val p = base64UrlEncode(payload.toString().toByteArray())
+        return "$h.$p.signature"
+    }
+
+    private fun base64UrlEncode(bytes: ByteArray): String =
+        Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
+
+    /** Fires the first pending clock task and advances the test dispatcher until idle. */
+    private fun executeScheduledRefresh() {
+        val task = staticClock.scheduledTasks.firstOrNull()
+            ?: throw AssertionError("Expected at least one scheduled refresh task")
+        staticClock.execute(task.time - staticClock.time)
+        dispatcher.scheduler.advanceUntilIdle()
+    }
+
+    /**
+     * Shared arrange/act/assert for the four exception-variant retry tests. Sets up a scripted
+     * provider that fails once with [exception] then succeeds, fires the refresh, simulates
+     * connectivity restored, and asserts the retry ran.
+     */
+    private fun assertConnectivityRetryFires(exception: Exception) = runTest(dispatcher) {
+        val provider = ScriptedProvider(
+            ArrayDeque(
+                listOf(
+                    Result.success(makeJwt()),
+                    Result.failure(exception),
+                    Result.success(makeJwt(EXP_SECONDS + 600, IAT_SECONDS + 600))
+                )
+            )
+        )
+        val manager = KlaviyoAuthTokenManager()
+        manager.registerProvider(provider)
+        dispatcher.scheduler.advanceUntilIdle()
+        assertEquals(1, provider.callCount)
+
+        executeScheduledRefresh()
+        assertEquals(2, provider.callCount)
+
+        fakeNetworkMonitor.simulateConnected(isConnected = true)
+        dispatcher.scheduler.advanceUntilIdle()
+        assertEquals("retry after ${exception::class.simpleName}", 3, provider.callCount)
+    }
+
+    // MARK: - Retry fires after reconnect
+
+    @Test
+    fun `connectivity retry fires after network comes back online after IOException`() = runTest(
+        dispatcher
+    ) {
+        val initialToken = makeJwt()
+        val retryToken = makeJwt(EXP_SECONDS + 600, IAT_SECONDS + 600)
+        val provider = ScriptedProvider(
+            ArrayDeque(
+                listOf(
+                    Result.success(initialToken),
+                    Result.failure(IOException("network down")),
+                    Result.success(retryToken)
+                )
+            )
+        )
+        val manager = KlaviyoAuthTokenManager()
+
+        manager.registerProvider(provider)
+        dispatcher.scheduler.advanceUntilIdle()
+        assertEquals("initial eager fetch", 1, provider.callCount)
+
+        // Fire the scheduled refresh — it fails with a network error
+        executeScheduledRefresh()
+        assertEquals("refresh attempt failed", 2, provider.callCount)
+
+        // connectivityWaitJob should be armed
+        assertNotNull(
+            "connectivityWaitJob should be armed after network failure",
+            manager.connectivityWaitJob
+        )
+        verify { spyLog.info(any()) }
+
+        // Simulate connectivity restored
+        fakeNetworkMonitor.simulateConnected(isConnected = true)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(
+            "connectivity retry should invoke provider a third time",
+            3,
+            provider.callCount
+        )
+        verify { spyLog.info(any()) }
+    }
+
+    @Test
+    fun `connectivity retry fires after UnknownHostException`() {
+        assertConnectivityRetryFires(UnknownHostException("host unknown"))
+    }
+
+    @Test
+    fun `connectivity retry fires after SocketTimeoutException`() {
+        assertConnectivityRetryFires(SocketTimeoutException("timed out"))
+    }
+
+    @Test
+    fun `connectivity retry fires after ConnectException`() {
+        assertConnectivityRetryFires(ConnectException("connection refused"))
+    }
+
+    @Test
+    fun `connectivity wait job is not armed when connectivity notification is offline`() = runTest(
+        dispatcher
+    ) {
+        val initialToken = makeJwt()
+        val retryToken = makeJwt(EXP_SECONDS + 600, IAT_SECONDS + 600)
+        val provider = ScriptedProvider(
+            ArrayDeque(
+                listOf(
+                    Result.success(initialToken),
+                    Result.failure(IOException("network down")),
+                    Result.success(retryToken)
+                )
+            )
+        )
+        val manager = KlaviyoAuthTokenManager()
+        manager.registerProvider(provider)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        executeScheduledRefresh()
+        assertEquals("initial refresh failed", 2, provider.callCount)
+
+        // Simulate still offline — should not trigger retry
+        fakeNetworkMonitor.simulateConnected(isConnected = false)
+        dispatcher.scheduler.advanceUntilIdle()
+        assertEquals("offline notification must not trigger retry", 2, provider.callCount)
+
+        // Simulate connected — should trigger retry
+        fakeNetworkMonitor.simulateConnected(isConnected = true)
+        dispatcher.scheduler.advanceUntilIdle()
+        assertEquals("connected notification should trigger retry", 3, provider.callCount)
+    }
+
+    @Test
+    fun `connectivity retry fires immediately when device is already online`() = runTest(
+        dispatcher
+    ) {
+        val initialToken = makeJwt()
+        val retryToken = makeJwt(EXP_SECONDS + 600, IAT_SECONDS + 600)
+        val provider = ScriptedProvider(
+            ArrayDeque(
+                listOf(
+                    Result.success(initialToken),
+                    Result.failure(SocketTimeoutException("timed out")),
+                    Result.success(retryToken)
+                )
+            )
+        )
+        val manager = KlaviyoAuthTokenManager()
+        manager.registerProvider(provider)
+        dispatcher.scheduler.advanceUntilIdle()
+        assertEquals(1, provider.callCount)
+
+        // Mark network as already online before firing the refresh
+        fakeNetworkMonitor.connected = true
+
+        // executeScheduledRefresh() calls advanceUntilIdle() internally, which runs:
+        //  1. performScheduledRefresh → fails with SocketTimeoutException → arms connectivity job
+        //  2. the armed coroutine → isNetworkConnected() is true → resumes immediately → retries
+        // Both happen in the same advanceUntilIdle pass, so count is 3 on return.
+        executeScheduledRefresh()
+        assertEquals(
+            "retry should fire immediately without waiting for a future connectivity event",
+            3,
+            provider.callCount
+        )
+    }
+
+    @Test
+    fun `persistent provider failure on connected device arms a waiting job not a tight loop`() =
+        runTest(dispatcher) {
+            // Scenario: device is online the whole time, but the provider keeps failing with
+            // IOException (e.g. the JWT endpoint itself is down). The first arm should resume
+            // immediately (resumeImmediatelyIfConnected=true). The second arm, kicked off by
+            // performScheduledRefresh(allowImmediateConnectivityRetry=false), must NOT resume
+            // immediately again — it waits for an actual connectivity transition. This prevents
+            // an uncontrolled tight-loop.
+            val successToken = makeJwt(EXP_SECONDS + 100, IAT_SECONDS + 100)
+            val provider = ScriptedProvider(
+                ArrayDeque(
+                    listOf(
+                        Result.success(makeJwt()), // eager fetch succeeds
+                        Result.failure(IOException("endpoint down")), // timer refresh fails
+                        Result.failure(IOException("still down")), // immediate retry fails
+                        Result.success(successToken) // eventual success
+                    )
+                )
+            )
+            val manager = KlaviyoAuthTokenManager()
+            manager.registerProvider(provider)
+            dispatcher.scheduler.advanceUntilIdle()
+            assertEquals(1, provider.callCount)
+
+            // Device is already connected for the entire test
+            fakeNetworkMonitor.connected = true
+
+            // executeScheduledRefresh() + advanceUntilIdle() runs:
+            //  1. timer fires → performScheduledRefresh(immediate=true) → fails (count=2)
+            //  2. arm1(resumeImmediately=true) → isNetworkConnected()=true → immediate resume
+            //  3. performScheduledRefresh(immediate=false) → fails (count=3)
+            //  4. arm2(resumeImmediately=false) → skips immediate check → suspends
+            // After advanceUntilIdle the coroutine tree is idle with arm2 waiting.
+            executeScheduledRefresh()
+            assertEquals("two failures, no extra calls", 3, provider.callCount)
+            assertNotNull("arm2 should be waiting (not looping)", manager.connectivityWaitJob)
+            assertEquals(
+                "arm2 should be active — it is waiting, not looping",
+                false,
+                manager.connectivityWaitJob?.isCancelled ?: true
+            )
+
+            // Simulate a genuine connectivity transition — arm2 resumes, retry succeeds
+            fakeNetworkMonitor.simulateConnected(isConnected = true)
+            dispatcher.scheduler.advanceUntilIdle()
+            assertEquals("eventual success on real connectivity event", 4, provider.callCount)
+        }
+
+    // MARK: - At-most-one job invariant
+
+    @Test
+    fun `rapid flap cancels existing connectivity wait job before arming new one`() = runTest(
+        dispatcher
+    ) {
+        val initialToken = makeJwt()
+        // Scripted to fail multiple times with network errors
+        val provider = ScriptedProvider(
+            ArrayDeque(
+                listOf(
+                    Result.success(initialToken),
+                    Result.failure(IOException("flap 1")),
+                    Result.failure(IOException("flap 2")),
+                    Result.failure(IOException("flap 3")),
+                    Result.success(makeJwt(EXP_SECONDS + 100, IAT_SECONDS + 100))
+                )
+            )
+        )
+        val manager = KlaviyoAuthTokenManager()
+        manager.registerProvider(provider)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        // Fire scheduled refresh — fails, arms connectivityWaitJob
+        executeScheduledRefresh()
+        assertEquals(2, provider.callCount)
+
+        val firstJob = manager.connectivityWaitJob
+        assertNotNull("first job should be armed", firstJob)
+
+        // Simulate connectivity restored → retry fires → fails again → re-arms
+        fakeNetworkMonitor.simulateConnected(isConnected = true)
+        dispatcher.scheduler.advanceUntilIdle()
+        assertEquals("first retry fired", 3, provider.callCount)
+
+        // Re-armed after second failure
+        val secondJob = manager.connectivityWaitJob
+        assertNotNull("second job should be re-armed", secondJob)
+
+        assertEquals("second job should be active", false, secondJob?.isCancelled ?: true)
+
+        // Only one observer should be registered in the network monitor at any time
+        // (first was de-registered on its completion, second is the only active one)
+        assertEquals(
+            "only one network observer should be registered after re-arm",
+            1,
+            fakeNetworkMonitor.observerCount()
+        )
+    }
+
+    @Test
+    fun `registering new provider while connectivity wait is armed cancels the job`() = runTest(
+        dispatcher
+    ) {
+        val initialToken = makeJwt()
+        val newToken = makeJwt(EXP_SECONDS + 200, IAT_SECONDS + 200)
+        val firstProvider = ScriptedProvider(
+            ArrayDeque(
+                listOf(
+                    Result.success(initialToken),
+                    Result.failure(IOException("network down"))
+                )
+            )
+        )
+        val secondProvider = CountingSuccessProvider(newToken)
+        val manager = KlaviyoAuthTokenManager()
+
+        manager.registerProvider(firstProvider)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        executeScheduledRefresh()
+        val armedJob = manager.connectivityWaitJob
+        assertNotNull("connectivityWaitJob should be armed", armedJob)
+
+        // Register new provider — should cancel the pending connectivity wait
+        manager.registerProvider(secondProvider)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertNull(
+            "connectivityWaitJob should be cleared after registerProvider",
+            manager.connectivityWaitJob
+        )
+        assertEquals("cancelled job should be inactive", true, armedJob?.isCancelled ?: false)
+        assertEquals(
+            "no network observer should remain after provider swap",
+            0,
+            fakeNetworkMonitor.observerCount()
+        )
+    }
+
+    // MARK: - Stale-guard: profileResetPending prevents arming
+
+    @Test
+    fun `network failure during profile reset does not arm connectivity wait job`() = runTest(
+        dispatcher
+    ) {
+        // invalidate() sets profileResetPending = true but does NOT cancel the refresh job, so
+        // the scheduled refresh fires normally — the new guard is the profileResetPending check
+        // in the catch block, not the generation guard in markRefreshTimerFired.
+        val provider = ScriptedProvider(
+            ArrayDeque(
+                listOf(
+                    Result.success(makeJwt()),
+                    Result.failure(IOException("network down"))
+                )
+            )
+        )
+        val manager = KlaviyoAuthTokenManager()
+        manager.registerProvider(provider)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        // Set profileResetPending = true before the scheduled refresh fires
+        manager.invalidate()
+
+        executeScheduledRefresh()
+
+        assertNull(
+            "armConnectivityWaitJob must not fire when profileResetPending is true",
+            manager.connectivityWaitJob
+        )
+        assertEquals(0, fakeNetworkMonitor.observerCount())
+    }
+
+    @Test
+    fun `network failure after mid-fetch profile transition does not arm connectivity wait job`() =
+        runTest(dispatcher) {
+            // Simulates the narrow race where a logout fires while the refresh is suspended on
+            // the network call, then the catch block runs after profileResetPending has been
+            // cleared by clearTokenState(). Without the resetGeneration snapshot guard the catch
+            // block would see provider != null && !profileResetPending and arm a zombie job.
+            //
+            // We reproduce by injecting invalidate() from inside the fetchToken callback — this
+            // bumps resetGeneration during the active fetch, so the snapshot captured at the
+            // start of performScheduledRefresh no longer matches by the time the catch runs.
+            val manager = KlaviyoAuthTokenManager()
+            val provider = object : AuthTokenProvider {
+                var callCount = 0
+
+                override fun fetchToken(callback: AuthTokenProvider.Callback) {
+                    callCount++
+                    if (callCount == 1) {
+                        callback.onSuccess(makeJwt())
+                    } else {
+                        // Mid-fetch profile transition: bump profileGeneration while the
+                        // refresh coroutine is running, before the failure is delivered.
+                        manager.invalidate()
+                        callback.onFailure(IOException("network down"))
+                    }
+                }
+            }
+
+            manager.registerProvider(provider)
+            dispatcher.scheduler.advanceUntilIdle()
+            assertEquals("eager fetch ran", 1, provider.callCount)
+
+            executeScheduledRefresh()
+            assertEquals("timer refresh ran (and failed)", 2, provider.callCount)
+
+            assertNull(
+                "connectivity job must not arm when resetGeneration advanced mid-fetch",
+                manager.connectivityWaitJob
+            )
+            assertEquals(0, fakeNetworkMonitor.observerCount())
+        }
+
+    // MARK: - Non-network failures do not arm the retry
+
+    @Test
+    fun `non-network exception does not arm connectivity wait job`() = runTest(dispatcher) {
+        val initialToken = makeJwt()
+        val provider = ScriptedProvider(
+            ArrayDeque(
+                listOf(
+                    Result.success(initialToken),
+                    Result.failure(RuntimeException("http 500"))
+                )
+            )
+        )
+        val manager = KlaviyoAuthTokenManager()
+        manager.registerProvider(provider)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        executeScheduledRefresh()
+
+        assertNull("RuntimeException must not arm connectivityWaitJob", manager.connectivityWaitJob)
+        assertEquals(
+            "no observer registered for non-network failure",
+            0,
+            fakeNetworkMonitor.observerCount()
+        )
+    }
+
+    @Test
+    fun `validation failure does not arm connectivity wait job`() = runTest(dispatcher) {
+        val provider = ScriptedProvider(
+            ArrayDeque(
+                listOf(
+                    Result.success(makeJwt()),
+                    Result.success("not-a-valid-jwt") // will fail validation
+                )
+            )
+        )
+        val manager = KlaviyoAuthTokenManager()
+        manager.registerProvider(provider)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        executeScheduledRefresh()
+
+        assertNull("ValidationFailed must not arm connectivityWaitJob", manager.connectivityWaitJob)
+        assertEquals(0, fakeNetworkMonitor.observerCount())
+    }
+
+    // MARK: - clearTokenState cancels the connectivity wait job
+
+    @Test
+    fun `clearTokenState cancels and clears connectivity wait job`() = runTest(dispatcher) {
+        val initialToken = makeJwt()
+        val provider = ScriptedProvider(
+            ArrayDeque(
+                listOf(
+                    Result.success(initialToken),
+                    Result.failure(IOException("network down"))
+                )
+            )
+        )
+        val manager = KlaviyoAuthTokenManager()
+        manager.registerProvider(provider)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        executeScheduledRefresh()
+
+        val armedJob = manager.connectivityWaitJob
+        assertNotNull("job must be armed before clear", armedJob)
+
+        // Clear token state (simulates logout / resetProfile)
+        manager.clearTokenState()
+
+        assertNull(
+            "connectivityWaitJob must be null after clearTokenState",
+            manager.connectivityWaitJob
+        )
+        assertEquals("armed job must be cancelled", true, armedJob?.isCancelled ?: false)
+        assertEquals(
+            "network observer should be de-registered on cancellation",
+            0,
+            fakeNetworkMonitor.observerCount()
+        )
+
+        // Subsequent connectivity event should NOT trigger a retry
+        fakeNetworkMonitor.simulateConnected(isConnected = true)
+        dispatcher.scheduler.advanceUntilIdle()
+        assertEquals("no retry after clearTokenState", 2, provider.callCount)
+    }
+
+    @Test
+    fun `clearTokenState with stale generation does not cancel connectivity wait job`() = runTest(
+        dispatcher
+    ) {
+        val initialToken = makeJwt()
+        val newToken = makeJwt(EXP_SECONDS + 600, IAT_SECONDS + 600)
+        val firstProvider = ScriptedProvider(
+            ArrayDeque(
+                listOf(
+                    Result.success(initialToken),
+                    Result.failure(IOException("network down"))
+                )
+            )
+        )
+        val secondProvider = CountingSuccessProvider(newToken)
+        val manager = KlaviyoAuthTokenManager()
+
+        manager.registerProvider(firstProvider)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        executeScheduledRefresh()
+
+        // Capture generation before registering new provider
+        val gen = manager.invalidate()
+
+        // New provider registration clears connectivityWaitJob
+        manager.registerProvider(secondProvider)
+        dispatcher.scheduler.advanceUntilIdle()
+        assertNull("registerProvider cleared connectivity job", manager.connectivityWaitJob)
+
+        // A late clearTokenState with the old generation is a no-op — must not wipe new state
+        manager.clearTokenState(expectedGeneration = gen)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        // New session is still healthy
+        val result = manager.currentToken()
+        assertEquals(newToken, result.rawToken)
+    }
+
+    // MARK: - Fake NetworkMonitor
+
+    /**
+     * A controllable [NetworkMonitor] implementation that lets tests drive connectivity transitions.
+     * Set [connected] to control the return value of [isNetworkConnected].
+     */
+    private class FakeNetworkMonitor : NetworkMonitor {
+        private val observers = CopyOnWriteArrayList<NetworkObserver>()
+        var connected: Boolean = false
+
+        fun simulateConnected(isConnected: Boolean) {
+            connected = isConnected
+            observers.forEach { it(isConnected) }
+        }
+
+        fun observerCount(): Int = observers.size
+
+        override fun onNetworkChange(observer: NetworkObserver) {
+            observers += observer
+        }
+
+        override fun offNetworkChange(observer: NetworkObserver) {
+            observers -= observer
+        }
+
+        override fun isNetworkConnected(): Boolean = connected
+
+        override fun getNetworkType(): NetworkMonitor.NetworkType = NetworkMonitor.NetworkType.Offline
+    }
+
+    // MARK: - Test doubles
+
+    private class ScriptedProvider(
+        private val results: ArrayDeque<Result<String>>
+    ) : AuthTokenProvider {
+        var callCount = 0
+            private set
+
+        override fun fetchToken(callback: AuthTokenProvider.Callback) {
+            callCount++
+            val result = results.removeFirstOrNull()
+                ?: throw AssertionError(
+                    "ScriptedProvider: unexpected call #$callCount — no more scripted results"
+                )
+            result.fold(
+                onSuccess = callback::onSuccess,
+                onFailure = callback::onFailure
+            )
+        }
+    }
+
+    private class CountingSuccessProvider(private val jwt: String) : AuthTokenProvider {
+        var callCount = 0
+            private set
+
+        override fun fetchToken(callback: AuthTokenProvider.Callback) {
+            callCount++
+            callback.onSuccess(jwt)
+        }
+    }
+}

--- a/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerConnectivityTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerConnectivityTest.kt
@@ -510,6 +510,7 @@ class KlaviyoAuthTokenManagerConnectivityTest : BaseTest() {
         assertNotNull("job must be armed before clear", armedJob)
 
         // Clear token state (simulates logout / resetProfile)
+        manager.invalidate()
         manager.clearTokenState()
 
         assertNull(
@@ -530,7 +531,7 @@ class KlaviyoAuthTokenManagerConnectivityTest : BaseTest() {
     }
 
     @Test
-    fun `clearTokenState with stale generation does not cancel connectivity wait job`() = runTest(
+    fun `clearTokenState after new provider registers does not cancel connectivity wait job`() = runTest(
         dispatcher
     ) {
         val initialToken = makeJwt()
@@ -551,16 +552,17 @@ class KlaviyoAuthTokenManagerConnectivityTest : BaseTest() {
 
         executeScheduledRefresh()
 
-        // Capture generation before registering new provider
-        val gen = manager.invalidate()
+        // Mark a pending reset, then register a new provider which clears profileResetPending
+        manager.invalidate()
 
         // New provider registration clears connectivityWaitJob
         manager.registerProvider(secondProvider)
         dispatcher.scheduler.advanceUntilIdle()
         assertNull("registerProvider cleared connectivity job", manager.connectivityWaitJob)
 
-        // A late clearTokenState with the old generation is a no-op — must not wipe new state
-        manager.clearTokenState(expectedGeneration = gen)
+        // A late clearTokenState is a no-op since registerProvider cleared the reset flag —
+        // must not wipe new state
+        manager.clearTokenState()
         dispatcher.scheduler.advanceUntilIdle()
 
         // New session is still healthy

--- a/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerRefreshTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerRefreshTest.kt
@@ -1,0 +1,645 @@
+package com.klaviyo.core.auth
+
+import com.klaviyo.core.Registry
+import com.klaviyo.core.config.Clock
+import com.klaviyo.core.lifecycle.ActivityEvent
+import com.klaviyo.core.lifecycle.ActivityObserver
+import com.klaviyo.fixtures.BaseTest
+import io.mockk.every
+import io.mockk.slot
+import io.mockk.verify
+import java.util.Base64
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class KlaviyoAuthTokenManagerRefreshTest : BaseTest() {
+
+    companion object {
+        private const val NOW_SECONDS = TIME / 1000L // staticClock baseline = 1234567890s
+        private const val IAT_SECONDS = NOW_SECONDS - 60
+        private const val EXP_SECONDS = NOW_SECONDS + 3600
+    }
+
+    private val observerSlot = slot<ActivityObserver>()
+
+    @Before
+    override fun setup() {
+        super.setup()
+        every { mockLifecycleMonitor.onActivityEvent(capture(observerSlot)) } returns Unit
+    }
+
+    // Fires a FirstStarted event into the captured observer and drains the dispatcher.
+    private fun KlaviyoAuthTokenManager.fireFirstStarted() {
+        observerSlot.captured.invoke(ActivityEvent.FirstStarted(mockActivity))
+        dispatcher.scheduler.advanceUntilIdle()
+    }
+
+    private fun makeJwt(expSeconds: Long = EXP_SECONDS, iatSeconds: Long = IAT_SECONDS): String {
+        val header = JSONObject(mapOf("alg" to "HS256", "typ" to "JWT"))
+        val payload = JSONObject(
+            mapOf("exp" to expSeconds.toDouble(), "iat" to iatSeconds.toDouble())
+        )
+        val h = base64UrlEncode(header.toString().toByteArray())
+        val p = base64UrlEncode(payload.toString().toByteArray())
+        return "$h.$p.signature"
+    }
+
+    private fun base64UrlEncode(bytes: ByteArray): String =
+        Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
+
+    // MARK: - computeRefreshTarget (pure-function tests, no coroutines)
+
+    @Test
+    fun `computeRefreshTarget returns 90-percent of lifetime when inside clamps`() {
+        // iat=1000s, exp=4600s → lifetime=3600s, ideal=iat+3240=4240s
+        // upper=4570s, lower=1005s → ideal is inside bounds
+        val token = ValidatedToken("", expiresAtEpochSeconds = 4600L, issuedAtEpochSeconds = 1000L)
+        val targetMs = KlaviyoAuthTokenManager.computeRefreshTarget(token, nowMs = 1_000_000L)
+        assertEquals(4_240_000L, targetMs)
+    }
+
+    @Test
+    fun `computeRefreshTarget clamps to upperBound when ideal exceeds exp minus leeway`() {
+        // iat=0s, exp=100s, now=0s → ideal=90s, upper=70s, lower=5s → upper wins
+        val token = ValidatedToken("", expiresAtEpochSeconds = 100L, issuedAtEpochSeconds = 0L)
+        val targetMs = KlaviyoAuthTokenManager.computeRefreshTarget(token, nowMs = 0L)
+        assertEquals(70_000L, targetMs)
+    }
+
+    @Test
+    fun `computeRefreshTarget clamps to lowerBound when ideal is in the past`() {
+        // iat=0s, exp=10s, now=1000s → ideal=9s, upper=-20s, lower=1005s → lower wins
+        val token = ValidatedToken("", expiresAtEpochSeconds = 10L, issuedAtEpochSeconds = 0L)
+        val targetMs = KlaviyoAuthTokenManager.computeRefreshTarget(token, nowMs = 1_000_000L)
+        assertEquals(1_005_000L, targetMs)
+    }
+
+    @Test
+    fun `computeRefreshTarget clamps to lowerBound when token lifetime is shorter than leeway`() {
+        // Degenerate: iat=0s, exp=4s, now=0s → ideal=3.6s, upper=-26s (exp-leeway < 0)
+        // Both ideal and upper fall below lowerBound (5s) → lowerBound wins
+        val token = ValidatedToken("", expiresAtEpochSeconds = 4L, issuedAtEpochSeconds = 0L)
+        val targetMs = KlaviyoAuthTokenManager.computeRefreshTarget(token, nowMs = 0L)
+        assertEquals(5_000L, targetMs)
+    }
+
+    @Test
+    fun `computeRefreshTarget degrades gracefully when exp precedes iat`() {
+        // Malformed token where exp < iat — JWTParser.parseAndValidate rejects this in production,
+        // but the math should produce a safe positive target rather than a negative delay.
+        // iat=1000s, exp=900s, now=0 → ideal=910s, upper=870s (exp-leeway), lower=5s → upper wins
+        val token = ValidatedToken("", expiresAtEpochSeconds = 900L, issuedAtEpochSeconds = 1000L)
+        val targetMs = KlaviyoAuthTokenManager.computeRefreshTarget(token, nowMs = 0L)
+        assertEquals(870_000L, targetMs)
+    }
+
+    // MARK: - Scheduling integration
+
+    @Test
+    fun `scheduleRefresh fires at computed target and chains next refresh`() = runTest(dispatcher) {
+        val token = makeJwt()
+        val provider = CountingSuccessProvider(token)
+        val manager = KlaviyoAuthTokenManager()
+
+        manager.registerProvider(provider)
+        dispatcher.scheduler.advanceUntilIdle()
+        assertEquals(1, provider.callCount)
+        assertEquals(
+            "refresh should be scheduled after eager fetch",
+            1,
+            staticClock.scheduledTasks.size
+        )
+
+        // Advance clock to fire the scheduled timer task
+        val timerTask = staticClock.scheduledTasks.first()
+        staticClock.execute(timerTask.time - staticClock.time)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals("timer should have triggered a second provider call", 2, provider.callCount)
+        assertEquals(
+            "chained refresh should be scheduled after success",
+            1,
+            staticClock.scheduledTasks.size
+        )
+    }
+
+    @Test
+    fun `failed scheduled refresh keeps prior cached token for callers`() = runTest(dispatcher) {
+        val token = makeJwt()
+        val provider = ScriptedProvider(
+            ArrayDeque(
+                listOf(
+                    Result.success(token),
+                    Result.failure(RuntimeException("refresh failed"))
+                )
+            )
+        )
+        val manager = KlaviyoAuthTokenManager()
+
+        manager.registerProvider(provider)
+        dispatcher.scheduler.advanceUntilIdle()
+        assertEquals(1, provider.callCount)
+
+        val timerTask = staticClock.scheduledTasks.first()
+        staticClock.execute(timerTask.time - staticClock.time)
+        dispatcher.scheduler.advanceUntilIdle()
+        assertEquals(
+            "scheduled refresh should attempt one additional provider call",
+            2,
+            provider.callCount
+        )
+
+        val cached = manager.currentToken()
+        assertEquals(token, cached.rawToken)
+        assertEquals(
+            "callers should keep using the prior cached token after refresh failure",
+            2,
+            provider.callCount
+        )
+    }
+
+    @Test
+    fun `timeout during scheduled refresh leaves one foreground retry`() = runTest(dispatcher) {
+        // Verifies that withTimeoutOrNull returning null → AuthTokenException.TimedOut is treated
+        // identically to a provider error: clearFiredFlagForFailedRefresh is called so the
+        // foreground transition can detect the missed refresh and retry exactly once.
+        //
+        // After a real timeout the scope.async deferred is NOT cancelled — the underlying
+        // invokeProvider is still suspended. The foreground retry (case 2) will JOIN that
+        // still-live deferred rather than starting a new provider call, so we assert the
+        // "case=missed-refresh" log rather than an incremented provider call count.
+        val initialToken = makeJwt()
+        val freshToken = makeJwt(EXP_SECONDS + 600, IAT_SECONDS + 600)
+        val provider = InitialThenResolvableProvider(initialToken)
+        val manager = KlaviyoAuthTokenManager()
+
+        manager.registerProvider(provider)
+        dispatcher.scheduler.advanceUntilIdle()
+        assertEquals(1, provider.callCount)
+
+        // Fire the refresh timer — provider hangs on call #2, inFlightFetch is set
+        val timerTask = staticClock.scheduledTasks.first()
+        staticClock.execute(timerTask.time - staticClock.time)
+        dispatcher.scheduler.runCurrent()
+        assertEquals("scheduled refresh should be in-flight", 2, provider.callCount)
+
+        // Advance coroutine virtual time past BACKGROUND_FETCH_TIMEOUT_MS to trigger
+        // withTimeoutOrNull inside currentTokenInternal — fires clearFiredFlagForFailedRefresh
+        dispatcher.scheduler.advanceTimeBy(AuthTokenManager.BACKGROUND_FETCH_TIMEOUT_MS + 1)
+        dispatcher.scheduler.runCurrent()
+
+        verify { spyLog.warning(match { it.contains("TimedOut") }, any()) }
+
+        // Foreground retry is available: case 2 fires because refreshAtWallClockMs still points
+        // to the past target and refreshTimerFired was reset by clearFiredFlagForFailedRefresh.
+        // The retry joins the still-live inFlightFetch — no new provider call.
+        manager.fireFirstStarted()
+        verify { spyLog.info(match { it.contains("case=missed-refresh") }) }
+
+        // Resolve the still-running in-flight deferred so runTest can complete cleanly
+        provider.resolve(freshToken)
+        dispatcher.scheduler.advanceUntilIdle()
+    }
+
+    @Test
+    fun `demand caller joins scheduled refresh in-flight fetch when cache expires mid-refresh`() =
+        runTest(dispatcher) {
+            // Verifies allowCachedToken=false + dedup: when performScheduledRefresh (allowCachedToken=false)
+            // has set inFlightFetch and the cached token subsequently expires, a demand currentToken()
+            // call must join the existing deferred rather than starting a duplicate provider invocation.
+            val initialToken = makeJwt()
+            val freshToken = makeJwt(EXP_SECONDS + 600, IAT_SECONDS + 600)
+            val provider = InitialThenResolvableProvider(initialToken)
+            val manager = KlaviyoAuthTokenManager()
+
+            manager.registerProvider(provider)
+            dispatcher.scheduler.advanceUntilIdle()
+            assertEquals(1, provider.callCount)
+
+            // Fire the scheduled refresh — provider hangs on call #2, inFlightFetch is set
+            val timerTask = staticClock.scheduledTasks.first()
+            staticClock.execute(timerTask.time - staticClock.time)
+            dispatcher.scheduler.runCurrent()
+            assertEquals("scheduled refresh should be in-flight", 2, provider.callCount)
+
+            // Advance clock past token expiry so the demand caller's optimistic read also misses
+            staticClock.time = (EXP_SECONDS - JWTParser.DEFAULT_LEEWAY_SECONDS) * 1000L
+
+            // Demand caller: sees expired cache, falls through to mutex, finds and joins inFlightFetch
+            val demandToken = async { manager.currentToken() }
+            dispatcher.scheduler.runCurrent()
+
+            // Resolve the shared in-flight fetch — both callers receive the fresh token
+            provider.resolve(freshToken)
+            dispatcher.scheduler.advanceUntilIdle()
+
+            assertEquals(
+                "demand caller should join the in-flight refresh fetch, not trigger a new provider call",
+                2,
+                provider.callCount
+            )
+            assertEquals(freshToken, demandToken.await().rawToken)
+        }
+
+    @Test
+    fun `registerProvider cancels pending refresh job`() = runTest(dispatcher) {
+        val tokenA = makeJwt()
+        val tokenB = makeJwt(EXP_SECONDS + 1, IAT_SECONDS + 1)
+        val providerA = CountingSuccessProvider(tokenA)
+        val providerB = CountingSuccessProvider(tokenB)
+        val manager = KlaviyoAuthTokenManager()
+
+        manager.registerProvider(providerA)
+        dispatcher.scheduler.advanceUntilIdle()
+        assertEquals(1, staticClock.scheduledTasks.size) // A's refresh scheduled
+
+        // Swap to B before the timer fires — should cancel A's scheduled refresh
+        manager.registerProvider(providerB)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        // Advance well past where A's refresh would have fired
+        staticClock.execute(5_000_000L)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals("A's refresh should have been cancelled, not fired", 1, providerA.callCount)
+    }
+
+    // MARK: - Foreground transitions
+
+    @Test
+    fun `foreground with still-valid token is no-op`() = runTest(dispatcher) {
+        val provider = CountingSuccessProvider(makeJwt())
+        val manager = KlaviyoAuthTokenManager()
+
+        manager.registerProvider(provider)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        manager.fireFirstStarted()
+
+        assertEquals("still-valid foreground should not trigger re-fetch", 1, provider.callCount)
+    }
+
+    @Test
+    fun `non-FirstStarted lifecycle events do not trigger foreground handler`() = runTest(
+        dispatcher
+    ) {
+        val provider = CountingSuccessProvider(makeJwt())
+        val manager = KlaviyoAuthTokenManager()
+
+        manager.registerProvider(provider)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        val observer = observerSlot.captured
+        observer.invoke(ActivityEvent.Started(mockActivity))
+        observer.invoke(ActivityEvent.Stopped(mockActivity))
+        observer.invoke(ActivityEvent.AllStopped())
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals("non-FirstStarted events must be ignored", 1, provider.callCount)
+    }
+
+    @Test
+    fun `foreground with missed refresh fires exactly once`() = runTest(dispatcher) {
+        val provider = CountingSuccessProvider(makeJwt())
+        val manager = KlaviyoAuthTokenManager()
+
+        manager.registerProvider(provider)
+        dispatcher.scheduler.advanceUntilIdle()
+        assertEquals(1, staticClock.scheduledTasks.size)
+
+        // Simulate background time passing past the refresh target without the timer firing
+        // (e.g., Doze suppressed the JVM Timer thread). Advance time directly, not via execute().
+        val timerTask = staticClock.scheduledTasks.first()
+        staticClock.time = timerTask.time + 1_000L
+
+        // Foreground transition should detect the missed refresh and fire it immediately
+        manager.fireFirstStarted()
+
+        assertEquals(
+            "missed refresh should trigger one additional provider call",
+            2,
+            provider.callCount
+        )
+        assertEquals(
+            "chained refresh should be scheduled after foreground retry",
+            1,
+            staticClock.scheduledTasks.size
+        )
+    }
+
+    @Test
+    fun `foreground after timer fires while refresh is in-flight is not treated as missed`() = runTest(
+        dispatcher
+    ) {
+        val initialToken = makeJwt()
+        val refreshedToken = makeJwt(EXP_SECONDS + 600, IAT_SECONDS + 600)
+        val provider = InitialThenResolvableProvider(initialToken)
+        val manager = KlaviyoAuthTokenManager()
+
+        manager.registerProvider(provider)
+        dispatcher.scheduler.advanceUntilIdle()
+        assertEquals(1, provider.callCount)
+
+        val timerTask = staticClock.scheduledTasks.first()
+        staticClock.execute(timerTask.time - staticClock.time)
+        dispatcher.scheduler.runCurrent()
+        assertEquals("scheduled refresh should be in-flight", 2, provider.callCount)
+
+        observerSlot.captured.invoke(ActivityEvent.FirstStarted(mockActivity))
+        dispatcher.scheduler.runCurrent()
+
+        verify(inverse = true) {
+            spyLog.info(match { it.contains("case=missed-refresh") })
+        }
+
+        provider.resolve(refreshedToken)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(
+            "foreground should not enqueue another forced provider fetch after timer success",
+            2,
+            provider.callCount
+        )
+    }
+
+    @Test
+    fun `foreground during in-flight refresh that subsequently fails defers retry to next foreground`() =
+        runTest(dispatcher) {
+            // Edge case: FirstStarted fires while the timer-driven refresh is still in-flight
+            // (refreshTimerFired=true → still-valid no-op). The refresh then fails and
+            // clearFiredFlagForFailedRefresh resets refreshTimerFired. refreshAtWallClockMs is NOT
+            // cleared in the else branch, so the NEXT foreground transition correctly detects the
+            // past target and fires case 2 (missed-refresh retry). The retry is deferred, not lost.
+            //
+            // A hanging provider (call #2 suspends until manually rejected) is required to keep the
+            // refresh in-flight while the foreground event fires — a synchronous failure would
+            // reset refreshTimerFired before the handler runs, bypassing the scenario under test.
+            val initialToken = makeJwt()
+            val retryToken = makeJwt(EXP_SECONDS + 600, IAT_SECONDS + 600)
+            var callCount = 0
+            val pendingCallbacks = ArrayDeque<AuthTokenProvider.Callback>()
+            val provider = object : AuthTokenProvider {
+                override fun fetchToken(callback: AuthTokenProvider.Callback) {
+                    callCount++
+                    when (callCount) {
+                        1 -> callback.onSuccess(initialToken)
+                        2 -> pendingCallbacks.addLast(callback) // hangs until manually rejected
+                        else -> callback.onSuccess(retryToken)
+                    }
+                }
+            }
+            val manager = KlaviyoAuthTokenManager()
+
+            manager.registerProvider(provider)
+            dispatcher.scheduler.advanceUntilIdle()
+            assertEquals(1, callCount)
+
+            // Fire the refresh timer — provider hangs on call #2, refreshTimerFired=true
+            val timerTask = staticClock.scheduledTasks.first()
+            staticClock.execute(timerTask.time - staticClock.time)
+            dispatcher.scheduler.runCurrent()
+            assertEquals("scheduled refresh should be in-flight", 2, callCount)
+
+            // Foreground fires while refresh is in-flight (refreshTimerFired=true) → still-valid
+            observerSlot.captured.invoke(ActivityEvent.FirstStarted(mockActivity))
+            dispatcher.scheduler.runCurrent()
+            verify(inverse = true) {
+                spyLog.info(match { it.contains("case=missed-refresh") })
+            }
+            verify { spyLog.info(match { it.contains("case=still-valid") }) }
+
+            // Fail the in-flight refresh — clearFiredFlagForFailedRefresh resets refreshTimerFired=false
+            pendingCallbacks.removeFirstOrNull()?.onFailure(
+                RuntimeException("in-flight refresh failed")
+            )
+            dispatcher.scheduler.advanceUntilIdle()
+            assertEquals("no new provider calls beyond the failed refresh", 2, callCount)
+
+            // refreshAtWallClockMs still holds the past target, refreshTimerFired=false.
+            // The NEXT foreground detects the past target and fires case 2 (retry is deferred, not lost).
+            manager.fireFirstStarted()
+
+            assertEquals(
+                "next foreground should detect the missed target and trigger the retry",
+                3,
+                callCount
+            )
+            verify { spyLog.info(match { it.contains("case=missed-refresh") }) }
+        }
+
+    @Test
+    fun `foreground racing with fired timer only launches one scheduled refresh`() = runTest(
+        dispatcher
+    ) {
+        val racingClock = FireOnCancelClock(TIME, ISO_TIME)
+        every { Registry.clock } returns racingClock
+        val provider = CountingSuccessProvider(makeJwt())
+        val manager = KlaviyoAuthTokenManager()
+
+        manager.registerProvider(provider)
+        dispatcher.scheduler.advanceUntilIdle()
+        assertEquals(1, provider.callCount)
+
+        val timerTask = racingClock.scheduledTasks.first()
+        racingClock.time = timerTask.time + 1_000L
+
+        manager.fireFirstStarted()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(
+            "racing timer and foreground handlers should share one provider fetch",
+            2,
+            provider.callCount
+        )
+        verify(exactly = 1) {
+            spyLog.info("Proactive token refresh fired")
+        }
+    }
+
+    @Test
+    fun `foreground retries after scheduled timer refresh fails`() = runTest(dispatcher) {
+        val initialToken = makeJwt()
+        val retryToken = makeJwt(EXP_SECONDS + 600, IAT_SECONDS + 600)
+        val provider = ScriptedProvider(
+            ArrayDeque(
+                listOf(
+                    Result.success(initialToken),
+                    Result.failure(RuntimeException("refresh failed")),
+                    Result.success(retryToken)
+                )
+            )
+        )
+        val manager = KlaviyoAuthTokenManager()
+
+        manager.registerProvider(provider)
+        dispatcher.scheduler.advanceUntilIdle()
+        assertEquals(1, provider.callCount)
+
+        val timerTask = staticClock.scheduledTasks.first()
+        staticClock.execute(timerTask.time - staticClock.time)
+        dispatcher.scheduler.advanceUntilIdle()
+        assertEquals("scheduled refresh should have failed", 2, provider.callCount)
+
+        manager.fireFirstStarted()
+
+        assertEquals(
+            "failed scheduled refresh should leave one foreground retry available",
+            3,
+            provider.callCount
+        )
+    }
+
+    @Test
+    fun `second foreground after successful retry is a no-op`() = runTest(dispatcher) {
+        // After the foreground case-2 branch fires and the retry succeeds, refreshAtWallClockMs
+        // is cleared before the retry coroutine launches. A subsequent foreground transition
+        // therefore has no past target to act on and must be a case=still-valid no-op.
+        val initialToken = makeJwt()
+        val retryToken = makeJwt(EXP_SECONDS + 600, IAT_SECONDS + 600)
+        val provider = ScriptedProvider(
+            ArrayDeque(
+                listOf(
+                    Result.success(initialToken),
+                    Result.failure(RuntimeException("timer refresh failed")),
+                    Result.success(retryToken)
+                )
+            )
+        )
+        val manager = KlaviyoAuthTokenManager()
+
+        manager.registerProvider(provider)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        val timerTask = staticClock.scheduledTasks.first()
+        staticClock.execute(timerTask.time - staticClock.time)
+        dispatcher.scheduler.advanceUntilIdle()
+        assertEquals(2, provider.callCount)
+
+        // First foreground → case 2 (missed refresh), retry succeeds and schedules next refresh
+        manager.fireFirstStarted()
+        assertEquals("foreground retry should fire", 3, provider.callCount)
+        verify(exactly = 1) { spyLog.info(match { it.contains("case=missed-refresh") }) }
+
+        // Second foreground → case 3: refreshAtWallClockMs was cleared before the retry launched,
+        // so the new refresh target (set by the retry's doFetch) is in the future — still-valid
+        manager.fireFirstStarted()
+        assertEquals("second foreground should be a no-op", 3, provider.callCount)
+        verify(atLeast = 1) { spyLog.info(match { it.contains("case=still-valid") }) }
+    }
+
+    @Test
+    fun `foreground with expired token clears cache and eager-fetches`() = runTest(dispatcher) {
+        val provider = CountingSuccessProvider(makeJwt())
+        val manager = KlaviyoAuthTokenManager()
+
+        manager.registerProvider(provider)
+        dispatcher.scheduler.advanceUntilIdle()
+        assertEquals(1, provider.callCount)
+
+        // Advance clock past the token's validity window (exp - leeway) without firing tasks
+        staticClock.time = (EXP_SECONDS - JWTParser.DEFAULT_LEEWAY_SECONDS) * 1000L
+
+        // Foreground transition should detect expiry and kick off an eager re-fetch
+        manager.fireFirstStarted()
+
+        assertEquals("expired-token foreground should trigger a re-fetch", 2, provider.callCount)
+    }
+
+    // MARK: - Helpers
+
+    /**
+     * A test [Clock] that fires a scheduled task synchronously when its [Clock.Cancellable.cancel]
+     * is called, modelling the race where a timer fires at the exact instant it is being cancelled.
+     * Used only by [foreground racing with fired timer only launches one scheduled refresh] to
+     * verify the generation-based deduplication guard.
+     *
+     * Note: [Clock.Cancellable.runNow] and [Clock.Cancellable.cancel] have the same effect —
+     * this is intentional; "cancel" here means "cancel the pending delay and run immediately."
+     */
+    private class FireOnCancelClock(
+        var time: Long,
+        private val formatted: String
+    ) : Clock {
+        val scheduledTasks = mutableListOf<ScheduledTask>()
+
+        override fun currentTimeMillis(): Long = time
+
+        override fun isoTime(milliseconds: Long): String = formatted
+
+        override fun schedule(delay: Long, task: () -> Unit): Clock.Cancellable {
+            val scheduledTask = ScheduledTask(currentTimeMillis() + delay, task)
+            scheduledTasks.add(scheduledTask)
+            return object : Clock.Cancellable {
+                override fun runNow() {
+                    if (scheduledTasks.remove(scheduledTask)) {
+                        task()
+                    }
+                }
+
+                override fun cancel(): Boolean {
+                    val removed = scheduledTasks.remove(scheduledTask)
+                    if (removed) {
+                        task()
+                    }
+                    return removed
+                }
+            }
+        }
+
+        class ScheduledTask(val time: Long, val task: () -> Unit)
+    }
+
+    private class CountingSuccessProvider(private val jwt: String) : AuthTokenProvider {
+        var callCount = 0
+            private set
+
+        override fun fetchToken(callback: AuthTokenProvider.Callback) {
+            callCount++
+            callback.onSuccess(jwt)
+        }
+    }
+
+    private class InitialThenResolvableProvider(private val initialJwt: String) : AuthTokenProvider {
+        var callCount = 0
+            private set
+
+        private val pendingCallbacks = ArrayDeque<AuthTokenProvider.Callback>()
+
+        override fun fetchToken(callback: AuthTokenProvider.Callback) {
+            callCount++
+            if (callCount == 1) {
+                callback.onSuccess(initialJwt)
+            } else {
+                pendingCallbacks.addLast(callback)
+            }
+        }
+
+        fun resolve(jwt: String) = pendingCallbacks.removeFirstOrNull()?.onSuccess(jwt)
+    }
+
+    private class ScriptedProvider(
+        private val results: ArrayDeque<Result<String>>
+    ) : AuthTokenProvider {
+        var callCount = 0
+            private set
+
+        override fun fetchToken(callback: AuthTokenProvider.Callback) {
+            callCount++
+            val result = results.removeFirstOrNull()
+                ?: throw AssertionError(
+                    "ScriptedProvider: unexpected call #$callCount — no more scripted results"
+                )
+            result.fold(
+                onSuccess = callback::onSuccess,
+                onFailure = callback::onFailure
+            )
+        }
+    }
+}

--- a/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerRefreshTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerRefreshTest.kt
@@ -552,6 +552,367 @@ class KlaviyoAuthTokenManagerRefreshTest : BaseTest() {
         assertEquals("expired-token foreground should trigger a re-fetch", 2, provider.callCount)
     }
 
+    // MARK: - Observer notification and clearTokenState
+
+    @Test
+    fun `refresh observer receives jwt on proactive refresh`() = runTest(dispatcher) {
+        val jwt = makeJwt()
+        val provider = CountingSuccessProvider(jwt)
+        val manager = KlaviyoAuthTokenManager()
+
+        val receivedTokens = mutableListOf<String>()
+        manager.onTokenRefresh { receivedTokens.add(it) }
+
+        manager.registerProvider(provider)
+        dispatcher.scheduler.advanceUntilIdle()
+        assertEquals("eager fetch should not notify observers", 0, receivedTokens.size)
+
+        // Fire the scheduled refresh
+        val timerTask = staticClock.scheduledTasks.first()
+        staticClock.execute(timerTask.time - staticClock.time)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals("observer should receive jwt after proactive refresh", 1, receivedTokens.size)
+        assertEquals(jwt, receivedTokens[0])
+    }
+
+    @Test
+    fun `multiple refresh observers all receive token`() = runTest(dispatcher) {
+        val jwt = makeJwt()
+        val provider = CountingSuccessProvider(jwt)
+        val manager = KlaviyoAuthTokenManager()
+
+        val receivedA = mutableListOf<String>()
+        val receivedB = mutableListOf<String>()
+        manager.onTokenRefresh { receivedA.add(it) }
+        manager.onTokenRefresh { receivedB.add(it) }
+
+        manager.registerProvider(provider)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        val timerTask = staticClock.scheduledTasks.first()
+        staticClock.execute(timerTask.time - staticClock.time)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals("observer A should receive jwt", 1, receivedA.size)
+        assertEquals("observer B should receive jwt", 1, receivedB.size)
+        assertEquals(jwt, receivedA[0])
+        assertEquals(jwt, receivedB[0])
+    }
+
+    @Test
+    fun `refresh observer not called on initial eager fetch`() = runTest(dispatcher) {
+        val provider = CountingSuccessProvider(makeJwt())
+        val manager = KlaviyoAuthTokenManager()
+
+        var notified = false
+        manager.onTokenRefresh { notified = true }
+
+        manager.registerProvider(provider)
+        dispatcher.scheduler.advanceUntilIdle()
+        assertEquals(1, provider.callCount)
+
+        assertEquals("eager fetch must not invoke observers", false, notified)
+    }
+
+    @Test
+    fun `observer throwing does not prevent other observers`() = runTest(dispatcher) {
+        val jwt = makeJwt()
+        val provider = CountingSuccessProvider(jwt)
+        val manager = KlaviyoAuthTokenManager()
+
+        val receivedBySecond = mutableListOf<String>()
+        manager.onTokenRefresh { throw RuntimeException("boom") }
+        manager.onTokenRefresh { receivedBySecond.add(it) }
+
+        manager.registerProvider(provider)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        val timerTask = staticClock.scheduledTasks.first()
+        staticClock.execute(timerTask.time - staticClock.time)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        verify { spyLog.warning(any(), any()) }
+        assertEquals("second observer should still receive jwt", 1, receivedBySecond.size)
+    }
+
+    @Test
+    fun `offTokenRefresh removes observer`() = runTest(dispatcher) {
+        val provider = CountingSuccessProvider(makeJwt())
+        val manager = KlaviyoAuthTokenManager()
+
+        var notified = false
+        val observer: TokenRefreshObserver = { notified = true }
+        manager.onTokenRefresh(observer)
+        manager.offTokenRefresh(observer)
+
+        manager.registerProvider(provider)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        val timerTask = staticClock.scheduledTasks.first()
+        staticClock.execute(timerTask.time - staticClock.time)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals("removed observer must not receive jwt", false, notified)
+    }
+
+    @Test
+    fun `clearTokenState drops cached token and cancels scheduled refresh`() = runTest(dispatcher) {
+        val provider = CountingSuccessProvider(makeJwt())
+        val manager = KlaviyoAuthTokenManager()
+
+        manager.registerProvider(provider)
+        dispatcher.scheduler.advanceUntilIdle()
+        assertEquals(1, provider.callCount)
+        assertEquals(
+            "refresh should be scheduled after eager fetch",
+            1,
+            staticClock.scheduledTasks.size
+        )
+
+        // Capture the original refresh target before clearing
+        val originalRefreshTarget = staticClock.scheduledTasks.first().time
+
+        manager.clearTokenState()
+
+        // The original scheduled task should be gone immediately after clearing
+        assertEquals(
+            "clearTokenState should cancel the scheduled refresh",
+            0,
+            staticClock.scheduledTasks.size
+        )
+
+        // Advance past the original refresh target — since the timer was cancelled, no new fetch
+        staticClock.execute(originalRefreshTarget - staticClock.time + 1_000L)
+        dispatcher.scheduler.advanceUntilIdle()
+        assertEquals(
+            "cancelled refresh timer must not trigger an additional provider call",
+            1,
+            provider.callCount
+        )
+
+        // Cache should be cleared: next currentToken() re-invokes provider
+        manager.currentToken()
+        dispatcher.scheduler.advanceUntilIdle()
+        assertEquals(
+            "clearTokenState should discard cache, forcing a new fetch",
+            2,
+            provider.callCount
+        )
+    }
+
+    @Test
+    fun `clearTokenState retains provider and observers`() = runTest(dispatcher) {
+        val provider = CountingSuccessProvider(makeJwt())
+        val manager = KlaviyoAuthTokenManager()
+
+        val received = mutableListOf<String>()
+        manager.onTokenRefresh { received.add(it) }
+
+        manager.registerProvider(provider)
+        dispatcher.scheduler.advanceUntilIdle()
+        assertEquals(1, provider.callCount)
+
+        manager.clearTokenState()
+
+        // Provider is retained: next fetch invokes it directly
+        manager.currentToken()
+        dispatcher.scheduler.advanceUntilIdle()
+        assertEquals("retained provider should serve the next fetch", 2, provider.callCount)
+
+        // Observer is retained: fire a new proactive refresh and verify it fires
+        val timerTask = staticClock.scheduledTasks.first()
+        staticClock.execute(timerTask.time - staticClock.time)
+        dispatcher.scheduler.advanceUntilIdle()
+        assertEquals(
+            "retained observer should receive jwt from post-reset refresh",
+            1,
+            received.size
+        )
+    }
+
+    @Test
+    fun `proactive refresh does not notify observers after clearTokenState races with fetch`() =
+        runTest(dispatcher) {
+            // Scenario: the scheduled refresh is in-flight when clearTokenState() runs.
+            //
+            // Primary path verified: clearTokenState() cancels inFlightFetch, which sets the
+            // CancellationException flag on the in-flight Deferred. When provider.resolve() fires,
+            // invokeProvider()'s isActive guard drops the late callback and doFetch() never writes
+            // the cache. The assertion therefore passes via the cancellation path.
+            //
+            // Secondary defense: if a fetch were to survive cancellation and write its token to the
+            // cache, the stale-token guard in performScheduledRefresh() (cachedToken?.rawToken ==
+            // token.rawToken) would prevent broadcasting since clearTokenState() already nulled
+            // cachedToken. Both layers are exercised end-to-end; cancellation is the dominant path.
+            val initialToken = makeJwt()
+            val refreshedToken = makeJwt(EXP_SECONDS + 600, IAT_SECONDS + 600)
+            val provider = InitialThenResolvableProvider(initialToken)
+            val manager = KlaviyoAuthTokenManager()
+
+            val received = mutableListOf<String>()
+            manager.onTokenRefresh { received.add(it) }
+
+            manager.registerProvider(provider)
+            dispatcher.scheduler.advanceUntilIdle()
+            assertEquals(1, provider.callCount)
+
+            // Fire the refresh timer — provider hangs on call #2, inFlightFetch is live
+            val timerTask = staticClock.scheduledTasks.first()
+            staticClock.execute(timerTask.time - staticClock.time)
+            dispatcher.scheduler.runCurrent()
+            assertEquals("scheduled refresh should be in-flight", 2, provider.callCount)
+
+            // Profile reset: clear token state while the refresh is still in-flight
+            manager.clearTokenState()
+
+            // Resolve the still-running provider callback (arrives after cancellation)
+            provider.resolve(refreshedToken)
+            dispatcher.scheduler.advanceUntilIdle()
+
+            assertEquals(
+                "observer must not receive a stale-profile token after clearTokenState",
+                0,
+                received.size
+            )
+        }
+
+    @Test
+    fun `clearTokenState with stale expectedGeneration is a no-op after new provider registers`() =
+        runTest(dispatcher) {
+            // Scenario mirrors resetProfile() followed immediately by registerAuthTokenProvider():
+            // invalidate() captures gen=N, registerProvider() advances gen to N+1, then the
+            // async clearTokenState(gen=N) fires and must NOT wipe the new session's state.
+            val initialJwt = makeJwt()
+            val newJwt = makeJwt(EXP_SECONDS + 600, IAT_SECONDS + 600)
+            val provider1 = CountingSuccessProvider(initialJwt)
+            val provider2 = CountingSuccessProvider(newJwt)
+            val manager = KlaviyoAuthTokenManager()
+
+            manager.registerProvider(provider1)
+            dispatcher.scheduler.advanceUntilIdle()
+            assertEquals("first eager fetch", 1, provider1.callCount)
+
+            // Step 1: invalidate() — simulates the sync part of resetProfile()
+            val gen = manager.invalidate()
+
+            // Step 2: registerProvider() for the new user — advances profileGeneration past gen
+            manager.registerProvider(provider2)
+            dispatcher.scheduler.advanceUntilIdle()
+            assertEquals("new provider eager fetch", 1, provider2.callCount)
+
+            // Step 3: clearTokenState(gen) — simulates the async part of resetProfile();
+            // because profileGeneration > gen, this must be a no-op.
+            manager.clearTokenState(expectedGeneration = gen)
+
+            // New session's cache is intact: currentToken() must NOT invoke provider2 again.
+            manager.currentToken()
+            dispatcher.scheduler.advanceUntilIdle()
+            assertEquals(
+                "clearTokenState must not wipe new session when provider was re-registered",
+                1,
+                provider2.callCount
+            )
+        }
+
+    @Test
+    fun `invalidate causes currentToken to bypass cache and trigger new fetch`() =
+        runTest(dispatcher) {
+            val jwt = makeJwt()
+            val provider = CountingSuccessProvider(jwt)
+            val manager = KlaviyoAuthTokenManager()
+
+            manager.registerProvider(provider)
+            dispatcher.scheduler.advanceUntilIdle()
+            assertEquals("eager fetch on register", 1, provider.callCount)
+
+            // Warm-cache sanity check: currentToken() should serve from cache without calling provider.
+            manager.currentToken()
+            dispatcher.scheduler.advanceUntilIdle()
+            assertEquals("cache hit — provider not called again", 1, provider.callCount)
+
+            // invalidate() sets profileResetPending; cachedToken is still non-null at this point.
+            manager.invalidate()
+
+            // currentToken() must not return the stale cached value — falls through to a fetch.
+            manager.currentToken()
+            dispatcher.scheduler.advanceUntilIdle()
+            assertEquals("invalidate forces a new provider fetch", 2, provider.callCount)
+        }
+
+    @Test
+    fun `invalidate prevents observer notification when refresh is in-flight at time of reset`() =
+        runTest(dispatcher) {
+            // Scenario A: performScheduledRefresh is already in-flight when resetProfile() calls
+            // invalidate() synchronously. The profileResetPending flag is set while the fetch
+            // is suspended; the post-fetch guard reads it and skips observer dispatch.
+            val initialToken = makeJwt()
+            val refreshedToken = makeJwt(EXP_SECONDS + 600, IAT_SECONDS + 600)
+            val provider = InitialThenResolvableProvider(initialToken)
+            val manager = KlaviyoAuthTokenManager()
+
+            val received = mutableListOf<String>()
+            manager.onTokenRefresh { received.add(it) }
+
+            manager.registerProvider(provider)
+            dispatcher.scheduler.advanceUntilIdle()
+            assertEquals(1, provider.callCount)
+
+            // Fire the scheduled refresh; provider hangs on call #2 while fetch is suspended
+            val timerTask = staticClock.scheduledTasks.first()
+            staticClock.execute(timerTask.time - staticClock.time)
+            dispatcher.scheduler.runCurrent()
+            assertEquals("scheduled refresh is in-flight", 2, provider.callCount)
+
+            // Synchronous invalidate() — simulates the sync step of resetProfile().
+            // clearTokenState() has NOT yet run; only profileResetPending is set.
+            manager.invalidate()
+
+            // Resolve the still-running provider callback (fetch completes after invalidate)
+            provider.resolve(refreshedToken)
+            dispatcher.scheduler.advanceUntilIdle()
+
+            assertEquals(
+                "observer must not fire after invalidate() even before clearTokenState runs",
+                0,
+                received.size
+            )
+        }
+
+    @Test
+    fun `invalidate prevents observer notification when refresh starts after profile reset`() =
+        runTest(dispatcher) {
+            // Scenario B (the gap bugbot found): the scheduled timer fires AFTER invalidate() runs.
+            // performScheduledRefresh never had a "pre-invalidate" state to compare against — the
+            // old captured-generation approach failed here because it captured the post-invalidate
+            // generation and the check passed. profileResetPending fixes this: the flag is already
+            // true when the refresh starts, so the post-fetch guard correctly skips observers.
+            val jwt = makeJwt()
+            val provider = CountingSuccessProvider(jwt)
+            val manager = KlaviyoAuthTokenManager()
+
+            val received = mutableListOf<String>()
+            manager.onTokenRefresh { received.add(it) }
+
+            manager.registerProvider(provider)
+            dispatcher.scheduler.advanceUntilIdle()
+            assertEquals(1, provider.callCount)
+
+            // Synchronous invalidate() fires BEFORE the refresh timer
+            manager.invalidate()
+
+            // Now fire the refresh timer — performScheduledRefresh starts after invalidate()
+            val timerTask = staticClock.scheduledTasks.first()
+            staticClock.execute(timerTask.time - staticClock.time)
+            dispatcher.scheduler.advanceUntilIdle()
+
+            assertEquals(
+                "observer must not fire when refresh starts after invalidate()",
+                0,
+                received.size
+            )
+        }
+
     // MARK: - Helpers
 
     /**

--- a/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerRefreshTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerRefreshTest.kt
@@ -673,6 +673,8 @@ class KlaviyoAuthTokenManagerRefreshTest : BaseTest() {
         // Capture the original refresh target before clearing
         val originalRefreshTarget = staticClock.scheduledTasks.first().time
 
+        // invalidate() sets profileResetPending so the subsequent clear proceeds (mirrors resetProfile)
+        manager.invalidate()
         manager.clearTokenState()
 
         // The original scheduled task should be gone immediately after clearing
@@ -713,6 +715,7 @@ class KlaviyoAuthTokenManagerRefreshTest : BaseTest() {
         dispatcher.scheduler.advanceUntilIdle()
         assertEquals(1, provider.callCount)
 
+        manager.invalidate()
         manager.clearTokenState()
 
         // Provider is retained: next fetch invokes it directly
@@ -764,6 +767,7 @@ class KlaviyoAuthTokenManagerRefreshTest : BaseTest() {
             assertEquals("scheduled refresh should be in-flight", 2, provider.callCount)
 
             // Profile reset: clear token state while the refresh is still in-flight
+            manager.invalidate()
             manager.clearTokenState()
 
             // Resolve the still-running provider callback (arrives after cancellation)
@@ -778,11 +782,11 @@ class KlaviyoAuthTokenManagerRefreshTest : BaseTest() {
         }
 
     @Test
-    fun `clearTokenState with stale expectedGeneration is a no-op after new provider registers`() =
+    fun `clearTokenState is a no-op after new provider registers since reset`() =
         runTest(dispatcher) {
             // Scenario mirrors resetProfile() followed immediately by registerAuthTokenProvider():
-            // invalidate() captures gen=N, registerProvider() advances gen to N+1, then the
-            // async clearTokenState(gen=N) fires and must NOT wipe the new session's state.
+            // invalidate() sets profileResetPending, registerProvider() clears it, then the async
+            // clearTokenState() fires and must NOT wipe the new session's state.
             val initialJwt = makeJwt()
             val newJwt = makeJwt(EXP_SECONDS + 600, IAT_SECONDS + 600)
             val provider1 = CountingSuccessProvider(initialJwt)
@@ -794,16 +798,16 @@ class KlaviyoAuthTokenManagerRefreshTest : BaseTest() {
             assertEquals("first eager fetch", 1, provider1.callCount)
 
             // Step 1: invalidate() — simulates the sync part of resetProfile()
-            val gen = manager.invalidate()
+            manager.invalidate()
 
-            // Step 2: registerProvider() for the new user — advances profileGeneration past gen
+            // Step 2: registerProvider() for the new user — clears profileResetPending
             manager.registerProvider(provider2)
             dispatcher.scheduler.advanceUntilIdle()
             assertEquals("new provider eager fetch", 1, provider2.callCount)
 
-            // Step 3: clearTokenState(gen) — simulates the async part of resetProfile();
-            // because profileGeneration > gen, this must be a no-op.
-            manager.clearTokenState(expectedGeneration = gen)
+            // Step 3: clearTokenState() — simulates the async part of resetProfile();
+            // because profileResetPending was cleared by registerProvider, this must be a no-op.
+            manager.clearTokenState()
 
             // New session's cache is intact: currentToken() must NOT invoke provider2 again.
             manager.currentToken()

--- a/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerTest.kt
@@ -1,0 +1,235 @@
+package com.klaviyo.core.auth
+
+import com.klaviyo.fixtures.BaseTest
+import io.mockk.verify
+import java.util.Base64
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.runTest
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class KlaviyoAuthTokenManagerTest : BaseTest() {
+
+    companion object {
+        // staticClock returns TIME = 1234567890000ms → 1234567890s
+        private const val NOW_SECONDS = 1234567890L
+        private const val IAT_SECONDS = NOW_SECONDS - 60
+        private const val EXP_SECONDS = NOW_SECONDS + 3600
+    }
+
+    @Test
+    fun `currentToken throws NoProviderRegistered when no provider registered`() = runTest {
+        val manager = KlaviyoAuthTokenManager()
+
+        try {
+            manager.currentToken()
+            fail("Expected AuthTokenException.NoProviderRegistered")
+        } catch (e: AuthTokenException.NoProviderRegistered) {
+            assertEquals("No auth token provider registered", e.message)
+        }
+    }
+
+    @Test
+    fun `currentToken returns provider token on first fetch`() = runTest {
+        val token = makeJwt(EXP_SECONDS, IAT_SECONDS)
+        val manager = KlaviyoAuthTokenManager()
+        manager.registerProvider(SuccessProvider(token))
+        dispatcher.scheduler.advanceUntilIdle()
+
+        val result = manager.currentToken()
+
+        assertEquals(token, result)
+    }
+
+    @Test
+    fun `currentToken returns cached token without re-invoking provider`() = runTest {
+        val token = makeJwt(EXP_SECONDS, IAT_SECONDS)
+        val provider = SuccessProvider(token)
+        val manager = KlaviyoAuthTokenManager()
+        manager.registerProvider(provider)
+        dispatcher.scheduler.advanceUntilIdle()
+        // Eager fetch in registerProvider already invoked the provider once
+        val callsAfterRegister = provider.callCount
+
+        val result = manager.currentToken()
+
+        assertEquals(token, result)
+        assertEquals(callsAfterRegister, provider.callCount)
+    }
+
+    @Test
+    fun `registerProvider replaces previous provider and discards cached token`() = runTest {
+        val firstToken = makeJwt(EXP_SECONDS, IAT_SECONDS)
+        val secondToken = makeJwt(EXP_SECONDS + 1, IAT_SECONDS + 1)
+        val firstProvider = SuccessProvider(firstToken)
+        val secondProvider = SuccessProvider(secondToken)
+
+        val manager = KlaviyoAuthTokenManager()
+        manager.registerProvider(firstProvider)
+        dispatcher.scheduler.advanceUntilIdle()
+        manager.currentToken()
+
+        manager.registerProvider(secondProvider)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        val result = manager.currentToken()
+        assertEquals(secondToken, result)
+    }
+
+    @Test
+    fun `registerProvider triggers eager fetch`() = runTest {
+        val token = makeJwt(EXP_SECONDS, IAT_SECONDS)
+        val provider = SuccessProvider(token)
+        val manager = KlaviyoAuthTokenManager()
+
+        manager.registerProvider(provider)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertTrue(
+            "registerProvider should have eagerly invoked the provider",
+            provider.callCount >= 1
+        )
+    }
+
+    @Test
+    fun `registerProvider cancellation during eager fetch does not log warning`() = runTest {
+        val provider = DeferredProvider()
+        val manager = KlaviyoAuthTokenManager()
+
+        manager.registerProvider(provider)
+        dispatcher.scheduler.runCurrent()
+        manager.scope.cancel(CancellationException("teardown"))
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(1, provider.callCount)
+        verify(exactly = 0) {
+            spyLog.warning(any(), any<Throwable>())
+        }
+    }
+
+    @Test
+    fun `currentToken throws when provider invokes onFailure`() = runTest {
+        val failure = RuntimeException("network down")
+        val manager = KlaviyoAuthTokenManager()
+        // Use a provider that fails on the explicit currentToken() call. The eager fetch
+        // in registerProvider will also fail, but its error is logged and not surfaced.
+        manager.registerProvider(FailureProvider(failure))
+        dispatcher.scheduler.advanceUntilIdle()
+
+        try {
+            manager.currentToken()
+            fail("Expected RuntimeException")
+        } catch (e: RuntimeException) {
+            assertEquals("network down", e.message)
+        }
+    }
+
+    @Test
+    fun `currentToken throws ValidationFailed and logs error when returned jwt is malformed`() = runTest {
+        val manager = KlaviyoAuthTokenManager()
+        manager.registerProvider(SuccessProvider("not-a-jwt"))
+        dispatcher.scheduler.advanceUntilIdle()
+
+        try {
+            manager.currentToken()
+            fail("Expected AuthTokenException.ValidationFailed")
+        } catch (e: AuthTokenException.ValidationFailed) {
+            // ValidationFailed.reason is non-null by construction; use it rather than
+            // Throwable.message (which is platform-typed String?).
+            assertTrue(
+                "Expected non-empty validation reason, got: '${e.reason}'",
+                e.reason.isNotEmpty()
+            )
+        }
+
+        verify {
+            spyLog.error(
+                match { it.startsWith("Auth token validation failed:") },
+                match { it is AuthTokenException.ValidationFailed }
+            )
+        }
+    }
+
+    @Test
+    fun `currentToken throws ValidationFailed when returned jwt is expired on receipt`() = runTest {
+        // exp within leeway of NOW → ExpiredOnReceipt
+        val expired = makeJwt(NOW_SECONDS, IAT_SECONDS)
+        val manager = KlaviyoAuthTokenManager()
+        manager.registerProvider(SuccessProvider(expired))
+        dispatcher.scheduler.advanceUntilIdle()
+
+        try {
+            manager.currentToken()
+            fail("Expected AuthTokenException.ValidationFailed")
+        } catch (e: AuthTokenException.ValidationFailed) {
+            assertEquals("ExpiredOnReceipt", e.reason)
+        }
+    }
+
+    @Test
+    fun `currentToken does not invoke onFailure-and-then-onSuccess twice`() = runTest {
+        // Late callback resolution should be harmlessly ignored (isActive guard).
+        val token = makeJwt(EXP_SECONDS, IAT_SECONDS)
+        val provider = AuthTokenProvider { callback ->
+            callback.onSuccess(token)
+            // Simulate buggy host calling back twice — should not throw.
+            callback.onSuccess(token)
+            callback.onFailure(RuntimeException("late failure"))
+        }
+        val manager = KlaviyoAuthTokenManager()
+        manager.registerProvider(provider)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        val result = manager.currentToken()
+        assertEquals(token, result)
+    }
+
+    // MARK: - Helpers
+
+    private class SuccessProvider(private val jwt: String) : AuthTokenProvider {
+        var callCount: Int = 0
+            private set
+
+        override fun fetchToken(callback: AuthTokenProvider.Callback) {
+            callCount++
+            callback.onSuccess(jwt)
+        }
+    }
+
+    private class FailureProvider(private val error: Throwable) : AuthTokenProvider {
+        override fun fetchToken(callback: AuthTokenProvider.Callback) {
+            callback.onFailure(error)
+        }
+    }
+
+    private class DeferredProvider : AuthTokenProvider {
+        var callCount: Int = 0
+            private set
+
+        override fun fetchToken(callback: AuthTokenProvider.Callback) {
+            callCount++
+        }
+    }
+
+    private fun makeJwt(expSeconds: Long, iatSeconds: Long): String {
+        val header = JSONObject(mapOf("alg" to "HS256", "typ" to "JWT"))
+        val payload = JSONObject(
+            mapOf(
+                "exp" to expSeconds.toDouble(),
+                "iat" to iatSeconds.toDouble()
+            )
+        )
+        val headerSegment = base64UrlEncode(header.toString().toByteArray())
+        val payloadSegment = base64UrlEncode(payload.toString().toByteArray())
+        return "$headerSegment.$payloadSegment.signature"
+    }
+
+    private fun base64UrlEncode(bytes: ByteArray): String =
+        Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
+}

--- a/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerTest.kt
@@ -44,7 +44,9 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
 
         val result = manager.currentToken()
 
-        assertEquals(token, result)
+        assertEquals(token, result.rawToken)
+        assertEquals(EXP_SECONDS, result.expiresAtEpochSeconds)
+        assertEquals(IAT_SECONDS, result.issuedAtEpochSeconds)
     }
 
     @Test
@@ -59,7 +61,7 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
 
         val result = manager.currentToken()
 
-        assertEquals(token, result)
+        assertEquals(token, result.rawToken)
         assertEquals(callsAfterRegister, provider.callCount)
     }
 
@@ -79,7 +81,7 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
         dispatcher.scheduler.advanceUntilIdle()
 
         val result = manager.currentToken()
-        assertEquals(secondToken, result)
+        assertEquals(secondToken, result.rawToken)
     }
 
     @Test
@@ -187,7 +189,7 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
         dispatcher.scheduler.advanceUntilIdle()
 
         val result = manager.currentToken()
-        assertEquals(token, result)
+        assertEquals(token, result.rawToken)
     }
 
     // MARK: - Helpers

--- a/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerTest.kt
@@ -6,9 +6,12 @@ import java.util.Base64
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Test
@@ -24,7 +27,9 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
     }
 
     @Test
-    fun `currentToken throws NoProviderRegistered when no provider registered`() = runTest {
+    fun `currentToken throws NoProviderRegistered when no provider registered`() = runTest(
+        dispatcher
+    ) {
         val manager = KlaviyoAuthTokenManager()
 
         try {
@@ -36,7 +41,7 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
     }
 
     @Test
-    fun `currentToken returns provider token on first fetch`() = runTest {
+    fun `currentToken returns provider token on first fetch`() = runTest(dispatcher) {
         val token = makeJwt(EXP_SECONDS, IAT_SECONDS)
         val manager = KlaviyoAuthTokenManager()
         manager.registerProvider(SuccessProvider(token))
@@ -50,7 +55,7 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
     }
 
     @Test
-    fun `currentToken returns cached token without re-invoking provider`() = runTest {
+    fun `currentToken returns cached token without re-invoking provider`() = runTest(dispatcher) {
         val token = makeJwt(EXP_SECONDS, IAT_SECONDS)
         val provider = SuccessProvider(token)
         val manager = KlaviyoAuthTokenManager()
@@ -66,7 +71,9 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
     }
 
     @Test
-    fun `registerProvider replaces previous provider and discards cached token`() = runTest {
+    fun `registerProvider replaces previous provider and discards cached token`() = runTest(
+        dispatcher
+    ) {
         val firstToken = makeJwt(EXP_SECONDS, IAT_SECONDS)
         val secondToken = makeJwt(EXP_SECONDS + 1, IAT_SECONDS + 1)
         val firstProvider = SuccessProvider(firstToken)
@@ -85,7 +92,7 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
     }
 
     @Test
-    fun `registerProvider triggers eager fetch`() = runTest {
+    fun `registerProvider triggers eager fetch`() = runTest(dispatcher) {
         val token = makeJwt(EXP_SECONDS, IAT_SECONDS)
         val provider = SuccessProvider(token)
         val manager = KlaviyoAuthTokenManager()
@@ -100,7 +107,9 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
     }
 
     @Test
-    fun `registerProvider cancellation during eager fetch does not log warning`() = runTest {
+    fun `registerProvider cancellation during eager fetch does not log warning`() = runTest(
+        dispatcher
+    ) {
         val provider = DeferredProvider()
         val manager = KlaviyoAuthTokenManager()
 
@@ -116,7 +125,7 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
     }
 
     @Test
-    fun `currentToken throws when provider invokes onFailure`() = runTest {
+    fun `currentToken throws when provider invokes onFailure`() = runTest(dispatcher) {
         val failure = RuntimeException("network down")
         val manager = KlaviyoAuthTokenManager()
         // Use a provider that fails on the explicit currentToken() call. The eager fetch
@@ -133,7 +142,9 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
     }
 
     @Test
-    fun `currentToken throws ValidationFailed and logs error when returned jwt is malformed`() = runTest {
+    fun `currentToken throws ValidationFailed and logs error when returned jwt is malformed`() = runTest(
+        dispatcher
+    ) {
         val manager = KlaviyoAuthTokenManager()
         manager.registerProvider(SuccessProvider("not-a-jwt"))
         dispatcher.scheduler.advanceUntilIdle()
@@ -159,7 +170,9 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
     }
 
     @Test
-    fun `currentToken throws ValidationFailed when returned jwt is expired on receipt`() = runTest {
+    fun `currentToken throws ValidationFailed when returned jwt is expired on receipt`() = runTest(
+        dispatcher
+    ) {
         // exp within leeway of NOW → ExpiredOnReceipt
         val expired = makeJwt(NOW_SECONDS, IAT_SECONDS)
         val manager = KlaviyoAuthTokenManager()
@@ -175,7 +188,7 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
     }
 
     @Test
-    fun `currentToken does not invoke onFailure-and-then-onSuccess twice`() = runTest {
+    fun `currentToken does not invoke onFailure-and-then-onSuccess twice`() = runTest(dispatcher) {
         // Late callback resolution should be harmlessly ignored (isActive guard).
         val token = makeJwt(EXP_SECONDS, IAT_SECONDS)
         val provider = AuthTokenProvider { callback ->
@@ -190,6 +203,256 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
 
         val result = manager.currentToken()
         assertEquals(token, result.rawToken)
+    }
+
+    // MARK: - Deduplication and Timeouts
+
+    @Test
+    fun `concurrent callers share a single provider invocation`() = runTest(dispatcher) {
+        val token = makeJwt(EXP_SECONDS, IAT_SECONDS)
+        val provider = ResolvableProvider()
+        val manager = KlaviyoAuthTokenManager()
+        manager.registerProvider(provider)
+        // Hold off on advancing — keep the eager fetch pending so all callers race the same deferred.
+
+        val results = mutableListOf<ValidatedToken>()
+        val jobs = (1..5).map {
+            launch { results.add(manager.currentToken()) }
+        }
+
+        // Let all coroutines start and reach their await() on the shared deferred.
+        dispatcher.scheduler.runCurrent()
+
+        // One provider resolution satisfies the deferred and all awaiting callers.
+        provider.resolve(token)
+        dispatcher.scheduler.advanceUntilIdle()
+        jobs.forEach { it.join() }
+
+        assertEquals(1, provider.callCount)
+        assertEquals(5, results.size)
+        assertTrue(results.all { it.rawToken == token })
+    }
+
+    @Test
+    fun `currentToken throws TimedOut when provider does not respond within timeout`() = runTest(
+        dispatcher
+    ) {
+        val manager = KlaviyoAuthTokenManager()
+        manager.registerProvider(DeferredProvider())
+        dispatcher.scheduler.runCurrent() // start eager fetch (also waiting on provider)
+
+        var caught: AuthTokenException.TimedOut? = null
+        val job = launch {
+            try {
+                manager.currentToken(timeoutMs = 100)
+            } catch (e: AuthTokenException.TimedOut) {
+                caught = e
+            }
+        }
+        dispatcher.scheduler.runCurrent()
+        dispatcher.scheduler.advanceTimeBy(101)
+        dispatcher.scheduler.runCurrent()
+        job.join()
+
+        assertNotNull("Expected TimedOut to be thrown", caught)
+        verify {
+            spyLog.warning(
+                match { it.contains("timed out", ignoreCase = true) },
+                any<AuthTokenException.TimedOut>()
+            )
+        }
+    }
+
+    @Test
+    fun `timeout does not cancel underlying fetch so later callers still benefit`() = runTest(
+        dispatcher
+    ) {
+        val token = makeJwt(EXP_SECONDS, IAT_SECONDS)
+        val provider = ResolvableProvider()
+        val manager = KlaviyoAuthTokenManager()
+        manager.registerProvider(provider)
+        dispatcher.scheduler.runCurrent() // eager fetch starts and suspends on provider
+
+        // First caller times out after 100ms.
+        var timedOut = false
+        val firstJob = launch {
+            try {
+                manager.currentToken(timeoutMs = 100)
+            } catch (_: AuthTokenException.TimedOut) {
+                timedOut = true
+            }
+        }
+        dispatcher.scheduler.runCurrent()
+        dispatcher.scheduler.advanceTimeBy(101)
+        dispatcher.scheduler.runCurrent()
+        firstJob.join()
+        assertTrue("First caller should have timed out", timedOut)
+
+        // Underlying fetch is still alive — resolve the provider now.
+        provider.resolve(token)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        // Second caller gets the token from cache populated by the completed underlying fetch.
+        val result = manager.currentToken()
+        assertEquals(token, result.rawToken)
+        assertEquals(1, provider.callCount)
+    }
+
+    @Test
+    fun `failure clears in-flight slot so next call re-invokes provider`() = runTest(dispatcher) {
+        val failure = RuntimeException("fetch failed")
+        val provider = CountingFailureProvider(failure)
+        val manager = KlaviyoAuthTokenManager()
+        manager.registerProvider(provider)
+        dispatcher.scheduler.advanceUntilIdle() // eager fetch fails (callCount = 1)
+
+        try { manager.currentToken() } catch (_: Exception) {}
+        val countAfterFirst = provider.callCount // eager + 1 explicit
+
+        try { manager.currentToken() } catch (_: Exception) {}
+
+        // Each call after a failure must re-invoke the provider (slot was cleared by invokeOnCompletion).
+        assertEquals(countAfterFirst + 1, provider.callCount)
+    }
+
+    @Test
+    fun `provider swap cancels in-flight fetch so stale token cannot poison cache`() = runTest(
+        dispatcher
+    ) {
+        val staleToken = makeJwt(EXP_SECONDS, IAT_SECONDS)
+        val freshToken = makeJwt(EXP_SECONDS + 100, IAT_SECONDS + 100)
+        val providerA = ResolvableProvider()
+        val providerB = SuccessProvider(freshToken)
+        val manager = KlaviyoAuthTokenManager()
+
+        manager.registerProvider(providerA)
+        dispatcher.scheduler.runCurrent() // eager fetch for A starts, awaits provider
+
+        // Swap provider while A's fetch is in-flight; B's eager fetch resolves immediately.
+        manager.registerProvider(providerB)
+        dispatcher.scheduler.advanceUntilIdle() // B's eager fetch completes → cache = freshToken
+
+        // A calls back late — its continuation is inactive (deferred was cancelled on swap).
+        providerA.resolve(staleToken)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        // Cache should hold freshToken, not staleToken.
+        val result = manager.currentToken()
+        assertEquals(freshToken, result.rawToken)
+    }
+
+    @Test
+    fun `caller waiting on in-flight fetch receives new provider token after provider swap`() = runTest(
+        dispatcher
+    ) {
+        // Regression: when registerProvider() cancels the in-flight deferred, deferred.await()
+        // throws CancellationException. Without the ensureActive() + retry fix in currentToken(),
+        // this propagates to the caller as if their coroutine was cancelled, breaking callers like
+        // KlaviyoWebViewClient that rethrow CancellationException for structured concurrency.
+        val freshToken = makeJwt(EXP_SECONDS + 100, IAT_SECONDS + 100)
+        val providerA = ResolvableProvider()
+        val providerB = SuccessProvider(freshToken)
+        val manager = KlaviyoAuthTokenManager()
+
+        manager.registerProvider(providerA)
+        dispatcher.scheduler.runCurrent() // A's eager fetch starts, suspends on provider
+
+        // Caller joins the in-flight deferred from provider A.
+        var result: ValidatedToken? = null
+        var caught: Throwable? = null
+        val callerJob = launch {
+            try {
+                result = manager.currentToken(timeoutMs = 5_000)
+            } catch (e: Throwable) {
+                caught = e
+            }
+        }
+        dispatcher.scheduler.runCurrent() // caller reaches deferred.await()
+
+        // Swap to B while caller is suspended — A's deferred is cancelled, which would throw
+        // CancellationException to the caller without the fix. With the fix the caller retries
+        // and transparently picks up B's token.
+        manager.registerProvider(providerB)
+        dispatcher.scheduler.advanceUntilIdle() // B completes; caller's retry finds the cache
+
+        callerJob.join()
+        assertNull("Caller should not have thrown but got: $caught", caught)
+        assertEquals(freshToken, result?.rawToken)
+    }
+
+    @Test
+    fun `outer timeout budget is respected when provider swap triggers retry`() = runTest(
+        dispatcher
+    ) {
+        // When the in-flight deferred is cancelled by a provider swap, currentToken() retries
+        // inside the SAME withTimeoutOrNull block. The retry creates a fresh inner
+        // withTimeoutOrNull(timeoutMs) starting from the current time, but the outer one was
+        // set at original call-time and fires first if the budget is nearly exhausted — so the
+        // caller's original deadline governs the total wait end-to-end.
+        val providerA = DeferredProvider() // never resolves
+        val providerB = DeferredProvider() // never resolves
+        val manager = KlaviyoAuthTokenManager()
+
+        manager.registerProvider(providerA)
+        dispatcher.scheduler.runCurrent() // A's eager fetch starts and suspends
+
+        // Caller has a 100ms total budget.
+        var caught: AuthTokenException.TimedOut? = null
+        val callerJob = launch {
+            try {
+                manager.currentToken(timeoutMs = 100)
+            } catch (e: AuthTokenException.TimedOut) {
+                caught = e
+            }
+        }
+        dispatcher.scheduler.runCurrent() // caller awaits A's deferred
+
+        // Swap at t=80ms — only 20ms of the original 100ms budget remains.
+        dispatcher.scheduler.advanceTimeBy(80)
+        manager.registerProvider(providerB)
+        // Retry starts and awaits B. Inner withTimeoutOrNull(100) would fire at t=180;
+        // outer withTimeoutOrNull(100) fires first at t=100.
+        dispatcher.scheduler.runCurrent()
+
+        dispatcher.scheduler.advanceTimeBy(21) // t=101ms — past the outer 100ms deadline
+        dispatcher.scheduler.runCurrent()
+        callerJob.join()
+
+        assertNotNull(
+            "Outer 100ms deadline should fire; inner retry budget must not extend it",
+            caught
+        )
+    }
+
+    @Test
+    fun `provider swap does not write stale token when callback fires before cancellation`() = runTest(
+        dispatcher
+    ) {
+        // Regression test for the uncontended-mutex cancellation gap:
+        // If invokeProvider() already returned a value before the deferred is cancelled,
+        // ensureActive() in doFetch() must throw CancellationException before the cache write —
+        // even though mutex.withLock would acquire an uncontended lock without suspending.
+        val staleToken = makeJwt(EXP_SECONDS, IAT_SECONDS)
+        val freshToken = makeJwt(EXP_SECONDS + 100, IAT_SECONDS + 100)
+        val providerA = ResolvableProvider()
+        val providerB = SuccessProvider(freshToken)
+        val manager = KlaviyoAuthTokenManager()
+
+        manager.registerProvider(providerA)
+        dispatcher.scheduler.runCurrent() // A's eager fetch starts and suspends on provider
+
+        // Resolve A's callback now — this schedules A's coroutine to resume with staleToken.
+        // A's doFetch() has not yet run past invokeProvider().
+        providerA.resolve(staleToken)
+
+        // Swap to B *before* the scheduler runs A's resumed coroutine. Without ensureActive(),
+        // A's doFetch() would proceed through validateOrThrow and write staleToken to the cache
+        // on an uncontended mutex.withLock (no suspension → no cancellation check there).
+        manager.registerProvider(providerB)
+        dispatcher.scheduler.advanceUntilIdle() // A hits ensureActive() and aborts; B completes
+
+        val result = manager.currentToken()
+        assertEquals(freshToken, result.rawToken)
     }
 
     // MARK: - Helpers
@@ -234,4 +497,38 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
 
     private fun base64UrlEncode(bytes: ByteArray): String =
         Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
+
+    /**
+     * Provider that captures callbacks so tests can resolve them manually, enabling
+     * deterministic control over when the provider "responds". Callbacks are queued so
+     * concurrent invocations (e.g. eager fetch + explicit caller) can each be resolved
+     * independently without the second call clobbering the first.
+     */
+    private class ResolvableProvider : AuthTokenProvider {
+        var callCount: Int = 0
+            private set
+        private val pendingCallbacks = ArrayDeque<AuthTokenProvider.Callback>()
+
+        override fun fetchToken(callback: AuthTokenProvider.Callback) {
+            callCount++
+            pendingCallbacks.addLast(callback)
+        }
+
+        fun resolve(jwt: String) = pendingCallbacks.removeFirstOrNull()?.onSuccess(jwt)
+        fun reject(error: Throwable) = pendingCallbacks.removeFirstOrNull()?.onFailure(error)
+    }
+
+    /**
+     * Failure provider that exposes an invocation counter for asserting that the in-flight slot
+     * is cleared on failure (so each new call re-invokes the provider).
+     */
+    private class CountingFailureProvider(private val error: Throwable) : AuthTokenProvider {
+        var callCount: Int = 0
+            private set
+
+        override fun fetchToken(callback: AuthTokenProvider.Callback) {
+            callCount++
+            callback.onFailure(error)
+        }
+    }
 }

--- a/sdk/fixtures/src/main/java/com/klaviyo/fixtures/KlaviyoMock.kt
+++ b/sdk/fixtures/src/main/java/com/klaviyo/fixtures/KlaviyoMock.kt
@@ -63,6 +63,7 @@ object KlaviyoMock {
         every { Klaviyo.handlePush(any()) } returns Klaviyo
         every { Klaviyo.registerDeepLinkHandler(any()) } returns Klaviyo
         every { Klaviyo.unregisterDeepLinkHandler() } returns Klaviyo
+        every { Klaviyo.registerAuthTokenProvider(any()) } returns Klaviyo
 
         // Mock getters to return test values
         every { Klaviyo.getEmail() } returns "test@example.com"
@@ -196,6 +197,12 @@ object KlaviyoMock {
     @JvmOverloads
     fun verifyUnregisterDeepLinkHandlerCalled(count: Int = 1) {
         verify(exactly = count) { Klaviyo.unregisterDeepLinkHandler() }
+    }
+
+    @JvmStatic
+    @JvmOverloads
+    fun verifyRegisterAuthTokenProviderCalled(count: Int = 1) {
+        verify(exactly = count) { Klaviyo.registerAuthTokenProvider(any()) }
     }
 
     @JvmStatic

--- a/sdk/forms/src/main/assets/InAppFormsTemplate.html
+++ b/sdk/forms/src/main/assets/InAppFormsTemplate.html
@@ -8,6 +8,7 @@
       data-klaviyo-local-tracking="1"
       data-klaviyo-profile="{}"
       data-klaviyo-device='DEVICE_INFO'
+      data-klaviyo-jwt='JWT_TOKEN'
 >
     <meta charset="UTF-8">
     <meta name="viewport"

--- a/sdk/forms/src/main/assets/InAppFormsTemplate.html
+++ b/sdk/forms/src/main/assets/InAppFormsTemplate.html
@@ -8,7 +8,7 @@
       data-klaviyo-local-tracking="1"
       data-klaviyo-profile="{}"
       data-klaviyo-device='DEVICE_INFO'
-      data-klaviyo-jwt='JWT_TOKEN'
+      data-klaviyo-jwt=''
 >
     <meta charset="UTF-8">
     <meta name="viewport"

--- a/sdk/forms/src/main/assets/klaviyo-js-bridge.js
+++ b/sdk/forms/src/main/assets/klaviyo-js-bridge.js
@@ -117,6 +117,21 @@ window.setSafeArea = function(left, top, right, bottom) {
     return true;
  }
 
+/**
+ * Updates the data-klaviyo-jwt attribute on the document head.
+ *
+ * Delivered via the JS bridge (rather than a static HTML attribute) so the SDK controls
+ * ordering: the JWT is set at jsReady, before profile identifiers are injected at handshake,
+ * which is what the onsite personalization module needs to trigger the authenticated fetch.
+ *
+ * @param token - JWT string, or empty string if auth is not enabled / token fetch failed
+ * @returns {boolean}
+ */
+window.jwtMutation = function (token) {
+    document.head.setAttribute("data-klaviyo-jwt", token)
+    return true
+}
+
 // Notify the SDK over the native bridge that these local JS scripts are initialized
 var bridgeName = document.head.getAttribute("data-native-bridge-name") || ""
 

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/JsBridge.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/JsBridge.kt
@@ -55,4 +55,12 @@ internal interface JsBridge {
      *
      */
     fun profileEvent(event: Event)
+
+    /**
+     * Inject the auth token into the webview as a data attribute.
+     *
+     * An empty [token] indicates auth is not enabled or the token fetch failed; the onsite JS
+     * module treats a missing/empty token as "unauthenticated" and skips the authenticated fetch.
+     */
+    fun jwtMutation(token: String)
 }

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/JwtObserver.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/JwtObserver.kt
@@ -1,0 +1,78 @@
+package com.klaviyo.forms.bridge
+
+import com.klaviyo.core.Registry
+import com.klaviyo.core.auth.AuthTokenException
+import com.klaviyo.core.auth.AuthTokenManager
+import com.klaviyo.core.safeLaunch
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+
+/**
+ * Delivers the auth token to the webview via [JsBridge.jwtMutation] at [NativeBridgeMessage.JsReady],
+ * before [ProfileMutationObserver] injects profile identifiers at HandShook.
+ *
+ * The onsite personalization module only triggers the authenticated profile fetch when both a JWT
+ * and profile identifiers are present, so the JWT must land first.
+ */
+internal class JwtObserver : JsBridgeObserver {
+
+    /**
+     * Completes once the JWT has been delivered. [ProfileMutationObserver] awaits this before
+     * injecting profile identifiers. Reused while still pending so a re-entrant start does not
+     * orphan a waiter that captured the previous reference.
+     */
+    @Volatile
+    internal var jwtReady: CompletableDeferred<Unit> = CompletableDeferred()
+        private set
+
+    @Volatile private var stopped = false
+
+    @Volatile private var latestFetch: Any? = null
+
+    private val scope = CoroutineScope(SupervisorJob() + Registry.dispatcher)
+    private var fetchJob: Job? = null
+
+    override fun startObserver() {
+        stopped = false
+        val thisFetch = Any()
+        latestFetch = thisFetch
+        val currentJwtReady = if (jwtReady.isCompleted) {
+            CompletableDeferred<Unit>().also { jwtReady = it }
+        } else {
+            jwtReady
+        }
+
+        fetchJob?.cancel()
+        fetchJob = scope.safeLaunch {
+            val token = try {
+                Registry.get<AuthTokenManager>()
+                    .currentToken(AuthTokenManager.INTERACTIVE_FETCH_TIMEOUT_MS)
+                    .rawToken
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: AuthTokenException.NoProviderRegistered) {
+                Registry.log.debug("Auth not enabled — injecting empty JWT")
+                null
+            } catch (_: Exception) {
+                Registry.log.warning("Auth token fetch failed — injecting empty JWT")
+                null
+            }
+
+            Registry.threadHelper.runOnUiThread {
+                if (latestFetch === thisFetch && !stopped) {
+                    Registry.get<JsBridge>().jwtMutation(token ?: "")
+                    currentJwtReady.complete(Unit)
+                }
+            }
+        }
+    }
+
+    override fun stopObserver() {
+        stopped = true
+        fetchJob?.cancel()
+        fetchJob = null
+    }
+}

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/KlaviyoJsBridge.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/KlaviyoJsBridge.kt
@@ -19,7 +19,8 @@ internal class KlaviyoJsBridge : JsBridge {
         openForm,
         closeForm,
         profileEvent,
-        setSafeArea
+        setSafeArea,
+        jwtMutation
     }
 
     override val handshake: List<HandshakeSpec> = listOf(
@@ -37,6 +38,10 @@ internal class KlaviyoJsBridge : JsBridge {
         ),
         HandshakeSpec(
             type = HelperFunction.profileEvent.name,
+            version = 1
+        ),
+        HandshakeSpec(
+            type = HelperFunction.jwtMutation.name,
             version = 1
         )
     )

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/KlaviyoJsBridge.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/KlaviyoJsBridge.kt
@@ -86,6 +86,11 @@ internal class KlaviyoJsBridge : JsBridge {
             bottom.toString()
         )
 
+    override fun jwtMutation(token: String) = evaluateJavascript(
+        HelperFunction.jwtMutation,
+        token
+    )
+
     /**
      * Evaluates a JS function in the webview with the given arguments
      */

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/KlaviyoObserverCollection.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/KlaviyoObserverCollection.kt
@@ -4,11 +4,14 @@ package com.klaviyo.forms.bridge
  * Manages the collection of observers that inject data into the webview
  */
 internal class KlaviyoObserverCollection : JsBridgeObserverCollection {
+    private val jwtObserver = JwtObserver()
+
     override val observers: List<JsBridgeObserver> by lazy {
         listOf(
             CompanyObserver(),
             LifecycleObserver(),
-            ProfileMutationObserver(),
+            jwtObserver,
+            ProfileMutationObserver(jwtObserver),
             ProfileEventObserver()
         )
     }

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/ProfileMutationObserver.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/ProfileMutationObserver.kt
@@ -4,19 +4,63 @@ import com.klaviyo.analytics.state.State
 import com.klaviyo.analytics.state.StateChange
 import com.klaviyo.analytics.state.StateChangeObserver
 import com.klaviyo.core.Registry
+import com.klaviyo.core.safeLaunch
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 
 /**
  * Observe [State] in the analytics package to synchronize profile identifiers with the webview
  */
-internal class ProfileMutationObserver : JsBridgeObserver, StateChangeObserver {
+internal class ProfileMutationObserver(
+    private val jwtObserver: JwtObserver? = null
+) : JsBridgeObserver, StateChangeObserver {
+
+    // Scope is intentionally long-lived and never cancelled — cancelling the scope permanently
+    // prevents future startObserver calls from launching coroutines. Per-session cleanup is done
+    // by cancelling initJob in stopObserver instead.
+    private val scope = CoroutineScope(SupervisorJob() + Registry.dispatcher)
+    private var initJob: Job? = null
+
+    /**
+     * Start on [NativeBridgeMessage.HandShook] rather than the default [NativeBridgeMessage.JsReady]
+     * so the initial profile injection fires *after* [JwtObserver] has delivered the JWT at JsReady.
+     *
+     * The onsite personalization module only triggers the authenticated profile fetch when both a
+     * JWT and profile identifiers are present. If profile is injected before the JWT, the module
+     * sees identifiers with no token and never makes the authenticated fetch.
+     *
+     * When [jwtObserver] is provided, the initial [injectProfile] call additionally awaits
+     * [JwtObserver.jwtReady] before injecting, eliminating the residual race where a slow async
+     * token fetch completes after [NativeBridgeMessage.HandShook] fires. Reading [jwtReady] from
+     * the observer (rather than capturing it at construction) ensures we always await the deferred
+     * that [JwtObserver.startObserver] created for the current WebView session.
+     */
+    override val startOn: NativeBridgeMessage get() = NativeBridgeMessage.HandShook
 
     override fun startObserver() {
-        // Set initial profile identifiers on startup
-        injectProfile()
-        Registry.get<State>().onStateChange(this)
+        val deferred = jwtObserver?.jwtReady
+        if (deferred != null) {
+            initJob?.cancel()
+            initJob = scope.safeLaunch {
+                try {
+                    deferred.await()
+                } catch (e: CancellationException) {
+                    throw e // WebView is being torn down — do not inject
+                }
+                injectAndSubscribe()
+            }
+        } else {
+            injectAndSubscribe()
+        }
     }
 
-    override fun stopObserver() = Registry.get<State>().offStateChange(this)
+    override fun stopObserver() {
+        initJob?.cancel()
+        initJob = null
+        Registry.get<State>().offStateChange(this)
+    }
 
     /**
      * Update profile in webview whenever an identifier changes, or profile is reset
@@ -26,6 +70,11 @@ internal class ProfileMutationObserver : JsBridgeObserver, StateChangeObserver {
             is StateChange.ProfileIdentifier, is StateChange.ProfileReset -> injectProfile()
             else -> Unit
         }
+    }
+
+    private fun injectAndSubscribe() {
+        injectProfile()
+        Registry.get<State>().onStateChange(this)
     }
 
     private fun injectProfile() = Registry.get<JsBridge>().profileMutation(

--- a/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
@@ -15,26 +15,19 @@ import androidx.webkit.WebViewCompat
 import androidx.webkit.WebViewFeature.WEB_MESSAGE_LISTENER
 import androidx.webkit.WebViewFeature.isFeatureSupported
 import com.klaviyo.core.Registry
-import com.klaviyo.core.auth.AuthTokenException
-import com.klaviyo.core.auth.AuthTokenManager
-import com.klaviyo.core.auth.ValidatedToken
 import com.klaviyo.core.config.Clock
-import com.klaviyo.core.safeLaunch
 import com.klaviyo.core.utils.WeakReferenceDelegate
 import com.klaviyo.core.utils.startActivityIfResolved
 import com.klaviyo.forms.bridge.DeviceInfoProvider
 import com.klaviyo.forms.bridge.HandshakeSpec
 import com.klaviyo.forms.bridge.JsBridge
 import com.klaviyo.forms.bridge.JsBridgeObserverCollection
+import com.klaviyo.forms.bridge.JwtObserver
 import com.klaviyo.forms.bridge.NativeBridge
 import com.klaviyo.forms.bridge.NativeBridgeMessage
 import com.klaviyo.forms.bridge.compileJson
 import com.klaviyo.forms.presentation.PresentationManager
 import java.io.BufferedReader
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
 
 /**
  * Manages the [KlaviyoWebView] instance that powers In-App Forms behavior, triggering, rendering and display,
@@ -54,27 +47,13 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
     private var webView: KlaviyoWebView? by WeakReferenceDelegate()
 
     /**
-     * Retained across [destroyWebView] so the client can be reinitialized. Individual jobs
-     * (currently [initJob]) are cancelled in [destroyWebView]; future `safeLaunch` callers must
-     * track their own [Job] or migrate to `scope.coroutineContext.cancelChildren()`.
-     */
-    private val scope = CoroutineScope(SupervisorJob() + Registry.dispatcher)
-
-    private var initJob: Job? = null
-
-    private companion object {
-        const val JWT_TOKEN_PLACEHOLDER = "JWT_TOKEN"
-    }
-
-    /**
      * Initialize a webview instance, with protection against duplication
      * and initialize klaviyo.js for In-App Forms with handshake data injected in the document head.
      *
-     * Template substitutions that don't require async work (SDK metadata, bridge config, device
-     * info) are applied synchronously on the calling (UI) thread. Auth token injection requires
-     * an async provider call, so the final [KlaviyoWebView.loadTemplate] invocation is deferred
-     * to a background coroutine that calls [AuthTokenManager.currentToken] and then dispatches
-     * back to the UI thread.
+     * All template substitutions (SDK metadata, bridge config, device info) run synchronously on
+     * the calling (UI) thread. The auth token is no longer injected into the template here — it is
+     * delivered after load via [JwtObserver] over the JS bridge so the SDK can control
+     * JWT/profile ordering. Live token refresh remains out of scope here.
      */
     override fun initializeWebView() {
         if (webView != null) {
@@ -112,86 +91,12 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
             // double-quoted strings.
             .replace("DEVICE_INFO", DeviceInfoProvider.current().toJson())
 
-        initJob = scope.safeLaunch {
-            loadTemplateWithAuthToken(webView, partialHtml, nativeBridge)
-        }
-    }
-
-    /**
-     * Fetch the auth token, then dispatch back to the UI thread to inject the (escaped) JWT into
-     * [partialHtml], load it, and log the auth outcome. [webView] is the locally-captured
-     * reference from [initializeWebView]; the body re-checks `this.webView !== webView` after the
-     * dispatch because the field is held weakly and may be cleared by destroy or GC mid-fetch.
-     */
-    private suspend fun loadTemplateWithAuthToken(
-        webView: KlaviyoWebView,
-        partialHtml: String,
-        nativeBridge: NativeBridge
-    ) {
-        // TODO: [MAGE-630] Subscribe to AuthTokenManager.onTokenRefresh for live updates.
-        // NoProviderRegistered is split out from generic fetch failures: the former is the
-        // expected state for apps not using JWT auth (logged at debug), the latter is degraded
-        // functionality with a fallback (logged at warning). Matches the AuthTokenException
-        // KDoc intent — "treat NoProviderRegistered as 'auth is not enabled' rather than 'auth
-        // failed.'"
-        val outcome: AuthOutcome = try {
-            AuthOutcome.Success(
-                Registry.get<AuthTokenManager>()
-                    .currentToken(AuthTokenManager.INTERACTIVE_FETCH_TIMEOUT_MS)
-            )
-        } catch (e: CancellationException) {
-            throw e
-        } catch (_: AuthTokenException.NoProviderRegistered) {
-            AuthOutcome.NotEnabled
-        } catch (_: Exception) {
-            AuthOutcome.FetchFailed
-        }
-
-        Registry.threadHelper.runOnUiThread {
-            if (this.webView !== webView) {
-                Registry.log.debug("Skipping IAF template load: WebView no longer current")
-                return@runOnUiThread
-            }
-            val token = (outcome as? AuthOutcome.Success)?.token
-            val jwtValue = token?.rawToken?.let(::escapeForHtmlAttribute).orEmpty()
-            partialHtml.replace(JWT_TOKEN_PLACEHOLDER, jwtValue).let { html ->
-                webView.loadTemplate(html, this, nativeBridge)
-                when (outcome) {
-                    is AuthOutcome.Success ->
-                        Registry.log.debug("Auth token injected at load")
-                    AuthOutcome.NotEnabled ->
-                        Registry.log.debug("Auth not enabled — proceeding without token")
-                    AuthOutcome.FetchFailed ->
-                        Registry.log.warning("Auth token fetch failed — proceeding without token")
-                }
-                handshakeTimer?.cancel()
-                handshakeTimer = Registry.clock.schedule(
-                    Registry.config.networkTimeout.toLong(),
-                    ::onJsHandshakeTimeout
-                )
-            }
-        }
-    }
-
-    /**
-     * Defense-in-depth escape for the single-quoted `data-klaviyo-jwt` attribute. Valid JWTs
-     * cannot contain these characters, but a custom `AuthTokenProvider` could bypass validation.
-     */
-    private fun escapeForHtmlAttribute(value: String): String =
-        value
-            .replace("&", "&amp;") // must escape first to avoid double-encoding entities below
-            .replace("'", "&#x27;")
-            .replace("<", "&lt;")
-
-    /**
-     * Three-way result of the auth-token fetch in [loadTemplateWithAuthToken]. Lets the call site
-     * differentiate "auth not enabled" (debug-level log) from "auth fetch failed" (warning-level
-     * log) without re-throwing or re-checking exception types after the catch block.
-     */
-    private sealed interface AuthOutcome {
-        data class Success(val token: ValidatedToken) : AuthOutcome
-        data object NotEnabled : AuthOutcome
-        data object FetchFailed : AuthOutcome
+        webView.loadTemplate(partialHtml, this, nativeBridge)
+        handshakeTimer?.cancel()
+        handshakeTimer = Registry.clock.schedule(
+            Registry.config.networkTimeout.toLong(),
+            ::onJsHandshakeTimeout
+        )
     }
 
     override fun onLocalJsReady() {
@@ -254,8 +159,6 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
      */
     override fun destroyWebView() = apply {
         handshakeTimer?.cancel()
-        initJob?.cancel()
-        initJob = null
         Registry.get<JsBridgeObserverCollection>().stopObservers()
         webView?.let { webView ->
             Registry.threadHelper.runOnUiThread {

--- a/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
@@ -15,7 +15,11 @@ import androidx.webkit.WebViewCompat
 import androidx.webkit.WebViewFeature.WEB_MESSAGE_LISTENER
 import androidx.webkit.WebViewFeature.isFeatureSupported
 import com.klaviyo.core.Registry
+import com.klaviyo.core.auth.AuthTokenException
+import com.klaviyo.core.auth.AuthTokenManager
+import com.klaviyo.core.auth.ValidatedToken
 import com.klaviyo.core.config.Clock
+import com.klaviyo.core.safeLaunch
 import com.klaviyo.core.utils.WeakReferenceDelegate
 import com.klaviyo.core.utils.startActivityIfResolved
 import com.klaviyo.forms.bridge.DeviceInfoProvider
@@ -27,6 +31,10 @@ import com.klaviyo.forms.bridge.NativeBridgeMessage
 import com.klaviyo.forms.bridge.compileJson
 import com.klaviyo.forms.presentation.PresentationManager
 import java.io.BufferedReader
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 
 /**
  * Manages the [KlaviyoWebView] instance that powers In-App Forms behavior, triggering, rendering and display,
@@ -46,17 +54,38 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
     private var webView: KlaviyoWebView? by WeakReferenceDelegate()
 
     /**
-     * Initialize a webview instance, with protection against duplication
-     * and initialize klaviyo.js for In-App Forms with handshake data injected in the document head
+     * Retained across [destroyWebView] so the client can be reinitialized. Individual jobs
+     * (currently [initJob]) are cancelled in [destroyWebView]; future `safeLaunch` callers must
+     * track their own [Job] or migrate to `scope.coroutineContext.cancelChildren()`.
      */
-    override fun initializeWebView(): Unit = webView?.let {
-        Registry.log.debug("Klaviyo webview is already initialized")
-    } ?: KlaviyoWebView().let { webView ->
+    private val scope = CoroutineScope(SupervisorJob() + Registry.dispatcher)
+
+    private var initJob: Job? = null
+
+    private companion object {
+        const val JWT_TOKEN_PLACEHOLDER = "JWT_TOKEN"
+    }
+
+    /**
+     * Initialize a webview instance, with protection against duplication
+     * and initialize klaviyo.js for In-App Forms with handshake data injected in the document head.
+     *
+     * Template substitutions that don't require async work (SDK metadata, bridge config, device
+     * info) are applied synchronously on the calling (UI) thread. Auth token injection requires
+     * an async provider call, so the final [KlaviyoWebView.loadTemplate] invocation is deferred
+     * to a background coroutine that calls [AuthTokenManager.currentToken] and then dispatches
+     * back to the UI thread.
+     */
+    override fun initializeWebView() {
+        if (webView != null) {
+            Registry.log.debug("Klaviyo webview is already initialized")
+            return
+        }
+
+        val webView = KlaviyoWebView().also { this.webView = it }
         val nativeBridge = Registry.get<NativeBridge>()
         val jsBridge = Registry.get<JsBridge>()
         val handshake: List<HandshakeSpec> = nativeBridge.handshake + jsBridge.handshake
-
-        this.webView = webView
 
         val klaviyoJsUrl = Registry.config.baseCdnUrl.toUri()
             .buildUpon()
@@ -66,7 +95,10 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
             .appendAssetSource()
             .build()
 
-        Registry.config.applicationContext.assets
+        // Apply all substitutions that can run synchronously on the calling (UI) thread.
+        // DeviceInfoProvider.current() reads UI-thread-only APIs (Display.rotation,
+        // decorView.rootWindowInsets) — snapshot it here while we are still on the main thread.
+        val partialHtml = Registry.config.applicationContext.assets
             .open("InAppFormsTemplate.html")
             .bufferedReader()
             .use(BufferedReader::readText)
@@ -79,14 +111,85 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
             // Raw JSON is safe inside the single-quoted HTML attribute because JSONObject emits
             // double-quoted strings.
             .replace("DEVICE_INFO", DeviceInfoProvider.current().toJson())
-            .let { html ->
+
+        initJob = scope.safeLaunch {
+            loadTemplateWithAuthToken(webView, partialHtml, nativeBridge)
+        }
+    }
+
+    /**
+     * Fetch the auth token, then dispatch back to the UI thread to inject the (escaped) JWT into
+     * [partialHtml], load it, and log the auth outcome. [webView] is the locally-captured
+     * reference from [initializeWebView]; the body re-checks `this.webView !== webView` after the
+     * dispatch because the field is held weakly and may be cleared by destroy or GC mid-fetch.
+     */
+    private suspend fun loadTemplateWithAuthToken(
+        webView: KlaviyoWebView,
+        partialHtml: String,
+        nativeBridge: NativeBridge
+    ) {
+        // TODO: [MAGE-628] AuthTokenManager will enforce its own 500ms best-effort deadline.
+        // TODO: [MAGE-630] Subscribe to AuthTokenManager.onTokenRefresh for live updates.
+        // NoProviderRegistered is split out from generic fetch failures: the former is the
+        // expected state for apps not using JWT auth (logged at debug), the latter is degraded
+        // functionality with a fallback (logged at warning). Matches the AuthTokenException
+        // KDoc intent — "treat NoProviderRegistered as 'auth is not enabled' rather than 'auth
+        // failed.'"
+        val outcome: AuthOutcome = try {
+            AuthOutcome.Success(Registry.get<AuthTokenManager>().currentToken())
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: AuthTokenException.NoProviderRegistered) {
+            AuthOutcome.NotEnabled
+        } catch (_: Exception) {
+            AuthOutcome.FetchFailed
+        }
+
+        Registry.threadHelper.runOnUiThread {
+            if (this.webView !== webView) {
+                Registry.log.debug("Skipping IAF template load: WebView no longer current")
+                return@runOnUiThread
+            }
+            val token = (outcome as? AuthOutcome.Success)?.token
+            val jwtValue = token?.rawToken?.let(::escapeForHtmlAttribute).orEmpty()
+            partialHtml.replace(JWT_TOKEN_PLACEHOLDER, jwtValue).let { html ->
                 webView.loadTemplate(html, this, nativeBridge)
+                when (outcome) {
+                    is AuthOutcome.Success ->
+                        Registry.log.debug("Auth token injected at load")
+                    AuthOutcome.NotEnabled ->
+                        Registry.log.debug("Auth not enabled — proceeding without token")
+                    AuthOutcome.FetchFailed ->
+                        Registry.log.warning("Auth token fetch failed — proceeding without token")
+                }
                 handshakeTimer?.cancel()
                 handshakeTimer = Registry.clock.schedule(
                     Registry.config.networkTimeout.toLong(),
                     ::onJsHandshakeTimeout
                 )
             }
+        }
+    }
+
+    /**
+     * Defense-in-depth escape for the single-quoted `data-klaviyo-jwt` attribute. Valid JWTs
+     * cannot contain these characters, but a custom `AuthTokenProvider` could bypass validation.
+     */
+    private fun escapeForHtmlAttribute(value: String): String =
+        value
+            .replace("&", "&amp;") // must escape first to avoid double-encoding entities below
+            .replace("'", "&#x27;")
+            .replace("<", "&lt;")
+
+    /**
+     * Three-way result of the auth-token fetch in [loadTemplateWithAuthToken]. Lets the call site
+     * differentiate "auth not enabled" (debug-level log) from "auth fetch failed" (warning-level
+     * log) without re-throwing or re-checking exception types after the catch block.
+     */
+    private sealed interface AuthOutcome {
+        data class Success(val token: ValidatedToken) : AuthOutcome
+        data object NotEnabled : AuthOutcome
+        data object FetchFailed : AuthOutcome
     }
 
     override fun onLocalJsReady() {
@@ -149,6 +252,8 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
      */
     override fun destroyWebView() = apply {
         handshakeTimer?.cancel()
+        initJob?.cancel()
+        initJob = null
         Registry.get<JsBridgeObserverCollection>().stopObservers()
         webView?.let { webView ->
             Registry.threadHelper.runOnUiThread {

--- a/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/webview/KlaviyoWebViewClient.kt
@@ -128,7 +128,6 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
         partialHtml: String,
         nativeBridge: NativeBridge
     ) {
-        // TODO: [MAGE-628] AuthTokenManager will enforce its own 500ms best-effort deadline.
         // TODO: [MAGE-630] Subscribe to AuthTokenManager.onTokenRefresh for live updates.
         // NoProviderRegistered is split out from generic fetch failures: the former is the
         // expected state for apps not using JWT auth (logged at debug), the latter is degraded
@@ -136,7 +135,10 @@ internal class KlaviyoWebViewClient() : AndroidWebViewClient(), WebViewClient, J
         // KDoc intent — "treat NoProviderRegistered as 'auth is not enabled' rather than 'auth
         // failed.'"
         val outcome: AuthOutcome = try {
-            AuthOutcome.Success(Registry.get<AuthTokenManager>().currentToken())
+            AuthOutcome.Success(
+                Registry.get<AuthTokenManager>()
+                    .currentToken(AuthTokenManager.INTERACTIVE_FETCH_TIMEOUT_MS)
+            )
         } catch (e: CancellationException) {
             throw e
         } catch (_: AuthTokenException.NoProviderRegistered) {

--- a/sdk/forms/src/test/java/com/klaviyo/forms/bridge/JsBridgeObserverTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/bridge/JsBridgeObserverTest.kt
@@ -50,10 +50,23 @@ class JsBridgeObserverTest {
         val klaviyoObserverCollection = KlaviyoObserverCollection()
         val observers = klaviyoObserverCollection.observers
 
-        assertEquals(4, klaviyoObserverCollection.observers.size)
+        assertEquals(5, klaviyoObserverCollection.observers.size)
         assert(observers.any { it is CompanyObserver }) { "Expected CompanyObserver in the collection" }
+        assert(observers.any { it is JwtObserver }) { "Expected JwtObserver in the collection" }
         assert(observers.any { it is ProfileMutationObserver }) { "Expected ProfileObserver in the collection" }
         assert(observers.any { it is LifecycleObserver }) { "Expected LifecycleObserver in the collection" }
         assert(observers.any { it is ProfileEventObserver }) { "Expected FormsProfileEventObserver in the collection" }
+    }
+
+    @Test
+    fun `JwtObserver is ordered before ProfileMutationObserver`() {
+        val observers = KlaviyoObserverCollection().observers
+        val jwtIndex = observers.indexOfFirst { it is JwtObserver }
+        val profileIndex = observers.indexOfFirst { it is ProfileMutationObserver }
+        assert(jwtIndex >= 0) { "JwtObserver not found in collection" }
+        assert(profileIndex >= 0) { "ProfileMutationObserver not found in collection" }
+        assert(jwtIndex < profileIndex) {
+            "JwtObserver ($jwtIndex) must precede ProfileMutationObserver ($profileIndex)"
+        }
     }
 }

--- a/sdk/forms/src/test/java/com/klaviyo/forms/bridge/JwtObserverTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/bridge/JwtObserverTest.kt
@@ -1,0 +1,216 @@
+package com.klaviyo.forms.bridge
+
+import com.klaviyo.core.Registry
+import com.klaviyo.core.auth.AuthTokenException
+import com.klaviyo.core.auth.AuthTokenManager
+import com.klaviyo.core.auth.ValidatedToken
+import com.klaviyo.fixtures.BaseTest
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.CompletableDeferred
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class JwtObserverTest : BaseTest() {
+
+    private val mockAuthTokenManager = mockk<AuthTokenManager>()
+    private val mockJsBridge = mockk<JsBridge>(relaxed = true)
+
+    private fun validatedToken(rawToken: String): ValidatedToken =
+        ValidatedToken(rawToken = rawToken, expiresAtEpochSeconds = 0L, issuedAtEpochSeconds = 0L)
+
+    @Before
+    override fun setup() {
+        super.setup()
+        Registry.register<AuthTokenManager>(mockAuthTokenManager)
+        Registry.register<JsBridge>(mockJsBridge)
+    }
+
+    @After
+    override fun cleanup() {
+        Registry.unregister<AuthTokenManager>()
+        Registry.unregister<JsBridge>()
+        super.cleanup()
+    }
+
+    @Test
+    fun `startOn defaults to JsReady so JWT is delivered before profile`() {
+        assert(JwtObserver().startOn == NativeBridgeMessage.JsReady)
+    }
+
+    @Test
+    fun `startObserver injects token when fetch succeeds`() {
+        val token = "header.payload.signature"
+        coEvery { mockAuthTokenManager.currentToken(any()) } returns validatedToken(token)
+
+        JwtObserver().startObserver()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        verify { mockJsBridge.jwtMutation(token) }
+    }
+
+    @Test
+    fun `startObserver injects empty string and logs debug when no provider registered`() {
+        coEvery { mockAuthTokenManager.currentToken(any()) } throws
+            AuthTokenException.NoProviderRegistered
+
+        JwtObserver().startObserver()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        verify { mockJsBridge.jwtMutation("") }
+        verify { spyLog.debug(match { it.contains("Auth not enabled") }) }
+    }
+
+    @Test
+    fun `startObserver injects empty string and logs warning when fetch fails`() {
+        coEvery { mockAuthTokenManager.currentToken(any()) } throws
+            AuthTokenException.ValidationFailed("Malformed")
+
+        JwtObserver().startObserver()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        verify { mockJsBridge.jwtMutation("") }
+        verify { spyLog.warning(match { it.contains("Auth token fetch failed") }) }
+    }
+
+    @Test
+    fun `stopObserver cancels in-flight fetch before injection`() {
+        val tokenCompletion = CompletableDeferred<ValidatedToken>()
+        coEvery { mockAuthTokenManager.currentToken(any()) } coAnswers { tokenCompletion.await() }
+
+        val observer = JwtObserver()
+        observer.startObserver()
+        dispatcher.scheduler.runCurrent()
+        coVerify(exactly = 1) { mockAuthTokenManager.currentToken(any()) }
+
+        observer.stopObserver()
+        tokenCompletion.complete(validatedToken("would-be-token"))
+        dispatcher.scheduler.advanceUntilIdle()
+
+        verify(inverse = true) { mockJsBridge.jwtMutation(any()) }
+    }
+
+    @Test
+    fun `startObserver completes jwtReady after successful injection`() {
+        coEvery { mockAuthTokenManager.currentToken(any()) } returns validatedToken("token")
+
+        val observer = JwtObserver()
+        observer.startObserver()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertTrue(observer.jwtReady.isCompleted)
+        assertFalse(observer.jwtReady.isCancelled)
+    }
+
+    @Test
+    fun `startObserver completes jwtReady even when auth is not enabled`() {
+        coEvery { mockAuthTokenManager.currentToken(any()) } throws
+            AuthTokenException.NoProviderRegistered
+
+        val observer = JwtObserver()
+        observer.startObserver()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertTrue(observer.jwtReady.isCompleted)
+        assertFalse(observer.jwtReady.isCancelled)
+    }
+
+    @Test
+    fun `startObserver allocates a fresh jwtReady on reinit after the previous completed`() {
+        coEvery { mockAuthTokenManager.currentToken(any()) } returns validatedToken("session-1")
+        val observer = JwtObserver()
+
+        observer.startObserver()
+        dispatcher.scheduler.advanceUntilIdle()
+        val firstSessionDeferred = observer.jwtReady
+        assertTrue(firstSessionDeferred.isCompleted)
+
+        observer.stopObserver()
+
+        coEvery { mockAuthTokenManager.currentToken(any()) } returns validatedToken("session-2")
+        observer.startObserver()
+        dispatcher.scheduler.advanceUntilIdle()
+        val secondSessionDeferred = observer.jwtReady
+        assertNotSame(firstSessionDeferred, secondSessionDeferred)
+        assertTrue(secondSessionDeferred.isCompleted)
+        assertFalse(secondSessionDeferred.isCancelled)
+        verify(exactly = 1) { mockJsBridge.jwtMutation("session-1") }
+        verify(exactly = 1) { mockJsBridge.jwtMutation("session-2") }
+    }
+
+    @Test
+    fun `startObserver reuses jwtReady when previous session is still in flight`() {
+        val firstCompletion = CompletableDeferred<ValidatedToken>()
+        coEvery { mockAuthTokenManager.currentToken(any()) } coAnswers { firstCompletion.await() }
+
+        val observer = JwtObserver()
+        val initialDeferred = observer.jwtReady
+
+        observer.startObserver()
+        dispatcher.scheduler.runCurrent()
+        assertSame(initialDeferred, observer.jwtReady)
+
+        coEvery { mockAuthTokenManager.currentToken(any()) } returns validatedToken("second")
+        observer.startObserver()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertSame(initialDeferred, observer.jwtReady)
+        assertTrue(observer.jwtReady.isCompleted)
+        verify(exactly = 1) { mockJsBridge.jwtMutation("second") }
+    }
+
+    @Test
+    fun `double startObserver cancels previous in-flight fetch`() {
+        val firstCompletion = CompletableDeferred<ValidatedToken>()
+        val secondToken = "second.token.value"
+        coEvery { mockAuthTokenManager.currentToken(any()) } coAnswers { firstCompletion.await() }
+
+        val observer = JwtObserver()
+        observer.startObserver()
+        dispatcher.scheduler.runCurrent()
+
+        // Second start before first fetch completes — should cancel the first job
+        coEvery { mockAuthTokenManager.currentToken(any()) } returns validatedToken(secondToken)
+        observer.startObserver()
+        firstCompletion.complete(validatedToken("first.token.value"))
+        dispatcher.scheduler.advanceUntilIdle()
+
+        // Only the second token should be injected
+        verify(exactly = 1) { mockJsBridge.jwtMutation(secondToken) }
+        verify(inverse = true) { mockJsBridge.jwtMutation("first.token.value") }
+    }
+
+    @Test
+    fun `queued ui callback from a superseded fetch does not inject its stale token`() {
+        // In prod, runOnUiThread posts to the real UI thread. If currentToken returns synchronously
+        // (cached) the first fetch can queue its UI callback before the second startObserver runs.
+        // Override the relaxed runOnUiThread answer with a manual queue so the test can observe the
+        // queued ordering.
+        val uiQueue = mutableListOf<() -> Unit>()
+        every { mockThreadHelper.runOnUiThread(any()) } answers {
+            uiQueue.add(firstArg())
+        }
+
+        coEvery { mockAuthTokenManager.currentToken(any()) } returns validatedToken("stale")
+        val observer = JwtObserver()
+        observer.startObserver()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        coEvery { mockAuthTokenManager.currentToken(any()) } returns validatedToken("fresh")
+        observer.startObserver()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        uiQueue.forEach { it.invoke() }
+
+        verify(inverse = true) { mockJsBridge.jwtMutation("stale") }
+        verify(exactly = 1) { mockJsBridge.jwtMutation("fresh") }
+    }
+}

--- a/sdk/forms/src/test/java/com/klaviyo/forms/bridge/KlaviyoJsBridgeTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/bridge/KlaviyoJsBridgeTest.kt
@@ -237,4 +237,36 @@ class KlaviyoJsBridgeTest : BaseTest() {
             )
         }
     }
+
+    @Test
+    fun `jwtMutation calls JS evaluator with correct JS`() {
+        every { jsEvaluator.evaluateJavascript(any(), any()) } answers {
+            secondArg<(Boolean) -> Unit>().invoke(true)
+        }
+
+        bridge.jwtMutation("jwt.token.value")
+
+        verify {
+            jsEvaluator.evaluateJavascript(
+                eq("""window.jwtMutation("jwt.token.value")"""),
+                any()
+            )
+        }
+    }
+
+    @Test
+    fun `jwtMutation with empty token calls JS evaluator with empty string`() {
+        every { jsEvaluator.evaluateJavascript(any(), any()) } answers {
+            secondArg<(Boolean) -> Unit>().invoke(true)
+        }
+
+        bridge.jwtMutation("")
+
+        verify {
+            jsEvaluator.evaluateJavascript(
+                eq("""window.jwtMutation("")"""),
+                any()
+            )
+        }
+    }
 }

--- a/sdk/forms/src/test/java/com/klaviyo/forms/bridge/KlaviyoJsBridgeTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/bridge/KlaviyoJsBridgeTest.kt
@@ -35,7 +35,7 @@ class KlaviyoJsBridgeTest : BaseTest() {
     fun `compileJson returns correct JSON for supported functions`() {
         val expectedJson = KlaviyoJsBridge().handshake.compileJson()
         val actualJson = """
-           [{"type":"profileMutation","version":1},{"type":"lifecycleEvent","version":1},{"type":"closeForm","version":1},{"type":"profileEvent","version":1}]
+           [{"type":"profileMutation","version":1},{"type":"lifecycleEvent","version":1},{"type":"closeForm","version":1},{"type":"profileEvent","version":1},{"type":"jwtMutation","version":1}]
         """.trimIndent()
         assertEquals(actualJson, expectedJson)
     }

--- a/sdk/forms/src/test/java/com/klaviyo/forms/bridge/ProfileMutationObserverAsyncTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/bridge/ProfileMutationObserverAsyncTest.kt
@@ -1,0 +1,128 @@
+package com.klaviyo.forms.bridge
+
+import com.klaviyo.analytics.model.Profile
+import com.klaviyo.analytics.state.State
+import com.klaviyo.core.Registry
+import com.klaviyo.core.auth.AuthTokenManager
+import com.klaviyo.core.auth.ValidatedToken
+import com.klaviyo.fixtures.BaseTest
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.After
+import org.junit.Assert.assertNotSame
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Tests for [ProfileMutationObserver] behaviour when a [JwtObserver] is provided —
+ * i.e. the coordination path used by [KlaviyoObserverCollection] to prevent profile injection
+ * from racing ahead of JWT delivery.
+ */
+class ProfileMutationObserverAsyncTest : BaseTest() {
+
+    private val stubProfile = Profile()
+    private val stateMock = mockk<State>(relaxed = true).apply {
+        every { getAsProfile() } returns stubProfile
+    }
+    private val mockBridge = mockk<JsBridge>(relaxed = true)
+
+    @Before
+    override fun setup() {
+        super.setup()
+        Registry.register<State>(stateMock)
+        Registry.register<JsBridge>(mockBridge)
+    }
+
+    @After
+    override fun cleanup() {
+        Registry.unregister<State>()
+        Registry.unregister<JsBridge>()
+        super.cleanup()
+    }
+
+    @Test
+    fun `startObserver awaits jwtReady before injecting profile`() {
+        // JwtObserver created but not started — jwtReady is the initial incomplete deferred,
+        // which we complete manually below to simulate JWT delivery.
+        val jwtObserver = JwtObserver()
+        ProfileMutationObserver(jwtObserver).startObserver()
+        dispatcher.scheduler.runCurrent()
+
+        // JWT not yet delivered — profile must not have been injected
+        verify(inverse = true) { mockBridge.profileMutation(any()) }
+
+        // JWT arrives — profile injection should now proceed
+        jwtObserver.jwtReady.complete(Unit)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        verify(exactly = 1) { mockBridge.profileMutation(stubProfile) }
+    }
+
+    @Test
+    fun `startObserver does not inject profile if jwtReady is cancelled`() {
+        val jwtObserver = JwtObserver()
+        val observer = ProfileMutationObserver(jwtObserver)
+        observer.startObserver()
+        dispatcher.scheduler.runCurrent()
+
+        // WebView destroyed before JWT delivered — deferred is cancelled
+        jwtObserver.jwtReady.cancel()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        verify(inverse = true) { mockBridge.profileMutation(any()) }
+    }
+
+    @Test
+    fun `startObserver works on reinit after stop — scope must not be permanently cancelled`() {
+        // Regression test: the old implementation called scope.cancel() in stopObserver(),
+        // which permanently destroyed the scope and made subsequent startObserver calls a no-op.
+        val jwtObserver = JwtObserver()
+        val observer = ProfileMutationObserver(jwtObserver)
+
+        // First session: start and immediately stop
+        observer.startObserver()
+        observer.stopObserver()
+
+        // Second session: should work even though stopObserver was previously called
+        observer.startObserver()
+        jwtObserver.jwtReady.complete(Unit)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        verify(exactly = 1) { mockBridge.profileMutation(stubProfile) }
+    }
+
+    @Test
+    fun `startObserver reads jwtReady fresh each session — regression for capture-at-construction`() {
+        val jwtObserver = JwtObserver()
+        val observer = ProfileMutationObserver(jwtObserver)
+        val sessionOneDeferred = jwtObserver.jwtReady
+
+        observer.startObserver()
+        sessionOneDeferred.cancel()
+        dispatcher.scheduler.advanceUntilIdle()
+        verify(inverse = true) { mockBridge.profileMutation(any()) }
+        observer.stopObserver()
+
+        val mockAuth = mockk<AuthTokenManager>()
+        coEvery { mockAuth.currentToken(any()) } returns ValidatedToken(
+            rawToken = "tok",
+            expiresAtEpochSeconds = 0L,
+            issuedAtEpochSeconds = 0L
+        )
+        Registry.register<AuthTokenManager>(mockAuth)
+        try {
+            jwtObserver.startObserver()
+            dispatcher.scheduler.advanceUntilIdle()
+            assertNotSame(sessionOneDeferred, jwtObserver.jwtReady)
+
+            observer.startObserver()
+            dispatcher.scheduler.advanceUntilIdle()
+
+            verify(exactly = 1) { mockBridge.profileMutation(stubProfile) }
+        } finally {
+            Registry.unregister<AuthTokenManager>()
+        }
+    }
+}

--- a/sdk/forms/src/test/java/com/klaviyo/forms/bridge/ProfileObserverTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/bridge/ProfileObserverTest.kt
@@ -12,6 +12,7 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 
@@ -40,6 +41,11 @@ class ProfileObserverTest {
         Registry.register<JsBridge>(mockBridge)
         ProfileMutationObserver().startObserver()
         return mockBridge
+    }
+
+    @Test
+    fun `observer starts on HandShook so JWT is injected before profile`() {
+        assertEquals(NativeBridgeMessage.HandShook, ProfileMutationObserver().startOn)
     }
 
     @Test

--- a/sdk/forms/src/test/java/com/klaviyo/forms/webview/KlaviyoWebViewClientTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/webview/KlaviyoWebViewClientTest.kt
@@ -132,7 +132,7 @@ class KlaviyoWebViewClientTest : BaseTest() {
         Registry.register<NativeBridge>(mockBridge)
         // Default: no provider registered — form loads without auth token (JWT_TOKEN → "").
         // Tests that need a fetch-failure outcome override this with a different exception type.
-        coEvery { mockAuthTokenManager.currentToken() } throws AuthTokenException.NoProviderRegistered
+        coEvery { mockAuthTokenManager.currentToken(any()) } throws AuthTokenException.NoProviderRegistered
         Registry.register<AuthTokenManager>(mockAuthTokenManager)
         mockDeviceProperties()
         every { mockConfig.isDebugBuild } returns false
@@ -518,7 +518,7 @@ class KlaviyoWebViewClientTest : BaseTest() {
     @Test
     fun `initializeWebView injects auth token into data-klaviyo-jwt when token is available`() {
         val fakeToken = "header.payload.signature"
-        coEvery { mockAuthTokenManager.currentToken() } returns validatedToken(fakeToken)
+        coEvery { mockAuthTokenManager.currentToken(any()) } returns validatedToken(fakeToken)
 
         val client = KlaviyoWebViewClient()
         client.initializeWebView()
@@ -537,7 +537,7 @@ class KlaviyoWebViewClientTest : BaseTest() {
     @Test
     fun `initializeWebView does not log injected token when stale webview skips template load`() {
         val fakeToken = "header.payload.signature"
-        coEvery { mockAuthTokenManager.currentToken() } returns validatedToken(fakeToken)
+        coEvery { mockAuthTokenManager.currentToken(any()) } returns validatedToken(fakeToken)
 
         val client = KlaviyoWebViewClient()
         var firstUiDispatch = true
@@ -586,7 +586,7 @@ class KlaviyoWebViewClientTest : BaseTest() {
         // Provider IS registered but its fetch fails — degraded functionality with fallback,
         // appropriate for a warning. ValidationFailed stands in for any non-NoProviderRegistered
         // AuthTokenException; a plain RuntimeException would hit the same branch.
-        coEvery { mockAuthTokenManager.currentToken() } throws
+        coEvery { mockAuthTokenManager.currentToken(any()) } throws
             AuthTokenException.ValidationFailed("Malformed")
 
         val client = KlaviyoWebViewClient()
@@ -607,7 +607,9 @@ class KlaviyoWebViewClientTest : BaseTest() {
     @Test
     fun `initializeWebView HTML-escapes special characters in auth token value`() {
         val mischievousToken = "a&b'c<d"
-        coEvery { mockAuthTokenManager.currentToken() } returns validatedToken(mischievousToken)
+        coEvery { mockAuthTokenManager.currentToken(any()) } returns validatedToken(
+            mischievousToken
+        )
 
         val client = KlaviyoWebViewClient()
         client.initializeWebView()
@@ -628,12 +630,12 @@ class KlaviyoWebViewClientTest : BaseTest() {
     @Test
     fun `destroyWebView cancels in-flight initJob during auth token fetch`() {
         val tokenCompletion = CompletableDeferred<ValidatedToken>()
-        coEvery { mockAuthTokenManager.currentToken() } coAnswers { tokenCompletion.await() }
+        coEvery { mockAuthTokenManager.currentToken(any()) } coAnswers { tokenCompletion.await() }
 
         val client = KlaviyoWebViewClient()
         client.initializeWebView()
         dispatcher.scheduler.runCurrent()
-        coVerify(exactly = 1) { mockAuthTokenManager.currentToken() }
+        coVerify(exactly = 1) { mockAuthTokenManager.currentToken(any()) }
 
         client.destroyWebView()
         tokenCompletion.complete(validatedToken("would-be-token"))
@@ -653,6 +655,6 @@ class KlaviyoWebViewClientTest : BaseTest() {
         dispatcher.scheduler.advanceUntilIdle()
 
         verify(inverse = true) { anyConstructed<KlaviyoWebView>().loadTemplate(any(), any(), any()) }
-        coVerify(exactly = 0) { mockAuthTokenManager.currentToken() }
+        coVerify(exactly = 0) { mockAuthTokenManager.currentToken(any()) }
     }
 }

--- a/sdk/forms/src/test/java/com/klaviyo/forms/webview/KlaviyoWebViewClientTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/webview/KlaviyoWebViewClientTest.kt
@@ -14,6 +14,9 @@ import androidx.core.view.ViewCompat
 import androidx.webkit.WebViewCompat
 import androidx.webkit.WebViewFeature
 import com.klaviyo.core.Registry
+import com.klaviyo.core.auth.AuthTokenException
+import com.klaviyo.core.auth.AuthTokenManager
+import com.klaviyo.core.auth.ValidatedToken
 import com.klaviyo.fixtures.BaseTest
 import com.klaviyo.fixtures.MockIntent
 import com.klaviyo.fixtures.mockDeviceProperties
@@ -25,6 +28,8 @@ import com.klaviyo.forms.bridge.NativeBridgeMessage
 import com.klaviyo.forms.bridge.compileJson
 import com.klaviyo.forms.presentation.PresentationManager
 import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -33,6 +38,7 @@ import io.mockk.mockkStatic
 import io.mockk.runs
 import io.mockk.verify
 import java.io.ByteArrayInputStream
+import kotlinx.coroutines.CompletableDeferred
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -51,6 +57,7 @@ class KlaviyoWebViewClientTest : BaseTest() {
                   data-forms-data-environment='FORMS_ENVIRONMENT'
                   data-klaviyo-local-tracking="1"
                   data-klaviyo-profile="{}"
+                  data-klaviyo-jwt='JWT_TOKEN'
             >
                 <meta charset="UTF-8">
                 <meta name="viewport"
@@ -75,6 +82,13 @@ class KlaviyoWebViewClientTest : BaseTest() {
             </html>
         """.trimIndent()
     }
+
+    private val mockAuthTokenManager = mockk<AuthTokenManager>()
+
+    // exp/iat are read by production logging in [KlaviyoAuthTokenManager] but not by the WebView
+    // injection path under test — any non-zero placeholder is fine for these tests.
+    private fun validatedToken(rawToken: String): ValidatedToken =
+        ValidatedToken(rawToken = rawToken, expiresAtEpochSeconds = 0L, issuedAtEpochSeconds = 0L)
 
     private val stubKlaviyoJs = "stubKlaviyoJs"
     private val mockKlaviyoJsUri = mockk<Uri>(relaxed = true).also {
@@ -116,6 +130,10 @@ class KlaviyoWebViewClientTest : BaseTest() {
         Registry.register<JsBridge>(mockJsBridge)
         Registry.register<JsBridgeObserverCollection>(mockObserverCollection)
         Registry.register<NativeBridge>(mockBridge)
+        // Default: no provider registered — form loads without auth token (JWT_TOKEN → "").
+        // Tests that need a fetch-failure outcome override this with a different exception type.
+        coEvery { mockAuthTokenManager.currentToken() } throws AuthTokenException.NoProviderRegistered
+        Registry.register<AuthTokenManager>(mockAuthTokenManager)
         mockDeviceProperties()
         every { mockConfig.isDebugBuild } returns false
         every { mockContext.assets } returns mockAssets
@@ -160,6 +178,7 @@ class KlaviyoWebViewClientTest : BaseTest() {
     override fun cleanup() {
         Registry.unregister<NativeBridge>()
         Registry.unregister<JsBridgeObserverCollection>()
+        Registry.unregister<AuthTokenManager>()
         clearAllMocks()
         super.cleanup()
     }
@@ -200,6 +219,7 @@ class KlaviyoWebViewClientTest : BaseTest() {
                   data-forms-data-environment='in-app'
                   data-klaviyo-local-tracking="1"
                   data-klaviyo-profile="{}"
+                  data-klaviyo-jwt=''
             >
                 <meta charset="UTF-8">
                 <meta name="viewport"
@@ -226,6 +246,7 @@ class KlaviyoWebViewClientTest : BaseTest() {
 
         val client = KlaviyoWebViewClient()
         client.initializeWebView()
+        dispatcher.scheduler.advanceUntilIdle()
 
         verify { mockAssets.open("InAppFormsTemplate.html") }
         verify { anyConstructed<KlaviyoWebView>().loadTemplate(expectedHtml, client, mockBridge) }
@@ -240,6 +261,7 @@ class KlaviyoWebViewClientTest : BaseTest() {
         val client = KlaviyoWebViewClient()
         client.initializeWebView()
         client.initializeWebView()
+        dispatcher.scheduler.advanceUntilIdle()
         // Verify that loadTemplate was only called once (which means WebView was only constructed once)
         verify(exactly = 1) { anyConstructed<KlaviyoWebView>().loadTemplate(any(), any(), any()) }
     }
@@ -250,6 +272,7 @@ class KlaviyoWebViewClientTest : BaseTest() {
 
         val client = KlaviyoWebViewClient()
         client.initializeWebView()
+        dispatcher.scheduler.advanceUntilIdle()
 
         verify {
             spyLog.debug(
@@ -282,6 +305,7 @@ class KlaviyoWebViewClientTest : BaseTest() {
 
         val client = KlaviyoWebViewClient()
         client.initializeWebView()
+        dispatcher.scheduler.advanceUntilIdle()
 
         verify { mockSettings.javaScriptEnabled = true }
         verify { mockSettings.userAgentString = "Mock User Agent" }
@@ -299,6 +323,7 @@ class KlaviyoWebViewClientTest : BaseTest() {
     fun `timeout cancels on handshake`() {
         val client = KlaviyoWebViewClient()
         client.initializeWebView()
+        dispatcher.scheduler.advanceUntilIdle()
 
         client.onJsHandshakeCompleted()
         staticClock.execute(10_000)
@@ -314,6 +339,7 @@ class KlaviyoWebViewClientTest : BaseTest() {
     fun `closes webview on timeout`() {
         val client = KlaviyoWebViewClient()
         client.initializeWebView()
+        dispatcher.scheduler.advanceUntilIdle()
         // notably no handshake
         staticClock.execute(10_000)
 
@@ -487,5 +513,146 @@ class KlaviyoWebViewClientTest : BaseTest() {
         every { mockConfig.assetSource } returns "test-asset-source"
         KlaviyoWebViewClient().onPageFinished(mockWebview, "https://example.com")
         verify { spyLog.debug(any()) }
+    }
+
+    @Test
+    fun `initializeWebView injects auth token into data-klaviyo-jwt when token is available`() {
+        val fakeToken = "header.payload.signature"
+        coEvery { mockAuthTokenManager.currentToken() } returns validatedToken(fakeToken)
+
+        val client = KlaviyoWebViewClient()
+        client.initializeWebView()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        verify {
+            anyConstructed<KlaviyoWebView>().loadTemplate(
+                match { it.contains("data-klaviyo-jwt='$fakeToken'") },
+                client,
+                mockBridge
+            )
+        }
+        verify { spyLog.debug(match { it.contains("Auth token injected") }) }
+    }
+
+    @Test
+    fun `initializeWebView does not log injected token when stale webview skips template load`() {
+        val fakeToken = "header.payload.signature"
+        coEvery { mockAuthTokenManager.currentToken() } returns validatedToken(fakeToken)
+
+        val client = KlaviyoWebViewClient()
+        var firstUiDispatch = true
+        every { mockThreadHelper.runOnUiThread(any()) } answers {
+            val runnable = firstArg<() -> Unit>()
+            if (firstUiDispatch) {
+                firstUiDispatch = false
+                client.destroyWebView()
+            }
+            runnable.invoke()
+        }
+
+        client.initializeWebView()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        verify(inverse = true) { anyConstructed<KlaviyoWebView>().loadTemplate(any(), any(), any()) }
+        verify {
+            spyLog.debug(
+                match { it.contains("Skipping IAF template load: WebView no longer current") }
+            )
+        }
+        verify(inverse = true) { spyLog.debug(match { it.contains("Auth token injected at load") }) }
+    }
+
+    @Test
+    fun `initializeWebView logs debug and proceeds without token when no provider is registered`() {
+        // Default mock throws NoProviderRegistered — the expected state for apps not using JWT
+        // auth. Should be a quiet diagnostic, not a warning.
+        val client = KlaviyoWebViewClient()
+        client.initializeWebView()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        verify {
+            anyConstructed<KlaviyoWebView>().loadTemplate(
+                match { it.contains("data-klaviyo-jwt=''") },
+                client,
+                mockBridge
+            )
+        }
+        verify { spyLog.debug(match { it.contains("Auth not enabled") }) }
+        verify(inverse = true) { spyLog.warning(match { it.contains("Auth token fetch failed") }) }
+    }
+
+    @Test
+    fun `initializeWebView logs warning and proceeds without token when provider fetch fails`() {
+        // Provider IS registered but its fetch fails — degraded functionality with fallback,
+        // appropriate for a warning. ValidationFailed stands in for any non-NoProviderRegistered
+        // AuthTokenException; a plain RuntimeException would hit the same branch.
+        coEvery { mockAuthTokenManager.currentToken() } throws
+            AuthTokenException.ValidationFailed("Malformed")
+
+        val client = KlaviyoWebViewClient()
+        client.initializeWebView()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        verify {
+            anyConstructed<KlaviyoWebView>().loadTemplate(
+                match { it.contains("data-klaviyo-jwt=''") },
+                client,
+                mockBridge
+            )
+        }
+        verify { spyLog.warning(match { it.contains("Auth token fetch failed") }) }
+        verify(inverse = true) { spyLog.debug(match { it.contains("Auth not enabled") }) }
+    }
+
+    @Test
+    fun `initializeWebView HTML-escapes special characters in auth token value`() {
+        val mischievousToken = "a&b'c<d"
+        coEvery { mockAuthTokenManager.currentToken() } returns validatedToken(mischievousToken)
+
+        val client = KlaviyoWebViewClient()
+        client.initializeWebView()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        verify {
+            anyConstructed<KlaviyoWebView>().loadTemplate(
+                match { html ->
+                    html.contains("data-klaviyo-jwt='a&amp;b&#x27;c&lt;d'") &&
+                        !html.contains("data-klaviyo-jwt='a&b'c<d'")
+                },
+                client,
+                mockBridge
+            )
+        }
+    }
+
+    @Test
+    fun `destroyWebView cancels in-flight initJob during auth token fetch`() {
+        val tokenCompletion = CompletableDeferred<ValidatedToken>()
+        coEvery { mockAuthTokenManager.currentToken() } coAnswers { tokenCompletion.await() }
+
+        val client = KlaviyoWebViewClient()
+        client.initializeWebView()
+        dispatcher.scheduler.runCurrent()
+        coVerify(exactly = 1) { mockAuthTokenManager.currentToken() }
+
+        client.destroyWebView()
+        tokenCompletion.complete(validatedToken("would-be-token"))
+        dispatcher.scheduler.advanceUntilIdle()
+
+        verify(inverse = true) { anyConstructed<KlaviyoWebView>().loadTemplate(any(), any(), any()) }
+        // Stale-ref log absence proves cancellation killed the coroutine at the suspension point
+        // rather than the guard catching a non-cancelled stale completion.
+        verify(inverse = true) { spyLog.debug(match { it.contains("no longer current") }) }
+    }
+
+    @Test
+    fun `destroyWebView before coroutine starts cancels initJob and prevents loadTemplate`() {
+        val client = KlaviyoWebViewClient()
+        client.initializeWebView()
+        client.destroyWebView()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        verify(inverse = true) { anyConstructed<KlaviyoWebView>().loadTemplate(any(), any(), any()) }
+        coVerify(exactly = 0) { mockAuthTokenManager.currentToken() }
     }
 }

--- a/sdk/forms/src/test/java/com/klaviyo/forms/webview/KlaviyoWebViewClientTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/webview/KlaviyoWebViewClientTest.kt
@@ -14,9 +14,6 @@ import androidx.core.view.ViewCompat
 import androidx.webkit.WebViewCompat
 import androidx.webkit.WebViewFeature
 import com.klaviyo.core.Registry
-import com.klaviyo.core.auth.AuthTokenException
-import com.klaviyo.core.auth.AuthTokenManager
-import com.klaviyo.core.auth.ValidatedToken
 import com.klaviyo.fixtures.BaseTest
 import com.klaviyo.fixtures.MockIntent
 import com.klaviyo.fixtures.mockDeviceProperties
@@ -28,8 +25,6 @@ import com.klaviyo.forms.bridge.NativeBridgeMessage
 import com.klaviyo.forms.bridge.compileJson
 import com.klaviyo.forms.presentation.PresentationManager
 import io.mockk.clearAllMocks
-import io.mockk.coEvery
-import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -38,7 +33,6 @@ import io.mockk.mockkStatic
 import io.mockk.runs
 import io.mockk.verify
 import java.io.ByteArrayInputStream
-import kotlinx.coroutines.CompletableDeferred
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -57,24 +51,24 @@ class KlaviyoWebViewClientTest : BaseTest() {
                   data-forms-data-environment='FORMS_ENVIRONMENT'
                   data-klaviyo-local-tracking="1"
                   data-klaviyo-profile="{}"
-                  data-klaviyo-jwt='JWT_TOKEN'
+                  data-klaviyo-jwt=''
             >
                 <meta charset="UTF-8">
                 <meta name="viewport"
                       content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0, viewport-fit=cover"/>
-            
+
                 <!--  This meta tag protects @imported fonts from being blocked by CORS  -->
                 <meta name="referrer" content="same-origin"/>
-            
+
                 <title>Klaviyo In-App Form Template</title>
-            
+
                 <!-- Load in JS helper functions from assets directory -->
                 <script type="text/javascript" src="file:///android_asset/onsite-bridge.js"></script>
-            
+
                 <!-- Static stylesheet for "websafe" fonts that may be unavailable or inconsistent from the system -->
                 <link rel="stylesheet" type="text/css"
                       href="https://static-forms.klaviyo.com/fonts/api/v1/in-app-web-fonts/websafe_fonts.css" crossorigin/>
-            
+
                 <!-- Placeholder script to load klaviyo.js -->
                 <script type="text/javascript" src="KLAVIYO_JS_URL"></script>
             </head>
@@ -82,13 +76,6 @@ class KlaviyoWebViewClientTest : BaseTest() {
             </html>
         """.trimIndent()
     }
-
-    private val mockAuthTokenManager = mockk<AuthTokenManager>()
-
-    // exp/iat are read by production logging in [KlaviyoAuthTokenManager] but not by the WebView
-    // injection path under test — any non-zero placeholder is fine for these tests.
-    private fun validatedToken(rawToken: String): ValidatedToken =
-        ValidatedToken(rawToken = rawToken, expiresAtEpochSeconds = 0L, issuedAtEpochSeconds = 0L)
 
     private val stubKlaviyoJs = "stubKlaviyoJs"
     private val mockKlaviyoJsUri = mockk<Uri>(relaxed = true).also {
@@ -130,10 +117,6 @@ class KlaviyoWebViewClientTest : BaseTest() {
         Registry.register<JsBridge>(mockJsBridge)
         Registry.register<JsBridgeObserverCollection>(mockObserverCollection)
         Registry.register<NativeBridge>(mockBridge)
-        // Default: no provider registered — form loads without auth token (JWT_TOKEN → "").
-        // Tests that need a fetch-failure outcome override this with a different exception type.
-        coEvery { mockAuthTokenManager.currentToken(any()) } throws AuthTokenException.NoProviderRegistered
-        Registry.register<AuthTokenManager>(mockAuthTokenManager)
         mockDeviceProperties()
         every { mockConfig.isDebugBuild } returns false
         every { mockContext.assets } returns mockAssets
@@ -178,7 +161,6 @@ class KlaviyoWebViewClientTest : BaseTest() {
     override fun cleanup() {
         Registry.unregister<NativeBridge>()
         Registry.unregister<JsBridgeObserverCollection>()
-        Registry.unregister<AuthTokenManager>()
         clearAllMocks()
         super.cleanup()
     }
@@ -513,148 +495,5 @@ class KlaviyoWebViewClientTest : BaseTest() {
         every { mockConfig.assetSource } returns "test-asset-source"
         KlaviyoWebViewClient().onPageFinished(mockWebview, "https://example.com")
         verify { spyLog.debug(any()) }
-    }
-
-    @Test
-    fun `initializeWebView injects auth token into data-klaviyo-jwt when token is available`() {
-        val fakeToken = "header.payload.signature"
-        coEvery { mockAuthTokenManager.currentToken(any()) } returns validatedToken(fakeToken)
-
-        val client = KlaviyoWebViewClient()
-        client.initializeWebView()
-        dispatcher.scheduler.advanceUntilIdle()
-
-        verify {
-            anyConstructed<KlaviyoWebView>().loadTemplate(
-                match { it.contains("data-klaviyo-jwt='$fakeToken'") },
-                client,
-                mockBridge
-            )
-        }
-        verify { spyLog.debug(match { it.contains("Auth token injected") }) }
-    }
-
-    @Test
-    fun `initializeWebView does not log injected token when stale webview skips template load`() {
-        val fakeToken = "header.payload.signature"
-        coEvery { mockAuthTokenManager.currentToken(any()) } returns validatedToken(fakeToken)
-
-        val client = KlaviyoWebViewClient()
-        var firstUiDispatch = true
-        every { mockThreadHelper.runOnUiThread(any()) } answers {
-            val runnable = firstArg<() -> Unit>()
-            if (firstUiDispatch) {
-                firstUiDispatch = false
-                client.destroyWebView()
-            }
-            runnable.invoke()
-        }
-
-        client.initializeWebView()
-        dispatcher.scheduler.advanceUntilIdle()
-
-        verify(inverse = true) { anyConstructed<KlaviyoWebView>().loadTemplate(any(), any(), any()) }
-        verify {
-            spyLog.debug(
-                match { it.contains("Skipping IAF template load: WebView no longer current") }
-            )
-        }
-        verify(inverse = true) { spyLog.debug(match { it.contains("Auth token injected at load") }) }
-    }
-
-    @Test
-    fun `initializeWebView logs debug and proceeds without token when no provider is registered`() {
-        // Default mock throws NoProviderRegistered — the expected state for apps not using JWT
-        // auth. Should be a quiet diagnostic, not a warning.
-        val client = KlaviyoWebViewClient()
-        client.initializeWebView()
-        dispatcher.scheduler.advanceUntilIdle()
-
-        verify {
-            anyConstructed<KlaviyoWebView>().loadTemplate(
-                match { it.contains("data-klaviyo-jwt=''") },
-                client,
-                mockBridge
-            )
-        }
-        verify { spyLog.debug(match { it.contains("Auth not enabled") }) }
-        verify(inverse = true) { spyLog.warning(match { it.contains("Auth token fetch failed") }) }
-    }
-
-    @Test
-    fun `initializeWebView logs warning and proceeds without token when provider fetch fails`() {
-        // Provider IS registered but its fetch fails — degraded functionality with fallback,
-        // appropriate for a warning. ValidationFailed stands in for any non-NoProviderRegistered
-        // AuthTokenException; a plain RuntimeException would hit the same branch.
-        coEvery { mockAuthTokenManager.currentToken(any()) } throws
-            AuthTokenException.ValidationFailed("Malformed")
-
-        val client = KlaviyoWebViewClient()
-        client.initializeWebView()
-        dispatcher.scheduler.advanceUntilIdle()
-
-        verify {
-            anyConstructed<KlaviyoWebView>().loadTemplate(
-                match { it.contains("data-klaviyo-jwt=''") },
-                client,
-                mockBridge
-            )
-        }
-        verify { spyLog.warning(match { it.contains("Auth token fetch failed") }) }
-        verify(inverse = true) { spyLog.debug(match { it.contains("Auth not enabled") }) }
-    }
-
-    @Test
-    fun `initializeWebView HTML-escapes special characters in auth token value`() {
-        val mischievousToken = "a&b'c<d"
-        coEvery { mockAuthTokenManager.currentToken(any()) } returns validatedToken(
-            mischievousToken
-        )
-
-        val client = KlaviyoWebViewClient()
-        client.initializeWebView()
-        dispatcher.scheduler.advanceUntilIdle()
-
-        verify {
-            anyConstructed<KlaviyoWebView>().loadTemplate(
-                match { html ->
-                    html.contains("data-klaviyo-jwt='a&amp;b&#x27;c&lt;d'") &&
-                        !html.contains("data-klaviyo-jwt='a&b'c<d'")
-                },
-                client,
-                mockBridge
-            )
-        }
-    }
-
-    @Test
-    fun `destroyWebView cancels in-flight initJob during auth token fetch`() {
-        val tokenCompletion = CompletableDeferred<ValidatedToken>()
-        coEvery { mockAuthTokenManager.currentToken(any()) } coAnswers { tokenCompletion.await() }
-
-        val client = KlaviyoWebViewClient()
-        client.initializeWebView()
-        dispatcher.scheduler.runCurrent()
-        coVerify(exactly = 1) { mockAuthTokenManager.currentToken(any()) }
-
-        client.destroyWebView()
-        tokenCompletion.complete(validatedToken("would-be-token"))
-        dispatcher.scheduler.advanceUntilIdle()
-
-        verify(inverse = true) { anyConstructed<KlaviyoWebView>().loadTemplate(any(), any(), any()) }
-        // Stale-ref log absence proves cancellation killed the coroutine at the suspension point
-        // rather than the guard catching a non-cancelled stale completion.
-        verify(inverse = true) { spyLog.debug(match { it.contains("no longer current") }) }
-    }
-
-    @Test
-    fun `destroyWebView before coroutine starts cancels initJob and prevents loadTemplate`() {
-        val client = KlaviyoWebViewClient()
-        client.initializeWebView()
-        client.destroyWebView()
-        dispatcher.scheduler.advanceUntilIdle()
-
-        verify(inverse = true) { anyConstructed<KlaviyoWebView>().loadTemplate(any(), any(), any()) }
-        coVerify(exactly = 0) { mockAuthTokenManager.currentToken(any()) }
     }
 }


### PR DESCRIPTION
## Summary

Refactors `KlaviyoAuthTokenManager` to an **actor-style** concurrency model. All mutable token state is now confined to a single-threaded coroutine context (`Registry.dispatcher.limitedParallelism(1)`), replacing the previous patchwork of `Mutex`, a JVM monitor lock, two `AtomicLong` generation counters, and six `@Volatile` fields.

### What changed

- **Serialization mechanism:** A single `actorContext = Registry.dispatcher.limitedParallelism(1)` serializes all state access. State reads/writes happen inside `withContext(actorContext)` / `scope.safeLaunch` blocks instead of `mutex.withLock` / `synchronized`.
- **Removed:** `Mutex`, `connectivityWaitLock` (JVM monitor), `connectivityWaitGeneration` (`AtomicLong`), `profileGeneration` (`AtomicLong`), and `@Volatile` on `provider`, `cachedToken`, `inFlightFetch`, `refreshJob`, `refreshAtWallClockMs`, `refreshTimerFired`. `refreshGeneration` downgraded from `AtomicLong` to a plain `Long` (actor-confined).
- **Kept `@Volatile`:** `profileResetPending` and `connectivityWaitJob` are read/written from the caller thread (outside the actor), and `resetGeneration` stays an `AtomicLong` because `invalidate()` runs on the calling thread.
- **`invalidate()`** simplified from `fun invalidate(): Long` to `fun invalidate()` — it just sets the `profileResetPending` flag rather than returning a generation token.
- **`clearTokenState()`** simplified from `clearTokenState(expectedGeneration: Long = -1L)` to no-arg `clearTokenState()` — it skips when `!profileResetPending` instead of comparing generation counters.
- **Connectivity wait job** clearing now uses reference identity (`connectivityWaitJob === selfRef`) in the `finally` block instead of a generation counter.

### Caller updates

`Klaviyo.resetProfile()` no longer threads a generation token through `invalidate()` → `clearTokenState()`.

## Testing

- `./gradlew :sdk:core:testDebugUnitTest --tests "com.klaviyo.core.auth.*"` — pass
- `./gradlew :sdk:analytics:testDebugUnitTest --tests "com.klaviyo.analytics.KlaviyoTest"` — pass
- `./gradlew :sdk:core:ktlintCheck :sdk:analytics:ktlintCheck` — pass

## Notes

Based on `feat/jwts-for-personalized-forms` (the JWT/auth integration branch, which includes the MAGE-684 connectivity-retry work and the #482 CodeRabbit fixes). Retarget to `master` if the base chain is restructured.

Related to MAGE-885

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated authentication token management system architecture and implementation.
  * Modified public API: `invalidate()` no longer returns a value; `clearTokenState()` no longer accepts parameters.
  * Improved internal state handling for profile reset and token lifecycle management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->