### PR TITLE
fix(core): key Registry on Class<*> to avoid kotlin.reflect cold init at startup (MAGE-805)

### DIFF
--- a/sdk/core/src/main/java/com/klaviyo/core/Registry.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/Registry.kt
@@ -15,15 +15,15 @@ import com.klaviyo.core.networking.KlaviyoNetworkMonitor
 import com.klaviyo.core.networking.NetworkMonitor
 import com.klaviyo.core.utils.KlaviyoThreadHelper
 import com.klaviyo.core.utils.ThreadHelper
-import kotlin.reflect.KType
-import kotlin.reflect.typeOf
 import kotlinx.coroutines.Dispatchers
 
 class MissingConfig : KlaviyoException("Klaviyo SDK accessed before initializing")
-class MissingRegistration(type: KType) : KlaviyoException(
+class MissingRegistration(type: Class<*>) : KlaviyoException(
     "No service registered for $type. Typically caused by accessing SDK before initializing or providing app lifecycle/context."
 )
-class InvalidRegistration(type: KType) : KlaviyoException("Registered service does not match $type")
+class InvalidRegistration(type: Class<*>) : KlaviyoException(
+    "Registered service does not match $type"
+)
 class MissingKlaviyoModule(moduleName: String) : RuntimeException(
     "$moduleName module not installed. Add 'com.klaviyo:$moduleName' dependency to enable this feature."
 )
@@ -83,13 +83,13 @@ object Registry {
      * Internal registry of registered service instances
      */
     @PublishedApi
-    internal val services = mutableMapOf<KType, Any>()
+    internal val services = mutableMapOf<Class<*>, Any>()
 
     /**
      * Internal registry of registered service lambdas
      */
     @PublishedApi
-    internal val registry = mutableMapOf<KType, Registration>()
+    internal val registry = mutableMapOf<Class<*>, Registration>()
 
     /**
      * Remove registered service by type, specified by generic parameter
@@ -97,8 +97,8 @@ object Registry {
      * @param T - Type, usually an interface, to register under
      */
     inline fun <reified T : Any> unregister() {
-        registry.remove(typeOf<T>())
-        services.remove(typeOf<T>())
+        registry.remove(T::class.java)
+        services.remove(T::class.java)
     }
 
     /**
@@ -109,7 +109,7 @@ object Registry {
      * @param service - The implementation
      */
     inline fun <reified T : Any> register(service: Any) {
-        val type = typeOf<T>()
+        val type = T::class.java
         unregister<T>()
         services[type] = service
     }
@@ -122,7 +122,7 @@ object Registry {
      * @param registration - Lambda that returns the implementation
      */
     inline fun <reified T : Any> register(noinline registration: Registration) {
-        val type = typeOf<T>()
+        val type = T::class.java
         unregister<T>()
         registry[type] = registration
     }
@@ -137,7 +137,7 @@ object Registry {
      */
     inline fun <reified T : Any> registerOnce(noinline registration: Registration) {
         if (!isRegistered<T>()) {
-            val type = typeOf<T>()
+            val type = T::class.java
             registry[type] = registration
         }
     }
@@ -148,7 +148,7 @@ object Registry {
      * @param T - Type, usually an interface, to register under
      * @return Whether service is registered
      */
-    inline fun <reified T : Any> isRegistered(): Boolean = typeOf<T>().let { type ->
+    inline fun <reified T : Any> isRegistered(): Boolean = T::class.java.let { type ->
         registry.containsKey(type) || services.containsKey(type)
     }
 
@@ -159,7 +159,7 @@ object Registry {
      * @return The instance of the service
      */
     inline fun <reified T : Any> getOrNull(): T? {
-        val type = typeOf<T>()
+        val type = T::class.java
         val service: Any? = services[type]
 
         if (service is T) return service
@@ -178,7 +178,7 @@ object Registry {
      * @throws MissingRegistration If no service is registered of that type
      */
     inline fun <reified T : Any> get(): T {
-        val type = typeOf<T>()
+        val type = T::class.java
         val service: Any? = services[type]
 
         if (service is T) return service
@@ -191,7 +191,7 @@ object Registry {
 
             is Any -> throw InvalidRegistration(type)
             else -> {
-                if (type == typeOf<Config>()) {
+                if (type == Config::class.java) {
                     throw MissingConfig()
                 } else {
                     throw MissingRegistration(type)

--- a/sdk/core/src/test/java/com/klaviyo/core/KlaviyoExceptionTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/KlaviyoExceptionTest.kt
@@ -8,7 +8,6 @@ import io.mockk.spyk
 import io.mockk.unmockkObject
 import io.mockk.verify
 import java.util.concurrent.ConcurrentLinkedQueue
-import kotlin.reflect.typeOf
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
@@ -84,7 +83,7 @@ class KlaviyoExceptionTest {
         val result1 = safeCall<Unit> { throw MissingConfig() }
         assertNull(result1)
 
-        val result2 = safeCall<Unit> { throw MissingRegistration(typeOf<String>()) }
+        val result2 = safeCall<Unit> { throw MissingRegistration(String::class.java) }
         assertNull(result2)
 
         verify(exactly = 1) { spyLog.error(any(), match { it is MissingConfig }) }


### PR DESCRIPTION
Keys the core Registry service-locator on `Class<*>` (`T::class.java`) instead of `KType` (`typeOf<T>()`), so the first reified Registry call — which `FormsInitProvider.onCreate()` runs on the main thread at startup — no longer cold-inits the kotlin.reflect subsystem (MAGE-805 / klaviyo-android-sdk#487).

Public inline reified signatures and all call sites are unchanged; only the internal map key type and the two exception constructors change. ktlint-clean (InvalidRegistration argument wrapped to satisfy argument-list-wrapping). This is the branch to merge.

Open as Draft.

Reca job ID: 68a6fe54-7337-42da-bad3-98f1be36cdd1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced the internal service registry mechanism for improved compatibility and consistency.
  * Updated exception handling to align with registry implementation changes.

* **Tests**
  * Updated test suite to reflect registry implementation modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->