### PR TITLE
Add network circuit breaker / dormancy mode (MAGE-694)

### DIFF
--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/KlaviyoApiClient.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/KlaviyoApiClient.kt
@@ -22,8 +22,10 @@ import com.klaviyo.analytics.networking.requests.UniversalClickTrackRequest
 import com.klaviyo.analytics.networking.requests.UnregisterPushTokenApiRequest
 import com.klaviyo.core.Registry
 import com.klaviyo.core.lifecycle.ActivityEvent
+import com.klaviyo.core.networking.CircuitBreaker
 import com.klaviyo.core.safeLaunch
 import com.klaviyo.core.utils.takeIf
+import java.net.HttpURLConnection
 import java.util.concurrent.ConcurrentLinkedDeque
 import java.util.concurrent.CopyOnWriteArrayList
 import kotlinx.coroutines.CoroutineScope
@@ -58,6 +60,20 @@ internal object KlaviyoApiClient : ApiClient {
     private var apiQueue = ConcurrentLinkedDeque<KlaviyoApiRequest>()
     private var queueInitialized = false
 
+    /**
+     * Failure-count circuit breaker. When the server appears hard-down it trips and we hold the
+     * persisted queue intact rather than fast-draining it against an unreachable backend. Tuning
+     * (including the kill-switch) is resolved lazily from [Registry.config] so tests and remote
+     * config can adjust it without rebuilding the client.
+     */
+    internal val circuitBreaker = CircuitBreaker(
+        failureThreshold = { Registry.config.circuitBreakerFailureThreshold },
+        baseOpenInterval = { Registry.config.circuitBreakerBaseOpenInterval },
+        maxOpenInterval = { Registry.config.circuitBreakerMaxOpenInterval },
+        clock = { Registry.clock.currentTimeMillis() },
+        jitter = { Registry.config.networkJitterRange.random().times(1_000L) }
+    )
+
     private val scheduler get() = Registry.getOrNull<QueueScheduler>()
         ?: WorkManagerQueueScheduler(Registry.config.applicationContext).also {
             Registry.register<QueueScheduler>(it)
@@ -77,6 +93,8 @@ internal object KlaviyoApiClient : ApiClient {
 
         Registry.networkMonitor.offNetworkChange(::onNetworkChange)
         Registry.networkMonitor.onNetworkChange(::onNetworkChange)
+
+        circuitBreaker.reset()
 
         restoreQueue(forceRestore = false)
 
@@ -456,9 +474,22 @@ internal object KlaviyoApiClient : ApiClient {
         var retryAfter: Long? = null
 
         while (apiQueue.isNotEmpty()) {
+            // Circuit breaker gate: when open, hold the persisted queue intact and back off
+            // instead of draining against an unreachable server. Half-open permits one probe.
+            if (!circuitBreaker.allowRequest()) {
+                retryAfter = circuitBreaker.remainingOpenInterval()
+                Registry.log.warning(
+                    "Circuit breaker open; holding ${apiQueue.size} requests for $retryAfter ms"
+                )
+                break
+            }
+
             val request = apiQueue.poll() ?: continue
 
-            when (request.sendAndBroadcast()) {
+            val status = request.sendAndBroadcast()
+            updateCircuitBreaker(request, status)
+
+            when (status) {
                 Status.Unsent -> {
                     // Incomplete state: put it back on the queue and break out of serial queue
                     apiQueue.offerFirst(request)
@@ -495,6 +526,39 @@ internal object KlaviyoApiClient : ApiClient {
         } else {
             Registry.log.verbose("Incomplete send: ${apiQueue.size} requests remain")
             FlushOutcome.Incomplete(retryAfter)
+        }
+    }
+
+    /**
+     * Translate a completed send attempt into a circuit-breaker outcome.
+     *
+     * The breaker trips on *unreachable* failures (retryable 5xx, network/IO errors, or a `429`
+     * with no usable `Retry-After`). Any response that proves the server is reachable — `2xx`, a
+     * deliberate `403` load-shed, a `429` carrying a `Retry-After`, or any other `4xx` — resets the
+     * breaker so dormancy never engages while the backend is merely rejecting or throttling us.
+     * Unsent (network unavailable) and Inflight (impossible) outcomes are not counted at all.
+     */
+    private fun updateCircuitBreaker(request: KlaviyoApiRequest, status: Status) {
+        when (status) {
+            Status.Unsent, Status.Inflight -> return
+            else -> Unit
+        }
+
+        when (request.responseCode) {
+            // No HTTP response despite an attempt: the server was unreachable.
+            null -> circuitBreaker.recordFailure()
+            in HttpURLConnection.HTTP_OK until HttpURLConnection.HTTP_MULT_CHOICE ->
+                circuitBreaker.recordSuccess()
+            // Deliberate load-shed: server is reachable, so bypass dormancy (do not count it).
+            HttpURLConnection.HTTP_FORBIDDEN -> circuitBreaker.recordSuccess()
+            KlaviyoApiRequest.HTTP_RETRY -> if (request.hasRetryAfterHeader) {
+                circuitBreaker.recordSuccess()
+            } else {
+                circuitBreaker.recordFailure()
+            }
+            in 500..599 -> circuitBreaker.recordFailure()
+            // Other 4xx: reachable, non-retryable.
+            else -> circuitBreaker.recordSuccess()
         }
     }
 

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/KlaviyoApiClient.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/KlaviyoApiClient.kt
@@ -486,8 +486,16 @@ internal object KlaviyoApiClient : ApiClient {
 
             val request = apiQueue.poll() ?: continue
 
+            val attemptsBefore = request.attempts
             val status = request.sendAndBroadcast()
-            updateCircuitBreaker(request, status)
+            if (request.attempts > attemptsBefore) {
+                // A real send attempt completed — feed its outcome to the breaker.
+                updateCircuitBreaker(request)
+            } else {
+                // No send actually occurred (e.g. network unavailable, so send() bailed early).
+                // Release any probe slot we reserved and don't count it as a failure.
+                circuitBreaker.releaseProbe()
+            }
 
             when (status) {
                 Status.Unsent -> {
@@ -530,20 +538,15 @@ internal object KlaviyoApiClient : ApiClient {
     }
 
     /**
-     * Translate a completed send attempt into a circuit-breaker outcome.
+     * Translate a completed send attempt into a circuit-breaker outcome. Only call this when a real
+     * send actually occurred (an attempt was made); skipped sends are handled by the caller.
      *
      * The breaker trips on *unreachable* failures (retryable 5xx, network/IO errors, or a `429`
      * with no usable `Retry-After`). Any response that proves the server is reachable — `2xx`, a
      * deliberate `403` load-shed, a `429` carrying a `Retry-After`, or any other `4xx` — resets the
      * breaker so dormancy never engages while the backend is merely rejecting or throttling us.
-     * Unsent (network unavailable) and Inflight (impossible) outcomes are not counted at all.
      */
-    private fun updateCircuitBreaker(request: KlaviyoApiRequest, status: Status) {
-        when (status) {
-            Status.Unsent, Status.Inflight -> return
-            else -> Unit
-        }
-
+    private fun updateCircuitBreaker(request: KlaviyoApiRequest) {
         when (request.responseCode) {
             // No HTTP response despite an attempt: the server was unreachable.
             null -> circuitBreaker.recordFailure()

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/KlaviyoApiClient.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/KlaviyoApiClient.kt
@@ -220,12 +220,18 @@ internal object KlaviyoApiClient : ApiClient {
                 while (apiQueue.size >= MAX_QUEUE_SIZE) {
                     // Evict the oldest request by enqueue timestamp, not the front of the deque —
                     // head-of-line requests are inserted at the front but are the newest.
+                    // The minByOrNull + remove pair is not atomic on the ConcurrentLinkedDeque, so a
+                    // concurrent enqueue could target the same victim. We gate the side effects on
+                    // remove()'s boolean: if another thread already evicted this request, remove()
+                    // returns false and the while-loop simply re-scans — a best-effort, self-healing
+                    // soft bound rather than a hard guarantee.
                     val evicted = apiQueue.minByOrNull { it.queuedTime } ?: break
-                    apiQueue.remove(evicted)
-                    Registry.dataStore.clear(evicted.uuid)
-                    Registry.log.warning(
-                        "API queue at capacity ($MAX_QUEUE_SIZE), evicting oldest request: ${evicted.type}"
-                    )
+                    if (apiQueue.remove(evicted)) {
+                        Registry.dataStore.clear(evicted.uuid)
+                        Registry.log.warning(
+                            "API queue at capacity ($MAX_QUEUE_SIZE), evicting oldest request: ${evicted.type}"
+                        )
+                    }
                 }
                 Registry.dataStore.store(request.uuid, request.toString())
                 if (headOfLine) {

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/KlaviyoApiClient.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/KlaviyoApiClient.kt
@@ -334,6 +334,10 @@ internal object KlaviyoApiClient : ApiClient {
      */
     fun getQueueSize(): Int = apiQueue.size
 
+    internal fun replaceQueueForTesting(queue: ConcurrentLinkedDeque<KlaviyoApiRequest>) {
+        apiQueue = queue
+    }
+
     /**
      * Reset the in-memory queue to the queue from data store
      *
@@ -484,7 +488,11 @@ internal object KlaviyoApiClient : ApiClient {
                 break
             }
 
-            val request = apiQueue.poll() ?: continue
+            val request = apiQueue.poll()
+            if (request == null) {
+                circuitBreaker.releaseProbe()
+                continue
+            }
 
             val attemptsBefore = request.attempts
             val status = request.sendAndBroadcast()
@@ -559,6 +567,8 @@ internal object KlaviyoApiClient : ApiClient {
             } else {
                 circuitBreaker.recordFailure()
             }
+            HttpURLConnection.HTTP_NOT_IMPLEMENTED,
+            HttpURLConnection.HTTP_VERSION -> circuitBreaker.recordSuccess()
             in 500..599 -> circuitBreaker.recordFailure()
             // Other 4xx: reachable, non-retryable.
             else -> circuitBreaker.recordSuccess()

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/KlaviyoApiClient.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/KlaviyoApiClient.kt
@@ -42,8 +42,10 @@ internal object KlaviyoApiClient : ApiClient {
      * Maximum number of requests that can sit in the API queue at one time.
      *
      * Matches the iOS SDK cap (200) for behavioural parity across platforms.
-     * When the queue reaches this limit, the oldest request (front of deque) is evicted
-     * to make room for the incoming one. This prevents the queue from growing unbounded during
+     * When the queue reaches this limit, the oldest request (smallest [KlaviyoApiRequest.queuedTime])
+     * is evicted to make room for the incoming one. Evicting by enqueue timestamp — rather than
+     * the front of the deque — protects freshly-enqueued head-of-line requests, which are inserted
+     * at the front but are the newest. This prevents the queue from growing unbounded during
      * request storms — for example, a push-token registration loop that floods the queue and
      * blocks legitimate new requests from ever reaching the network.
      */
@@ -216,7 +218,10 @@ internal object KlaviyoApiClient : ApiClient {
         }.forEach { request ->
             if (!apiQueue.contains(request)) {
                 while (apiQueue.size >= MAX_QUEUE_SIZE) {
-                    val evicted = apiQueue.pollFirst() ?: break
+                    // Evict the oldest request by enqueue timestamp, not the front of the deque —
+                    // head-of-line requests are inserted at the front but are the newest.
+                    val evicted = apiQueue.minByOrNull { it.queuedTime } ?: break
+                    apiQueue.remove(evicted)
                     Registry.dataStore.clear(evicted.uuid)
                     Registry.log.warning(
                         "API queue at capacity ($MAX_QUEUE_SIZE), evicting oldest request: ${evicted.type}"

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/KlaviyoApiClient.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/KlaviyoApiClient.kt
@@ -38,6 +38,17 @@ import org.json.JSONObject
 internal object KlaviyoApiClient : ApiClient {
     internal const val QUEUE_KEY = "klaviyo_api_request_queue"
 
+    /**
+     * Maximum number of requests that can sit in the API queue at one time.
+     *
+     * Matches the iOS SDK cap (200) for behavioural parity across platforms.
+     * When the queue reaches this limit, the oldest request (front of deque) is evicted
+     * to make room for the incoming one. This prevents the queue from growing unbounded during
+     * request storms — for example, a push-token registration loop that floods the queue and
+     * blocks legitimate new requests from ever reaching the network.
+     */
+    internal const val MAX_QUEUE_SIZE: Int = 200
+
     private var handlerThread = Registry.threadHelper.getHandlerThread(
         KlaviyoApiClient::class.simpleName
     )
@@ -204,6 +215,13 @@ internal object KlaviyoApiClient : ApiClient {
             }
         }.forEach { request ->
             if (!apiQueue.contains(request)) {
+                while (apiQueue.size >= MAX_QUEUE_SIZE) {
+                    val evicted = apiQueue.pollFirst() ?: break
+                    Registry.dataStore.clear(evicted.uuid)
+                    Registry.log.warning(
+                        "API queue at capacity ($MAX_QUEUE_SIZE), evicting oldest request: ${evicted.type}"
+                    )
+                }
                 Registry.dataStore.store(request.uuid, request.toString())
                 if (headOfLine) {
                     apiQueue.offerFirst(request)
@@ -489,8 +507,6 @@ internal object KlaviyoApiClient : ApiClient {
 
         private var flushInterval: Long = defaultFlushInterval
 
-        private val flushDepth: Int = Registry.config.networkFlushDepth
-
         /**
          * Send queued requests serially
          * The queue will flush whenever the triggers specified in config are met
@@ -499,7 +515,7 @@ internal object KlaviyoApiClient : ApiClient {
         override fun run() {
             val queueTimePassed = Registry.clock.currentTimeMillis() - enqueuedTime
 
-            if (getQueueSize() < flushDepth && queueTimePassed < flushInterval && !force) {
+            if (queueTimePassed < flushInterval && !force) {
                 return requeue()
             }
 

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequest.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequest.kt
@@ -509,6 +509,15 @@ internal open class KlaviyoApiRequest(
     }
 
     /**
+     * Whether the latest response carried a usable (non-empty) `Retry-After` header.
+     *
+     * Used by the circuit breaker to distinguish a deliberate, server-directed throttle (which
+     * proves the server is reachable) from an ambiguous failure that should count toward dormancy.
+     */
+    val hasRetryAfterHeader: Boolean
+        get() = responseHeaders[HEADER_RETRY_AFTER]?.getOrNull(0)?.isNotEmpty() == true
+
+    /**
      * Clear a mutable map and add new key value pairs
      * Utility to replace all headers
      */

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequest.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequest.kt
@@ -432,8 +432,12 @@ internal open class KlaviyoApiRequest(
 
         status = when (responseCode) {
             in successCodes -> Status.Complete
-            // 429 rate limit, 500, 502, 503 and 504 are all treated as retryable
-            HTTP_RETRY, 500, in 502..504 -> {
+            // 429 rate limit plus the entire 5xx range (500–599) are treated as retryable.
+            // Widening from the legacy {500,502,503,504} allowlist to the full range covers
+            // transient CDN/edge failures such as Cloudflare's 520–527 codes, which were the
+            // codes observed during the cannot-access-klaviyo-com incident. 4xx codes
+            // (including 403 load-shed) remain non-retryable so the backend can shed load.
+            HTTP_RETRY, in 500..599 -> {
                 if (attempts < maxAttempts) {
                     Status.PendingRetry
                 } else {

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequest.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequest.kt
@@ -490,12 +490,7 @@ internal open class KlaviyoApiRequest(
         )
 
         try {
-            // Look up Retry-After case-insensitively: HTTP header names are case-insensitive and an
-            // HTTP/2 stack may deliver it lowercased, so a case-sensitive map lookup could miss it.
-            // headerFields can contain a null key (the status line), so compare from the constant.
-            val retryAfter = this.responseHeaders.entries
-                .firstOrNull { HEADER_RETRY_AFTER.equals(it.key, ignoreCase = true) }
-                ?.value?.getOrNull(0)
+            val retryAfter = retryAfterHeaderValue
 
             if (retryAfter?.isNotEmpty() == true) {
                 val retryAfterInterval = (retryAfter.toInt() + jitterSeconds).times(1_000L)
@@ -515,7 +510,12 @@ internal open class KlaviyoApiRequest(
      * proves the server is reachable) from an ambiguous failure that should count toward dormancy.
      */
     val hasRetryAfterHeader: Boolean
-        get() = responseHeaders[HEADER_RETRY_AFTER]?.getOrNull(0)?.isNotEmpty() == true
+        get() = retryAfterHeaderValue?.isNotEmpty() == true
+
+    private val retryAfterHeaderValue: String?
+        get() = responseHeaders.entries
+            .firstOrNull { HEADER_RETRY_AFTER.equals(it.key, ignoreCase = true) }
+            ?.value?.getOrNull(0)
 
     /**
      * Clear a mutable map and add new key value pairs

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequest.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequest.kt
@@ -469,32 +469,38 @@ internal open class KlaviyoApiRequest(
     /**
      * Compute a retry interval based on state of the request
      *
-     * If present, obey the Retry-After response header, plus some jitter.
-     * Absent the header, use an exponential backoff algorithm, with a
-     * floor set by current network connection, and ceiling set by the config.
+     * Always compute an exponential backoff interval, with a floor set by the
+     * current network connection and a ceiling set by the config. If the server
+     * sent a usable Retry-After response header, wait the GREATER of that header
+     * value and the exponential backoff (each plus the same jitter). Taking the
+     * greater of the two ensures a request deep in a rate-limit storm keeps
+     * backing off rather than retrying too soon just because the server's
+     * rate-limit window reset to a short Retry-After.
      */
     fun computeRetryInterval(): Long {
         val jitterSeconds = Registry.config.networkJitterRange.random()
-
-        try {
-            val retryAfter = this.responseHeaders[HEADER_RETRY_AFTER]?.getOrNull(0)
-
-            if (retryAfter?.isNotEmpty() == true) {
-                return (retryAfter.toInt() + jitterSeconds).times(1_000L)
-            }
-        } catch (e: NumberFormatException) {
-            Registry.log.warning("Invalid Retry-After header value", e)
-        }
 
         val networkType = Registry.networkMonitor.getNetworkType().position
         val minRetryInterval = Registry.config.networkFlushIntervals[networkType]
         val exponentialBackoff = (2.0.pow(attempts).toLong() + jitterSeconds).times(1_000L)
         val maxRetryInterval = Registry.config.networkMaxRetryInterval
-
-        return min(
+        val backoffInterval = min(
             max(minRetryInterval, exponentialBackoff),
             maxRetryInterval
         )
+
+        try {
+            val retryAfter = this.responseHeaders[HEADER_RETRY_AFTER]?.getOrNull(0)
+
+            if (retryAfter?.isNotEmpty() == true) {
+                val retryAfterInterval = (retryAfter.toInt() + jitterSeconds).times(1_000L)
+                return max(retryAfterInterval, backoffInterval)
+            }
+        } catch (e: NumberFormatException) {
+            Registry.log.warning("Invalid Retry-After header value", e)
+        }
+
+        return backoffInterval
     }
 
     /**

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequest.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequest.kt
@@ -432,11 +432,17 @@ internal open class KlaviyoApiRequest(
 
         status = when (responseCode) {
             in successCodes -> Status.Complete
-            // 429 rate limit plus the entire 5xx range (500–599) are treated as retryable.
-            // Widening from the legacy {500,502,503,504} allowlist to the full range covers
-            // transient CDN/edge failures such as Cloudflare's 520–527 codes, which were the
-            // codes observed during the cannot-access-klaviyo-com incident. 4xx codes
-            // (including 403 load-shed) remain non-retryable so the backend can shed load.
+            // 501 (Not Implemented) and 505 (HTTP Version Not Supported) are permanent,
+            // deterministic server errors: retrying the identical request will always fail
+            // the same way, so they are treated as non-retryable like a 4xx. This branch must
+            // precede the `in 500..599` branch below so these codes short-circuit out of it.
+            501, 505 -> Status.Failed
+            // 429 rate limit plus the rest of the 5xx range (500–599, except 501/505 above)
+            // are treated as retryable. Widening from the legacy {500,502,503,504} allowlist
+            // to the full range covers transient CDN/edge failures such as Cloudflare's
+            // 520–527 codes, which were the codes observed during the cannot-access-klaviyo-com
+            // incident. 4xx codes (including 403 load-shed) remain non-retryable so the backend
+            // can shed load.
             HTTP_RETRY, in 500..599 -> {
                 if (attempts < maxAttempts) {
                     Status.PendingRetry

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequest.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequest.kt
@@ -490,7 +490,12 @@ internal open class KlaviyoApiRequest(
         )
 
         try {
-            val retryAfter = this.responseHeaders[HEADER_RETRY_AFTER]?.getOrNull(0)
+            // Look up Retry-After case-insensitively: HTTP header names are case-insensitive and an
+            // HTTP/2 stack may deliver it lowercased, so a case-sensitive map lookup could miss it.
+            // headerFields can contain a null key (the status line), so compare from the constant.
+            val retryAfter = this.responseHeaders.entries
+                .firstOrNull { HEADER_RETRY_AFTER.equals(it.key, ignoreCase = true) }
+                ?.value?.getOrNull(0)
 
             if (retryAfter?.isNotEmpty() == true) {
                 val retryAfterInterval = (retryAfter.toInt() + jitterSeconds).times(1_000L)

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/KlaviyoApiClientTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/KlaviyoApiClientTest.kt
@@ -46,6 +46,7 @@ import io.mockk.verify
 import io.mockk.verifyOrder
 import java.net.HttpURLConnection
 import java.net.URL
+import java.util.concurrent.ConcurrentLinkedDeque
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
@@ -76,6 +77,19 @@ internal class KlaviyoApiClientTest : BaseTest() {
     private companion object {
         private val slotOnActivityEvent = slot<ActivityObserver>()
         private val slotOnNetworkChange = slot<NetworkObserver>()
+    }
+
+    private class NullPollQueue(
+        request: KlaviyoApiRequest
+    ) : ConcurrentLinkedDeque<KlaviyoApiRequest>() {
+        init {
+            offer(request)
+        }
+
+        override fun poll(): KlaviyoApiRequest? {
+            clear()
+            return null
+        }
     }
 
     @Before
@@ -1345,6 +1359,30 @@ internal class KlaviyoApiClientTest : BaseTest() {
     }
 
     @Test
+    fun `Circuit breaker is not tripped by deterministic reachable 501 and 505 responses`() = runTest {
+        every { mockConfig.circuitBreakerFailureThreshold } returns 2
+
+        KlaviyoApiClient.enqueueRequest(
+            mockRequest(
+                "cb-501",
+                KlaviyoApiRequest.Status.Failed,
+                HttpURLConnection.HTTP_NOT_IMPLEMENTED
+            ),
+            mockRequest(
+                "cb-505",
+                KlaviyoApiRequest.Status.Failed,
+                HttpURLConnection.HTTP_VERSION
+            )
+        )
+
+        val outcome = KlaviyoApiClient.awaitFlushQueueOutcome()
+
+        assert(outcome is FlushOutcome.Complete)
+        assertEquals(0, KlaviyoApiClient.getQueueSize())
+        assertEquals(CircuitBreaker.State.CLOSED, KlaviyoApiClient.circuitBreaker.state())
+    }
+
+    @Test
     fun `Circuit breaker does not count a skipped send where no attempt was made`() = runTest {
         every { mockConfig.circuitBreakerFailureThreshold } returns 3
 
@@ -1360,5 +1398,42 @@ internal class KlaviyoApiClientTest : BaseTest() {
 
         assertEquals(CircuitBreaker.State.CLOSED, KlaviyoApiClient.circuitBreaker.state())
         assertEquals(1, KlaviyoApiClient.getQueueSize())
+    }
+
+    @Test
+    fun `Circuit breaker releases half-open probe when queue poll returns null`() = runTest {
+        every { mockConfig.circuitBreakerFailureThreshold } returns 1
+        every { mockConfig.circuitBreakerBaseOpenInterval } returns 30_000L
+        every { mockConfig.circuitBreakerMaxOpenInterval } returns 300_000L
+
+        val failingRequest = mockRequest(
+            "cb-null-poll-open",
+            KlaviyoApiRequest.Status.PendingRetry,
+            HttpURLConnection.HTTP_UNAVAILABLE
+        )
+        every { failingRequest.computeRetryInterval() } returns 1_000L
+        KlaviyoApiClient.enqueueRequest(failingRequest)
+
+        assert(KlaviyoApiClient.awaitFlushQueueOutcome() is FlushOutcome.Incomplete)
+        assertEquals(CircuitBreaker.State.OPEN, KlaviyoApiClient.circuitBreaker.state())
+
+        staticClock.time += 30_000L
+        val placeholder = mockRequest("cb-null-poll-placeholder")
+        KlaviyoApiClient.replaceQueueForTesting(NullPollQueue(placeholder))
+
+        assert(KlaviyoApiClient.awaitFlushQueueOutcome() is FlushOutcome.Complete)
+        assertEquals(CircuitBreaker.State.HALF_OPEN, KlaviyoApiClient.circuitBreaker.state())
+
+        KlaviyoApiClient.replaceQueueForTesting(ConcurrentLinkedDeque())
+        val probeRequest = mockRequest(
+            "cb-null-poll-probe",
+            KlaviyoApiRequest.Status.Complete,
+            HttpURLConnection.HTTP_ACCEPTED
+        )
+        KlaviyoApiClient.enqueueRequest(probeRequest)
+
+        assert(KlaviyoApiClient.awaitFlushQueueOutcome() is FlushOutcome.Complete)
+        verify(exactly = 1) { probeRequest.send(any()) }
+        assertEquals(CircuitBreaker.State.CLOSED, KlaviyoApiClient.circuitBreaker.state())
     }
 }

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/KlaviyoApiClientTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/KlaviyoApiClientTest.kt
@@ -735,7 +735,8 @@ internal class KlaviyoApiClientTest : BaseTest() {
 
         fun expectedBackoffInterval(startAttempts: Int) =
             expectedBackoffIntervals.getOrElse(startAttempts) {
-                300_000L // Max backoff time should be used from here on, because 512s > 300s
+                // Max backoff (cap) should be used from here on, because 512s > the configured cap
+                Registry.config.networkMaxRetryInterval
             }
 
         // First unsent request, which we will retry till max attempts
@@ -792,7 +793,7 @@ internal class KlaviyoApiClientTest : BaseTest() {
 
         // First request should have been retried exactly 50 times
         assertEquals(50, request1.attempts)
-        assertEquals(300_000L, scheduledIntervals.maxOrNull() ?: 0L)
+        assertEquals(Registry.config.networkMaxRetryInterval, scheduledIntervals.maxOrNull() ?: 0L)
 
         // Upon final failure, request 1 should have been dropped from the queue
         assertEquals(1, KlaviyoApiClient.getQueueSize())

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/KlaviyoApiClientTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/KlaviyoApiClientTest.kt
@@ -69,7 +69,6 @@ internal class KlaviyoApiClientTest : BaseTest() {
     private val flushIntervalWifi = 10_000L
     private val flushIntervalCell = 20_000L
     private val flushIntervalOffline = 30_000L
-    private val queueDepth = 10
     private var postedJob: KlaviyoApiClient.NetworkRunnable? = null
     private val mockQueueScheduler = mockk<QueueScheduler>(relaxed = true)
 
@@ -97,7 +96,6 @@ internal class KlaviyoApiClientTest : BaseTest() {
             flushIntervalCell,
             flushIntervalOffline
         )
-        every { mockConfig.networkFlushDepth } returns queueDepth
         every { mockNetworkMonitor.isNetworkConnected() } returns false
         every { mockNetworkMonitor.getNetworkType() } returns NetworkMonitor.NetworkType.Wifi
         every { mockLifecycleMonitor.onActivityEvent(capture(slotOnActivityEvent)) } returns Unit
@@ -446,18 +444,6 @@ internal class KlaviyoApiClientTest : BaseTest() {
     }
 
     @Test
-    fun `Flushes queue when configured size is reached`() {
-        repeat(queueDepth) {
-            KlaviyoApiClient.enqueueRequest(mockRequest("uuid-$it"))
-            assertEquals(it + 1, KlaviyoApiClient.getQueueSize())
-        }
-
-        postedJob!!.run()
-
-        assertEquals(0, KlaviyoApiClient.getQueueSize())
-    }
-
-    @Test
     fun `Flushes queue when configured time has elapsed`() {
         val requestMock = mockRequest()
 
@@ -471,20 +457,19 @@ internal class KlaviyoApiClientTest : BaseTest() {
     }
 
     @Test
-    fun `Does not flush queue if no criteria is met`() {
-        repeat(queueDepth - 1) {
-            KlaviyoApiClient.enqueueRequest(mockRequest("uuid-$it"))
-            assertEquals(it + 1, KlaviyoApiClient.getQueueSize())
-        }
+    fun `Does not flush queue if flush interval has not elapsed`() {
+        KlaviyoApiClient.enqueueRequest(mockRequest("uuid-0"))
+        assertEquals(1, KlaviyoApiClient.getQueueSize())
 
+        // Time has not advanced, so flush interval has not elapsed
         postedJob!!.run()
 
-        assertEquals(queueDepth - 1, KlaviyoApiClient.getQueueSize())
+        assertEquals(1, KlaviyoApiClient.getQueueSize())
     }
 
     @Test
-    fun `Flushes queue if forced when no criteria is met`() {
-        repeat(queueDepth - 1) {
+    fun `Flushes queue if forced when flush interval has not elapsed`() {
+        repeat(5) {
             KlaviyoApiClient.enqueueRequest(mockRequest("uuid-$it"))
             assertEquals(it + 1, KlaviyoApiClient.getQueueSize())
         }
@@ -492,6 +477,35 @@ internal class KlaviyoApiClientTest : BaseTest() {
         KlaviyoApiClient.flushQueue()
 
         assertEquals(0, KlaviyoApiClient.getQueueSize())
+    }
+
+    @Test
+    fun `Queue cap evicts oldest request on overflow and emits warning log`() {
+        // Fill the queue to capacity
+        repeat(KlaviyoApiClient.MAX_QUEUE_SIZE) {
+            KlaviyoApiClient.enqueueRequest(mockRequest("uuid-$it"))
+        }
+        assertEquals(KlaviyoApiClient.MAX_QUEUE_SIZE, KlaviyoApiClient.getQueueSize())
+
+        // The oldest request (uuid-0) is at the front of the deque
+        val oldestUuid = "uuid-0"
+        assertNotNull(spyDataStore.fetch(oldestUuid))
+
+        // Enqueue one more request — should evict uuid-0
+        val newestRequest = mockRequest("uuid-newest")
+        KlaviyoApiClient.enqueueRequest(newestRequest)
+
+        // Queue size stays at the cap
+        assertEquals(KlaviyoApiClient.MAX_QUEUE_SIZE, KlaviyoApiClient.getQueueSize())
+
+        // Oldest was evicted from the datastore
+        assertNull(spyDataStore.fetch(oldestUuid))
+
+        // Newest request is present in the datastore
+        assertNotNull(spyDataStore.fetch("uuid-newest"))
+
+        // A warning log was emitted for the eviction
+        verify(atLeast = 1) { spyLog.warning(any(), null) }
     }
 
     @Test

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/KlaviyoApiClientTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/KlaviyoApiClientTest.kt
@@ -1230,6 +1230,103 @@ internal class KlaviyoApiClientTest : BaseTest() {
     }
 
     @Test
+    fun `Successful circuit breaker probe closes the breaker and resumes draining`() = runTest {
+        every { mockConfig.circuitBreakerFailureThreshold } returns 2
+        every { mockConfig.circuitBreakerBaseOpenInterval } returns 30_000L
+        every { mockConfig.circuitBreakerMaxOpenInterval } returns 300_000L
+
+        val request = mockRequest("cb-probe-success", KlaviyoApiRequest.Status.Unsent)
+        every { request.state } answers {
+            when (request.attempts) {
+                0 -> KlaviyoApiRequest.Status.Unsent.name
+                1, 2 -> KlaviyoApiRequest.Status.PendingRetry.name
+                else -> KlaviyoApiRequest.Status.Complete.name
+            }
+        }
+        every { request.responseCode } answers {
+            if (request.attempts >= 3) {
+                HttpURLConnection.HTTP_ACCEPTED
+            } else {
+                HttpURLConnection.HTTP_UNAVAILABLE
+            }
+        }
+        every { request.computeRetryInterval() } returns 1_000L
+
+        KlaviyoApiClient.enqueueRequest(request)
+
+        repeat(2) {
+            assert(KlaviyoApiClient.awaitFlushQueueOutcome() is FlushOutcome.Incomplete)
+        }
+        verify(exactly = 2) { request.send(any()) }
+        assertEquals(CircuitBreaker.State.OPEN, KlaviyoApiClient.circuitBreaker.state())
+
+        staticClock.time += 30_000L
+        val outcome = KlaviyoApiClient.awaitFlushQueueOutcome()
+
+        assert(outcome is FlushOutcome.Complete)
+        verify(exactly = 3) { request.send(any()) }
+        assertEquals(CircuitBreaker.State.CLOSED, KlaviyoApiClient.circuitBreaker.state())
+        assertEquals(0, KlaviyoApiClient.getQueueSize())
+    }
+
+    @Test
+    fun `429 with Retry-After resets circuit breaker failures`() = runTest {
+        every { mockConfig.circuitBreakerFailureThreshold } returns 2
+
+        val request = mockRequest("cb-429-retry-after", KlaviyoApiRequest.Status.Unsent)
+        every { request.state } answers {
+            when (request.attempts) {
+                0 -> KlaviyoApiRequest.Status.Unsent.name
+                else -> KlaviyoApiRequest.Status.PendingRetry.name
+            }
+        }
+        every { request.responseCode } answers {
+            if (request.attempts == 2) {
+                KlaviyoApiRequest.HTTP_RETRY
+            } else {
+                HttpURLConnection.HTTP_UNAVAILABLE
+            }
+        }
+        every { request.responseHeaders } answers {
+            if (request.attempts == 2) {
+                mapOf("retry-after" to listOf("60"))
+            } else {
+                emptyMap()
+            }
+        }
+        every { request.computeRetryInterval() } returns 1_000L
+
+        KlaviyoApiClient.enqueueRequest(request)
+
+        repeat(3) {
+            assert(KlaviyoApiClient.awaitFlushQueueOutcome() is FlushOutcome.Incomplete)
+        }
+
+        verify(exactly = 3) { request.send(any()) }
+        assertEquals(CircuitBreaker.State.CLOSED, KlaviyoApiClient.circuitBreaker.state())
+        assertEquals(1, KlaviyoApiClient.getQueueSize())
+    }
+
+    @Test
+    fun `Null response code counts as a circuit breaker failure`() = runTest {
+        every { mockConfig.circuitBreakerFailureThreshold } returns 2
+
+        val request = mockRequest("cb-null-response", KlaviyoApiRequest.Status.PendingRetry)
+        every { request.responseCode } returns null
+        every { request.computeRetryInterval() } returns 1_000L
+
+        KlaviyoApiClient.enqueueRequest(request)
+
+        repeat(2) {
+            assert(KlaviyoApiClient.awaitFlushQueueOutcome() is FlushOutcome.Incomplete)
+        }
+
+        verify(exactly = 2) { request.send(any()) }
+        assertEquals(CircuitBreaker.State.OPEN, KlaviyoApiClient.circuitBreaker.state())
+        assertEquals(1, KlaviyoApiClient.getQueueSize())
+    }
+
+    @Test
     fun `Circuit breaker is not tripped by 403 load-shed responses`() = runTest {
         every { mockConfig.circuitBreakerFailureThreshold } returns 3
 

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/KlaviyoApiClientTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/KlaviyoApiClientTest.kt
@@ -1246,4 +1246,22 @@ internal class KlaviyoApiClientTest : BaseTest() {
         assertEquals(0, KlaviyoApiClient.getQueueSize())
         assertEquals(CircuitBreaker.State.CLOSED, KlaviyoApiClient.circuitBreaker.state())
     }
+
+    @Test
+    fun `Circuit breaker does not count a skipped send where no attempt was made`() = runTest {
+        every { mockConfig.circuitBreakerFailureThreshold } returns 3
+
+        // Simulate send() bailing out (e.g. network offline): status stays Unsent and no
+        // attempt is made (attempts is not incremented), so it must not count as a failure.
+        val request = mockRequest("cb-skip", KlaviyoApiRequest.Status.Unsent)
+        every { request.send(any()) } returns KlaviyoApiRequest.Status.Unsent
+
+        KlaviyoApiClient.enqueueRequest(request)
+
+        // Far more skipped flushes than the threshold — the breaker must remain closed
+        repeat(5) { KlaviyoApiClient.awaitFlushQueueOutcome() }
+
+        assertEquals(CircuitBreaker.State.CLOSED, KlaviyoApiClient.circuitBreaker.state())
+        assertEquals(1, KlaviyoApiClient.getQueueSize())
+    }
 }

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/KlaviyoApiClientTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/KlaviyoApiClientTest.kt
@@ -480,29 +480,69 @@ internal class KlaviyoApiClientTest : BaseTest() {
     }
 
     @Test
-    fun `Queue cap evicts oldest request on overflow and emits warning log`() {
-        // Fill the queue to capacity
+    fun `Queue cap evicts request with oldest queuedTime on overflow and emits warning log`() {
+        // Fill the queue to capacity, advancing the clock so each request captures a
+        // progressively later queuedTime — uuid-0 therefore holds the oldest queuedTime.
         repeat(KlaviyoApiClient.MAX_QUEUE_SIZE) {
-            KlaviyoApiClient.enqueueRequest(mockRequest("uuid-$it"))
+            val request = mockRequest("uuid-$it") // queuedTime is captured from staticClock here
+            KlaviyoApiClient.enqueueRequest(request)
+            staticClock.time += 1
         }
         assertEquals(KlaviyoApiClient.MAX_QUEUE_SIZE, KlaviyoApiClient.getQueueSize())
 
-        // The oldest request (uuid-0) is at the front of the deque
+        // uuid-0 has the oldest queuedTime
         val oldestUuid = "uuid-0"
         assertNotNull(spyDataStore.fetch(oldestUuid))
 
-        // Enqueue one more request — should evict uuid-0
+        // Enqueue one more request — should evict the request with the oldest queuedTime
         val newestRequest = mockRequest("uuid-newest")
         KlaviyoApiClient.enqueueRequest(newestRequest)
 
         // Queue size stays at the cap
         assertEquals(KlaviyoApiClient.MAX_QUEUE_SIZE, KlaviyoApiClient.getQueueSize())
 
-        // Oldest was evicted from the datastore
+        // The oldest request by queuedTime was evicted from the datastore
         assertNull(spyDataStore.fetch(oldestUuid))
 
         // Newest request is present in the datastore
         assertNotNull(spyDataStore.fetch("uuid-newest"))
+
+        // A warning log was emitted for the eviction
+        verify(atLeast = 1) { spyLog.warning(any(), null) }
+    }
+
+    @Test
+    fun `Queue cap protects freshly-enqueued head-of-line request and evicts oldest by queuedTime`() {
+        // Fill the queue with regular requests just under capacity, advancing the clock so
+        // uuid-0 holds the oldest queuedTime and sits at the front (head) of the deque.
+        repeat(KlaviyoApiClient.MAX_QUEUE_SIZE - 1) {
+            val request = mockRequest("uuid-$it") // queuedTime is captured from staticClock here
+            KlaviyoApiClient.enqueueRequest(request)
+            staticClock.time += 1
+        }
+        assertEquals(KlaviyoApiClient.MAX_QUEUE_SIZE - 1, KlaviyoApiClient.getQueueSize())
+
+        // A head-of-line request is enqueued last, so it has the NEWEST queuedTime, and it is
+        // inserted at the FRONT of the deque via offerFirst. This is the exact shape that used to
+        // break: blindly evicting the front would remove this freshly-enqueued priority request.
+        val headOfLineRequest = mockRequest("hol-newest")
+        KlaviyoApiClient.enqueueRequest(headOfLineRequest, headOfLine = true)
+        staticClock.time += 1
+        assertEquals(KlaviyoApiClient.MAX_QUEUE_SIZE, KlaviyoApiClient.getQueueSize())
+
+        // Enqueuing one more request overflows the cap and triggers eviction.
+        val incomingRequest = mockRequest("uuid-incoming")
+        KlaviyoApiClient.enqueueRequest(incomingRequest)
+
+        // The oldest request by queuedTime (uuid-0) is evicted — NOT the front of the deque.
+        assertNull(spyDataStore.fetch("uuid-0"))
+
+        // The freshly-enqueued head-of-line request is protected because it is the newest.
+        assertNotNull(spyDataStore.fetch("hol-newest"))
+
+        // The incoming request was accepted and the queue stays bounded at the cap.
+        assertNotNull(spyDataStore.fetch("uuid-incoming"))
+        assertEquals(KlaviyoApiClient.MAX_QUEUE_SIZE, KlaviyoApiClient.getQueueSize())
 
         // A warning log was emitted for the eviction
         verify(atLeast = 1) { spyLog.warning(any(), null) }

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/KlaviyoApiClientTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/KlaviyoApiClientTest.kt
@@ -720,6 +720,23 @@ internal class KlaviyoApiClientTest : BaseTest() {
     fun `Rate limited requests are retried with backoff until max attempts in absence of Retry-After header`() {
         val defaultInterval =
             Registry.config.networkFlushIntervals[NetworkMonitor.NetworkType.Wifi.position]
+        val expectedBackoffIntervals = listOf(
+            defaultInterval, // First attempt starts after default interval
+            defaultInterval, // First RETRY starts after default interval bc 2s < 10s
+            defaultInterval, // Second RETRY starts after default interval bc 4s < 10s
+            defaultInterval, // Third RETRY starts after default interval bc 8s < 10s
+            16_000L, // Exp. backoff time should be used bc 16s > 10s
+            32_000L, // Exp. backoff time should be used bc 32s > 10s
+            64_000L, // Exp. backoff time should be used bc 64s > 10s
+            128_000L, // Exp. backoff time should be used bc 128s > 10s
+            256_000L // Exp. backoff time should be used bc 256s > 10s
+        )
+        val scheduledIntervals = mutableListOf<Long>()
+
+        fun expectedBackoffInterval(startAttempts: Int) =
+            expectedBackoffIntervals.getOrElse(startAttempts) {
+                300_000L // Max backoff time should be used from here on, because 512s > 300s
+            }
 
         // First unsent request, which we will retry till max attempts
         val request1 = mockRequest("uuid-retry", KlaviyoApiRequest.Status.Unsent).also {
@@ -732,6 +749,14 @@ internal class KlaviyoApiClientTest : BaseTest() {
                 50 -> KlaviyoApiRequest.Status.Failed.name
                 else -> KlaviyoApiRequest.Status.PendingRetry.name
             }
+        }
+        every { request1.computeRetryInterval() } answers {
+            expectedBackoffInterval(request1.attempts - 1)
+        }
+        every { mockHandler.postDelayed(any(), any()) } answers {
+            postedJob = firstArg<KlaviyoApiClient.NetworkRunnable>()
+            scheduledIntervals += secondArg<Long>()
+            true
         }
 
         // Second unset request in queue to ensure which shouldn't sent until first has failed
@@ -750,22 +775,16 @@ internal class KlaviyoApiClientTest : BaseTest() {
             val startAttempts = request1.attempts
 
             // Advance the time with our expected backoff interval
-            staticClock.time += listOf(
-                defaultInterval, // First attempt starts after default interval
-                defaultInterval, // First RETRY starts after default interval bc 2s < 10s
-                defaultInterval, // Second RETRY starts after default interval bc 4s < 10s
-                defaultInterval, // Third RETRY starts after default interval bc 8s < 10s
-                16_000L, // Exp. backoff time should be used bc 16s > 10s
-                32_000L, // Exp. backoff time should be used bc 32s > 10s
-                64_000L, // Exp. backoff time should be used bc 64s > 10s
-                128_000L // Exp. backoff time should be used bc 128s > 10s
-            ).getOrElse(startAttempts) { 180_000L } // Max backoff time should be used from here on, because 256s > 180s
+            staticClock.time += expectedBackoffInterval(startAttempts)
 
             // Run after advancing the clock (this mimics how handler.postDelay would run jobs)
             postedJob!!.run()
 
             // It should have attempted one send if the correct time elapsed
             assertEquals(startAttempts + 1, request1.attempts)
+            if (request1.state != KlaviyoApiRequest.Status.Failed.name) {
+                assertEquals(expectedBackoffInterval(startAttempts), scheduledIntervals.last())
+            }
 
             // Fail test if we exceed max attempts
             assert(request1.attempts <= 50)
@@ -773,6 +792,7 @@ internal class KlaviyoApiClientTest : BaseTest() {
 
         // First request should have been retried exactly 50 times
         assertEquals(50, request1.attempts)
+        assertEquals(300_000L, scheduledIntervals.maxOrNull() ?: 0L)
 
         // Upon final failure, request 1 should have been dropped from the queue
         assertEquals(1, KlaviyoApiClient.getQueueSize())

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/KlaviyoApiClientTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/KlaviyoApiClientTest.kt
@@ -23,6 +23,7 @@ import com.klaviyo.core.MissingConfig
 import com.klaviyo.core.Registry
 import com.klaviyo.core.lifecycle.ActivityEvent
 import com.klaviyo.core.lifecycle.ActivityObserver
+import com.klaviyo.core.networking.CircuitBreaker
 import com.klaviyo.core.networking.NetworkMonitor
 import com.klaviyo.core.networking.NetworkObserver
 import com.klaviyo.core.utils.takeIf
@@ -1200,5 +1201,49 @@ internal class KlaviyoApiClientTest : BaseTest() {
 
         // Verify that scheduleFlush was NOT called for custom events
         verify(exactly = 0) { mockQueueScheduler.scheduleFlush() }
+    }
+
+    @Test
+    fun `Circuit breaker opens after consecutive failures, holds the queue, then probes`() = runTest {
+        every { mockConfig.circuitBreakerFailureThreshold } returns 3
+        every { mockConfig.circuitBreakerBaseOpenInterval } returns 30_000L
+        every { mockConfig.circuitBreakerMaxOpenInterval } returns 300_000L
+
+        val request = mockRequest("cb-uuid", KlaviyoApiRequest.Status.PendingRetry, 503)
+        every { request.computeRetryInterval() } returns 1_000L
+        KlaviyoApiClient.enqueueRequest(request)
+
+        // Three consecutive failed flushes trip the breaker
+        repeat(3) { assert(KlaviyoApiClient.awaitFlushQueueOutcome() is FlushOutcome.Incomplete) }
+        verify(exactly = 3) { request.send(any()) }
+        assertEquals(CircuitBreaker.State.OPEN, KlaviyoApiClient.circuitBreaker.state())
+
+        // While open, the queue is held intact and no further sends occur
+        assert(KlaviyoApiClient.awaitFlushQueueOutcome() is FlushOutcome.Incomplete)
+        verify(exactly = 3) { request.send(any()) }
+        assertEquals(1, KlaviyoApiClient.getQueueSize())
+
+        // Once the open interval elapses, exactly one probe is permitted through
+        staticClock.time += 30_000L
+        assert(KlaviyoApiClient.awaitFlushQueueOutcome() is FlushOutcome.Incomplete)
+        verify(exactly = 4) { request.send(any()) }
+    }
+
+    @Test
+    fun `Circuit breaker is not tripped by 403 load-shed responses`() = runTest {
+        every { mockConfig.circuitBreakerFailureThreshold } returns 3
+
+        // Three 403s would exceed the threshold if they were (incorrectly) counted as failures
+        KlaviyoApiClient.enqueueRequest(
+            mockRequest("cb-403-1", KlaviyoApiRequest.Status.Failed, 403),
+            mockRequest("cb-403-2", KlaviyoApiRequest.Status.Failed, 403),
+            mockRequest("cb-403-3", KlaviyoApiRequest.Status.Failed, 403)
+        )
+
+        val outcome = KlaviyoApiClient.awaitFlushQueueOutcome()
+
+        assert(outcome is FlushOutcome.Complete)
+        assertEquals(0, KlaviyoApiClient.getQueueSize())
+        assertEquals(CircuitBreaker.State.CLOSED, KlaviyoApiClient.circuitBreaker.state())
     }
 }

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequestTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequestTest.kt
@@ -230,6 +230,21 @@ internal class KlaviyoApiRequestTest : BaseApiRequestTest<KlaviyoApiRequest>() {
     }
 
     @Test
+    fun `Reads Retry-After header case-insensitively`() {
+        // An HTTP/2 stack may deliver the header lowercased; the lookup must still find it.
+        val expectedHeaders = mapOf("retry-after" to listOf("25"))
+        every { mockNetworkMonitor.getNetworkType() } returns NetworkMonitor.NetworkType.Wifi
+        every { mockConfig.networkJitterRange } returns 1..1
+        withConnectionMock(URL(expectedFullUrl)).also {
+            every { it.headerFields } returns expectedHeaders
+        }
+
+        val request = makeTestRequest()
+        request.send()
+        assertEquals(26_000L, request.computeRetryInterval())
+    }
+
+    @Test
     fun `Falls back on network interval without jitter when Retry-After header is missing or invalid`() {
         // Wifi interval is 10s, force jitter to be 1s
         every { mockNetworkMonitor.getNetworkType() } returns NetworkMonitor.NetworkType.Wifi

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequestTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequestTest.kt
@@ -216,17 +216,33 @@ internal class KlaviyoApiRequestTest : BaseApiRequestTest<KlaviyoApiRequest>() {
 
     @Test
     fun `Uses exponential backoff interval when greater than Retry-After header`() {
-        // Retry-After is 2s but the Wifi backoff floor is 10s, so backoff wins. Jitter forced to 1s.
+        // Retry-After is 2s and the Wifi backoff floor is 10s; after 4 attempts,
+        // 16s exponential backoff wins.
         val expectedHeaders = mapOf("Retry-After" to listOf("2"))
         every { mockNetworkMonitor.getNetworkType() } returns NetworkMonitor.NetworkType.Wifi
-        every { mockConfig.networkJitterRange } returns 1..1
+        every { mockConfig.networkJitterRange } returns 0..0
         withConnectionMock(URL(expectedFullUrl)).also {
             every { it.headerFields } returns expectedHeaders
         }
 
         val request = makeTestRequest()
-        request.send()
-        assertEquals(10_000L, request.computeRetryInterval())
+        repeat(4) {
+            request.send()
+        }
+        assertEquals(16_000L, request.computeRetryInterval())
+    }
+
+    @Test
+    fun `Caps exponential backoff interval at configured maximum`() {
+        every { mockNetworkMonitor.getNetworkType() } returns NetworkMonitor.NetworkType.Wifi
+        every { mockConfig.networkJitterRange } returns 0..0
+        withConnectionMock(URL(expectedFullUrl))
+
+        val request = makeTestRequest()
+        repeat(9) {
+            request.send()
+        }
+        assertEquals(300_000L, request.computeRetryInterval())
     }
 
     @Test

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequestTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequestTest.kt
@@ -200,8 +200,10 @@ internal class KlaviyoApiRequestTest : BaseApiRequestTest<KlaviyoApiRequest>() {
     }
 
     @Test
-    fun `Parses Retry-After header if present and adds jitter`() {
+    fun `Uses Retry-After header plus jitter when greater than exponential backoff`() {
+        // Retry-After is 25s; Wifi backoff floor is 10s, so Retry-After wins. Jitter forced to 1s.
         val expectedHeaders = mapOf("Retry-After" to listOf("25"))
+        every { mockNetworkMonitor.getNetworkType() } returns NetworkMonitor.NetworkType.Wifi
         every { mockConfig.networkJitterRange } returns 1..1
         withConnectionMock(URL(expectedFullUrl)).also {
             every { it.headerFields } returns expectedHeaders
@@ -210,6 +212,21 @@ internal class KlaviyoApiRequestTest : BaseApiRequestTest<KlaviyoApiRequest>() {
         val request = makeTestRequest()
         request.send()
         assertEquals(26_000L, request.computeRetryInterval())
+    }
+
+    @Test
+    fun `Uses exponential backoff interval when greater than Retry-After header`() {
+        // Retry-After is 2s but the Wifi backoff floor is 10s, so backoff wins. Jitter forced to 1s.
+        val expectedHeaders = mapOf("Retry-After" to listOf("2"))
+        every { mockNetworkMonitor.getNetworkType() } returns NetworkMonitor.NetworkType.Wifi
+        every { mockConfig.networkJitterRange } returns 1..1
+        withConnectionMock(URL(expectedFullUrl)).also {
+            every { it.headerFields } returns expectedHeaders
+        }
+
+        val request = makeTestRequest()
+        request.send()
+        assertEquals(10_000L, request.computeRetryInterval())
     }
 
     @Test

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequestTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequestTest.kt
@@ -761,6 +761,38 @@ internal class KlaviyoApiRequestTest : BaseApiRequestTest<KlaviyoApiRequest>() {
     }
 
     @Test
+    fun `522 Cloudflare response code returns PendingRetry when under max attempts`() {
+        // 522 (connection timed out) is a Cloudflare edge code outside the legacy allowlist
+        // and was one of the codes observed during the cannot-access-klaviyo-com incident.
+        val connectionMock = withConnectionMock(URL(expectedFullUrl))
+        every { connectionMock.responseCode } returns 522
+
+        val request = makeTestRequest()
+        assertEquals(KlaviyoApiRequest.Status.PendingRetry, request.send())
+        assertEquals(1, request.attempts)
+    }
+
+    @Test
+    fun `525 Cloudflare response code returns PendingRetry when under max attempts`() {
+        val connectionMock = withConnectionMock(URL(expectedFullUrl))
+        every { connectionMock.responseCode } returns 525
+
+        val request = makeTestRequest()
+        assertEquals(KlaviyoApiRequest.Status.PendingRetry, request.send())
+        assertEquals(1, request.attempts)
+    }
+
+    @Test
+    fun `599 upper-bound 5xx response code returns PendingRetry when under max attempts`() {
+        val connectionMock = withConnectionMock(URL(expectedFullUrl))
+        every { connectionMock.responseCode } returns 599
+
+        val request = makeTestRequest()
+        assertEquals(KlaviyoApiRequest.Status.PendingRetry, request.send())
+        assertEquals(1, request.attempts)
+    }
+
+    @Test
     fun `5xx response code after max attempts returns Failed`() {
         val connectionMock = withConnectionMock(URL(expectedFullUrl))
         every { connectionMock.responseCode } returns 500

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequestTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequestTest.kt
@@ -261,6 +261,18 @@ internal class KlaviyoApiRequestTest : BaseApiRequestTest<KlaviyoApiRequest>() {
     }
 
     @Test
+    fun `Detects Retry-After header case-insensitively`() {
+        val expectedHeaders = mapOf("retry-after" to listOf("25"))
+        withConnectionMock(URL(expectedFullUrl)).also {
+            every { it.headerFields } returns expectedHeaders
+        }
+
+        val request = makeTestRequest()
+        request.send()
+        assertEquals(true, request.hasRetryAfterHeader)
+    }
+
+    @Test
     fun `Falls back on network interval without jitter when Retry-After header is missing or invalid`() {
         // Wifi interval is 10s, force jitter to be 1s
         every { mockNetworkMonitor.getNetworkType() } returns NetworkMonitor.NetworkType.Wifi

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequestTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequestTest.kt
@@ -793,6 +793,52 @@ internal class KlaviyoApiRequestTest : BaseApiRequestTest<KlaviyoApiRequest>() {
     }
 
     @Test
+    fun `501 response code returns Failed immediately`() {
+        // 501 (Not Implemented) is a permanent server error excluded from the retryable
+        // 5xx range: retrying the identical request will always fail the same way.
+        val connectionMock = withConnectionMock(URL(expectedFullUrl))
+        every { connectionMock.responseCode } returns 501
+
+        val request = makeTestRequest()
+        assertEquals(KlaviyoApiRequest.Status.Failed, request.send())
+        assertEquals(1, request.attempts)
+    }
+
+    @Test
+    fun `505 response code returns Failed immediately`() {
+        // 505 (HTTP Version Not Supported) is a permanent server error excluded from the
+        // retryable 5xx range: retrying the identical request will always fail the same way.
+        val connectionMock = withConnectionMock(URL(expectedFullUrl))
+        every { connectionMock.responseCode } returns 505
+
+        val request = makeTestRequest()
+        assertEquals(KlaviyoApiRequest.Status.Failed, request.send())
+        assertEquals(1, request.attempts)
+    }
+
+    @Test
+    fun `499 response code returns Failed immediately`() {
+        // Lower-bound sanity: 499 sits just below the 5xx range and must stay non-retryable.
+        val connectionMock = withConnectionMock(URL(expectedFullUrl))
+        every { connectionMock.responseCode } returns 499
+
+        val request = makeTestRequest()
+        assertEquals(KlaviyoApiRequest.Status.Failed, request.send())
+        assertEquals(1, request.attempts)
+    }
+
+    @Test
+    fun `600 response code returns Failed immediately`() {
+        // Upper-bound sanity: 600 sits just above the 5xx range and must stay non-retryable.
+        val connectionMock = withConnectionMock(URL(expectedFullUrl))
+        every { connectionMock.responseCode } returns 600
+
+        val request = makeTestRequest()
+        assertEquals(KlaviyoApiRequest.Status.Failed, request.send())
+        assertEquals(1, request.attempts)
+    }
+
+    @Test
     fun `5xx response code after max attempts returns Failed`() {
         val connectionMock = withConnectionMock(URL(expectedFullUrl))
         every { connectionMock.responseCode } returns 500

--- a/sdk/core/src/main/java/com/klaviyo/core/config/Config.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/config/Config.kt
@@ -41,6 +41,15 @@ interface Config {
         fun networkFlushInterval(networkFlushInterval: Long, type: NetworkMonitor.NetworkType): Builder
         fun networkMaxAttempts(networkMaxAttempts: Int): Builder
         fun networkMaxRetryInterval(networkMaxRetryInterval: Long): Builder
+
+        @Deprecated(
+            message = "Depth-triggered flushing has been removed. The queue now flushes only on " +
+                "the timer interval (see networkFlushInterval) and is internally bounded by a " +
+                "size cap. This setter has no effect and will be removed in a future major release.",
+            level = DeprecationLevel.WARNING
+        )
+        fun networkFlushDepth(networkFlushDepth: Int): Builder
+
         fun build(): Config
     }
 }

--- a/sdk/core/src/main/java/com/klaviyo/core/config/Config.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/config/Config.kt
@@ -21,7 +21,6 @@ interface Config {
     val networkTimeout: Int
     val uxNetworkTimeout: Int
     val networkFlushIntervals: LongArray
-    val networkFlushDepth: Int
     val networkMaxAttempts: Int
     val networkMaxRetryInterval: Long
     val networkJitterRange: IntRange
@@ -40,7 +39,6 @@ interface Config {
         fun networkTimeout(networkTimeout: Int): Builder
         fun uxNetworkTimeout(uxNetworkTimeout: Int): Builder
         fun networkFlushInterval(networkFlushInterval: Long, type: NetworkMonitor.NetworkType): Builder
-        fun networkFlushDepth(networkFlushDepth: Int): Builder
         fun networkMaxAttempts(networkMaxAttempts: Int): Builder
         fun networkMaxRetryInterval(networkMaxRetryInterval: Long): Builder
         fun build(): Config

--- a/sdk/core/src/main/java/com/klaviyo/core/config/Config.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/config/Config.kt
@@ -25,6 +25,22 @@ interface Config {
     val networkMaxRetryInterval: Long
     val networkJitterRange: IntRange
 
+    /**
+     * Number of consecutive transient failures that trip the network circuit breaker into a
+     * dormant state. A value `<= 0` disables the breaker (kill-switch).
+     */
+    val circuitBreakerFailureThreshold: Int
+
+    /**
+     * Initial dormancy interval (milliseconds) the circuit breaker holds the queue once tripped.
+     */
+    val circuitBreakerBaseOpenInterval: Long
+
+    /**
+     * Maximum dormancy interval (milliseconds) for the circuit breaker's exponential backoff.
+     */
+    val circuitBreakerMaxOpenInterval: Long
+
     fun getManifestInt(key: String, defaultValue: Int): Int
 
     interface Builder {

--- a/sdk/core/src/main/java/com/klaviyo/core/config/KlaviyoConfig.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/config/KlaviyoConfig.kt
@@ -256,6 +256,17 @@ object KlaviyoConfig : Config {
             }
         }
 
+        @Deprecated(
+            message = "Depth-triggered flushing has been removed. The queue now flushes only on " +
+                "the timer interval (see networkFlushInterval) and is internally bounded by a " +
+                "size cap. This setter has no effect and will be removed in a future major release.",
+            level = DeprecationLevel.WARNING
+        )
+        override fun networkFlushDepth(networkFlushDepth: Int) = apply {
+            // No-op: depth-triggered flushing was removed; retained for one release as a
+            // deprecated setter so existing caller code keeps compiling.
+        }
+
         override fun build(): Config {
             val context = applicationContext ?: throw MissingContext()
             val packageInfo = context.packageManager.getPackageInfoCompat(

--- a/sdk/core/src/main/java/com/klaviyo/core/config/KlaviyoConfig.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/config/KlaviyoConfig.kt
@@ -89,6 +89,24 @@ object KlaviyoConfig : Config {
      */
     private const val NETWORK_MAX_RETRY_INTERVAL_DEFAULT: Long = 300_000
 
+    /**
+     * Number of consecutive transient failures that trip the network circuit breaker.
+     *
+     * Reasoning: A handful of consecutive failures is a strong signal the server is unreachable
+     * (rather than a one-off blip), at which point we should stop draining and go dormant.
+     */
+    private const val CIRCUIT_BREAKER_FAILURE_THRESHOLD_DEFAULT: Int = 5
+
+    /**
+     * Initial dormancy interval the circuit breaker holds the queue once tripped, in milliseconds.
+     */
+    private const val CIRCUIT_BREAKER_BASE_OPEN_INTERVAL_DEFAULT: Long = 30_000
+
+    /**
+     * Ceiling on the circuit breaker's exponential dormancy backoff, in milliseconds (5 minutes).
+     */
+    private const val CIRCUIT_BREAKER_MAX_OPEN_INTERVAL_DEFAULT: Long = 300_000
+
     override val isDebugBuild = BuildConfig.DEBUG
 
     override var baseUrl: String = BuildConfig.KLAVIYO_SERVER_URL
@@ -129,6 +147,13 @@ object KlaviyoConfig : Config {
     override var networkMaxRetryInterval = NETWORK_MAX_RETRY_INTERVAL_DEFAULT
         private set
     override val networkJitterRange = 0..10
+
+    // Circuit breaker tuning is currently fixed (not Builder-customizable); the failure threshold
+    // doubles as a kill-switch (set <= 0 to disable). Promoting these to Builder setters is a
+    // follow-up if integrators need to tune them.
+    override val circuitBreakerFailureThreshold = CIRCUIT_BREAKER_FAILURE_THRESHOLD_DEFAULT
+    override val circuitBreakerBaseOpenInterval = CIRCUIT_BREAKER_BASE_OPEN_INTERVAL_DEFAULT
+    override val circuitBreakerMaxOpenInterval = CIRCUIT_BREAKER_MAX_OPEN_INTERVAL_DEFAULT
 
     override fun getManifestInt(key: String, defaultValue: Int): Int =
         if (!this::applicationContext.isInitialized) {

--- a/sdk/core/src/main/java/com/klaviyo/core/config/KlaviyoConfig.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/config/KlaviyoConfig.kt
@@ -75,14 +75,6 @@ object KlaviyoConfig : Config {
     private const val NETWORK_FLUSH_INTERVAL_OFFLINE_DEFAULT = 60_000L
 
     /**
-     * How many API requests can be enqueued before flush
-     *
-     * Reasoning: The goal of depth control is to limit duration that radios are active
-     * if a typical request takes 1-3 seconds, this should ideally limit us to 30-90 seconds
-     */
-    private const val NETWORK_FLUSH_DEPTH_DEFAULT: Int = 25
-
-    /**
      * How many retries to allow an API request before permanent failure
      *
      * Reasoning: Most likely the rate limit should be cleared within 2-3 retries with exp backoff.
@@ -131,8 +123,6 @@ object KlaviyoConfig : Config {
         NETWORK_FLUSH_INTERVAL_OFFLINE_DEFAULT
     )
         private set
-    override var networkFlushDepth = NETWORK_FLUSH_DEPTH_DEFAULT
-        private set
     override var networkMaxAttempts = NETWORK_MAX_ATTEMPTS_DEFAULT
         private set
     override var networkMaxRetryInterval = NETWORK_MAX_RETRY_INTERVAL_DEFAULT
@@ -167,7 +157,6 @@ object KlaviyoConfig : Config {
             NETWORK_FLUSH_INTERVAL_CELL_DEFAULT,
             NETWORK_FLUSH_INTERVAL_OFFLINE_DEFAULT
         )
-        private var networkFlushDepth = NETWORK_FLUSH_DEPTH_DEFAULT
         private var networkMaxAttempts = NETWORK_MAX_ATTEMPTS_DEFAULT
         private var networkMaxRetryInterval = NETWORK_MAX_RETRY_INTERVAL_DEFAULT
 
@@ -247,16 +236,6 @@ object KlaviyoConfig : Config {
             }
         }
 
-        override fun networkFlushDepth(networkFlushDepth: Int) = apply {
-            if (networkFlushDepth > 0) {
-                this.networkFlushDepth = networkFlushDepth
-            } else {
-                Registry.log.error(
-                    "${KlaviyoConfig::networkFlushDepth.name} must be greater than 0"
-                )
-            }
-        }
-
         override fun networkMaxAttempts(networkMaxAttempts: Int) = apply {
             if (networkMaxAttempts >= 0) {
                 this.networkMaxAttempts = networkMaxAttempts
@@ -305,7 +284,6 @@ object KlaviyoConfig : Config {
             KlaviyoConfig.networkTimeout = networkTimeout
             KlaviyoConfig.uxNetworkTimeout = uxNetworkTimeout
             KlaviyoConfig.networkFlushIntervals = networkFlushIntervals
-            KlaviyoConfig.networkFlushDepth = networkFlushDepth
             KlaviyoConfig.networkMaxAttempts = networkMaxAttempts
             KlaviyoConfig.networkMaxRetryInterval = networkMaxRetryInterval
 

--- a/sdk/core/src/main/java/com/klaviyo/core/config/KlaviyoConfig.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/config/KlaviyoConfig.kt
@@ -82,11 +82,12 @@ object KlaviyoConfig : Config {
     private const val NETWORK_MAX_ATTEMPTS_DEFAULT: Int = 50
 
     /**
-     * Maximum interval between retries for the exponential backoff, in milliseconds (3 minutes)
+     * Maximum interval between retries for the exponential backoff, in milliseconds (5 minutes)
      *
-     * Reasoning: We don't want to wait so long that the user has left the app.
+     * Reasoning: We don't want to wait so long that the user has left the app, but 180s was more
+     * aggressive than comparable SDKs (Segment caps at 300s), so we align with 300s (MAGE-500).
      */
-    private const val NETWORK_MAX_RETRY_INTERVAL_DEFAULT: Long = 180_000
+    private const val NETWORK_MAX_RETRY_INTERVAL_DEFAULT: Long = 300_000
 
     override val isDebugBuild = BuildConfig.DEBUG
 

--- a/sdk/core/src/main/java/com/klaviyo/core/networking/CircuitBreaker.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/networking/CircuitBreaker.kt
@@ -109,6 +109,16 @@ class CircuitBreaker(
     }
 
     /**
+     * Release a half-open probe slot that was reserved by [allowRequest] but never used — e.g. the
+     * send was skipped because the network was unavailable, so no real attempt occurred. This frees
+     * the breaker to probe again on a later cycle instead of being stuck half-open forever. It does
+     * not touch the failure counter or open window, since nothing actually failed or succeeded.
+     */
+    fun releaseProbe() {
+        probeInFlight = false
+    }
+
+    /**
      * Reset all breaker state. Intended to be called when the API client (re)starts.
      */
     fun reset() = recordSuccess()

--- a/sdk/core/src/main/java/com/klaviyo/core/networking/CircuitBreaker.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/networking/CircuitBreaker.kt
@@ -1,0 +1,125 @@
+package com.klaviyo.core.networking
+
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.pow
+
+/**
+ * A failure-count circuit breaker used to put the network queue into a dormant state when the
+ * server appears to be hard-down, rather than continuously draining the queue against an
+ * unreachable backend.
+ *
+ * The breaker trips on the number of *consecutive* failures, deliberately ignoring the specific
+ * HTTP status code. During an outage the recovery phase can emit a mix of unrelated codes
+ * (e.g. 403/404/525); counting failures is robust to that churn whereas classifying each code is
+ * not. Deliberate load-shed signals such as `403` are handled by the caller as an authoritative
+ * "reachable" outcome (see [recordSuccess]) so they bypass dormancy entirely.
+ *
+ * Three states:
+ * - **Closed**: normal operation; every failure increments the counter, any success resets it.
+ * - **Open**: once [failureThreshold] consecutive failures occur the breaker opens for a backoff
+ *   interval, during which [allowRequest] returns `false` and the caller should hold the queue.
+ * - **Half-open**: once the open interval elapses, [allowRequest] permits exactly one probe
+ *   request. A successful probe closes the breaker; a failed probe re-opens it with a longer,
+ *   exponentially-increasing interval (bounded by [maxOpenInterval]).
+ *
+ * All collaborators are supplied as providers so the breaker stays free of Android/Registry
+ * dependencies and remains trivially unit-testable. The breaker is disabled (always closed) when
+ * [failureThreshold] resolves to a value `<= 0`, which doubles as a kill-switch.
+ *
+ * This class is not thread-safe; it is expected to be driven from the single serial network
+ * worker thread that owns the queue.
+ *
+ * @property failureThreshold Provider for the number of consecutive failures required to open.
+ * @property baseOpenInterval Provider for the initial open interval in milliseconds.
+ * @property maxOpenInterval Provider for the ceiling on the open interval in milliseconds.
+ * @property clock Provider for the current wall-clock time in milliseconds.
+ * @property jitter Provider for a random jitter (milliseconds) added to each open interval.
+ */
+class CircuitBreaker(
+    private val failureThreshold: () -> Int,
+    private val baseOpenInterval: () -> Long,
+    private val maxOpenInterval: () -> Long,
+    private val clock: () -> Long,
+    private val jitter: () -> Long
+) {
+    enum class State { CLOSED, OPEN, HALF_OPEN }
+
+    private var consecutiveFailures = 0
+    private var openCycle = 0
+    private var openUntil = 0L
+    private var probeInFlight = false
+
+    private val isEnabled get() = failureThreshold() > 0
+
+    /**
+     * The current state, derived from the configured open window and the clock.
+     */
+    fun state(): State = when {
+        !isEnabled || openUntil == 0L -> State.CLOSED
+        clock() < openUntil -> State.OPEN
+        else -> State.HALF_OPEN
+    }
+
+    /**
+     * Whether a request may be sent right now.
+     *
+     * In [State.HALF_OPEN] this permits exactly one in-flight probe; subsequent calls return
+     * `false` until the probe's outcome is recorded via [recordSuccess]/[recordFailure].
+     */
+    fun allowRequest(): Boolean = when (state()) {
+        State.CLOSED -> true
+        State.OPEN -> false
+        State.HALF_OPEN -> if (probeInFlight) {
+            false
+        } else {
+            probeInFlight = true
+            true
+        }
+    }
+
+    /**
+     * Milliseconds remaining until the breaker would permit a probe. Zero when not open.
+     */
+    fun remainingOpenInterval(): Long = max(0L, openUntil - clock())
+
+    /**
+     * Record a reachable/successful outcome. Resets the breaker to a fully closed state. This is
+     * also the correct outcome for deliberate load-shed responses (e.g. `403`): the server is
+     * reachable, so dormancy must not engage.
+     */
+    fun recordSuccess() {
+        consecutiveFailures = 0
+        openCycle = 0
+        openUntil = 0L
+        probeInFlight = false
+    }
+
+    /**
+     * Record a transient/unreachable failure (retryable 5xx, network/IO error, or a `429` with no
+     * usable `Retry-After`). Opens the breaker once [failureThreshold] consecutive failures occur.
+     */
+    fun recordFailure() {
+        if (!isEnabled) return
+        probeInFlight = false
+        consecutiveFailures += 1
+        if (consecutiveFailures >= failureThreshold()) {
+            open()
+        }
+    }
+
+    /**
+     * Reset all breaker state. Intended to be called when the API client (re)starts.
+     */
+    fun reset() = recordSuccess()
+
+    private fun open() {
+        openCycle += 1
+        // Exponential growth bounded by the configured ceiling. Using Double math keeps us safe
+        // from overflow on a long outage: 2^n eventually yields Infinity, whose toLong() is
+        // Long.MAX_VALUE, so min() clamps it to maxOpenInterval before we add jitter.
+        val backoff = (baseOpenInterval() * 2.0.pow(openCycle - 1)).toLong()
+        val interval = min(backoff, maxOpenInterval()) + jitter()
+        openUntil = clock() + interval
+    }
+}

--- a/sdk/core/src/test/java/com/klaviyo/core/config/KlaviyoConfigTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/config/KlaviyoConfigTest.kt
@@ -126,7 +126,7 @@ internal class KlaviyoConfigTest : BaseTest() {
             KlaviyoConfig.networkFlushIntervals[NetworkMonitor.NetworkType.Offline.position]
         )
         assertEquals(50, KlaviyoConfig.networkMaxAttempts)
-        assertEquals(180_000L, KlaviyoConfig.networkMaxRetryInterval)
+        assertEquals(300_000L, KlaviyoConfig.networkMaxRetryInterval)
         assertEquals("android", KlaviyoConfig.sdkName)
         assertEquals("9.9.9", KlaviyoConfig.sdkVersion)
     }
@@ -162,7 +162,7 @@ internal class KlaviyoConfigTest : BaseTest() {
             KlaviyoConfig.networkFlushIntervals[NetworkMonitor.NetworkType.Offline.position]
         )
         assertEquals(50, KlaviyoConfig.networkMaxAttempts)
-        assertEquals(180_000, KlaviyoConfig.networkMaxRetryInterval)
+        assertEquals(300_000, KlaviyoConfig.networkMaxRetryInterval)
         assertEquals("android", KlaviyoConfig.sdkName)
         assertEquals("9.9.9", KlaviyoConfig.sdkVersion)
         // Each bad call should have generated an error log

--- a/sdk/core/src/test/java/com/klaviyo/core/config/KlaviyoConfigTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/config/KlaviyoConfigTest.kt
@@ -70,7 +70,6 @@ internal class KlaviyoConfigTest : BaseTest() {
             .networkFlushInterval(1, NetworkMonitor.NetworkType.Wifi)
             .networkFlushInterval(3, NetworkMonitor.NetworkType.Cell)
             .networkFlushInterval(6, NetworkMonitor.NetworkType.Offline)
-            .networkFlushDepth(4)
             .networkMaxAttempts(5)
             .networkMaxRetryInterval(7)
             .baseCdnUrl("spider-water.com")
@@ -95,7 +94,6 @@ internal class KlaviyoConfigTest : BaseTest() {
             6,
             KlaviyoConfig.networkFlushIntervals[NetworkMonitor.NetworkType.Offline.position]
         )
-        assertEquals(4, KlaviyoConfig.networkFlushDepth)
         assertEquals(5, KlaviyoConfig.networkMaxAttempts)
         assertEquals(7, KlaviyoConfig.networkMaxRetryInterval)
         assertEquals("android", KlaviyoConfig.sdkName)
@@ -127,7 +125,6 @@ internal class KlaviyoConfigTest : BaseTest() {
             60_000L,
             KlaviyoConfig.networkFlushIntervals[NetworkMonitor.NetworkType.Offline.position]
         )
-        assertEquals(25, KlaviyoConfig.networkFlushDepth)
         assertEquals(50, KlaviyoConfig.networkMaxAttempts)
         assertEquals(180_000L, KlaviyoConfig.networkMaxRetryInterval)
         assertEquals("android", KlaviyoConfig.sdkName)
@@ -145,7 +142,6 @@ internal class KlaviyoConfigTest : BaseTest() {
             .networkFlushInterval(-5000, NetworkMonitor.NetworkType.Wifi)
             .networkFlushInterval(-5000, NetworkMonitor.NetworkType.Cell)
             .networkFlushInterval(-5000, NetworkMonitor.NetworkType.Offline)
-            .networkFlushDepth(-10)
             .networkMaxAttempts(-10)
             .networkMaxRetryInterval(-1)
             .build()
@@ -165,13 +161,12 @@ internal class KlaviyoConfigTest : BaseTest() {
             60_000,
             KlaviyoConfig.networkFlushIntervals[NetworkMonitor.NetworkType.Offline.position]
         )
-        assertEquals(25, KlaviyoConfig.networkFlushDepth)
         assertEquals(50, KlaviyoConfig.networkMaxAttempts)
         assertEquals(180_000, KlaviyoConfig.networkMaxRetryInterval)
         assertEquals("android", KlaviyoConfig.sdkName)
         assertEquals("9.9.9", KlaviyoConfig.sdkVersion)
         // Each bad call should have generated an error log
-        verify(exactly = 9) { spyLog.error(any(), null) }
+        verify(exactly = 8) { spyLog.error(any(), null) }
     }
 
     @Test

--- a/sdk/core/src/test/java/com/klaviyo/core/networking/CircuitBreakerTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/networking/CircuitBreakerTest.kt
@@ -128,6 +128,23 @@ class CircuitBreakerTest {
     }
 
     @Test
+    fun `releaseProbe frees an unused half-open slot so a later cycle can probe again`() {
+        val breaker = makeBreaker()
+        repeat(3) { breaker.recordFailure() }
+        now += 1_000L // half-open
+
+        assertTrue(breaker.allowRequest()) // probe slot taken
+        assertFalse(breaker.allowRequest()) // blocked while probe is "in flight"
+
+        // The probe was never actually used (e.g. send skipped while offline)
+        breaker.releaseProbe()
+
+        // The slot is available again, and no failure/open state changed
+        assertEquals(CircuitBreaker.State.HALF_OPEN, breaker.state())
+        assertTrue(breaker.allowRequest())
+    }
+
+    @Test
     fun `reset returns the breaker to a fully closed state`() {
         val breaker = makeBreaker()
         repeat(3) { breaker.recordFailure() }

--- a/sdk/core/src/test/java/com/klaviyo/core/networking/CircuitBreakerTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/networking/CircuitBreakerTest.kt
@@ -1,0 +1,140 @@
+package com.klaviyo.core.networking
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CircuitBreakerTest {
+
+    private var now = 0L
+    private var threshold = 3
+
+    private fun makeBreaker(
+        base: Long = 1_000L,
+        max: Long = 8_000L,
+        jitter: Long = 0L
+    ) = CircuitBreaker(
+        failureThreshold = { threshold },
+        baseOpenInterval = { base },
+        maxOpenInterval = { max },
+        clock = { now },
+        jitter = { jitter }
+    )
+
+    @Test
+    fun `starts closed and allows requests`() {
+        val breaker = makeBreaker()
+        assertEquals(CircuitBreaker.State.CLOSED, breaker.state())
+        assertTrue(breaker.allowRequest())
+        assertEquals(0L, breaker.remainingOpenInterval())
+    }
+
+    @Test
+    fun `stays closed below the failure threshold`() {
+        val breaker = makeBreaker()
+        breaker.recordFailure()
+        breaker.recordFailure()
+        assertEquals(CircuitBreaker.State.CLOSED, breaker.state())
+        assertTrue(breaker.allowRequest())
+    }
+
+    @Test
+    fun `opens once consecutive failures reach the threshold`() {
+        val breaker = makeBreaker()
+        repeat(3) { breaker.recordFailure() }
+        assertEquals(CircuitBreaker.State.OPEN, breaker.state())
+        assertFalse(breaker.allowRequest())
+        assertEquals(1_000L, breaker.remainingOpenInterval())
+    }
+
+    @Test
+    fun `success resets the consecutive failure counter`() {
+        val breaker = makeBreaker()
+        breaker.recordFailure()
+        breaker.recordFailure()
+        breaker.recordSuccess()
+        assertEquals(CircuitBreaker.State.CLOSED, breaker.state())
+
+        // Two more failures should not trip it: the counter was reset
+        breaker.recordFailure()
+        breaker.recordFailure()
+        assertEquals(CircuitBreaker.State.CLOSED, breaker.state())
+    }
+
+    @Test
+    fun `transitions to half-open after the open interval elapses and allows one probe`() {
+        val breaker = makeBreaker()
+        repeat(3) { breaker.recordFailure() }
+        assertEquals(CircuitBreaker.State.OPEN, breaker.state())
+
+        now += 1_000L // advance to the end of the open window
+        assertEquals(CircuitBreaker.State.HALF_OPEN, breaker.state())
+        assertEquals(0L, breaker.remainingOpenInterval())
+
+        // Exactly one probe is allowed through
+        assertTrue(breaker.allowRequest())
+        assertFalse(breaker.allowRequest())
+    }
+
+    @Test
+    fun `successful probe closes the breaker`() {
+        val breaker = makeBreaker()
+        repeat(3) { breaker.recordFailure() }
+        now += 1_000L
+        assertTrue(breaker.allowRequest()) // probe
+        breaker.recordSuccess()
+
+        assertEquals(CircuitBreaker.State.CLOSED, breaker.state())
+        assertTrue(breaker.allowRequest())
+    }
+
+    @Test
+    fun `failed probe re-opens with a longer exponential interval`() {
+        val breaker = makeBreaker()
+        repeat(3) { breaker.recordFailure() }
+        assertEquals(1_000L, breaker.remainingOpenInterval()) // cycle 1: base
+
+        now += 1_000L
+        assertTrue(breaker.allowRequest()) // probe
+        breaker.recordFailure() // probe fails -> cycle 2
+
+        assertEquals(CircuitBreaker.State.OPEN, breaker.state())
+        assertEquals(2_000L, breaker.remainingOpenInterval()) // base * 2^1
+    }
+
+    @Test
+    fun `open interval is capped at the configured maximum`() {
+        val breaker = makeBreaker(base = 1_000L, max = 8_000L)
+        repeat(3) { breaker.recordFailure() }
+
+        // Drive several failed probe cycles; the interval must never exceed the maximum
+        repeat(10) {
+            now += breaker.remainingOpenInterval()
+            assertTrue(breaker.allowRequest())
+            breaker.recordFailure()
+        }
+
+        assertEquals(8_000L, breaker.remainingOpenInterval())
+    }
+
+    @Test
+    fun `is disabled when the threshold is not positive`() {
+        threshold = 0
+        val breaker = makeBreaker()
+        repeat(50) { breaker.recordFailure() }
+        assertEquals(CircuitBreaker.State.CLOSED, breaker.state())
+        assertTrue(breaker.allowRequest())
+    }
+
+    @Test
+    fun `reset returns the breaker to a fully closed state`() {
+        val breaker = makeBreaker()
+        repeat(3) { breaker.recordFailure() }
+        assertEquals(CircuitBreaker.State.OPEN, breaker.state())
+
+        breaker.reset()
+        assertEquals(CircuitBreaker.State.CLOSED, breaker.state())
+        assertEquals(0L, breaker.remainingOpenInterval())
+    }
+}

--- a/sdk/fixtures/src/main/java/com/klaviyo/fixtures/BaseTest.kt
+++ b/sdk/fixtures/src/main/java/com/klaviyo/fixtures/BaseTest.kt
@@ -87,6 +87,11 @@ abstract class BaseTest {
         every { networkTimeout } returns 1000
         every { uxNetworkTimeout } returns 100
         every { networkMaxRetryInterval } returns 300_000L
+        // Circuit breaker disabled by default so existing retry/flush tests are unaffected;
+        // tests that exercise the breaker override circuitBreakerFailureThreshold explicitly.
+        every { circuitBreakerFailureThreshold } returns 0
+        every { circuitBreakerBaseOpenInterval } returns 30_000L
+        every { circuitBreakerMaxOpenInterval } returns 300_000L
         every { networkFlushIntervals } returns longArrayOf(10_000, 30_000, 60_000)
         every { networkJitterRange } returns 0..0
         every { baseUrl } returns "https://test.fake-klaviyo.com"

--- a/sdk/fixtures/src/main/java/com/klaviyo/fixtures/BaseTest.kt
+++ b/sdk/fixtures/src/main/java/com/klaviyo/fixtures/BaseTest.kt
@@ -86,7 +86,7 @@ abstract class BaseTest {
         every { networkMaxAttempts } returns 50
         every { networkTimeout } returns 1000
         every { uxNetworkTimeout } returns 100
-        every { networkMaxRetryInterval } returns 180_000L
+        every { networkMaxRetryInterval } returns 300_000L
         every { networkFlushIntervals } returns longArrayOf(10_000, 30_000, 60_000)
         every { networkJitterRange } returns 0..0
         every { baseUrl } returns "https://test.fake-klaviyo.com"


### PR DESCRIPTION
Implements L2 of the SDK retry & outage-resilience spec for Android: a failure-count circuit breaker that holds the persisted queue dormant during a sustained outage instead of fast-draining against an unreachable server.

**Changes**
- New `CircuitBreaker` state machine in `sdk/core` (closed/open/half-open), keyed on consecutive failures rather than status code, with exponential open-interval backoff bounded by a configurable max. Disabled when the failure threshold is `<= 0` (kill-switch).
- `KlaviyoApiClient` gates the serial flush loop on the breaker and classifies each send outcome: retryable 5xx, network/IO errors, and `429`-without-`Retry-After` are failures; `2xx`, `403` load-shed, `429`-with-`Retry-After`, and other `4xx` are reachable successes that reset the breaker. `403` therefore bypasses dormancy, preserving the backend's load-shedding valve.
- Breaker settings added to the `Config` interface (fixed defaults: threshold 5, base 30s, max 5min); resets on `startService`.
- Tests: `CircuitBreakerTest` (state machine) and `KlaviyoApiClient` trip/hold/probe + `403`-bypass tests. Breaker is disabled by default in `BaseTest`, so existing retry/flush tests are unchanged.

NOT validated locally: the Reca sandbox is Linux with no Android toolchain, so ./gradlew test and ktlintCheck could not be run. Please rely on CI / a local JDK 17 + Android env to validate before merge.

Follow-ups: Swift parity (matching breaker), exposing breaker tuning via Config.Builder, persisting open-state across process restart, and the L3 queue-retention audit. Branch is based on master, independent of feat/mage-694-retry-all-5xx.

Reca job ID: b11a3ef7-fd4a-437c-a1a7-431da69e4219