### PR TITLE
feat(push): KlaviyoTrampolineActivity with opt-in automatic push tracking [MAGE-767]

### DIFF
--- a/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
@@ -31,11 +31,9 @@ object Constants {
 
     /**
      * Manifest `<meta-data>` key a host app sets to opt into automatic push open tracking.
-     * When enabled, Klaviyo notification taps route through `KlaviyoTrampolineActivity`, which
-     * calls `Klaviyo.handlePush` itself — removing the need for `handlePush` in host Activities.
      *
      * Lives in core (not push-fcm) because telemetry's push token request must read it, and core
-     * cannot depend on push-fcm. Re-exposed as `KlaviyoPushService.METADATA_AUTOMATIC_PUSH_TRACKING`.
+     * cannot depend on push-fcm.
      */
     const val AUTOMATIC_PUSH_TRACKING = PACKAGE_PREFIX + "automatic_push_tracking"
 

--- a/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
@@ -30,6 +30,16 @@ object Constants {
     const val NOTIFICATION_TAG_EXTRA = INTERNAL_PREFIX + "notification_tag"
 
     /**
+     * Manifest `<meta-data>` key a host app sets to opt into automatic push open tracking.
+     * When enabled, Klaviyo notification taps route through `KlaviyoTrampolineActivity`, which
+     * calls `Klaviyo.handlePush` itself — removing the need for `handlePush` in host Activities.
+     *
+     * Lives in core (not push-fcm) because telemetry's push token request must read it, and core
+     * cannot depend on push-fcm. Re-exposed as `KlaviyoPushService.METADATA_AUTOMATIC_PUSH_TRACKING`.
+     */
+    const val AUTOMATIC_PUSH_TRACKING = PACKAGE_PREFIX + "automatic_push_tracking"
+
+    /**
      * Fixed notification ID used in all notify/cancel calls.
      * Notifications are uniquely identified by their string tag, not this ID.
      */

--- a/sdk/core/src/main/java/com/klaviyo/core/config/Config.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/config/Config.kt
@@ -28,6 +28,8 @@ interface Config {
 
     fun getManifestInt(key: String, defaultValue: Int): Int
 
+    fun getManifestBoolean(key: String, defaultValue: Boolean): Boolean
+
     interface Builder {
         fun apiKey(apiKey: String): Builder
         fun applicationContext(context: Context): Builder

--- a/sdk/core/src/main/java/com/klaviyo/core/config/KlaviyoConfig.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/config/KlaviyoConfig.kt
@@ -146,6 +146,13 @@ object KlaviyoConfig : Config {
             applicationContext.getManifestInt(key, defaultValue)
         }
 
+    override fun getManifestBoolean(key: String, defaultValue: Boolean): Boolean =
+        if (!this::applicationContext.isInitialized) {
+            defaultValue
+        } else {
+            applicationContext.getManifestBoolean(key, defaultValue)
+        }
+
     /**
      * Nested class to enable the builder pattern for easy declaration of custom configurations
      */
@@ -363,4 +370,15 @@ fun Context.getManifestInt(key: String, defaultValue: Int): Int {
     val appInfo = pkgManager.getApplicationInfoCompat(pkgName, PackageManager.GET_META_DATA)
     val manifestMetadata = appInfo?.metaData ?: Bundle.EMPTY
     return manifestMetadata.getInt(key, defaultValue)
+}
+
+/**
+ * Extension method to get a boolean value from the manifest metadata
+ */
+fun Context.getManifestBoolean(key: String, defaultValue: Boolean): Boolean {
+    val pkgName = packageName
+    val pkgManager = packageManager
+    val appInfo = pkgManager.getApplicationInfoCompat(pkgName, PackageManager.GET_META_DATA)
+    val manifestMetadata = appInfo?.metaData ?: Bundle.EMPTY
+    return manifestMetadata.getBoolean(key, defaultValue)
 }

--- a/sdk/core/src/main/java/com/klaviyo/core/utils/IntentExtension.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/utils/IntentExtension.kt
@@ -12,8 +12,7 @@ fun Intent.startActivityIfResolved(context: Context) {
     if (activityResolved(context)) {
         context.startActivity(this)
     } else {
-        // Log only the action/component, never the whole intent — its `data` and extras can carry
-        // payload-derived URLs (deep links, browser URLs) with customer identifiers or tokens.
+        // Avoid logging the full intent — data/extras can carry deep-link URLs with PII.
         Registry.log.error(
             "No activity found to handle intent (action=$action, component=$component)"
         )

--- a/sdk/core/src/main/java/com/klaviyo/core/utils/IntentExtension.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/utils/IntentExtension.kt
@@ -12,7 +12,11 @@ fun Intent.startActivityIfResolved(context: Context) {
     if (activityResolved(context)) {
         context.startActivity(this)
     } else {
-        Registry.log.error("No activity found to handle intent: $this")
+        // Log only the action/component, never the whole intent — its `data` and extras can carry
+        // payload-derived URLs (deep links, browser URLs) with customer identifiers or tokens.
+        Registry.log.error(
+            "No activity found to handle intent (action=$action, component=$component)"
+        )
     }
 }
 

--- a/sdk/core/src/test/java/com/klaviyo/core/config/KlaviyoConfigTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/config/KlaviyoConfigTest.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import android.os.Build
+import android.os.Bundle
 import com.klaviyo.core.BuildConfig
 import com.klaviyo.core.R
 import com.klaviyo.core.Registry
@@ -220,5 +221,42 @@ internal class KlaviyoConfigTest : BaseTest() {
             PackageManager.GET_PERMISSIONS
         )
         verify { mockPackageManager.getPackageInfo(BuildConfig.LIBRARY_PACKAGE_NAME, any<Int>()) }
+    }
+
+    @Test
+    fun `getManifestBoolean reads metadata value when present, else returns default`() {
+        val mockMetadata = mockk<Bundle>()
+        mockApplicationInfo.metaData = mockMetadata
+        val key = "com.klaviyo.automatic_push_tracking"
+
+        // Tiramisu+ path resolves application info via the ApplicationInfoFlags overload.
+        mockkStatic(PackageManager.ApplicationInfoFlags::class)
+        val mockApplicationInfoFlags = mockk<PackageManager.ApplicationInfoFlags>()
+        every { PackageManager.ApplicationInfoFlags.of(any()) } returns mockApplicationInfoFlags
+        setFinalStatic(Build.VERSION::class.java.getField("SDK_INT"), 33)
+        every {
+            mockPackageManager.getApplicationInfo(
+                BuildConfig.LIBRARY_PACKAGE_NAME,
+                mockApplicationInfoFlags
+            )
+        } returns mockApplicationInfo
+        every { mockMetadata.getBoolean(key, false) } returns true
+        assertEquals(true, mockContext.getManifestBoolean(key, false))
+
+        // Pre-Tiramisu path uses the simple getApplicationInfo(pkgName, flags) overload.
+        setFinalStatic(Build.VERSION::class.java.getField("SDK_INT"), 23)
+        every {
+            @Suppress("DEPRECATION")
+            mockPackageManager.getApplicationInfo(
+                BuildConfig.LIBRARY_PACKAGE_NAME,
+                PackageManager.GET_META_DATA
+            )
+        } returns mockApplicationInfo
+        // Present + false
+        every { mockMetadata.getBoolean(key, true) } returns false
+        assertEquals(false, mockContext.getManifestBoolean(key, true))
+        // Absent → metadata returns the supplied default unchanged
+        every { mockMetadata.getBoolean("missing.key", true) } returns true
+        assertEquals(true, mockContext.getManifestBoolean("missing.key", true))
     }
 }

--- a/sdk/core/src/test/java/com/klaviyo/core/config/KlaviyoConfigTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/config/KlaviyoConfigTest.kt
@@ -225,9 +225,19 @@ internal class KlaviyoConfigTest : BaseTest() {
 
     @Test
     fun `getManifestBoolean reads metadata value when present, else returns default`() {
-        val mockMetadata = mockk<Bundle>()
+        // Back the Bundle with a real map so getBoolean has genuine present/absent semantics
+        // (stored value wins, missing key returns the supplied default) rather than echoing a
+        // stubbed return — the latter would only restate the assertion.
+        val metadata = mutableMapOf(
+            "com.klaviyo.present_true" to true,
+            "com.klaviyo.present_false" to false
+        )
+        val mockMetadata = mockk<Bundle> {
+            every { getBoolean(any(), any()) } answers {
+                metadata[firstArg<String>()] ?: secondArg<Boolean>()
+            }
+        }
         mockApplicationInfo.metaData = mockMetadata
-        val key = "com.klaviyo.automatic_push_tracking"
 
         // Tiramisu+ path resolves application info via the ApplicationInfoFlags overload.
         mockkStatic(PackageManager.ApplicationInfoFlags::class)
@@ -240,8 +250,8 @@ internal class KlaviyoConfigTest : BaseTest() {
                 mockApplicationInfoFlags
             )
         } returns mockApplicationInfo
-        every { mockMetadata.getBoolean(key, false) } returns true
-        assertEquals(true, mockContext.getManifestBoolean(key, false))
+        // Reads the requested key from metadata, ignoring the (opposite) default.
+        assertEquals(true, mockContext.getManifestBoolean("com.klaviyo.present_true", false))
 
         // Pre-Tiramisu path uses the simple getApplicationInfo(pkgName, flags) overload.
         setFinalStatic(Build.VERSION::class.java.getField("SDK_INT"), 23)
@@ -252,11 +262,10 @@ internal class KlaviyoConfigTest : BaseTest() {
                 PackageManager.GET_META_DATA
             )
         } returns mockApplicationInfo
-        // Present + false
-        every { mockMetadata.getBoolean(key, true) } returns false
-        assertEquals(false, mockContext.getManifestBoolean(key, true))
-        // Absent → metadata returns the supplied default unchanged
-        every { mockMetadata.getBoolean("missing.key", true) } returns true
+        // Stored false wins over a true default.
+        assertEquals(false, mockContext.getManifestBoolean("com.klaviyo.present_false", true))
+        // Absent key falls back to whichever default is supplied (both directions).
         assertEquals(true, mockContext.getManifestBoolean("missing.key", true))
+        assertEquals(false, mockContext.getManifestBoolean("missing.key", false))
     }
 }

--- a/sdk/fixtures/src/main/java/com/klaviyo/fixtures/BaseTest.kt
+++ b/sdk/fixtures/src/main/java/com/klaviyo/fixtures/BaseTest.kt
@@ -96,6 +96,8 @@ abstract class BaseTest {
         every { sdkName } returns "klaviyo-android-sdk"
         every { sdkVersion } returns "4.20.69"
         every { formEnvironment } returns FormEnvironment.IN_APP
+        // Default to the passed default (e.g. automatic push tracking off); override per-test to flip on
+        every { getManifestBoolean(any(), any()) } answers { secondArg() }
     }
 
     protected val mockActivity: Activity = mockk(relaxed = true)

--- a/sdk/fixtures/src/main/java/com/klaviyo/fixtures/MockIntent.kt
+++ b/sdk/fixtures/src/main/java/com/klaviyo/fixtures/MockIntent.kt
@@ -2,6 +2,7 @@ package com.klaviyo.fixtures
 
 import android.annotation.SuppressLint
 import android.app.PendingIntent
+import android.content.ComponentName
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
@@ -66,9 +67,22 @@ data class MockIntent(
             every { anyConstructed<Intent>().flags } answers {
                 if (flags.isCaptured) flags.captured else 0
             }
-            // No setComponent is used in production (we set class via setClassName); stub the getter
-            // so reads (e.g. error logging) don't throw on the constructed mock.
-            every { anyConstructed<Intent>().component } returns null
+            // Mirror Android: setClassName(pkg, cls) makes getComponent() return the corresponding
+            // ComponentName. When only setPackage was used (e.g. deep-link intents), component is null.
+            every { anyConstructed<Intent>().component } answers {
+                if (className.isCaptured) {
+                    val capturedPkg = if (packageName.isCaptured) packageName.captured else ""
+                    val capturedCls = className.captured
+                    mockk<ComponentName>(relaxed = true) {
+                        every { getPackageName() } returns capturedPkg
+                        every { getClassName() } returns capturedCls
+                        every { flattenToShortString() } returns "$capturedPkg/$capturedCls"
+                        every { toString() } returns "ComponentInfo{$capturedPkg/$capturedCls}"
+                    }
+                } else {
+                    null
+                }
+            }
 
             return mockIntent
         }

--- a/sdk/fixtures/src/main/java/com/klaviyo/fixtures/MockIntent.kt
+++ b/sdk/fixtures/src/main/java/com/klaviyo/fixtures/MockIntent.kt
@@ -66,6 +66,9 @@ data class MockIntent(
             every { anyConstructed<Intent>().flags } answers {
                 if (flags.isCaptured) flags.captured else 0
             }
+            // No setComponent is used in production (we set class via setClassName); stub the getter
+            // so reads (e.g. error logging) don't throw on the constructed mock.
+            every { anyConstructed<Intent>().component } returns null
 
             return mockIntent
         }

--- a/sdk/push-fcm/src/main/AndroidManifest.xml
+++ b/sdk/push-fcm/src/main/AndroidManifest.xml
@@ -13,7 +13,9 @@
             android:name="com.klaviyo.pushFcm.KlaviyoTrampolineActivity"
             android:exported="false"
             android:excludeFromRecents="true"
+            android:launchMode="singleTask"
             android:noHistory="true"
+            android:taskAffinity=""
             android:theme="@android:style/Theme.Translucent.NoTitleBar" />
     </application>
 </manifest>

--- a/sdk/push-fcm/src/main/AndroidManifest.xml
+++ b/sdk/push-fcm/src/main/AndroidManifest.xml
@@ -9,6 +9,11 @@
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />
             </intent-filter>
         </service>
+        <!--
+            Trampoline activity that tracks the push open then forwards the intent. Configured to be
+            invisible and transient: translucent theme (no UI), noHistory + excludeFromRecents (never
+            in the back stack or recents), taskAffinity="" + singleTask (no task of its own).
+        -->
         <activity
             android:name="com.klaviyo.pushFcm.KlaviyoTrampolineActivity"
             android:exported="false"

--- a/sdk/push-fcm/src/main/AndroidManifest.xml
+++ b/sdk/push-fcm/src/main/AndroidManifest.xml
@@ -10,9 +10,14 @@
             </intent-filter>
         </service>
         <!--
-            Trampoline activity that tracks the push open then forwards the intent. Configured to be
-            invisible and transient: translucent theme (no UI), noHistory + excludeFromRecents (never
-            in the back stack or recents), taskAffinity="" + singleTask (no task of its own).
+            Invisible, transient activity that routes notification taps (deep links, URLs, app opens).
+            Attribute reference:
+              exported="false"          - internal only; never launched by other apps
+              excludeFromRecents="true" - never appears in the recents/overview screen
+              launchMode="singleTask"   - reuses a single instance rather than stacking
+              noHistory="true"          - removed from the back stack as soon as it finishes
+              taskAffinity=""           - doesn't attach to or create the host app's task
+              theme="...Translucent..." - no visible UI while it runs
         -->
         <activity
             android:name="com.klaviyo.pushFcm.KlaviyoTrampolineActivity"

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoNotification.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoNotification.kt
@@ -264,8 +264,13 @@ class KlaviyoNotification(private val message: RemoteMessage) {
         }
 
         if (deepLink != null) {
-            // With automatic tracking on, route through the trampoline (carrying the deep link as
-            // intent data) so it calls handlePush; otherwise target the host directly as before.
+            // With automatic tracking on, route through the trampoline carrying the deep link as
+            // intent data so it calls handlePush; otherwise target the host directly as before.
+            //
+            // Unlike makeResolvedDeepLinkIntent, we keep the deep link on the intent even when no
+            // Activity resolves it: this is intentional so a registered DeepLinkHandler receives
+            // every link regardless of intent-filter resolution (the common single-Activity case).
+            // The trampoline only consults Activity resolvability when no handler is registered.
             val intent = if (autoTracking) {
                 KlaviyoTrampolineActivity.forDestination(context, deepLink)
             } else {
@@ -366,6 +371,8 @@ class KlaviyoNotification(private val message: RemoteMessage) {
                 val uri = button.url.toUri()
                 // With auto-tracking on, route through the trampoline carrying the deep link as
                 // intent data so it calls handlePush; otherwise target the host directly as before.
+                // See makeOpenedIntent: the deep link is deliberately kept even when unresolvable so
+                // a registered DeepLinkHandler still receives it.
                 if (autoTracking) {
                     KlaviyoTrampolineActivity.forDestination(context, uri)
                 } else {

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoNotification.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoNotification.kt
@@ -166,8 +166,15 @@ class KlaviyoNotification(private val message: RemoteMessage) {
         notificationTag: String
     ): NotificationCompat.Builder {
         val requestCodeBase = generateId()
+        // When the host opts into automatic push tracking, body/deep_link/open_app taps route
+        // through KlaviyoTrampolineActivity so it can call handlePush itself. open_url already
+        // routes through the trampoline regardless (the browser would otherwise swallow the intent).
+        val autoTracking = Registry.config.getManifestBoolean(
+            KlaviyoPushService.METADATA_AUTOMATIC_PUSH_TRACKING,
+            false
+        )
         return NotificationCompat.Builder(context, message.channel_id)
-            .setContentIntent(makePendingIntent(context, requestCodeBase))
+            .setContentIntent(makePendingIntent(context, requestCodeBase, autoTracking))
             .setSmallIcon(message.getSmallIcon(context))
             .also { message.getColor(context)?.let { color -> it.setColor(color) } }
             .setContentTitle(message.title)
@@ -177,7 +184,7 @@ class KlaviyoNotification(private val message: RemoteMessage) {
             .setNumber(message.notificationCount)
             .setPriority(message.notificationPriority)
             .setAutoCancel(true)
-            .addActionButtons(context, requestCodeBase, notificationTag)
+            .addActionButtons(context, requestCodeBase, notificationTag, autoTracking)
     }
 
     private fun URL.applyToNotification(builder: NotificationCompat.Builder) {
@@ -228,11 +235,11 @@ class KlaviyoNotification(private val message: RemoteMessage) {
      *
      * @return [PendingIntent]
      */
-    private fun makePendingIntent(context: Context, requestCode: Int) =
+    private fun makePendingIntent(context: Context, requestCode: Int, autoTracking: Boolean) =
         PendingIntent.getActivity(
             context,
             requestCode,
-            makeOpenedIntent(context),
+            makeOpenedIntent(context, autoTracking),
             PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_ONE_SHOT
         )
 
@@ -246,7 +253,7 @@ class KlaviyoNotification(private val message: RemoteMessage) {
      * creation, so this is only reachable via direct API calls or test tooling — we
      * warn so the misconfiguration is debuggable.
      */
-    private fun makeOpenedIntent(context: Context): Intent? {
+    private fun makeOpenedIntent(context: Context, autoTracking: Boolean): Intent? {
         val deepLink = message.deepLink
         val webUrl = message.webUrl
 
@@ -257,11 +264,18 @@ class KlaviyoNotification(private val message: RemoteMessage) {
         }
 
         if (deepLink != null) {
-            return makeResolvedDeepLinkIntent(
-                context,
-                deepLink,
-                "Push message contained unsupported deep link: $deepLink"
-            )?.apply {
+            // With automatic tracking on, route through the trampoline (carrying the deep link as
+            // intent data) so it calls handlePush; otherwise target the host directly as before.
+            val intent = if (autoTracking) {
+                KlaviyoTrampolineActivity.forDestination(context, deepLink)
+            } else {
+                makeResolvedDeepLinkIntent(
+                    context,
+                    deepLink,
+                    "Push message contained unsupported deep link: $deepLink"
+                )
+            }
+            return intent?.apply {
                 addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
                 appendKlaviyoExtras(message)
             }
@@ -275,7 +289,13 @@ class KlaviyoNotification(private val message: RemoteMessage) {
             }
         }
 
-        return DeepLinking.makeLaunchIntent(context)?.apply {
+        // Plain open: route through the trampoline when auto-tracking, else launch the host directly.
+        val intent = if (autoTracking) {
+            KlaviyoTrampolineActivity.forDestination(context)
+        } else {
+            DeepLinking.makeLaunchIntent(context)
+        }
+        return intent?.apply {
             addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
             appendKlaviyoExtras(message)
         }
@@ -297,7 +317,8 @@ class KlaviyoNotification(private val message: RemoteMessage) {
     private fun NotificationCompat.Builder.addActionButtons(
         context: Context,
         requestCodeBase: Int,
-        notificationTag: String
+        notificationTag: String,
+        autoTracking: Boolean
     ): NotificationCompat.Builder {
         val actionButtons = message.actionButtons ?: return this
 
@@ -306,7 +327,15 @@ class KlaviyoNotification(private val message: RemoteMessage) {
             // request codes need to be unique, add index + offset to generate unique code
             // offset required due to zero index, so body and first button have unique codes
             val requestCode = requestCodeBase + index + ACTION_REQUEST_CODE_OFFSET
-            val action = createButtonAction(context, index, requestCode, button, notificationTag) ?: return@forEachIndexed
+            val action = createButtonAction(
+                context,
+                index,
+                requestCode,
+                button,
+                notificationTag,
+                autoTracking
+            )
+                ?: return@forEachIndexed
             addAction(action)
 
             val (actionType, destination) = when (button) {
@@ -329,16 +358,23 @@ class KlaviyoNotification(private val message: RemoteMessage) {
         index: Int,
         requestCode: Int,
         button: ActionButton,
-        notificationTag: String
+        notificationTag: String,
+        autoTracking: Boolean
     ): NotificationCompat.Action? {
         val intent = when (button) {
             is ActionButton.DeepLink -> {
                 val uri = button.url.toUri()
-                makeResolvedDeepLinkIntent(
-                    context,
-                    uri,
-                    "Action button $index contained unsupported deep link: $uri"
-                )
+                // With auto-tracking on, route through the trampoline carrying the deep link as
+                // intent data so it calls handlePush; otherwise target the host directly as before.
+                if (autoTracking) {
+                    KlaviyoTrampolineActivity.forDestination(context, uri)
+                } else {
+                    makeResolvedDeepLinkIntent(
+                        context,
+                        uri,
+                        "Action button $index contained unsupported deep link: $uri"
+                    )
+                }
             }
             is ActionButton.OpenUrl -> {
                 // Route through the trampoline so handlePush tracks $opened_push
@@ -346,7 +382,11 @@ class KlaviyoNotification(private val message: RemoteMessage) {
                 KlaviyoTrampolineActivity.forBrowserUrl(context, button.url)
             }
             is ActionButton.OpenApp -> {
-                DeepLinking.makeLaunchIntent(context)
+                if (autoTracking) {
+                    KlaviyoTrampolineActivity.forDestination(context)
+                } else {
+                    DeepLinking.makeLaunchIntent(context)
+                }
             }
         }?.apply {
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoNotification.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoNotification.kt
@@ -20,6 +20,7 @@ import com.google.firebase.messaging.RemoteMessage
 import com.klaviyo.analytics.linking.DeepLinking
 import com.klaviyo.core.Constants
 import com.klaviyo.core.Registry
+import com.klaviyo.core.config.getManifestBoolean
 import com.klaviyo.core.utils.activityResolved
 import com.klaviyo.pushFcm.KlaviyoRemoteMessage.ActionButton
 import com.klaviyo.pushFcm.KlaviyoRemoteMessage.actionButtons
@@ -169,7 +170,12 @@ class KlaviyoNotification(private val message: RemoteMessage) {
         // When the host opts into automatic push tracking, body/deep_link/open_app taps route
         // through KlaviyoTrampolineActivity so it can call handlePush itself. open_url already
         // routes through the trampoline regardless (the browser would otherwise swallow the intent).
-        val autoTracking = Registry.config.getManifestBoolean(
+        //
+        // Read the manifest flag from the build-time [context] rather than Registry.config, which
+        // returns the default until Klaviyo.initialize runs. FCM can build a notification before the
+        // host initializes (e.g. when init happens in an Activity, not Application), and the flag is
+        // static manifest data readable from any context — so reading it here keeps opt-in reliable.
+        val autoTracking = context.getManifestBoolean(
             KlaviyoPushService.METADATA_AUTOMATIC_PUSH_TRACKING,
             false
         )

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoNotification.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoNotification.kt
@@ -167,14 +167,10 @@ class KlaviyoNotification(private val message: RemoteMessage) {
         notificationTag: String
     ): NotificationCompat.Builder {
         val requestCodeBase = generateId()
-        // When the host opts into automatic push tracking, body/deep_link/open_app taps route
-        // through KlaviyoTrampolineActivity so it can call handlePush itself. open_url already
-        // routes through the trampoline regardless (the browser would otherwise swallow the intent).
-        //
-        // Read the manifest flag from the build-time [context] rather than Registry.config, which
-        // returns the default until Klaviyo.initialize runs. FCM can build a notification before the
-        // host initializes (e.g. when init happens in an Activity, not Application), and the flag is
-        // static manifest data readable from any context — so reading it here keeps opt-in reliable.
+        // When the host opts into automatic push tracking, taps route through
+        // KlaviyoTrampolineActivity so it can call handlePush itself.
+        // Read the flag from the build-time context, not Registry.config, since FCM can build a
+        // notification before Klaviyo.initialize runs (e.g. init in an Activity, not Application).
         val autoTracking = context.getManifestBoolean(
             KlaviyoPushService.METADATA_AUTOMATIC_PUSH_TRACKING,
             false

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoPushService.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoPushService.kt
@@ -26,7 +26,9 @@ open class KlaviyoPushService : FirebaseMessagingService() {
         /**
          * Manifest `<meta-data>` key to opt into automatic push open tracking. When set, Klaviyo
          * notification taps route through [KlaviyoTrampolineActivity], which tracks the open itself
-         * so the host app no longer needs to call `Klaviyo.handlePush(intent)` in its Activities:
+         * so the host app no longer needs to call `Klaviyo.handlePush(intent)` in its Activities.
+         *
+         * Host apps opt in by adding this to their `AndroidManifest.xml`:
          *
          * ```xml
          * <meta-data

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoPushService.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoPushService.kt
@@ -3,6 +3,7 @@ package com.klaviyo.pushFcm
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import com.klaviyo.analytics.Klaviyo
+import com.klaviyo.core.Constants
 import com.klaviyo.core.Registry
 import com.klaviyo.pushFcm.KlaviyoRemoteMessage.hasKlaviyoKeyValuePairs
 import com.klaviyo.pushFcm.KlaviyoRemoteMessage.isKlaviyoMessage
@@ -21,6 +22,19 @@ open class KlaviyoPushService : FirebaseMessagingService() {
     companion object {
         const val METADATA_DEFAULT_ICON = "com.klaviyo.push.default_notification_icon"
         const val METADATA_DEFAULT_COLOR = "com.klaviyo.push.default_notification_color"
+
+        /**
+         * Manifest `<meta-data>` key to opt into automatic push open tracking. When set, Klaviyo
+         * notification taps route through [KlaviyoTrampolineActivity], which tracks the open itself
+         * so the host app no longer needs to call `Klaviyo.handlePush(intent)` in its Activities:
+         *
+         * ```xml
+         * <meta-data
+         *     android:name="com.klaviyo.automatic_push_tracking"
+         *     android:value="true" />
+         * ```
+         */
+        const val METADATA_AUTOMATIC_PUSH_TRACKING = Constants.AUTOMATIC_PUSH_TRACKING
     }
 
     /**

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoPushService.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoPushService.kt
@@ -24,17 +24,9 @@ open class KlaviyoPushService : FirebaseMessagingService() {
         const val METADATA_DEFAULT_COLOR = "com.klaviyo.push.default_notification_color"
 
         /**
-         * Manifest `<meta-data>` key to opt into automatic push open tracking. When set, Klaviyo
-         * notification taps route through [KlaviyoTrampolineActivity], which tracks the open itself
-         * so the host app no longer needs to call `Klaviyo.handlePush(intent)` in its Activities.
-         *
-         * Host apps opt in by adding this to their `AndroidManifest.xml`:
-         *
-         * ```xml
-         * <meta-data
-         *     android:name="com.klaviyo.automatic_push_tracking"
-         *     android:value="true" />
-         * ```
+         * Manifest `<meta-data>` key (boolean) to opt into automatic push open tracking. When set to
+         * `true`, Klaviyo notification taps route through [KlaviyoTrampolineActivity], which tracks the
+         * open itself so the host app no longer needs to call `Klaviyo.handlePush(intent)` in its Activities.
          */
         const val METADATA_AUTOMATIC_PUSH_TRACKING = Constants.AUTOMATIC_PUSH_TRACKING
     }

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivity.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivity.kt
@@ -109,7 +109,7 @@ internal class KlaviyoTrampolineActivity : Activity() {
 
         private fun dispatchDestination(intent: Intent, context: Context) {
             intent.getStringExtra(BROWSER_URL_EXTRA)?.let { url ->
-                Registry.log.verbose("Trampoline dispatching browser intent: $url")
+                Registry.log.verbose("Trampoline dispatching browser intent")
                 DeepLinking.makeBrowserIntent(url.toUri()).startActivityIfResolved(context)
                 return
             }
@@ -134,11 +134,11 @@ internal class KlaviyoTrampolineActivity : Activity() {
                         copyIntent = intent
                     )
                     if (viewIntent.activityResolved(context)) {
-                        Registry.log.verbose("Trampoline dispatching deep link via VIEW: $deepLink")
+                        Registry.log.verbose("Trampoline dispatching deep link via VIEW")
                         viewIntent
                     } else {
                         Registry.log.error(
-                            "Trampoline could not resolve deep link $deepLink; falling back to launcher"
+                            "Trampoline could not resolve deep link; falling back to launcher"
                         )
                         DeepLinking.makeLaunchIntent(context, intent.extras)
                     }
@@ -156,7 +156,15 @@ internal class KlaviyoTrampolineActivity : Activity() {
             }
 
             destination?.apply {
-                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+                // CLEAR_TOP mirrors the non-trampoline path (KlaviyoNotification adds it to the
+                // contentIntent, but it's consumed launching the trampoline rather than forwarded),
+                // preserving back-stack behavior. NEW_TASK is required here since we launch from the
+                // trampoline's own (taskAffinity="") task.
+                addFlags(
+                    Intent.FLAG_ACTIVITY_NEW_TASK or
+                        Intent.FLAG_ACTIVITY_SINGLE_TOP or
+                        Intent.FLAG_ACTIVITY_CLEAR_TOP
+                )
             }?.startActivityIfResolved(context)
         }
     }

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivity.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivity.kt
@@ -50,10 +50,8 @@ internal class KlaviyoTrampolineActivity : Activity() {
             handleTrampolineIntent(intent, this)
         } finally {
             // Always finish — leaving a translucent activity onscreen after an exception would look
-            // like a stuck blank screen. Post via the UI thread *after* dispatching the destination:
-            // some OEMs (Xiaomi MIUI) fail to foreground the destination if the trampoline finishes
-            // synchronously (matches OneSignal's trampoline handling).
-            Registry.threadHelper.runOnUiThread { finish() }
+            // like a stuck blank screen to the user.
+            finish()
         }
     }
 

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivity.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivity.kt
@@ -166,6 +166,7 @@ internal class KlaviyoTrampolineActivity : Activity() {
                         Intent.FLAG_ACTIVITY_CLEAR_TOP
                 )
             }?.startActivityIfResolved(context)
+                ?: Registry.log.warning("No launch intent found for host app; nothing to start")
         }
     }
 }

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivity.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivity.kt
@@ -3,12 +3,14 @@ package com.klaviyo.pushFcm
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import androidx.core.net.toUri
 import com.klaviyo.analytics.Klaviyo
 import com.klaviyo.analytics.Klaviyo.isKlaviyoNotificationIntent
 import com.klaviyo.analytics.linking.DeepLinking
 import com.klaviyo.core.Registry
+import com.klaviyo.core.utils.activityResolved
 import com.klaviyo.core.utils.startActivityIfResolved
 
 /**
@@ -17,24 +19,41 @@ import com.klaviyo.core.utils.startActivityIfResolved
  * invoking the registered deep link handler) before forwarding the user to the actual
  * destination.
  *
- * Currently used for `open_url` push payloads — the destination is a browser intent
- * embedded as [BROWSER_URL_EXTRA]. Additional dispatch paths can be added to
- * [dispatchDestination] as new use cases (e.g. automatic open tracking) introduce
- * their own routing extras.
+ * Dispatch is driven by intent contents, not by any flag:
+ * - `open_url` payloads embed a browser URL as [BROWSER_URL_EXTRA] and route to the browser.
+ * - body / `deep_link` / `open_app` taps (when automatic push tracking is enabled at
+ *   notification-build time) carry the deep link as the intent `data` and route into the host app.
  *
- * Declared `android:exported="false"`, `android:noHistory="true"`, and
- * `android:excludeFromRecents="true"` with a translucent theme so it never appears
- * in the recents UI or flashes onscreen.
+ * Declared `android:exported="false"`, `android:noHistory="true"`,
+ * `android:excludeFromRecents="true"`, `android:launchMode="singleTask"`, and
+ * `android:taskAffinity=""` with a translucent theme so it never appears in the recents UI,
+ * flashes onscreen, or becomes the cold-start task root.
  */
 internal class KlaviyoTrampolineActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        process(intent)
+    }
+
+    /**
+     * `singleTask` re-entry: a tap while the trampoline instance already exists is delivered here
+     * rather than to a fresh [onCreate], so route it through the same handler.
+     */
+    override fun onNewIntent(intent: Intent?) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        process(intent)
+    }
+
+    private fun process(intent: Intent?) {
         try {
             handleTrampolineIntent(intent, this)
         } finally {
-            // Always finish — leaving a translucent activity onscreen after an exception
-            // would look like a stuck blank screen to the user.
-            finish()
+            // Always finish — leaving a translucent activity onscreen after an exception would look
+            // like a stuck blank screen. Post via the UI thread *after* dispatching the destination:
+            // some OEMs (Xiaomi MIUI) fail to foreground the destination if the trampoline finishes
+            // synchronously (matches OneSignal's trampoline handling).
+            Registry.threadHelper.runOnUiThread { finish() }
         }
     }
 
@@ -61,6 +80,20 @@ internal class KlaviyoTrampolineActivity : Activity() {
         }
 
         /**
+         * Build a trampoline intent for a body tap or action button when automatic push tracking is
+         * enabled. The trampoline runs `Klaviyo.handlePush` then forwards to the host app, dispatching
+         * to [deepLink] (carried as the intent `data`) when present, otherwise to the launcher.
+         *
+         * Uses [Intent.setClassName] instead of the `Intent(Context, Class)` constructor — same test
+         * seam as [forBrowserUrl]. Callers append their own Klaviyo extras for parity with the
+         * non-trampoline intents they replace.
+         */
+        internal fun forDestination(context: Context, deepLink: Uri? = null): Intent = Intent().apply {
+            setClassName(context.packageName, KlaviyoTrampolineActivity::class.java.name)
+            deepLink?.let { data = it }
+        }
+
+        /**
          * Run the trampoline behavior: track `$opened_push`, dismiss the notification,
          * then dispatch to the destination. Extracted from [onCreate] so unit tests can
          * exercise it without instantiating an Android [Activity].
@@ -78,16 +111,55 @@ internal class KlaviyoTrampolineActivity : Activity() {
 
         private fun dispatchDestination(intent: Intent, context: Context) {
             intent.getStringExtra(BROWSER_URL_EXTRA)?.let { url ->
+                Registry.log.verbose("Trampoline dispatching browser intent: $url")
                 DeepLinking.makeBrowserIntent(url.toUri()).startActivityIfResolved(context)
                 return
             }
-            // Add additional dispatch branches here as new routing extras are introduced.
-            // Reaching this point means a Klaviyo notification intent targeted the trampoline
-            // without any recognized dispatch extra — an internal SDK contract break, not
-            // graceful degradation. Log `wtf` to flag the bug.
-            Registry.log.wtf(
-                "KlaviyoTrampolineActivity launched without a recognized dispatch extra"
-            )
+            startDestination(intent, context)
+        }
+
+        /**
+         * Forward a body/`deep_link`/`open_app` tap into the host app.
+         *
+         * - Deep link present and no [DeepLinkHandler][com.klaviyo.analytics.linking.DeepLinkHandler]
+         *   registered → `ACTION_VIEW` into the host, falling back to the launcher if unresolvable.
+         * - Handler registered, or no deep link → launcher only. `handlePush` already dispatched the
+         *   handler, so an additional `ACTION_VIEW` would double-deliver navigation.
+         */
+        private fun startDestination(intent: Intent, context: Context) {
+            val deepLink = intent.data
+            val destination: Intent? = when {
+                deepLink != null && !DeepLinking.isHandlerRegistered -> {
+                    val viewIntent = DeepLinking.makeDeepLinkIntent(
+                        deepLink,
+                        context,
+                        copyIntent = intent
+                    )
+                    if (viewIntent.activityResolved(context)) {
+                        Registry.log.verbose("Trampoline dispatching deep link via VIEW: $deepLink")
+                        viewIntent
+                    } else {
+                        Registry.log.error(
+                            "Trampoline could not resolve deep link $deepLink; falling back to launcher"
+                        )
+                        DeepLinking.makeLaunchIntent(context, intent.extras)
+                    }
+                }
+                else -> {
+                    if (deepLink != null) {
+                        Registry.log.verbose(
+                            "Trampoline dispatching deep link via handler; launching host"
+                        )
+                    } else {
+                        Registry.log.verbose("Trampoline dispatching launch intent")
+                    }
+                    DeepLinking.makeLaunchIntent(context, intent.extras)
+                }
+            }
+
+            destination?.apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+            }?.startActivityIfResolved(context)
         }
     }
 }

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivity.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivity.kt
@@ -137,7 +137,7 @@ internal class KlaviyoTrampolineActivity : Activity() {
                         Registry.log.verbose("Trampoline dispatching deep link via VIEW")
                         viewIntent
                     } else {
-                        Registry.log.error(
+                        Registry.log.warning(
                             "Trampoline could not resolve deep link; falling back to launcher"
                         )
                         DeepLinking.makeLaunchIntent(context, intent.extras)

--- a/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoNotificationTest.kt
+++ b/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoNotificationTest.kt
@@ -9,6 +9,7 @@ import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import com.google.firebase.messaging.RemoteMessage
 import com.klaviyo.analytics.linking.DeepLinking
+import com.klaviyo.core.config.getManifestBoolean
 import com.klaviyo.fixtures.BaseTest
 import com.klaviyo.fixtures.MockIntent
 import com.klaviyo.pushFcm.KlaviyoNotification.Companion.BODY_KEY
@@ -114,8 +115,12 @@ class KlaviyoNotificationTest : BaseTest() {
         every {
             KlaviyoTrampolineActivity.forDestination(any(), any())
         } returns mockk(relaxed = true)
-        // Automatic push tracking is off by default (BaseTest mockConfig returns the passed default);
-        // flag-on tests override this explicitly.
+        // buildNotification reads the auto-tracking flag from the build-time context via the
+        // Context.getManifestBoolean extension. Default to off (return the passed default);
+        // flag-on tests override via enableAutomaticTracking().
+        mockkStatic("com.klaviyo.core.config.KlaviyoConfigKt")
+        // Extension fn: receiver is the first arg, so the default value is the third arg.
+        every { mockContext.getManifestBoolean(any(), any()) } answers { thirdArg() }
 
         with(KlaviyoRemoteMessage) {
             every { mockRemoteMessage.webUrl } returns null
@@ -126,6 +131,7 @@ class KlaviyoNotificationTest : BaseTest() {
     override fun cleanup() {
         MockIntent.unmockPendingIntent()
         unmockkStatic(Uri::class)
+        unmockkStatic("com.klaviyo.core.config.KlaviyoConfigKt")
         super.cleanup()
     }
 
@@ -834,8 +840,10 @@ class KlaviyoNotificationTest : BaseTest() {
 
     /** Opt into automatic push tracking for the duration of a test. */
     private fun enableAutomaticTracking() {
+        // Overrides the flag-off default stubbed in setup(); buildNotification reads this off the
+        // build-time context (not Registry.config), so it works pre-init.
         every {
-            mockConfig.getManifestBoolean(
+            mockContext.getManifestBoolean(
                 KlaviyoPushService.METADATA_AUTOMATIC_PUSH_TRACKING,
                 false
             )

--- a/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoNotificationTest.kt
+++ b/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoNotificationTest.kt
@@ -111,6 +111,11 @@ class KlaviyoNotificationTest : BaseTest() {
         every {
             KlaviyoTrampolineActivity.forBrowserUrl(any(), any())
         } returns mockk(relaxed = true)
+        every {
+            KlaviyoTrampolineActivity.forDestination(any(), any())
+        } returns mockk(relaxed = true)
+        // Automatic push tracking is off by default (BaseTest mockConfig returns the passed default);
+        // flag-on tests override this explicitly.
 
         with(KlaviyoRemoteMessage) {
             every { mockRemoteMessage.webUrl } returns null
@@ -825,5 +830,122 @@ class KlaviyoNotificationTest : BaseTest() {
         verify { mockTrampolineIntent.putExtra("com.klaviyo.Button Label", "Open Website") }
         verify { mockTrampolineIntent.putExtra("com.klaviyo.Button Action", "Open URL") }
         verify { mockTrampolineIntent.putExtra("com.klaviyo.Button Link", "https://example.com") }
+    }
+
+    /** Opt into automatic push tracking for the duration of a test. */
+    private fun enableAutomaticTracking() {
+        every {
+            mockConfig.getManifestBoolean(
+                KlaviyoPushService.METADATA_AUTOMATIC_PUSH_TRACKING,
+                false
+            )
+        } returns true
+    }
+
+    @Test
+    fun `automatic tracking on - body deep link tap routes through trampoline`() {
+        enableAutomaticTracking()
+        val mockDeepLinkUri = mockk<Uri>(relaxed = true)
+        val mockTrampolineIntent = mockk<Intent>(relaxed = true)
+        val intentSlot = slot<Intent>()
+
+        with(KlaviyoRemoteMessage) {
+            every { mockRemoteMessage.deepLink } returns mockDeepLinkUri
+        }
+        every { KlaviyoTrampolineActivity.forDestination(mockContext, mockDeepLinkUri) } returns mockTrampolineIntent
+        every {
+            PendingIntent.getActivity(any(), any(), capture(intentSlot), any())
+        } returns mockk(relaxed = true)
+
+        notification.displayNotification(mockContext)
+
+        verify { KlaviyoTrampolineActivity.forDestination(mockContext, mockDeepLinkUri) }
+        // Deep link must NOT target the host directly when auto-tracking is on.
+        verify(exactly = 0) { DeepLinking.makeDeepLinkIntent(any(), any()) }
+        assertEquals(mockTrampolineIntent, intentSlot.captured)
+    }
+
+    @Test
+    fun `automatic tracking on - plain body tap routes through trampoline launch`() {
+        enableAutomaticTracking()
+        val mockTrampolineIntent = mockk<Intent>(relaxed = true)
+        val intentSlot = slot<Intent>()
+
+        with(KlaviyoRemoteMessage) {
+            every { mockRemoteMessage.deepLink } returns null
+            every { mockRemoteMessage.webUrl } returns null
+        }
+        every { KlaviyoTrampolineActivity.forDestination(mockContext, null) } returns mockTrampolineIntent
+        every {
+            PendingIntent.getActivity(any(), any(), capture(intentSlot), any())
+        } returns mockk(relaxed = true)
+
+        notification.displayNotification(mockContext)
+
+        verify { KlaviyoTrampolineActivity.forDestination(mockContext, null) }
+        verify(exactly = 0) { DeepLinking.makeLaunchIntent(any()) }
+        assertEquals(mockTrampolineIntent, intentSlot.captured)
+    }
+
+    @Test
+    fun `automatic tracking on - deep_link action button routes through trampoline`() {
+        enableAutomaticTracking()
+        val parsedUri = mockk<Uri>(relaxed = true)
+        every { Uri.parse("klaviyotest://order/123") } returns parsedUri
+
+        with(KlaviyoRemoteMessage) {
+            every { mockRemoteMessage.actionButtons } returns listOf(
+                ActionButton.DeepLink(
+                    id = "com.klaviyo.test.view",
+                    label = "View Order",
+                    url = "klaviyotest://order/123"
+                )
+            )
+        }
+        every {
+            PendingIntent.getActivity(any(), any(), any(), any())
+        } returns mockk(relaxed = true)
+
+        notification.displayNotification(mockContext)
+
+        verify { KlaviyoTrampolineActivity.forDestination(mockContext, parsedUri) }
+        verify(exactly = 0) { DeepLinking.makeDeepLinkIntent(any(), any()) }
+    }
+
+    @Test
+    fun `automatic tracking on - open_app action button routes through trampoline`() {
+        enableAutomaticTracking()
+
+        with(KlaviyoRemoteMessage) {
+            every { mockRemoteMessage.actionButtons } returns listOf(
+                ActionButton.OpenApp(id = "open", label = "Open")
+            )
+        }
+        every {
+            PendingIntent.getActivity(any(), any(), any(), any())
+        } returns mockk(relaxed = true)
+
+        notification.displayNotification(mockContext)
+
+        verify { KlaviyoTrampolineActivity.forDestination(mockContext, null) }
+        verify(exactly = 0) { DeepLinking.makeLaunchIntent(any()) }
+    }
+
+    @Test
+    fun `open_url tap targets trampoline even with automatic tracking on`() {
+        enableAutomaticTracking()
+        with(KlaviyoRemoteMessage) {
+            every { mockRemoteMessage.webUrl } returns "https://example.com"
+            every { mockRemoteMessage.deepLink } returns null
+        }
+        every {
+            PendingIntent.getActivity(any(), any(), any(), any())
+        } returns mockk(relaxed = true)
+
+        notification.displayNotification(mockContext)
+
+        // open_url always uses the browser-URL trampoline factory, never the deep-link/launch one.
+        verify { KlaviyoTrampolineActivity.forBrowserUrl(mockContext, "https://example.com") }
+        verify(exactly = 0) { KlaviyoTrampolineActivity.forDestination(any(), any()) }
     }
 }

--- a/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoNotificationTest.kt
+++ b/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoNotificationTest.kt
@@ -863,6 +863,9 @@ class KlaviyoNotificationTest : BaseTest() {
         // Deep link must NOT target the host directly when auto-tracking is on.
         verify(exactly = 0) { DeepLinking.makeDeepLinkIntent(any(), any()) }
         assertEquals(mockTrampolineIntent, intentSlot.captured)
+        // Extras parity: the trampoline intent still carries the Klaviyo extras.
+        verify { mockTrampolineIntent.putExtra("com.klaviyo._k", "test_tracking_id") }
+        verify { mockTrampolineIntent.putExtra("com.klaviyo.title", "Test Title") }
     }
 
     @Test
@@ -888,12 +891,15 @@ class KlaviyoNotificationTest : BaseTest() {
     }
 
     @Test
-    fun `automatic tracking on - deep_link action button routes through trampoline`() {
+    fun `automatic tracking on - deep_link action button routes through trampoline with extras`() {
         enableAutomaticTracking()
         val parsedUri = mockk<Uri>(relaxed = true)
         every { Uri.parse("klaviyotest://order/123") } returns parsedUri
+        val mockButtonIntent = mockk<Intent>(relaxed = true)
+        every { KlaviyoTrampolineActivity.forDestination(mockContext, parsedUri) } returns mockButtonIntent
 
         with(KlaviyoRemoteMessage) {
+            every { mockRemoteMessage.notificationTag } returns "test_tag"
             every { mockRemoteMessage.actionButtons } returns listOf(
                 ActionButton.DeepLink(
                     id = "com.klaviyo.test.view",
@@ -908,15 +914,24 @@ class KlaviyoNotificationTest : BaseTest() {
 
         notification.displayNotification(mockContext)
 
+        // Routed through the trampoline, not a direct ACTION_VIEW…
         verify { KlaviyoTrampolineActivity.forDestination(mockContext, parsedUri) }
         verify(exactly = 0) { DeepLinking.makeDeepLinkIntent(any(), any()) }
+        // …carrying the same extras the non-trampoline button intent does today.
+        verify { mockButtonIntent.putExtra("_klaviyo.notification_tag", "test_tag") }
+        verify { mockButtonIntent.putExtra("com.klaviyo._k", "test_tracking_id") }
+        verify { mockButtonIntent.putExtra("com.klaviyo.Button Label", "View Order") }
+        verify { mockButtonIntent.putExtra("com.klaviyo.Button Link", "klaviyotest://order/123") }
     }
 
     @Test
-    fun `automatic tracking on - open_app action button routes through trampoline`() {
+    fun `automatic tracking on - open_app action button routes through trampoline with extras`() {
         enableAutomaticTracking()
+        val mockButtonIntent = mockk<Intent>(relaxed = true)
+        every { KlaviyoTrampolineActivity.forDestination(mockContext, null) } returns mockButtonIntent
 
         with(KlaviyoRemoteMessage) {
+            every { mockRemoteMessage.notificationTag } returns "test_tag"
             every { mockRemoteMessage.actionButtons } returns listOf(
                 ActionButton.OpenApp(id = "open", label = "Open")
             )
@@ -929,6 +944,9 @@ class KlaviyoNotificationTest : BaseTest() {
 
         verify { KlaviyoTrampolineActivity.forDestination(mockContext, null) }
         verify(exactly = 0) { DeepLinking.makeLaunchIntent(any()) }
+        // Extras parity: notification tag (for dismissal) + Klaviyo extras still applied.
+        verify { mockButtonIntent.putExtra("_klaviyo.notification_tag", "test_tag") }
+        verify { mockButtonIntent.putExtra("com.klaviyo._k", "test_tracking_id") }
     }
 
     @Test

--- a/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivityTest.kt
+++ b/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivityTest.kt
@@ -106,6 +106,20 @@ class KlaviyoTrampolineActivityTest : BaseTest() {
     }
 
     @Test
+    fun `handleTrampolineIntent with no launch intent warns and starts nothing`() {
+        val intent = klaviyoIntent() // no browser extra, no deep link data
+        // Host app has no launcher activity → makeLaunchIntent yields null.
+        every { DeepLinking.makeLaunchIntent(any(), any()) } returns null
+
+        KlaviyoTrampolineActivity.handleTrampolineIntent(intent, mockTrampolineContext)
+
+        verify { Klaviyo.handlePush(intent) }
+        verify(exactly = 0) { mockTrampolineContext.startActivity(any()) }
+        // Mirrors the non-trampoline diagnostic so a missing launcher is still debuggable.
+        verify { spyLog.warning(any(), null) }
+    }
+
+    @Test
     fun `handleTrampolineIntent with deep link and no handler dispatches ACTION_VIEW into host`() {
         val intent = klaviyoIntent()
         val deepLink = mockk<Uri>(relaxed = true)

--- a/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivityTest.kt
+++ b/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivityTest.kt
@@ -151,7 +151,8 @@ class KlaviyoTrampolineActivityTest : BaseTest() {
         verify { DeepLinking.makeLaunchIntent(mockTrampolineContext, any()) }
         verify { mockTrampolineContext.startActivity(mockLaunchIntent) }
         verify(exactly = 0) { mockTrampolineContext.startActivity(mockDeepLinkIntent) }
-        verify { spyLog.error(any(), null) }
+        // Degraded-but-handled (fell back to launcher) → WARNING, not ERROR.
+        verify { spyLog.warning(any(), null) }
     }
 
     @Test

--- a/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivityTest.kt
+++ b/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivityTest.kt
@@ -23,6 +23,8 @@ import org.junit.Test
 class KlaviyoTrampolineActivityTest : BaseTest() {
 
     private val mockBrowserIntent = mockk<Intent>(relaxed = true)
+    private val mockDeepLinkIntent = mockk<Intent>(relaxed = true)
+    private val mockLaunchIntent = mockk<Intent>(relaxed = true)
     private val trampolineContextPackageManager = mockk<PackageManager>(relaxed = true)
     private val mockTrampolineContext = mockk<Context>(relaxed = true).apply {
         every { packageManager } returns trampolineContextPackageManager
@@ -41,9 +43,15 @@ class KlaviyoTrampolineActivityTest : BaseTest() {
         every { Uri.parse(any()) } returns mockk(relaxed = true)
         every { Klaviyo.handlePush(any()) } returns Klaviyo
         every { DeepLinking.makeBrowserIntent(any()) } returns mockBrowserIntent
-        // Make the browser intent appear resolvable so startActivityIfResolved
-        // actually dispatches to context.startActivity (vs logging an error).
+        every { DeepLinking.makeDeepLinkIntent(any(), any(), any()) } returns mockDeepLinkIntent
+        every { DeepLinking.makeLaunchIntent(any(), any()) } returns mockLaunchIntent
+        // No deep link handler registered by default; flip per-test for the handler branch.
+        every { DeepLinking.isHandlerRegistered } returns false
+        // Make intents appear resolvable so startActivityIfResolved actually dispatches to
+        // context.startActivity (vs logging an error). Override per-test for the unresolvable case.
         every { mockBrowserIntent.resolveActivity(any()) } returns mockk()
+        every { mockDeepLinkIntent.resolveActivity(any()) } returns mockk()
+        every { mockLaunchIntent.resolveActivity(any()) } returns mockk()
     }
 
     @After
@@ -61,6 +69,8 @@ class KlaviyoTrampolineActivityTest : BaseTest() {
      */
     private fun klaviyoIntent(): Intent = mockk(relaxed = true) {
         every { getStringExtra(PACKAGE_PREFIX + TRACKING_PARAMETER) } returns "tracking-id"
+        every { getStringExtra(KlaviyoTrampolineActivity.BROWSER_URL_EXTRA) } returns null
+        every { data } returns null
     }
 
     @Test
@@ -83,20 +93,65 @@ class KlaviyoTrampolineActivityTest : BaseTest() {
     }
 
     @Test
-    fun `handleTrampolineIntent with Klaviyo intent but no dispatch extra tracks open and logs wtf`() {
-        val intent = klaviyoIntent()
-        every {
-            intent.getStringExtra(KlaviyoTrampolineActivity.BROWSER_URL_EXTRA)
-        } returns null
+    fun `handleTrampolineIntent with no deep link launches the host app`() {
+        val intent = klaviyoIntent() // no browser extra, no deep link data
 
         KlaviyoTrampolineActivity.handleTrampolineIntent(intent, mockTrampolineContext)
 
-        // handlePush still runs for any Klaviyo notification intent — only dispatch is skipped.
         verify { Klaviyo.handlePush(intent) }
         verify(exactly = 0) { DeepLinking.makeBrowserIntent(any()) }
-        verify(exactly = 0) { mockTrampolineContext.startActivity(any()) }
-        // wtf, not warning: reaching this branch is an internal contract break.
-        verify { spyLog.wtf(any(), null) }
+        verify(exactly = 0) { DeepLinking.makeDeepLinkIntent(any(), any(), any()) }
+        verify { DeepLinking.makeLaunchIntent(mockTrampolineContext, any()) }
+        verify { mockTrampolineContext.startActivity(mockLaunchIntent) }
+    }
+
+    @Test
+    fun `handleTrampolineIntent with deep link and no handler dispatches ACTION_VIEW into host`() {
+        val intent = klaviyoIntent()
+        val deepLink = mockk<Uri>(relaxed = true)
+        every { intent.data } returns deepLink
+        every { DeepLinking.isHandlerRegistered } returns false
+
+        KlaviyoTrampolineActivity.handleTrampolineIntent(intent, mockTrampolineContext)
+
+        verify { Klaviyo.handlePush(intent) }
+        verify { DeepLinking.makeDeepLinkIntent(deepLink, mockTrampolineContext, intent) }
+        verify { mockTrampolineContext.startActivity(mockDeepLinkIntent) }
+        verify(exactly = 0) { DeepLinking.makeLaunchIntent(any(), any()) }
+    }
+
+    @Test
+    fun `handleTrampolineIntent with deep link but handler registered launches host without ACTION_VIEW`() {
+        val intent = klaviyoIntent()
+        val deepLink = mockk<Uri>(relaxed = true)
+        every { intent.data } returns deepLink
+        // handlePush already dispatched the registered handler — a VIEW intent would double-deliver.
+        every { DeepLinking.isHandlerRegistered } returns true
+
+        KlaviyoTrampolineActivity.handleTrampolineIntent(intent, mockTrampolineContext)
+
+        verify { Klaviyo.handlePush(intent) }
+        verify(exactly = 0) { DeepLinking.makeDeepLinkIntent(any(), any(), any()) }
+        verify { DeepLinking.makeLaunchIntent(mockTrampolineContext, any()) }
+        verify { mockTrampolineContext.startActivity(mockLaunchIntent) }
+    }
+
+    @Test
+    fun `handleTrampolineIntent with unresolvable deep link falls back to launcher`() {
+        val intent = klaviyoIntent()
+        val deepLink = mockk<Uri>(relaxed = true)
+        every { intent.data } returns deepLink
+        every { DeepLinking.isHandlerRegistered } returns false
+        // Deep link target cannot be resolved → fall back to the launcher.
+        every { mockDeepLinkIntent.resolveActivity(any()) } returns null
+
+        KlaviyoTrampolineActivity.handleTrampolineIntent(intent, mockTrampolineContext)
+
+        verify { DeepLinking.makeDeepLinkIntent(deepLink, mockTrampolineContext, intent) }
+        verify { DeepLinking.makeLaunchIntent(mockTrampolineContext, any()) }
+        verify { mockTrampolineContext.startActivity(mockLaunchIntent) }
+        verify(exactly = 0) { mockTrampolineContext.startActivity(mockDeepLinkIntent) }
+        verify { spyLog.error(any(), null) }
     }
 
     @Test


### PR DESCRIPTION
# Description

Routes Klaviyo notification taps (body, `deep_link`, `open_app`) through the transparent `KlaviyoTrampolineActivity` when a host opts in via the `com.klaviyo.automatic_push_tracking` manifest flag, so the SDK tracks `$opened_push` itself — removing the need for `Klaviyo.handlePush(intent)` in every host Activity. Builds on the trampoline from #448; flag off (default) is unchanged.

## Due Diligence
- [ ] I have tested this on an emulator and/or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all Android versions the SDK currently supports.

## Release/Versioning Considerations
- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [x] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [x] This is planned work for an upcoming release.
  - Part of the Automatic Push Open Tracking milestone (MAGE-765 telemetry, MAGE-768 dedup). Targets the `feat/auto-push-tracking` integration branch, not `master`.

## Changelog / Code Overview
- **core:** add `Config.getManifestBoolean` (+ `Context.getManifestBoolean` extension) and the `Constants.AUTOMATIC_PUSH_TRACKING` manifest key, re-exposed as `KlaviyoPushService.METADATA_AUTOMATIC_PUSH_TRACKING`.
- **push-fcm:** extend `KlaviyoTrampolineActivity` with a shared `forDestination` factory, `onNewIntent` (singleTask re-entry), and generalized dispatch — browser URL (unchanged, #448) / deep-link-via-`ACTION_VIEW` when no `DeepLinkHandler` is registered / launch fallback. `KlaviyoNotification` reads the flag once per build and routes body + action-button intents through the trampoline when enabled. Manifest hardened with `singleTask` + `taskAffinity=""` + `excludeFromRecents`.
- Flag **off** → body/`deep_link`/`open_app` intents byte-identical to today; `open_url` always routes through the trampoline regardless (per #448).

**Out of scope (sibling tickets):** the dedup guard (MAGE-768) and any standalone telemetry (MAGE-765). Until MAGE-768 lands, an opt-in host with a leftover manual `handlePush` will double-count opens — expected and acceptable while unreleased.

## Test Plan
- Unit: `:sdk:core` + `:sdk:push-fcm` `testDebugUnitTest` (JDK 17) green; ktlint clean. Covers the trampoline dispatch matrix (handler registered/unregistered, deep link present/absent/unresolvable, non-Klaviyo), flag-on/off notification routing with extras parity, and `getManifestBoolean` across both SDK API paths.
- Manual (pending): sample app on emulator — flag on: body + action-button taps from foreground/background/cold start track the open and land on the correct destination; flag off: `open_url` still tracks and opens the browser.

## Related Issues/Tickets
- MAGE-767 — https://linear.app/klaviyo/issue/MAGE-767


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional **automatic push tracking** mode that routes notification body taps and action buttons through the unified in-app trampoline flow, controlled via manifest metadata.
* **Bug Fixes**
  * Improved trampoline routing for deep links, unresolved deep links, and standard launches, including more reliable back-stack behavior.
  * Reduced sensitive/verbose logging when an intent can’t be resolved.
* **Tests**
  * Expanded automated coverage for body taps, deep-link actions, open-app actions, and browser links in both tracking modes.
* **Documentation**
  * Added support for reading boolean manifest metadata values with a default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->