### PR TITLE
Retry all 5xx server errors (MAGE-694)

### DIFF
--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequest.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequest.kt
@@ -432,8 +432,12 @@ internal open class KlaviyoApiRequest(
 
         status = when (responseCode) {
             in successCodes -> Status.Complete
-            // 429 rate limit, 500, 502, 503 and 504 are all treated as retryable
-            HTTP_RETRY, 500, in 502..504 -> {
+            // 429 rate limit plus the entire 5xx range (500–599) are treated as retryable.
+            // Widening from the legacy {500,502,503,504} allowlist to the full range covers
+            // transient CDN/edge failures such as Cloudflare's 520–527 codes, which were the
+            // codes observed during the cannot-access-klaviyo-com incident. 4xx codes
+            // (including 403 load-shed) remain non-retryable so the backend can shed load.
+            HTTP_RETRY, in 500..599 -> {
                 if (attempts < maxAttempts) {
                     Status.PendingRetry
                 } else {

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequest.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequest.kt
@@ -69,6 +69,9 @@ internal open class KlaviyoApiRequest(
         const val HTTP_MULT_CHOICE = HttpURLConnection.HTTP_MULT_CHOICE
         const val HTTP_RETRY = 429 // oddly not a const in HttpURLConnection
         const val HTTP_BAD_REQUEST = HttpURLConnection.HTTP_BAD_REQUEST
+        const val HTTP_NOT_IMPLEMENTED = 501
+        const val HTTP_VERSION_NOT_SUPPORTED = 505
+        val HTTP_5XX_RETRYABLE_RANGE = 500..599
 
         // JSON keys for persistence
         const val TYPE_JSON_KEY = "request_type"
@@ -435,15 +438,16 @@ internal open class KlaviyoApiRequest(
             // 501 (Not Implemented) and 505 (HTTP Version Not Supported) are permanent,
             // deterministic server errors: retrying the identical request will always fail
             // the same way, so they are treated as non-retryable like a 4xx. This branch must
-            // precede the `in 500..599` branch below so these codes short-circuit out of it.
-            501, 505 -> Status.Failed
+            // precede the `in HTTP_5XX_RETRYABLE_RANGE` branch below so these codes short-circuit
+            // out of it.
+            HTTP_NOT_IMPLEMENTED, HTTP_VERSION_NOT_SUPPORTED -> Status.Failed
             // 429 rate limit plus the rest of the 5xx range (500–599, except 501/505 above)
             // are treated as retryable. Widening from the legacy {500,502,503,504} allowlist
             // to the full range covers transient CDN/edge failures such as Cloudflare's
             // 520–527 codes, which were the codes observed during the cannot-access-klaviyo-com
             // incident. 4xx codes (including 403 load-shed) remain non-retryable so the backend
             // can shed load.
-            HTTP_RETRY, in 500..599 -> {
+            HTTP_RETRY, in HTTP_5XX_RETRYABLE_RANGE -> {
                 if (attempts < maxAttempts) {
                     Status.PendingRetry
                 } else {

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequest.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequest.kt
@@ -432,11 +432,17 @@ internal open class KlaviyoApiRequest(
 
         status = when (responseCode) {
             in successCodes -> Status.Complete
-            // 429 rate limit plus the entire 5xx range (500–599) are treated as retryable.
-            // Widening from the legacy {500,502,503,504} allowlist to the full range covers
-            // transient CDN/edge failures such as Cloudflare's 520–527 codes, which were the
-            // codes observed during the cannot-access-klaviyo-com incident. 4xx codes
-            // (including 403 load-shed) remain non-retryable so the backend can shed load.
+            // 501 (Not Implemented) and 505 (HTTP Version Not Supported) are permanent,
+            // deterministic server errors: retrying the identical request will always fail
+            // the same way, so they are treated as non-retryable like a 4xx. This branch must
+            // precede the `in 500..599` branch below so these codes short-circuit out of it.
+            501, 505 -> Status.Failed
+            // 429 rate limit plus the rest of the 5xx range (500–599, except 501/505 above)
+            // are treated as retryable. Widening from the legacy {500,502,503,504} allowlist
+            // to the full range covers transient CDN/edge failures such as Cloudflare's
+            // 520–527 codes, which were the codes observed during the cannot-access-klaviyo-com
+            // incident. 4xx codes (including 403 load-shed) remain non-retryable so the backend
+            // can shed load.
             HTTP_RETRY, in 500..599 -> {
                 if (attempts < maxAttempts) {
                     Status.PendingRetry

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequest.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequest.kt
@@ -69,8 +69,6 @@ internal open class KlaviyoApiRequest(
         const val HTTP_MULT_CHOICE = HttpURLConnection.HTTP_MULT_CHOICE
         const val HTTP_RETRY = 429 // oddly not a const in HttpURLConnection
         const val HTTP_BAD_REQUEST = HttpURLConnection.HTTP_BAD_REQUEST
-        const val HTTP_NOT_IMPLEMENTED = 501
-        const val HTTP_VERSION_NOT_SUPPORTED = 505
         val HTTP_5XX_RETRYABLE_RANGE = 500..599
 
         // JSON keys for persistence
@@ -435,18 +433,15 @@ internal open class KlaviyoApiRequest(
 
         status = when (responseCode) {
             in successCodes -> Status.Complete
-            // 501 (Not Implemented) and 505 (HTTP Version Not Supported) are permanent,
-            // deterministic server errors: retrying the identical request will always fail
-            // the same way, so they are treated as non-retryable like a 4xx. This branch must
-            // precede the `in HTTP_5XX_RETRYABLE_RANGE` branch below so these codes short-circuit
-            // out of it.
-            HTTP_NOT_IMPLEMENTED, HTTP_VERSION_NOT_SUPPORTED -> Status.Failed
-            // 429 rate limit plus the rest of the 5xx range (500–599, except 501/505 above)
-            // are treated as retryable. Widening from the legacy {500,502,503,504} allowlist
-            // to the full range covers transient CDN/edge failures such as Cloudflare's
-            // 520–527 codes, which were the codes observed during the cannot-access-klaviyo-com
-            // incident. 4xx codes (including 403 load-shed) remain non-retryable so the backend
-            // can shed load.
+            // 429 rate limit plus the entire 5xx range (500–599) are treated as retryable.
+            // Widening from the legacy {500,502,503,504} allowlist to the full range covers
+            // transient CDN/edge failures such as Cloudflare's 520–527 codes, which were the
+            // codes observed during the cannot-access-klaviyo-com incident. We deliberately
+            // retry even 501 (Not Implemented) and 505 (HTTP Version Not Supported): for the
+            // SDK's fixed request shapes a genuine origin 501/505 is effectively unreachable,
+            // so any 5xx we actually observe is almost certainly edge/proxy noise during an
+            // incident — exactly what we want to retry. 4xx codes (including 403 load-shed)
+            // remain non-retryable so the backend can shed load.
             HTTP_RETRY, in HTTP_5XX_RETRYABLE_RANGE -> {
                 if (attempts < maxAttempts) {
                     Status.PendingRetry

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequestTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequestTest.kt
@@ -75,6 +75,20 @@ internal class KlaviyoApiRequestTest : BaseApiRequestTest<KlaviyoApiRequest>() {
         return connectionSpy
     }
 
+    /**
+     * Sends a single request against a connection stubbed to return [responseCode] and asserts the
+     * resulting [KlaviyoApiRequest.Status] and that exactly one attempt was made. Shared by the
+     * single-send status-code tests to keep their boilerplate DRY.
+     */
+    private fun assertStatusForResponseCode(responseCode: Int, expected: KlaviyoApiRequest.Status) {
+        val connectionMock = withConnectionMock(URL(expectedFullUrl))
+        every { connectionMock.responseCode } returns responseCode
+
+        val request = makeTestRequest()
+        assertEquals(expected, request.send())
+        assertEquals(1, request.attempts)
+    }
+
     @Before
     override fun setup() {
         super.setup()
@@ -722,120 +736,65 @@ internal class KlaviyoApiRequestTest : BaseApiRequestTest<KlaviyoApiRequest>() {
 
     @Test
     fun `500 response code returns PendingRetry when under max attempts`() {
-        val connectionMock = withConnectionMock(URL(expectedFullUrl))
-        every { connectionMock.responseCode } returns 500
-
-        val request = makeTestRequest()
-        assertEquals(KlaviyoApiRequest.Status.PendingRetry, request.send())
-        assertEquals(1, request.attempts)
+        assertStatusForResponseCode(500, KlaviyoApiRequest.Status.PendingRetry)
     }
 
     @Test
     fun `502 response code returns PendingRetry when under max attempts`() {
-        val connectionMock = withConnectionMock(URL(expectedFullUrl))
-        every { connectionMock.responseCode } returns 502
-
-        val request = makeTestRequest()
-        assertEquals(KlaviyoApiRequest.Status.PendingRetry, request.send())
-        assertEquals(1, request.attempts)
+        assertStatusForResponseCode(502, KlaviyoApiRequest.Status.PendingRetry)
     }
 
     @Test
     fun `503 response code returns PendingRetry when under max attempts`() {
-        val connectionMock = withConnectionMock(URL(expectedFullUrl))
-        every { connectionMock.responseCode } returns 503
-
-        val request = makeTestRequest()
-        assertEquals(KlaviyoApiRequest.Status.PendingRetry, request.send())
-        assertEquals(1, request.attempts)
+        assertStatusForResponseCode(503, KlaviyoApiRequest.Status.PendingRetry)
     }
 
     @Test
     fun `504 response code returns PendingRetry when under max attempts`() {
-        val connectionMock = withConnectionMock(URL(expectedFullUrl))
-        every { connectionMock.responseCode } returns 504
-
-        val request = makeTestRequest()
-        assertEquals(KlaviyoApiRequest.Status.PendingRetry, request.send())
-        assertEquals(1, request.attempts)
+        assertStatusForResponseCode(504, KlaviyoApiRequest.Status.PendingRetry)
     }
 
     @Test
     fun `522 Cloudflare response code returns PendingRetry when under max attempts`() {
         // 522 (connection timed out) is a Cloudflare edge code outside the legacy allowlist
         // and was one of the codes observed during the cannot-access-klaviyo-com incident.
-        val connectionMock = withConnectionMock(URL(expectedFullUrl))
-        every { connectionMock.responseCode } returns 522
-
-        val request = makeTestRequest()
-        assertEquals(KlaviyoApiRequest.Status.PendingRetry, request.send())
-        assertEquals(1, request.attempts)
+        assertStatusForResponseCode(522, KlaviyoApiRequest.Status.PendingRetry)
     }
 
     @Test
     fun `525 Cloudflare response code returns PendingRetry when under max attempts`() {
-        val connectionMock = withConnectionMock(URL(expectedFullUrl))
-        every { connectionMock.responseCode } returns 525
-
-        val request = makeTestRequest()
-        assertEquals(KlaviyoApiRequest.Status.PendingRetry, request.send())
-        assertEquals(1, request.attempts)
+        assertStatusForResponseCode(525, KlaviyoApiRequest.Status.PendingRetry)
     }
 
     @Test
     fun `599 upper-bound 5xx response code returns PendingRetry when under max attempts`() {
-        val connectionMock = withConnectionMock(URL(expectedFullUrl))
-        every { connectionMock.responseCode } returns 599
-
-        val request = makeTestRequest()
-        assertEquals(KlaviyoApiRequest.Status.PendingRetry, request.send())
-        assertEquals(1, request.attempts)
+        assertStatusForResponseCode(599, KlaviyoApiRequest.Status.PendingRetry)
     }
 
     @Test
     fun `501 response code returns Failed immediately`() {
         // 501 (Not Implemented) is a permanent server error excluded from the retryable
         // 5xx range: retrying the identical request will always fail the same way.
-        val connectionMock = withConnectionMock(URL(expectedFullUrl))
-        every { connectionMock.responseCode } returns 501
-
-        val request = makeTestRequest()
-        assertEquals(KlaviyoApiRequest.Status.Failed, request.send())
-        assertEquals(1, request.attempts)
+        assertStatusForResponseCode(501, KlaviyoApiRequest.Status.Failed)
     }
 
     @Test
     fun `505 response code returns Failed immediately`() {
         // 505 (HTTP Version Not Supported) is a permanent server error excluded from the
         // retryable 5xx range: retrying the identical request will always fail the same way.
-        val connectionMock = withConnectionMock(URL(expectedFullUrl))
-        every { connectionMock.responseCode } returns 505
-
-        val request = makeTestRequest()
-        assertEquals(KlaviyoApiRequest.Status.Failed, request.send())
-        assertEquals(1, request.attempts)
+        assertStatusForResponseCode(505, KlaviyoApiRequest.Status.Failed)
     }
 
     @Test
     fun `499 response code returns Failed immediately`() {
         // Lower-bound sanity: 499 sits just below the 5xx range and must stay non-retryable.
-        val connectionMock = withConnectionMock(URL(expectedFullUrl))
-        every { connectionMock.responseCode } returns 499
-
-        val request = makeTestRequest()
-        assertEquals(KlaviyoApiRequest.Status.Failed, request.send())
-        assertEquals(1, request.attempts)
+        assertStatusForResponseCode(499, KlaviyoApiRequest.Status.Failed)
     }
 
     @Test
     fun `600 response code returns Failed immediately`() {
         // Upper-bound sanity: 600 sits just above the 5xx range and must stay non-retryable.
-        val connectionMock = withConnectionMock(URL(expectedFullUrl))
-        every { connectionMock.responseCode } returns 600
-
-        val request = makeTestRequest()
-        assertEquals(KlaviyoApiRequest.Status.Failed, request.send())
-        assertEquals(1, request.attempts)
+        assertStatusForResponseCode(600, KlaviyoApiRequest.Status.Failed)
     }
 
     @Test
@@ -856,41 +815,21 @@ internal class KlaviyoApiRequestTest : BaseApiRequestTest<KlaviyoApiRequest>() {
 
     @Test
     fun `400 response code returns Failed immediately`() {
-        val connectionMock = withConnectionMock(URL(expectedFullUrl))
-        every { connectionMock.responseCode } returns 400
-
-        val request = makeTestRequest()
-        assertEquals(KlaviyoApiRequest.Status.Failed, request.send())
-        assertEquals(1, request.attempts)
+        assertStatusForResponseCode(400, KlaviyoApiRequest.Status.Failed)
     }
 
     @Test
     fun `401 response code returns Failed immediately`() {
-        val connectionMock = withConnectionMock(URL(expectedFullUrl))
-        every { connectionMock.responseCode } returns 401
-
-        val request = makeTestRequest()
-        assertEquals(KlaviyoApiRequest.Status.Failed, request.send())
-        assertEquals(1, request.attempts)
+        assertStatusForResponseCode(401, KlaviyoApiRequest.Status.Failed)
     }
 
     @Test
     fun `403 response code returns Failed immediately`() {
-        val connectionMock = withConnectionMock(URL(expectedFullUrl))
-        every { connectionMock.responseCode } returns 403
-
-        val request = makeTestRequest()
-        assertEquals(KlaviyoApiRequest.Status.Failed, request.send())
-        assertEquals(1, request.attempts)
+        assertStatusForResponseCode(403, KlaviyoApiRequest.Status.Failed)
     }
 
     @Test
     fun `404 response code returns Failed immediately`() {
-        val connectionMock = withConnectionMock(URL(expectedFullUrl))
-        every { connectionMock.responseCode } returns 404
-
-        val request = makeTestRequest()
-        assertEquals(KlaviyoApiRequest.Status.Failed, request.send())
-        assertEquals(1, request.attempts)
+        assertStatusForResponseCode(404, KlaviyoApiRequest.Status.Failed)
     }
 }

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequestTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequestTest.kt
@@ -772,17 +772,20 @@ internal class KlaviyoApiRequestTest : BaseApiRequestTest<KlaviyoApiRequest>() {
     }
 
     @Test
-    fun `501 response code returns Failed immediately`() {
-        // 501 (Not Implemented) is a permanent server error excluded from the retryable
-        // 5xx range: retrying the identical request will always fail the same way.
-        assertStatusForResponseCode(501, KlaviyoApiRequest.Status.Failed)
+    fun `501 response code returns PendingRetry when under max attempts`() {
+        // 501 (Not Implemented) is inside the full 5xx retryable range and we deliberately
+        // retry it: for the SDK's fixed request shapes a genuine origin 501 is effectively
+        // unreachable, so an observed 501 is almost certainly edge/proxy noise worth retrying.
+        assertStatusForResponseCode(501, KlaviyoApiRequest.Status.PendingRetry)
     }
 
     @Test
-    fun `505 response code returns Failed immediately`() {
-        // 505 (HTTP Version Not Supported) is a permanent server error excluded from the
-        // retryable 5xx range: retrying the identical request will always fail the same way.
-        assertStatusForResponseCode(505, KlaviyoApiRequest.Status.Failed)
+    fun `505 response code returns PendingRetry when under max attempts`() {
+        // 505 (HTTP Version Not Supported) is inside the full 5xx retryable range and we
+        // deliberately retry it: for the SDK's fixed request shapes a genuine origin 505 is
+        // effectively unreachable, so an observed 505 is almost certainly edge/proxy noise
+        // worth retrying.
+        assertStatusForResponseCode(505, KlaviyoApiRequest.Status.PendingRetry)
     }
 
     @Test

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequestTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequestTest.kt
@@ -761,6 +761,38 @@ internal class KlaviyoApiRequestTest : BaseApiRequestTest<KlaviyoApiRequest>() {
     }
 
     @Test
+    fun `522 Cloudflare response code returns PendingRetry when under max attempts`() {
+        // 522 (connection timed out) is a Cloudflare edge code outside the legacy allowlist
+        // and was one of the codes observed during the cannot-access-klaviyo-com incident.
+        val connectionMock = withConnectionMock(URL(expectedFullUrl))
+        every { connectionMock.responseCode } returns 522
+
+        val request = makeTestRequest()
+        assertEquals(KlaviyoApiRequest.Status.PendingRetry, request.send())
+        assertEquals(1, request.attempts)
+    }
+
+    @Test
+    fun `525 Cloudflare response code returns PendingRetry when under max attempts`() {
+        val connectionMock = withConnectionMock(URL(expectedFullUrl))
+        every { connectionMock.responseCode } returns 525
+
+        val request = makeTestRequest()
+        assertEquals(KlaviyoApiRequest.Status.PendingRetry, request.send())
+        assertEquals(1, request.attempts)
+    }
+
+    @Test
+    fun `599 upper-bound 5xx response code returns PendingRetry when under max attempts`() {
+        val connectionMock = withConnectionMock(URL(expectedFullUrl))
+        every { connectionMock.responseCode } returns 599
+
+        val request = makeTestRequest()
+        assertEquals(KlaviyoApiRequest.Status.PendingRetry, request.send())
+        assertEquals(1, request.attempts)
+    }
+
+    @Test
     fun `5xx response code after max attempts returns Failed`() {
         val connectionMock = withConnectionMock(URL(expectedFullUrl))
         every { connectionMock.responseCode } returns 500

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequestTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequestTest.kt
@@ -793,6 +793,52 @@ internal class KlaviyoApiRequestTest : BaseApiRequestTest<KlaviyoApiRequest>() {
     }
 
     @Test
+    fun `501 response code returns Failed immediately`() {
+        // 501 (Not Implemented) is a permanent server error excluded from the retryable
+        // 5xx range: retrying the identical request will always fail the same way.
+        val connectionMock = withConnectionMock(URL(expectedFullUrl))
+        every { connectionMock.responseCode } returns 501
+
+        val request = makeTestRequest()
+        assertEquals(KlaviyoApiRequest.Status.Failed, request.send())
+        assertEquals(1, request.attempts)
+    }
+
+    @Test
+    fun `505 response code returns Failed immediately`() {
+        // 505 (HTTP Version Not Supported) is a permanent server error excluded from the
+        // retryable 5xx range: retrying the identical request will always fail the same way.
+        val connectionMock = withConnectionMock(URL(expectedFullUrl))
+        every { connectionMock.responseCode } returns 505
+
+        val request = makeTestRequest()
+        assertEquals(KlaviyoApiRequest.Status.Failed, request.send())
+        assertEquals(1, request.attempts)
+    }
+
+    @Test
+    fun `499 response code returns Failed immediately`() {
+        // Lower-bound sanity: 499 sits just below the 5xx range and must stay non-retryable.
+        val connectionMock = withConnectionMock(URL(expectedFullUrl))
+        every { connectionMock.responseCode } returns 499
+
+        val request = makeTestRequest()
+        assertEquals(KlaviyoApiRequest.Status.Failed, request.send())
+        assertEquals(1, request.attempts)
+    }
+
+    @Test
+    fun `600 response code returns Failed immediately`() {
+        // Upper-bound sanity: 600 sits just above the 5xx range and must stay non-retryable.
+        val connectionMock = withConnectionMock(URL(expectedFullUrl))
+        every { connectionMock.responseCode } returns 600
+
+        val request = makeTestRequest()
+        assertEquals(KlaviyoApiRequest.Status.Failed, request.send())
+        assertEquals(1, request.attempts)
+    }
+
+    @Test
     fun `5xx response code after max attempts returns Failed`() {
         val connectionMock = withConnectionMock(URL(expectedFullUrl))
         every { connectionMock.responseCode } returns 500


### PR DESCRIPTION
Widens the retryable status classification in `KlaviyoApiRequest.parseResponse` from the `{429,500,502,503,504}` allowlist to `429` plus the full 5xx range (500-599). This covers transient CDN/edge failures such as Cloudflare's 520-527 codes, observed during the cannot-access-klaviyo-com incident with zero overlap with the old allowlist, causing data loss for the outage duration. 4xx codes (including 403 load-shed) remain non-retryable so the backend can still shed load. Adds KlaviyoApiRequestTest cases for Cloudflare 522/525 and the 599 upper bound.

NOTE: required gates (./gradlew test, ktlintCheck) were NOT run locally — the Reca sandbox is Linux with no JDK/Gradle/Android SDK. Please rely on CI / a local Android env (JDK 17) to validate before merge. Per branch policy, feat/* should target the active rel/* branch. Companion circuit-breaker design is in the Linear doc 'Implementation spec: SDK circuit breaker / dormancy (MAGE-694)'.

Reca job ID: b11a3ef7-fd4a-437c-a1a7-431da69e4219

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retry handling by retrying on rate-limit responses (429) and any server error in the 5xx range (500–599).
  * Broadened retryable temporary failures to include additional 5xx status codes, while keeping certain out-of-range responses as immediate, non-retryable failures.
* **Tests**
  * Refactored unit tests to reduce duplication and added coverage for more retryable and non-retryable HTTP status codes, including edge-case 5xx values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->