### PR TITLE
test(core): cold-start regression test + Class<*> fix (MAGE-805 — expected GREEN)

### DIFF
--- a/sdk/core/src/main/java/com/klaviyo/core/Registry.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/Registry.kt
@@ -15,15 +15,15 @@ import com.klaviyo.core.networking.KlaviyoNetworkMonitor
 import com.klaviyo.core.networking.NetworkMonitor
 import com.klaviyo.core.utils.KlaviyoThreadHelper
 import com.klaviyo.core.utils.ThreadHelper
-import kotlin.reflect.KType
-import kotlin.reflect.typeOf
 import kotlinx.coroutines.Dispatchers
 
 class MissingConfig : KlaviyoException("Klaviyo SDK accessed before initializing")
-class MissingRegistration(type: KType) : KlaviyoException(
+class MissingRegistration(type: Class<*>) : KlaviyoException(
     "No service registered for $type. Typically caused by accessing SDK before initializing or providing app lifecycle/context."
 )
-class InvalidRegistration(type: KType) : KlaviyoException("Registered service does not match $type")
+class InvalidRegistration(type: Class<*>) : KlaviyoException(
+    "Registered service does not match $type"
+)
 class MissingKlaviyoModule(moduleName: String) : RuntimeException(
     "$moduleName module not installed. Add 'com.klaviyo:$moduleName' dependency to enable this feature."
 )
@@ -83,13 +83,13 @@ object Registry {
      * Internal registry of registered service instances
      */
     @PublishedApi
-    internal val services = mutableMapOf<KType, Any>()
+    internal val services = mutableMapOf<Class<*>, Any>()
 
     /**
      * Internal registry of registered service lambdas
      */
     @PublishedApi
-    internal val registry = mutableMapOf<KType, Registration>()
+    internal val registry = mutableMapOf<Class<*>, Registration>()
 
     /**
      * Remove registered service by type, specified by generic parameter
@@ -97,8 +97,8 @@ object Registry {
      * @param T - Type, usually an interface, to register under
      */
     inline fun <reified T : Any> unregister() {
-        registry.remove(typeOf<T>())
-        services.remove(typeOf<T>())
+        registry.remove(T::class.java)
+        services.remove(T::class.java)
     }
 
     /**
@@ -109,7 +109,7 @@ object Registry {
      * @param service - The implementation
      */
     inline fun <reified T : Any> register(service: Any) {
-        val type = typeOf<T>()
+        val type = T::class.java
         unregister<T>()
         services[type] = service
     }
@@ -122,7 +122,7 @@ object Registry {
      * @param registration - Lambda that returns the implementation
      */
     inline fun <reified T : Any> register(noinline registration: Registration) {
-        val type = typeOf<T>()
+        val type = T::class.java
         unregister<T>()
         registry[type] = registration
     }
@@ -137,7 +137,7 @@ object Registry {
      */
     inline fun <reified T : Any> registerOnce(noinline registration: Registration) {
         if (!isRegistered<T>()) {
-            val type = typeOf<T>()
+            val type = T::class.java
             registry[type] = registration
         }
     }
@@ -148,7 +148,7 @@ object Registry {
      * @param T - Type, usually an interface, to register under
      * @return Whether service is registered
      */
-    inline fun <reified T : Any> isRegistered(): Boolean = typeOf<T>().let { type ->
+    inline fun <reified T : Any> isRegistered(): Boolean = T::class.java.let { type ->
         registry.containsKey(type) || services.containsKey(type)
     }
 
@@ -159,7 +159,7 @@ object Registry {
      * @return The instance of the service
      */
     inline fun <reified T : Any> getOrNull(): T? {
-        val type = typeOf<T>()
+        val type = T::class.java
         val service: Any? = services[type]
 
         if (service is T) return service
@@ -178,7 +178,7 @@ object Registry {
      * @throws MissingRegistration If no service is registered of that type
      */
     inline fun <reified T : Any> get(): T {
-        val type = typeOf<T>()
+        val type = T::class.java
         val service: Any? = services[type]
 
         if (service is T) return service
@@ -191,7 +191,7 @@ object Registry {
 
             is Any -> throw InvalidRegistration(type)
             else -> {
-                if (type == typeOf<Config>()) {
+                if (type == Config::class.java) {
                     throw MissingConfig()
                 } else {
                     throw MissingRegistration(type)

--- a/sdk/core/src/test/java/com/klaviyo/core/KlaviyoExceptionTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/KlaviyoExceptionTest.kt
@@ -8,7 +8,6 @@ import io.mockk.spyk
 import io.mockk.unmockkObject
 import io.mockk.verify
 import java.util.concurrent.ConcurrentLinkedQueue
-import kotlin.reflect.typeOf
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
@@ -84,7 +83,7 @@ class KlaviyoExceptionTest {
         val result1 = safeCall<Unit> { throw MissingConfig() }
         assertNull(result1)
 
-        val result2 = safeCall<Unit> { throw MissingRegistration(typeOf<String>()) }
+        val result2 = safeCall<Unit> { throw MissingRegistration(String::class.java) }
         assertNull(result2)
 
         verify(exactly = 1) { spyLog.error(any(), match { it is MissingConfig }) }

--- a/sdk/core/src/test/java/com/klaviyo/core/benchmark/RegistryStartupBenchmark.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/benchmark/RegistryStartupBenchmark.kt
@@ -69,5 +69,5 @@ private fun totalLoadedClasses(): Long {
     val managementFactory = Class.forName("java.lang.management.ManagementFactory")
     val bean = managementFactory.getMethod("getClassLoadingMXBean").invoke(null)
     val beanInterface = Class.forName("java.lang.management.ClassLoadingMXBean")
-    return (beanInterface.getMethod("getTotalLoadedClassCount").invoke(bean) as Int).toLong()
+    return beanInterface.getMethod("getTotalLoadedClassCount").invoke(bean) as Long
 }

--- a/sdk/core/src/test/java/com/klaviyo/core/benchmark/RegistryStartupBenchmark.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/benchmark/RegistryStartupBenchmark.kt
@@ -1,7 +1,6 @@
 package com.klaviyo.core.benchmark
 
 import com.klaviyo.core.Registry
-import java.lang.management.ManagementFactory
 
 /**
  * A unique marker type used only to drive a first-of-its-kind reified Registry
@@ -23,11 +22,11 @@ private interface RegistryStartupBenchmarkMarker
  * - With the MAGE-805 fix the call routes through `T::class.java` (a direct class
  *   literal) and loads only a handful of classes — no reflection subsystem.
  *
- * The primary signal is the number of classes loaded during the call, captured via
- * [ManagementFactory]'s class-loading bean. Class count is deterministic and
- * hardware-independent, unlike wall-clock time (CI runners are far faster than the
- * low-end devices where the ANR reproduces), so it gives a stable red/green split.
- * Elapsed time is also reported for context.
+ * The primary signal is the number of classes loaded during the call (see
+ * [totalLoadedClasses]). Class count is deterministic and hardware-independent,
+ * unlike wall-clock time (CI runners are far faster than the low-end devices where
+ * the ANR reproduces), so it gives a stable red/green split. Elapsed time is also
+ * reported for context.
  *
  * A fresh JVM is required because the reflection subsystem is process-global and
  * warms up exactly once; the cost is invisible in the already-warmed test JVM.
@@ -35,13 +34,12 @@ private interface RegistryStartupBenchmarkMarker
  * Output contract (stdout): a `CLASSES_LOADED=<n>` line and an `ELAPSED_NS=<n>` line.
  */
 fun main() {
-    val classLoading = ManagementFactory.getClassLoadingMXBean()
+    // Warm up the measurement/printing machinery first (including the reflective
+    // ManagementFactory lookup) so the measured delta is attributable to the
+    // Registry call rather than incidental class loading.
+    println("WARMUP=${totalLoadedClasses()}")
 
-    // Warm up the measurement/printing machinery first so the measured delta is
-    // attributable to the Registry call rather than incidental class loading.
-    println("WARMUP=${classLoading.totalLoadedClassCount}")
-
-    val loadedBefore = classLoading.totalLoadedClassCount
+    val loadedBefore = totalLoadedClasses()
     val start = System.nanoTime()
     // First reified Registry call in this process — the cold-start hot path.
     // registerOnce -> isRegistered -> key derivation: typeOf<T>() on master
@@ -50,8 +48,26 @@ fun main() {
         object : RegistryStartupBenchmarkMarker {}
     }
     val elapsedNs = System.nanoTime() - start
-    val classesLoaded = classLoading.totalLoadedClassCount - loadedBefore
+    val classesLoaded = totalLoadedClasses() - loadedBefore
 
     println("CLASSES_LOADED=$classesLoaded")
     println("ELAPSED_NS=$elapsedNs")
+}
+
+/**
+ * Total number of classes this JVM has loaded so far, read from
+ * `java.lang.management.ClassLoadingMXBean`.
+ *
+ * Accessed reflectively on purpose: the `java.lang.management` package is NOT on
+ * the Android unit-test COMPILE classpath (Android's `android.jar` omits it), so a
+ * direct import does not compile. It IS present at RUNTIME in the forked JDK that
+ * runs this `main`, so reflection resolves it there. Methods are invoked via the
+ * exported `ClassLoadingMXBean` interface to avoid JPMS access issues with the
+ * (non-exported) bean implementation class.
+ */
+private fun totalLoadedClasses(): Long {
+    val managementFactory = Class.forName("java.lang.management.ManagementFactory")
+    val bean = managementFactory.getMethod("getClassLoadingMXBean").invoke(null)
+    val beanInterface = Class.forName("java.lang.management.ClassLoadingMXBean")
+    return (beanInterface.getMethod("getTotalLoadedClassCount").invoke(bean) as Int).toLong()
 }


### PR DESCRIPTION
The benchmark branch with the MAGE-805 fix on top. The identical test routes through T::class.java, loads only a handful of classes, and PASSES — the green half of the comparison. Diff the test result against the baseline PR.

Open as Draft.

Reca job ID: 68a6fe54-7337-42da-bad3-98f1be36cdd1