### PR TITLE
test(core): cold-start regression test for first Registry reified call (MAGE-805 baseline — expected RED)

### DIFF
--- a/sdk/core/src/test/java/com/klaviyo/core/benchmark/RegistryStartupBenchmark.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/benchmark/RegistryStartupBenchmark.kt
@@ -69,5 +69,5 @@ private fun totalLoadedClasses(): Long {
     val managementFactory = Class.forName("java.lang.management.ManagementFactory")
     val bean = managementFactory.getMethod("getClassLoadingMXBean").invoke(null)
     val beanInterface = Class.forName("java.lang.management.ClassLoadingMXBean")
-    return (beanInterface.getMethod("getTotalLoadedClassCount").invoke(bean) as Int).toLong()
+    return beanInterface.getMethod("getTotalLoadedClassCount").invoke(bean) as Long
 }

--- a/sdk/core/src/test/java/com/klaviyo/core/benchmark/RegistryStartupBenchmark.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/benchmark/RegistryStartupBenchmark.kt
@@ -1,7 +1,6 @@
 package com.klaviyo.core.benchmark
 
 import com.klaviyo.core.Registry
-import java.lang.management.ManagementFactory
 
 /**
  * A unique marker type used only to drive a first-of-its-kind reified Registry
@@ -23,11 +22,11 @@ private interface RegistryStartupBenchmarkMarker
  * - With the MAGE-805 fix the call routes through `T::class.java` (a direct class
  *   literal) and loads only a handful of classes — no reflection subsystem.
  *
- * The primary signal is the number of classes loaded during the call, captured via
- * [ManagementFactory]'s class-loading bean. Class count is deterministic and
- * hardware-independent, unlike wall-clock time (CI runners are far faster than the
- * low-end devices where the ANR reproduces), so it gives a stable red/green split.
- * Elapsed time is also reported for context.
+ * The primary signal is the number of classes loaded during the call (see
+ * [totalLoadedClasses]). Class count is deterministic and hardware-independent,
+ * unlike wall-clock time (CI runners are far faster than the low-end devices where
+ * the ANR reproduces), so it gives a stable red/green split. Elapsed time is also
+ * reported for context.
  *
  * A fresh JVM is required because the reflection subsystem is process-global and
  * warms up exactly once; the cost is invisible in the already-warmed test JVM.
@@ -35,13 +34,12 @@ private interface RegistryStartupBenchmarkMarker
  * Output contract (stdout): a `CLASSES_LOADED=<n>` line and an `ELAPSED_NS=<n>` line.
  */
 fun main() {
-    val classLoading = ManagementFactory.getClassLoadingMXBean()
+    // Warm up the measurement/printing machinery first (including the reflective
+    // ManagementFactory lookup) so the measured delta is attributable to the
+    // Registry call rather than incidental class loading.
+    println("WARMUP=${totalLoadedClasses()}")
 
-    // Warm up the measurement/printing machinery first so the measured delta is
-    // attributable to the Registry call rather than incidental class loading.
-    println("WARMUP=${classLoading.totalLoadedClassCount}")
-
-    val loadedBefore = classLoading.totalLoadedClassCount
+    val loadedBefore = totalLoadedClasses()
     val start = System.nanoTime()
     // First reified Registry call in this process — the cold-start hot path.
     // registerOnce -> isRegistered -> key derivation: typeOf<T>() on master
@@ -50,8 +48,26 @@ fun main() {
         object : RegistryStartupBenchmarkMarker {}
     }
     val elapsedNs = System.nanoTime() - start
-    val classesLoaded = classLoading.totalLoadedClassCount - loadedBefore
+    val classesLoaded = totalLoadedClasses() - loadedBefore
 
     println("CLASSES_LOADED=$classesLoaded")
     println("ELAPSED_NS=$elapsedNs")
+}
+
+/**
+ * Total number of classes this JVM has loaded so far, read from
+ * `java.lang.management.ClassLoadingMXBean`.
+ *
+ * Accessed reflectively on purpose: the `java.lang.management` package is NOT on
+ * the Android unit-test COMPILE classpath (Android's `android.jar` omits it), so a
+ * direct import does not compile. It IS present at RUNTIME in the forked JDK that
+ * runs this `main`, so reflection resolves it there. Methods are invoked via the
+ * exported `ClassLoadingMXBean` interface to avoid JPMS access issues with the
+ * (non-exported) bean implementation class.
+ */
+private fun totalLoadedClasses(): Long {
+    val managementFactory = Class.forName("java.lang.management.ManagementFactory")
+    val bean = managementFactory.getMethod("getClassLoadingMXBean").invoke(null)
+    val beanInterface = Class.forName("java.lang.management.ClassLoadingMXBean")
+    return (beanInterface.getMethod("getTotalLoadedClassCount").invoke(bean) as Int).toLong()
 }

--- a/sdk/core/src/test/java/com/klaviyo/core/benchmark/RegistryStartupBenchmark.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/benchmark/RegistryStartupBenchmark.kt
@@ -1,0 +1,57 @@
+package com.klaviyo.core.benchmark
+
+import com.klaviyo.core.Registry
+import java.lang.management.ManagementFactory
+
+/**
+ * A unique marker type used only to drive a first-of-its-kind reified Registry
+ * call. It must never be registered anywhere else so that [main] always
+ * exercises the very first registration of this type in the process.
+ */
+private interface RegistryStartupBenchmarkMarker
+
+/**
+ * Standalone entrypoint, launched in a FRESH JVM by [RegistryStartupBenchmarkTest].
+ *
+ * It measures what the FIRST reified [Registry] call costs in a cold process — the
+ * exact work `FormsInitProvider.onCreate()` performs on the main thread at app
+ * startup (MAGE-805):
+ * - On master the call routes through `kotlin.reflect.typeOf<T>()`, whose first
+ *   invocation cold-initializes the Kotlin reflection subsystem
+ *   (RuntimeModuleData / DeserializationComponentsForJava / JvmBuiltIns). That
+ *   class-loads the entire reflection descriptor stack — hundreds of classes.
+ * - With the MAGE-805 fix the call routes through `T::class.java` (a direct class
+ *   literal) and loads only a handful of classes — no reflection subsystem.
+ *
+ * The primary signal is the number of classes loaded during the call, captured via
+ * [ManagementFactory]'s class-loading bean. Class count is deterministic and
+ * hardware-independent, unlike wall-clock time (CI runners are far faster than the
+ * low-end devices where the ANR reproduces), so it gives a stable red/green split.
+ * Elapsed time is also reported for context.
+ *
+ * A fresh JVM is required because the reflection subsystem is process-global and
+ * warms up exactly once; the cost is invisible in the already-warmed test JVM.
+ *
+ * Output contract (stdout): a `CLASSES_LOADED=<n>` line and an `ELAPSED_NS=<n>` line.
+ */
+fun main() {
+    val classLoading = ManagementFactory.getClassLoadingMXBean()
+
+    // Warm up the measurement/printing machinery first so the measured delta is
+    // attributable to the Registry call rather than incidental class loading.
+    println("WARMUP=${classLoading.totalLoadedClassCount}")
+
+    val loadedBefore = classLoading.totalLoadedClassCount
+    val start = System.nanoTime()
+    // First reified Registry call in this process — the cold-start hot path.
+    // registerOnce -> isRegistered -> key derivation: typeOf<T>() on master
+    // (reflection cold init), T::class.java with the MAGE-805 fix (no reflection).
+    Registry.registerOnce<RegistryStartupBenchmarkMarker> {
+        object : RegistryStartupBenchmarkMarker {}
+    }
+    val elapsedNs = System.nanoTime() - start
+    val classesLoaded = classLoading.totalLoadedClassCount - loadedBefore
+
+    println("CLASSES_LOADED=$classesLoaded")
+    println("ELAPSED_NS=$elapsedNs")
+}

--- a/sdk/core/src/test/java/com/klaviyo/core/benchmark/RegistryStartupBenchmarkTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/benchmark/RegistryStartupBenchmarkTest.kt
@@ -1,0 +1,80 @@
+package com.klaviyo.core.benchmark
+
+import java.io.File
+import org.junit.Test
+
+/**
+ * Cold-start regression test for MAGE-805.
+ *
+ * Launches a FRESH JVM (see [RegistryStartupBenchmark.main]) and asserts that the
+ * first reified [com.klaviyo.core.Registry] call — the work `FormsInitProvider`
+ * runs on the main thread at app startup — does NOT cold-initialize the Kotlin
+ * reflection subsystem.
+ *
+ * The discriminating signal is the number of classes loaded during that first call:
+ * - On master the call routes through `kotlin.reflect.typeOf<T>()`, which cold-inits
+ *   the reflection descriptor stack and class-loads hundreds of classes → this test
+ *   FAILS (red).
+ * - With the MAGE-805 `Class<*>` fix the call routes through `T::class.java` and
+ *   loads only a handful → this test PASSES (green).
+ *
+ * Class-load count is used instead of wall-clock time because it is deterministic
+ * and hardware-independent (CI runners are far faster than the low-end devices where
+ * the ANR reproduces). A fresh process is required because the reflection subsystem
+ * is process-global and warms up once.
+ *
+ * The [MAX_CLASSES_LOADED] ceiling sits in the wide gap between the two paths; the
+ * failure message reports the observed count so the threshold can be tuned from CI.
+ */
+class RegistryStartupBenchmarkTest {
+
+    private companion object {
+        /**
+         * Upper bound on classes loaded by the first Registry call. The fixed path
+         * loads a few dozen at most; the reflection cold-init path loads several
+         * hundred. This sits between them with margin on both sides.
+         */
+        const val MAX_CLASSES_LOADED = 100L
+    }
+
+    @Test
+    fun `first Registry call must not cold-init kotlin reflect at startup`() {
+        val javaBin = File(File(System.getProperty("java.home"), "bin"), "java").absolutePath
+        val classpath = System.getProperty("java.class.path")
+        val mainClass = "com.klaviyo.core.benchmark.RegistryStartupBenchmarkKt"
+
+        val process = ProcessBuilder(javaBin, "-cp", classpath, mainClass)
+            .redirectErrorStream(true)
+            .start()
+
+        val output = process.inputStream.bufferedReader().use { it.readText() }
+        val exitCode = process.waitFor()
+
+        println("[RegistryStartupBenchmark] subprocess exit=$exitCode, output:\n$output")
+
+        val classesLoaded = output.metric("CLASSES_LOADED")
+            ?: throw AssertionError(
+                "Subprocess emitted no CLASSES_LOADED (exit=$exitCode).\nOutput:\n$output"
+            )
+        val elapsedMs = (output.metric("ELAPSED_NS") ?: 0L) / 1_000_000.0
+
+        println(
+            "[RegistryStartupBenchmark] first Registry reified call (cold process): " +
+                "$classesLoaded classes loaded, ${elapsedMs}ms"
+        )
+
+        if (classesLoaded > MAX_CLASSES_LOADED) {
+            throw AssertionError(
+                "First Registry call loaded $classesLoaded classes (max $MAX_CLASSES_LOADED), " +
+                    "indicating kotlin.reflect cold init on the cold-start path (MAGE-805). " +
+                    "Took ${elapsedMs}ms. The Class<*>-keyed Registry should load far fewer."
+            )
+        }
+    }
+
+    private fun String.metric(key: String): Long? = lineSequence()
+        .firstOrNull { it.startsWith("$key=") }
+        ?.substringAfter("$key=")
+        ?.trim()
+        ?.toLongOrNull()
+}


### PR DESCRIPTION
Baseline (without fix). Adds a forked-JVM unit test asserting the first reified Registry call does NOT cold-init kotlin.reflect, measured by classes loaded (ceiling 100). On master the call routes through typeOf<T>() and loads hundreds of classes, so this PR is EXPECTED TO FAIL — that red is the proof the regression is detected. Compare against perf/mage-805-registry-startup-benchmark-with-fix.

Open as Draft.

Reca job ID: 68a6fe54-7337-42da-bad3-98f1be36cdd1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added performance benchmarks and validation tests for registry startup optimization to ensure efficient initialization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->