### PR TITLE
feat(core): public unregisterAuthTokenProvider API

### DIFF
--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -160,6 +160,24 @@ object Klaviyo {
     }
 
     /**
+     * Detach the registered auth token provider and tear down all associated token state.
+     *
+     * Call this when the user logs out and the app can no longer supply a valid JWT. Cancels any
+     * in-flight token fetch, scheduled proactive refresh, and connectivity-retry job, then clears
+     * the cached token and the provider reference. Subsequent personalized form displays will
+     * render without authentication until a new provider is registered via
+     * [registerAuthTokenProvider].
+     *
+     * Has no effect if no provider is currently registered.
+     *
+     * @return Returns [Klaviyo] for call chaining
+     */
+    @JvmStatic
+    fun unregisterAuthTokenProvider() = safeApply {
+        Registry.get<AuthTokenManager>().unregisterProvider()
+    }
+
+    /**
      * Assign new identifiers and attributes to the currently tracked profile.
      * If a profile has already been identified, it will be overwritten by calling [resetProfile].
      *

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoJavaApiTest.java
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoJavaApiTest.java
@@ -324,6 +324,17 @@ public class KlaviyoJavaApiTest {
     }
 
     @Test
+    public void testUnregisterAuthTokenProvider() {
+        Klaviyo result1 = Klaviyo.INSTANCE.unregisterAuthTokenProvider();
+        assertEquals(Klaviyo.INSTANCE, result1);
+
+        Klaviyo result2 = Klaviyo.unregisterAuthTokenProvider();
+        assertEquals(Klaviyo.INSTANCE, result2);
+
+        KlaviyoMock.verifyUnregisterAuthTokenProviderCalled(2);
+    }
+
+    @Test
     @SuppressWarnings("deprecation")
     public void testIsKlaviyoIntent() {
         boolean result1 = Klaviyo.INSTANCE.isKlaviyoIntent(mockIntent);

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
@@ -27,9 +27,11 @@ import com.klaviyo.fixtures.BaseTest
 import com.klaviyo.fixtures.MockIntent
 import com.klaviyo.fixtures.mockDeviceProperties
 import com.klaviyo.fixtures.unmockDeviceProperties
+import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkConstructor
 import io.mockk.mockkObject
@@ -131,6 +133,7 @@ internal class KlaviyoTest : BaseTest() {
     private val mockAuthTokenManager = mockk<AuthTokenManager>().apply {
         every { invalidate() } returns 1L
         coEvery { clearTokenState(any()) } returns Unit
+        every { unregisterProvider() } just Runs
     }
 
     private val capturedProfile = slot<Profile>()
@@ -506,6 +509,12 @@ internal class KlaviyoTest : BaseTest() {
         dispatcher.scheduler.advanceUntilIdle()
         verify(exactly = 1) { mockAuthTokenManager.invalidate() }
         coVerify(exactly = 1) { mockAuthTokenManager.clearTokenState(expectedGeneration = 1L) }
+    }
+
+    @Test
+    fun `unregisterAuthTokenProvider delegates to AuthTokenManager`() {
+        Klaviyo.unregisterAuthTokenProvider()
+        verify(exactly = 1) { mockAuthTokenManager.unregisterProvider() }
     }
 
     @Test

--- a/sdk/core/src/main/java/com/klaviyo/core/auth/AuthTokenManager.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/AuthTokenManager.kt
@@ -45,6 +45,19 @@ interface AuthTokenManager {
     fun registerProvider(provider: AuthTokenProvider)
 
     /**
+     * Detach the registered [AuthTokenProvider] and tear down all associated token state.
+     *
+     * Cancels any in-flight token fetch, scheduled proactive refresh, and connectivity-wait job,
+     * then clears the cached token and the provider reference. Subsequent calls to [currentToken]
+     * will throw [AuthTokenException.NoProviderRegistered] until a new provider is registered via
+     * [Klaviyo.registerAuthTokenProvider][com.klaviyo.analytics.Klaviyo.registerAuthTokenProvider].
+     *
+     * Has no effect if no provider is currently registered. This method returns immediately —
+     * all teardown is synchronous.
+     */
+    fun unregisterProvider()
+
+    /**
      * Return a currently-valid [ValidatedToken], fetching from the registered provider if no
      * cached token is available or the cached token has expired. Callers that only need the raw
      * JWT string should read [ValidatedToken.rawToken]; consumers that benefit from the parsed

--- a/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
@@ -156,9 +156,14 @@ internal class KlaviyoAuthTokenManager(
     }
 
     override fun unregisterProvider() {
+        // Fast path: nothing to do if no provider is registered.
+        if (provider == null) return
         // Mirror registerProvider's synchronous teardown path, but null out the provider rather
         // than setting a new one, and skip the eager fetch. All @Volatile writes here are safe
-        // without the mutex because they only need to be visible, not read-modify-written atomically.
+        // without the mutex for the same reason as registerProvider: they only need to be visible,
+        // not read-modify-written atomically. The same narrow doFetch cache-write window that
+        // exists for registerProvider applies here; the inFlightFetch?.cancel() + ensureActive()
+        // guards reduce it to a negligible race and the residual is an accepted trade-off.
         inFlightFetch?.cancel()
         inFlightFetch = null
         refreshJob?.cancel()

--- a/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
@@ -183,9 +183,17 @@ internal class KlaviyoAuthTokenManager(
         // was in-flight when this ran will see a generation mismatch in shouldArmConnectivityRetry
         // and skip arming a connectivity retry for the now-cleared session.
         resetGeneration.incrementAndGet()
-        // Clear the reset-pending flag in case invalidate() was called just before unregister.
-        profileResetPending = false
+        // Null the cache BEFORE clearing profileResetPending. An in-flight performScheduledRefresh
+        // that has already fetched its token checks `cachedToken?.rawToken == token.rawToken &&
+        // !profileResetPending` before notifying observers. If invalidate() was called just before
+        // unregister (typical logout: resetProfile → unregisterAuthTokenProvider), profileResetPending
+        // is true — the suppression flag. Clearing it before nulling the cache opens a window where
+        // the in-flight refresh passes both guards and delivers a now-invalid JWT to observers.
+        // Nulling the cache first closes that window: the rawToken comparison fails (null != token),
+        // so the notify path is skipped regardless of profileResetPending. This matches the ordering
+        // in clearTokenState(), which also nulls cachedToken before clearing profileResetPending.
         cachedToken = null
+        profileResetPending = false
         Registry.log.info("AuthTokenProvider unregistered")
     }
 

--- a/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
@@ -155,6 +155,33 @@ internal class KlaviyoAuthTokenManager(
         scope.safeLaunch { tryEagerFetch() }
     }
 
+    override fun unregisterProvider() {
+        // Mirror registerProvider's synchronous teardown path, but null out the provider rather
+        // than setting a new one, and skip the eager fetch. All @Volatile writes here are safe
+        // without the mutex because they only need to be visible, not read-modify-written atomically.
+        inFlightFetch?.cancel()
+        inFlightFetch = null
+        refreshJob?.cancel()
+        refreshJob = null
+        refreshAtWallClockMs = null
+        refreshTimerFired = false
+        cancelConnectivityWaitJob()
+        refreshGeneration.incrementAndGet()
+        // Advance profileGeneration so any pending clearTokenState(expectedGeneration) from a
+        // prior resetProfile() sees the generation mismatch and skips — the state was already
+        // cleared here.
+        profileGeneration.incrementAndGet()
+        // Bump resetGeneration to signal a logout-like event: any performScheduledRefresh that
+        // was in-flight when this ran will see a generation mismatch in shouldArmConnectivityRetry
+        // and skip arming a connectivity retry for the now-cleared session.
+        resetGeneration.incrementAndGet()
+        // Clear the reset-pending flag in case invalidate() was called just before unregister.
+        profileResetPending = false
+        cachedToken = null
+        provider = null
+        Registry.log.info("AuthTokenProvider unregistered")
+    }
+
     override fun onTokenRefresh(observer: TokenRefreshObserver) {
         refreshObservers.add(observer)
     }

--- a/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
@@ -158,12 +158,15 @@ internal class KlaviyoAuthTokenManager(
     override fun unregisterProvider() {
         // Fast path: nothing to do if no provider is registered.
         if (provider == null) return
-        // Mirror registerProvider's synchronous teardown path, but null out the provider rather
-        // than setting a new one, and skip the eager fetch. All @Volatile writes here are safe
-        // without the mutex for the same reason as registerProvider: they only need to be visible,
-        // not read-modify-written atomically. The same narrow doFetch cache-write window that
-        // exists for registerProvider applies here; the inFlightFetch?.cancel() + ensureActive()
-        // guards reduce it to a negligible race and the residual is an accepted trade-off.
+        // Null the provider FIRST — before cancelling the in-flight fetch — so that any concurrent
+        // getOrFetchToken() path that races past the `if (provider == null)` guard lands in
+        // invokeProvider() and immediately receives NoProviderRegistered, rather than starting a
+        // fresh acquisition against the now-unregistered provider. This differs from
+        // registerProvider, where the new provider is set last (after teardown cancels the old
+        // fetch); here there is no replacement provider, so the guard must close as early as
+        // possible. All @Volatile writes below are safe without the mutex for the same reason as
+        // registerProvider: they only need to be visible, not read-modify-written atomically.
+        provider = null
         inFlightFetch?.cancel()
         inFlightFetch = null
         refreshJob?.cancel()
@@ -183,7 +186,6 @@ internal class KlaviyoAuthTokenManager(
         // Clear the reset-pending flag in case invalidate() was called just before unregister.
         profileResetPending = false
         cachedToken = null
-        provider = null
         Registry.log.info("AuthTokenProvider unregistered")
     }
 

--- a/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerConnectivityTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerConnectivityTest.kt
@@ -487,6 +487,42 @@ class KlaviyoAuthTokenManagerConnectivityTest : BaseTest() {
         assertEquals(0, fakeNetworkMonitor.observerCount())
     }
 
+    // MARK: - unregisterProvider cancels the connectivity wait job
+
+    @Test
+    fun `unregisterProvider cancels and clears connectivity wait job`() = runTest(dispatcher) {
+        val provider = ScriptedProvider(
+            ArrayDeque(
+                listOf(
+                    Result.success(makeJwt()),
+                    Result.failure(IOException("network down"))
+                )
+            )
+        )
+        val manager = KlaviyoAuthTokenManager()
+        manager.registerProvider(provider)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        executeScheduledRefresh()
+
+        val armedJob = manager.connectivityWaitJob
+        assertNotNull("connectivityWaitJob should be armed after network failure", armedJob)
+
+        manager.unregisterProvider()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertNull(
+            "connectivityWaitJob should be null after unregisterProvider",
+            manager.connectivityWaitJob
+        )
+        assertEquals("armed job must be cancelled", true, armedJob?.isCancelled ?: false)
+        assertEquals(
+            "network observer should be de-registered on cancellation",
+            0,
+            fakeNetworkMonitor.observerCount()
+        )
+    }
+
     // MARK: - clearTokenState cancels the connectivity wait job
 
     @Test

--- a/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerTest.kt
@@ -537,7 +537,10 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
         dispatcher.scheduler.advanceUntilIdle()
 
         manager.unregisterProvider()
-        staticClock.scheduledTasks.clear() // clear any residual tasks before re-register
+        // unregisterProvider cancels the refresh job (removes it from scheduledTasks). An explicit
+        // clear is defensive in case the cancel path leaves an entry; see the dedicated
+        // "unregisterProvider cancels pending refresh job" test for the canonical assertion.
+        staticClock.scheduledTasks.clear()
 
         manager.registerProvider(secondProvider)
         dispatcher.scheduler.advanceUntilIdle()

--- a/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerTest.kt
@@ -455,6 +455,105 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
         assertEquals(freshToken, result.rawToken)
     }
 
+    // MARK: - unregisterProvider
+
+    @Test
+    fun `unregisterProvider while idle clears provider and subsequent currentToken throws`() = runTest(
+        dispatcher
+    ) {
+        val token = makeJwt(EXP_SECONDS, IAT_SECONDS)
+        val manager = KlaviyoAuthTokenManager()
+        manager.registerProvider(SuccessProvider(token))
+        dispatcher.scheduler.advanceUntilIdle()
+
+        manager.unregisterProvider()
+
+        try {
+            manager.currentToken()
+            fail("Expected AuthTokenException.NoProviderRegistered after unregister")
+        } catch (_: AuthTokenException.NoProviderRegistered) { /* expected */ }
+    }
+
+    @Test
+    fun `unregisterProvider cancels pending refresh job`() = runTest(dispatcher) {
+        val token = makeJwt(EXP_SECONDS, IAT_SECONDS)
+        val manager = KlaviyoAuthTokenManager()
+        manager.registerProvider(SuccessProvider(token))
+        dispatcher.scheduler.advanceUntilIdle()
+        assertTrue(
+            "A refresh job should be scheduled after a successful token fetch",
+            staticClock.scheduledTasks.isNotEmpty()
+        )
+
+        manager.unregisterProvider()
+
+        assertTrue(
+            "Refresh job should be cancelled after unregisterProvider",
+            staticClock.scheduledTasks.isEmpty()
+        )
+    }
+
+    @Test
+    fun `unregisterProvider cancels in-flight fetch — concurrent currentToken callers receive error`() = runTest(
+        dispatcher
+    ) {
+        val provider = DeferredProvider()
+        val manager = KlaviyoAuthTokenManager()
+        manager.registerProvider(provider)
+        dispatcher.scheduler.runCurrent() // eager fetch starts, suspends on provider
+
+        var caught: Throwable? = null
+        val callerJob = launch {
+            try {
+                manager.currentToken(timeoutMs = 5_000)
+            } catch (e: Throwable) {
+                caught = e
+            }
+        }
+        dispatcher.scheduler.runCurrent() // caller awaits the in-flight deferred
+
+        manager.unregisterProvider()
+        dispatcher.scheduler.advanceUntilIdle()
+        callerJob.join()
+
+        // The caller's retry after cancellation hits provider == null → NoProviderRegistered
+        assertTrue(
+            "Caller should receive NoProviderRegistered after unregister, got: $caught",
+            caught is AuthTokenException.NoProviderRegistered
+        )
+    }
+
+    @Test
+    fun `re-registering after unregister triggers fresh eager fetch and refresh schedule`() = runTest(
+        dispatcher
+    ) {
+        val firstToken = makeJwt(EXP_SECONDS, IAT_SECONDS)
+        val secondToken = makeJwt(EXP_SECONDS + 600, IAT_SECONDS + 600)
+        val firstProvider = SuccessProvider(firstToken)
+        val secondProvider = SuccessProvider(secondToken)
+        val manager = KlaviyoAuthTokenManager()
+
+        manager.registerProvider(firstProvider)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        manager.unregisterProvider()
+        staticClock.scheduledTasks.clear() // clear any residual tasks before re-register
+
+        manager.registerProvider(secondProvider)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        val result = manager.currentToken()
+        assertEquals(
+            "Re-register should use the new provider's token",
+            secondToken,
+            result.rawToken
+        )
+        assertTrue(
+            "Re-register should schedule a fresh proactive refresh",
+            staticClock.scheduledTasks.isNotEmpty()
+        )
+    }
+
     // MARK: - Helpers
 
     private class SuccessProvider(private val jwt: String) : AuthTokenProvider {

--- a/sdk/fixtures/src/main/java/com/klaviyo/fixtures/KlaviyoMock.kt
+++ b/sdk/fixtures/src/main/java/com/klaviyo/fixtures/KlaviyoMock.kt
@@ -64,6 +64,7 @@ object KlaviyoMock {
         every { Klaviyo.registerDeepLinkHandler(any()) } returns Klaviyo
         every { Klaviyo.unregisterDeepLinkHandler() } returns Klaviyo
         every { Klaviyo.registerAuthTokenProvider(any()) } returns Klaviyo
+        every { Klaviyo.unregisterAuthTokenProvider() } returns Klaviyo
 
         // Mock getters to return test values
         every { Klaviyo.getEmail() } returns "test@example.com"
@@ -203,6 +204,12 @@ object KlaviyoMock {
     @JvmOverloads
     fun verifyRegisterAuthTokenProviderCalled(count: Int = 1) {
         verify(exactly = count) { Klaviyo.registerAuthTokenProvider(any()) }
+    }
+
+    @JvmStatic
+    @JvmOverloads
+    fun verifyUnregisterAuthTokenProviderCalled(count: Int = 1) {
+        verify(exactly = count) { Klaviyo.unregisterAuthTokenProvider() }
     }
 
     @JvmStatic


### PR DESCRIPTION
# Description
Adds \`Klaviyo.unregisterAuthTokenProvider()\` so host apps can detach the registered auth token provider — e.g., on user logout. The call synchronously tears down all associated token state (in-flight fetch, scheduled proactive refresh, connectivity-wait job, cached token) and nulls the provider reference.

## Due Diligence
- [x] I have tested this on an emulator and/or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all Android versions the SDK currently supports.

## Release/Versioning Considerations
- [ ] \`Patch\` Contains internal changes or backwards-compatible bug fixes.
- [x] \`Minor\` Contains changes to the public API.
- [ ] \`Major\` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [x] This is planned work for an upcoming release.

## Changelog / Code Overview

**New public API**
- \`Klaviyo.unregisterAuthTokenProvider()\` — \`@JvmStatic\`, returns \`Klaviyo\` for call chaining. Forwards to \`AuthTokenManager.unregisterProvider()\`.

**\`AuthTokenManager\` interface** (\`sdk/core\`)
- Adds \`fun unregisterProvider()\`.

**\`KlaviyoAuthTokenManager\` implementation** (\`sdk/core\`)
- Nulls \`provider\` **first** — before cancelling the in-flight fetch — so any concurrent \`getOrFetchToken()\` path that races past the \`if (provider == null)\` guard lands in \`invokeProvider()\` and immediately receives \`NoProviderRegistered\`, rather than starting a fresh acquisition against the now-unregistered provider. Matches the spec's stated ordering rationale and the iOS implementation (MAGE-685).
- Mirrors \`registerProvider()\`'s synchronous teardown: cancels \`inFlightFetch\`, \`refreshJob\`, and \`connectivityWaitJob\`.
- Nulls \`cachedToken\` **before** clearing \`profileResetPending\`, matching the ordering in \`clearTokenState()\`. This closes the window where an in-flight \`performScheduledRefresh\` that has already fetched its token could pass both observer-notify guards (\`cachedToken\` matches + \`profileResetPending\` false) and deliver an invalidated JWT after a \`resetProfile\` → \`unregisterAuthTokenProvider\` logout sequence.
- Additionally bumps \`resetGeneration\` (unlike \`registerProvider\`) so any \`performScheduledRefresh\` that was in-flight at unregister time sees a generation mismatch in \`shouldArmConnectivityRetry\` and skips arming a zombie connectivity retry job for the now-cleared session.
- Early-returns when \`provider == null\` — no-op semantics match the KDoc.

**\`KlaviyoMock.kt\` fixture** — adds mock + \`verifyUnregisterAuthTokenProviderCalled\` helper for Java test compatibility.

## Test Plan

Unit tests added:
- \`unregisterProvider while idle clears provider and subsequent currentToken throws\` — core contract
- \`unregisterProvider cancels pending refresh job\` — no stale timer fires
- \`unregisterProvider cancels in-flight fetch — concurrent currentToken callers receive error\` — deferred teardown
- \`re-registering after unregister triggers fresh eager fetch and refresh schedule\` — recovery path
- \`unregisterProvider cancels and clears connectivity wait job\` (connectivity test suite) — network observer de-registered
- \`KlaviyoTest\` — delegation to \`AuthTokenManager.unregisterProvider()\`
- \`KlaviyoJavaApiTest\` — Java interop via both \`Klaviyo.INSTANCE.unregisterAuthTokenProvider()\` and static call

All existing tests pass. \`ktlintCheck\` passes.

## Related Issues/Tickets
Resolves MAGE-686
Part of MAGE-618

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to unregister authentication providers and clear associated token state. When unregistered, all in-flight authentication operations are cancelled, cached tokens are cleared, and personalized features render without authentication until a new provider is registered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->