### PR TITLE
feat(push): loosen open_url scheme gate to allowlist (PUSH-834)

### DIFF
--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/linking/DeepLinking.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/linking/DeepLinking.kt
@@ -9,6 +9,9 @@ import com.klaviyo.analytics.model.Profile
 import com.klaviyo.analytics.networking.ApiClient
 import com.klaviyo.analytics.networking.requests.ResolveDestinationResult
 import com.klaviyo.analytics.state.State
+import com.klaviyo.core.Constants.DIAL_SCHEME
+import com.klaviyo.core.Constants.SENDTO_SCHEMES
+import com.klaviyo.core.Constants.WEB_SCHEMES
 import com.klaviyo.core.Registry
 import com.klaviyo.core.lifecycle.LifecycleMonitor.Companion.ACTIVITY_TRANSITION_GRACE_PERIOD
 import com.klaviyo.core.safeLaunch
@@ -117,17 +120,38 @@ object DeepLinking {
     }
 
     /**
-     * Create an intent to open a URL in the default browser.
+     * Create an intent to open a URI externally (browser, mail client, dialer, etc.).
      *
      * Unlike [makeDeepLinkIntent], this intent is not scoped to the host application package,
-     * so the OS routes it to the default browser.
+     * so the OS routes it to the appropriate external handler.
      *
-     * @param uri The web URL to open
-     * @return An intent configured to open the URL in the default browser
+     * The action is chosen by scheme so the OS can resolve a handler reliably: [Intent.ACTION_DIAL]
+     * for `tel:`, [Intent.ACTION_SENDTO] for `mailto:`/`sms:`/`smsto:`, and [Intent.ACTION_VIEW] for
+     * web and any other scheme. [Intent.CATEGORY_BROWSABLE] is added only for http/https so the OS
+     * routes those to a browser.
+     *
+     * The URI is normalized via [Uri.normalizeScheme] before being set as the intent data, since
+     * Android's intent-filter scheme matching is case-sensitive and a mixed-case scheme
+     * (e.g. `MAILTO:`) would otherwise fail to resolve.
+     *
+     * @param uri The URI to open externally
+     * @return An intent configured to open the URI in the appropriate external app
      */
-    fun makeBrowserIntent(uri: Uri) = Intent(Intent.ACTION_VIEW, uri).apply {
-        addCategory(Intent.CATEGORY_BROWSABLE)
-        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    fun makeExternalIntent(uri: Uri): Intent {
+        val normalizedUri = uri.normalizeScheme()
+        val scheme = normalizedUri.scheme
+        return Intent().apply {
+            data = normalizedUri
+            action = when {
+                scheme in SENDTO_SCHEMES -> Intent.ACTION_SENDTO
+                scheme == DIAL_SCHEME -> Intent.ACTION_DIAL
+                else -> Intent.ACTION_VIEW
+            }
+            if (scheme in WEB_SCHEMES) {
+                addCategory(Intent.CATEGORY_BROWSABLE)
+            }
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
     }
 
     /**

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/linking/DeepLinkingTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/linking/DeepLinkingTest.kt
@@ -164,6 +164,145 @@ internal class DeepLinkingTest : BaseTest() {
         assertEquals(Intent.ACTION_VIEW, result.action)
     }
 
+    /**
+     * Mock a Uri with an already-normalized (lowercase) scheme, self-normalizing via
+     * [Uri.normalizeScheme] the way a real normalized Uri would.
+     */
+    private fun mockUriWithScheme(scheme: String): Uri {
+        val uri = mockk<Uri>(relaxed = true)
+        every { uri.scheme } returns scheme
+        every { uri.normalizeScheme() } returns uri
+        return uri
+    }
+
+    @Test
+    fun `makeExternalIntent adds CATEGORY_BROWSABLE for https URI`() {
+        MockIntent.setupIntentMocking()
+        val categories = mutableListOf<String>()
+        every {
+            anyConstructed<Intent>().addCategory(capture(categories))
+        } returns mockk(relaxed = true)
+
+        DeepLinking.makeExternalIntent(mockUriWithScheme("https"))
+
+        assertTrue(Intent.CATEGORY_BROWSABLE in categories)
+    }
+
+    @Test
+    fun `makeExternalIntent adds CATEGORY_BROWSABLE for http URI`() {
+        MockIntent.setupIntentMocking()
+        val categories = mutableListOf<String>()
+        every {
+            anyConstructed<Intent>().addCategory(capture(categories))
+        } returns mockk(relaxed = true)
+
+        DeepLinking.makeExternalIntent(mockUriWithScheme("http"))
+
+        assertTrue(Intent.CATEGORY_BROWSABLE in categories)
+    }
+
+    @Test
+    fun `makeExternalIntent does not add CATEGORY_BROWSABLE for mailto URI`() {
+        MockIntent.setupIntentMocking()
+        val categories = mutableListOf<String>()
+        every {
+            anyConstructed<Intent>().addCategory(capture(categories))
+        } returns mockk(relaxed = true)
+
+        DeepLinking.makeExternalIntent(mockUriWithScheme("mailto"))
+
+        assertFalse(Intent.CATEGORY_BROWSABLE in categories)
+    }
+
+    @Test
+    fun `makeExternalIntent does not add CATEGORY_BROWSABLE for tel URI`() {
+        MockIntent.setupIntentMocking()
+        val categories = mutableListOf<String>()
+        every {
+            anyConstructed<Intent>().addCategory(capture(categories))
+        } returns mockk(relaxed = true)
+
+        DeepLinking.makeExternalIntent(mockUriWithScheme("tel"))
+
+        assertFalse(Intent.CATEGORY_BROWSABLE in categories)
+    }
+
+    @Test
+    fun `makeExternalIntent always adds FLAG_ACTIVITY_NEW_TASK`() {
+        MockIntent.setupIntentMocking()
+        val flagsSlot = mutableListOf<Int>()
+        every {
+            anyConstructed<Intent>().addFlags(capture(flagsSlot))
+        } returns mockk(relaxed = true)
+        every { anyConstructed<Intent>().addCategory(any()) } returns mockk(relaxed = true)
+
+        DeepLinking.makeExternalIntent(mockUriWithScheme("https"))
+        DeepLinking.makeExternalIntent(mockUriWithScheme("mailto"))
+
+        assertEquals(2, flagsSlot.size)
+        assertTrue(flagsSlot.all { it and Intent.FLAG_ACTIVITY_NEW_TASK != 0 })
+    }
+
+    @Test
+    fun `makeExternalIntent uses ACTION_DIAL for tel URI`() {
+        MockIntent.setupIntentMocking()
+
+        val result = DeepLinking.makeExternalIntent(mockUriWithScheme("tel"))
+
+        assertEquals(Intent.ACTION_DIAL, result.action)
+    }
+
+    @Test
+    fun `makeExternalIntent uses ACTION_SENDTO for mailto URI`() {
+        MockIntent.setupIntentMocking()
+
+        val result = DeepLinking.makeExternalIntent(mockUriWithScheme("mailto"))
+
+        assertEquals(Intent.ACTION_SENDTO, result.action)
+    }
+
+    @Test
+    fun `makeExternalIntent uses ACTION_SENDTO for sms URI`() {
+        MockIntent.setupIntentMocking()
+
+        val result = DeepLinking.makeExternalIntent(mockUriWithScheme("sms"))
+
+        assertEquals(Intent.ACTION_SENDTO, result.action)
+    }
+
+    @Test
+    fun `makeExternalIntent uses ACTION_SENDTO for smsto URI`() {
+        MockIntent.setupIntentMocking()
+
+        val result = DeepLinking.makeExternalIntent(mockUriWithScheme("smsto"))
+
+        assertEquals(Intent.ACTION_SENDTO, result.action)
+    }
+
+    @Test
+    fun `makeExternalIntent uses ACTION_VIEW for https URI`() {
+        MockIntent.setupIntentMocking()
+        every { anyConstructed<Intent>().addCategory(any()) } returns mockk(relaxed = true)
+
+        val result = DeepLinking.makeExternalIntent(mockUriWithScheme("https"))
+
+        assertEquals(Intent.ACTION_VIEW, result.action)
+    }
+
+    @Test
+    fun `makeExternalIntent normalizes mixed-case scheme before dispatch`() {
+        MockIntent.setupIntentMocking()
+        val normalizedUri = mockUriWithScheme("mailto")
+        val mixedCaseUri = mockk<Uri>(relaxed = true)
+        every { mixedCaseUri.scheme } returns "MAILTO"
+        every { mixedCaseUri.normalizeScheme() } returns normalizedUri
+
+        val result = DeepLinking.makeExternalIntent(mixedCaseUri)
+
+        assertEquals(Intent.ACTION_SENDTO, result.action)
+        assertEquals(normalizedUri, result.data)
+    }
+
     @Test
     fun `makeLaunchIntent returns configured intent when launch intent exists`() {
         val mockLaunchIntent = mockk<Intent>(relaxed = true)

--- a/sdk/core/src/main/AndroidManifest.xml
+++ b/sdk/core/src/main/AndroidManifest.xml
@@ -14,5 +14,24 @@
             <category android:name="android.intent.category.BROWSABLE" />
             <data android:scheme="http" />
         </intent>
+        <!-- open_url non-web schemes (PUSH-834): required so resolveActivity() can see the
+             dialer/SMS/mail handlers under Android 11+ package visibility. Must match the
+             actions/schemes dispatched by DeepLinking.makeExternalIntent. -->
+        <intent>
+            <action android:name="android.intent.action.DIAL" />
+            <data android:scheme="tel" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.SENDTO" />
+            <data android:scheme="mailto" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.SENDTO" />
+            <data android:scheme="sms" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.SENDTO" />
+            <data android:scheme="smsto" />
+        </intent>
     </queries>
 </manifest>

--- a/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
@@ -34,4 +34,28 @@ object Constants {
      * Notifications are uniquely identified by their string tag, not this ID.
      */
     const val NOTIFICATION_ID = 0
+
+    /**
+     * URI schemes routed to a web browser. External intents for these schemes add
+     * `Intent.CATEGORY_BROWSABLE` so the OS resolves them to a browser rather than
+     * a generic activity chooser.
+     */
+    val WEB_SCHEMES = setOf("http", "https")
+
+    /**
+     * URI schemes that compose a message, dispatched externally via `Intent.ACTION_SENDTO`.
+     */
+    val SENDTO_SCHEMES = setOf("mailto", "sms", "smsto")
+
+    /**
+     * URI scheme that opens the dialer, dispatched externally via `Intent.ACTION_DIAL`.
+     */
+    const val DIAL_SCHEME = "tel"
+
+    /**
+     * Full set of URI schemes accepted by the `web_url` field and `open_url` action buttons.
+     * Schemes outside this set are silently dropped to prevent routing dangerous or
+     * unintended URIs (e.g. intent:, javascript:, file:) through the SDK.
+     */
+    val ALLOWED_OPEN_URL_SCHEMES = WEB_SCHEMES + SENDTO_SCHEMES + DIAL_SCHEME
 }

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoRemoteMessage.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoRemoteMessage.kt
@@ -15,6 +15,7 @@ import androidx.core.graphics.toColorInt
 import androidx.core.net.toUri
 import com.google.firebase.messaging.CommonNotificationBuilder
 import com.google.firebase.messaging.RemoteMessage
+import com.klaviyo.core.Constants.ALLOWED_OPEN_URL_SCHEMES
 import com.klaviyo.core.Constants.PACKAGE_PREFIX
 import com.klaviyo.core.Constants.TRACKING_PARAMETER
 import com.klaviyo.core.Registry
@@ -132,32 +133,31 @@ object KlaviyoRemoteMessage {
     val RemoteMessage.body: String? get() = this.data[KlaviyoNotification.BODY_KEY]
 
     /**
-     * Parse the external web URL from the payload, if present.
+     * True if the string parses as a Uri whose scheme is in [ALLOWED_OPEN_URL_SCHEMES].
+     */
+    internal fun String.hasAllowedOpenUrlScheme(): Boolean =
+        this.toUri().scheme?.lowercase() in ALLOWED_OPEN_URL_SCHEMES
+
+    /**
+     * Parse the external URL from the payload, if present.
      *
      * Reads the `web_url` field. The presence of this field indicates the tap should open
-     * the URL in the system browser rather than route through the app's deep link handling.
-     * Returns null if the field is absent, blank, or the URL's scheme is not http(s) —
-     * non-web schemes are rejected to prevent routing back into the app via Intent dispatch.
+     * the URL externally rather than route through the app's deep link handling.
+     * Returns null if the field is absent, blank, or the URL's scheme is not in
+     * [ALLOWED_OPEN_URL_SCHEMES] — disallowed schemes are rejected to prevent routing
+     * dangerous URIs (e.g. intent:, javascript:, file:) through the SDK.
      */
     val RemoteMessage.webUrl: String?
         get() {
             val urlString = this.data[KlaviyoNotification.WEB_URL_KEY]?.takeIf { it.isNotBlank() }
                 ?: return null
-            return if (urlString.isWebUrl()) {
+            return if (urlString.hasAllowedOpenUrlScheme()) {
                 urlString
             } else {
-                Registry.log.warning("web_url '$urlString' has non-web scheme; ignoring.")
+                Registry.log.warning("web_url '$urlString' has a disallowed scheme; ignoring.")
                 null
             }
         }
-
-    /**
-     * True if the string parses as a Uri with http or https scheme.
-     */
-    internal fun String.isWebUrl(): Boolean {
-        val scheme = this.toUri().scheme?.lowercase()
-        return scheme == "http" || scheme == "https"
-    }
 
     /**
      * Parse deep link into a [Uri] if present
@@ -296,9 +296,10 @@ object KlaviyoRemoteMessage {
                                     )
                                     null
                                 }
-                                !urlString.isWebUrl() -> {
+                                !urlString.hasAllowedOpenUrlScheme() -> {
                                     Registry.log.warning(
-                                        "Skipping OPEN_URL action button $i: url '$urlString' has non-web scheme"
+                                        "Skipping OPEN_URL action button $i: url '$urlString' " +
+                                            "has a disallowed scheme"
                                     )
                                     null
                                 }

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivity.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivity.kt
@@ -17,8 +17,10 @@ import com.klaviyo.core.utils.startActivityIfResolved
  * invoking the registered deep link handler) before forwarding the user to the actual
  * destination.
  *
- * Currently used for `open_url` push payloads — the destination is a browser intent
- * embedded as [BROWSER_URL_EXTRA]. Additional dispatch paths can be added to
+ * Currently used for `open_url` push payloads — the URL is embedded as [BROWSER_URL_EXTRA]
+ * and routed to the appropriate external handler via [DeepLinking.makeExternalIntent] — a
+ * browser for `http`/`https`, or the mail, dialer, or SMS app for
+ * `mailto:`/`tel:`/`sms:`/`smsto:` schemes. Additional dispatch paths can be added to
  * [dispatchDestination] as new use cases (e.g. automatic open tracking) introduce
  * their own routing extras.
  *
@@ -40,7 +42,7 @@ internal class KlaviyoTrampolineActivity : Activity() {
 
     companion object {
         /**
-         * Intent extra carrying a web URL to be launched in the default browser after
+         * Intent extra carrying an `open_url` URL to be dispatched to its external handler after
          * `Klaviyo.handlePush` runs. Uses the `_klaviyo.` prefix (matching
          * [com.klaviyo.core.Constants.NOTIFICATION_TAG_EXTRA]) so this internal routing
          * extra is skipped by the `com.klaviyo.*` extras sweep in
@@ -49,7 +51,8 @@ internal class KlaviyoTrampolineActivity : Activity() {
         internal const val BROWSER_URL_EXTRA = "_klaviyo.browser_url"
 
         /**
-         * Build a trampoline intent that dispatches to the default browser with [url].
+         * Build a trampoline intent that dispatches [url] to its external handler
+         * via [DeepLinking.makeExternalIntent].
          *
          * Uses [Intent.setClassName] instead of the `Intent(Context, Class)` constructor
          * so the JVM unit-test environment (which can't satisfy the native ComponentName
@@ -78,7 +81,7 @@ internal class KlaviyoTrampolineActivity : Activity() {
 
         private fun dispatchDestination(intent: Intent, context: Context) {
             intent.getStringExtra(BROWSER_URL_EXTRA)?.let { url ->
-                DeepLinking.makeBrowserIntent(url.toUri()).startActivityIfResolved(context)
+                DeepLinking.makeExternalIntent(url.toUri()).startActivityIfResolved(context)
                 return
             }
             // Add additional dispatch branches here as new routing extras are introduced.

--- a/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoNotificationTest.kt
+++ b/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoNotificationTest.kt
@@ -100,7 +100,7 @@ class KlaviyoNotificationTest : BaseTest() {
             mockkObject(DeepLinking)
             every { makeLaunchIntent(any()) } returns mockk(relaxed = true)
             every { makeDeepLinkIntent(any(), any()) } returns mockk(relaxed = true)
-            every { makeBrowserIntent(any()) } returns mockk(relaxed = true)
+            every { makeExternalIntent(any()) } returns mockk(relaxed = true)
         }
 
         // Mock makeIntent to avoid constructing a real Intent. This test class doesn't call
@@ -720,7 +720,7 @@ class KlaviyoNotificationTest : BaseTest() {
         verify {
             KlaviyoTrampolineActivity.forBrowserUrl(mockContext, "https://example.com")
         }
-        verify(exactly = 0) { DeepLinking.makeBrowserIntent(any()) }
+        verify(exactly = 0) { DeepLinking.makeExternalIntent(any()) }
         verify(exactly = 0) { DeepLinking.makeDeepLinkIntent(any(), any()) }
         verify(exactly = 0) { DeepLinking.makeLaunchIntent(any()) }
     }
@@ -770,7 +770,7 @@ class KlaviyoNotificationTest : BaseTest() {
         notification.displayNotification(mockContext)
 
         verify { DeepLinking.makeLaunchIntent(mockContext) }
-        verify(exactly = 0) { DeepLinking.makeBrowserIntent(any()) }
+        verify(exactly = 0) { DeepLinking.makeExternalIntent(any()) }
         verify { mockLaunchIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP) }
         assertEquals(mockLaunchIntent, intentSlot.captured)
     }
@@ -796,7 +796,7 @@ class KlaviyoNotificationTest : BaseTest() {
         verify {
             KlaviyoTrampolineActivity.forBrowserUrl(mockContext, "https://example.com")
         }
-        verify(exactly = 0) { DeepLinking.makeBrowserIntent(any()) }
+        verify(exactly = 0) { DeepLinking.makeExternalIntent(any()) }
     }
 
     @Test

--- a/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoRemoteMessageTest.kt
+++ b/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoRemoteMessageTest.kt
@@ -580,18 +580,47 @@ class KlaviyoRemoteMessageTest : BaseTest() {
     }
 
     @Test
-    fun `webUrl returns null when web_url has a non-web scheme`() {
+    fun `webUrl returns null when web_url has a blocked scheme`() {
         val mockUri = mockk<android.net.Uri>(relaxed = true)
-        every { mockUri.scheme } returns "myapp"
+        every { mockUri.scheme } returns "javascript"
         mockkStatic(android.net.Uri::class)
-        every { android.net.Uri.parse("myapp://home") } returns mockUri
+        every { android.net.Uri.parse("javascript:alert(1)") } returns mockUri
 
         val msg = mockk<RemoteMessage>()
         every { msg.data } returns stubMessage.toMutableMap().apply {
-            put(KlaviyoNotification.WEB_URL_KEY, "myapp://home")
+            put(KlaviyoNotification.WEB_URL_KEY, "javascript:alert(1)")
         }
 
         assert(msg.webUrl == null)
+
+        unmockkStatic(android.net.Uri::class)
+    }
+
+    @Test
+    fun `webUrl returns url when web_url has an allowlisted communication scheme`() {
+        mockkStatic(android.net.Uri::class)
+
+        val schemes = listOf(
+            "mailto" to "mailto:user@example.com",
+            "tel" to "tel:+15555550100",
+            "sms" to "sms:+15555550100",
+            "smsto" to "smsto:+15555550100"
+        )
+
+        for ((scheme, url) in schemes) {
+            val mockUri = mockk<android.net.Uri>(relaxed = true)
+            every { mockUri.scheme } returns scheme
+            every { android.net.Uri.parse(url) } returns mockUri
+
+            val msg = mockk<RemoteMessage>()
+            every { msg.data } returns stubMessage.toMutableMap().apply {
+                put(KlaviyoNotification.WEB_URL_KEY, url)
+            }
+
+            assert(msg.webUrl == url) {
+                "Expected webUrl to return '$url' for scheme $scheme"
+            }
+        }
 
         unmockkStatic(android.net.Uri::class)
     }
@@ -650,18 +679,18 @@ class KlaviyoRemoteMessageTest : BaseTest() {
     }
 
     @Test
-    fun `actionButtons skips open_url with non-web scheme`() {
+    fun `actionButtons skips open_url with blocked scheme`() {
         val mockUri = mockk<android.net.Uri>(relaxed = true)
-        every { mockUri.scheme } returns "myapp"
+        every { mockUri.scheme } returns "intent"
         mockkStatic(android.net.Uri::class)
-        every { android.net.Uri.parse("myapp://home") } returns mockUri
+        every { android.net.Uri.parse("intent://evil") } returns mockUri
 
         val actionButtonsData = listOf(
             mapOf(
                 "id" to "open.url",
                 "label" to "Open Website",
                 "action" to "open_url",
-                "url" to "myapp://home"
+                "url" to "intent://evil"
             )
         )
         val messageWithActions = stubMessage.toMutableMap().apply {
@@ -672,6 +701,51 @@ class KlaviyoRemoteMessageTest : BaseTest() {
         every { msg.data } returns messageWithActions
 
         assert(msg.actionButtons == null)
+
+        unmockkStatic(android.net.Uri::class)
+    }
+
+    @Test
+    fun `actionButtons accepts open_url with allowlisted communication schemes`() {
+        mockkStatic(android.net.Uri::class)
+
+        val schemes = listOf(
+            "mailto" to "mailto:user@example.com",
+            "tel" to "tel:+15555550100",
+            "sms" to "sms:+15555550100",
+            "smsto" to "smsto:+15555550100"
+        )
+
+        for ((scheme, url) in schemes) {
+            val mockUri = mockk<android.net.Uri>(relaxed = true)
+            every { mockUri.scheme } returns scheme
+            every { android.net.Uri.parse(url) } returns mockUri
+
+            val actionButtonsData = listOf(
+                mapOf(
+                    "id" to "comms.button",
+                    "label" to "Contact",
+                    "action" to "open_url",
+                    "url" to url
+                )
+            )
+            val messageWithActions = stubMessage.toMutableMap().apply {
+                put(ACTION_BUTTONS_KEY, JSONArray(actionButtonsData).toString())
+            }
+
+            val msg = mockk<RemoteMessage>()
+            every { msg.data } returns messageWithActions
+
+            val buttons = msg.actionButtons
+            assert(buttons != null) { "Expected button for scheme $scheme to be accepted" }
+            assert(buttons?.size == 1) { "Expected 1 button for scheme $scheme" }
+            assert(buttons?.get(0) is ActionButton.OpenUrl) {
+                "Expected OpenUrl button for scheme $scheme"
+            }
+            assert((buttons?.get(0) as? ActionButton.OpenUrl)?.url == url) {
+                "Expected url $url for scheme $scheme"
+            }
+        }
 
         unmockkStatic(android.net.Uri::class)
     }

--- a/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivityTest.kt
+++ b/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivityTest.kt
@@ -40,7 +40,7 @@ class KlaviyoTrampolineActivityTest : BaseTest() {
         mockkStatic(Uri::class)
         every { Uri.parse(any()) } returns mockk(relaxed = true)
         every { Klaviyo.handlePush(any()) } returns Klaviyo
-        every { DeepLinking.makeBrowserIntent(any()) } returns mockBrowserIntent
+        every { DeepLinking.makeExternalIntent(any()) } returns mockBrowserIntent
         // Make the browser intent appear resolvable so startActivityIfResolved
         // actually dispatches to context.startActivity (vs logging an error).
         every { mockBrowserIntent.resolveActivity(any()) } returns mockk()
@@ -76,9 +76,9 @@ class KlaviyoTrampolineActivityTest : BaseTest() {
 
         verify { Klaviyo.handlePush(intent) }
         // Assert the exact URL from the extra round-trips through Uri.parse and into
-        // makeBrowserIntent — catches regressions where a string is mangled, swallowed,
+        // makeExternalIntent — catches regressions where a string is mangled, swallowed,
         // or replaced silently with something else.
-        verify { DeepLinking.makeBrowserIntent(parsedUri) }
+        verify { DeepLinking.makeExternalIntent(parsedUri) }
         verify { mockTrampolineContext.startActivity(mockBrowserIntent) }
     }
 
@@ -93,7 +93,7 @@ class KlaviyoTrampolineActivityTest : BaseTest() {
 
         // handlePush still runs for any Klaviyo notification intent — only dispatch is skipped.
         verify { Klaviyo.handlePush(intent) }
-        verify(exactly = 0) { DeepLinking.makeBrowserIntent(any()) }
+        verify(exactly = 0) { DeepLinking.makeExternalIntent(any()) }
         verify(exactly = 0) { mockTrampolineContext.startActivity(any()) }
         // wtf, not warning: reaching this branch is an internal contract break.
         verify { spyLog.wtf(any(), null) }
@@ -107,7 +107,7 @@ class KlaviyoTrampolineActivityTest : BaseTest() {
         KlaviyoTrampolineActivity.handleTrampolineIntent(intent, mockTrampolineContext)
 
         verify(exactly = 0) { Klaviyo.handlePush(any()) }
-        verify(exactly = 0) { DeepLinking.makeBrowserIntent(any()) }
+        verify(exactly = 0) { DeepLinking.makeExternalIntent(any()) }
         verify(exactly = 0) { mockTrampolineContext.startActivity(any()) }
         verify { spyLog.warning(any(), null) }
     }
@@ -117,8 +117,24 @@ class KlaviyoTrampolineActivityTest : BaseTest() {
         KlaviyoTrampolineActivity.handleTrampolineIntent(null, mockTrampolineContext)
 
         verify(exactly = 0) { Klaviyo.handlePush(any()) }
-        verify(exactly = 0) { DeepLinking.makeBrowserIntent(any()) }
+        verify(exactly = 0) { DeepLinking.makeExternalIntent(any()) }
         verify(exactly = 0) { mockTrampolineContext.startActivity(any()) }
         verify { spyLog.warning(any(), null) }
+    }
+
+    @Test
+    fun `handleTrampolineIntent dispatches non-web scheme URL via makeExternalIntent`() {
+        val intent = klaviyoIntent()
+        every {
+            intent.getStringExtra(KlaviyoTrampolineActivity.BROWSER_URL_EXTRA)
+        } returns "mailto:user@example.com"
+        val parsedUri = mockk<Uri>(relaxed = true)
+        every { Uri.parse("mailto:user@example.com") } returns parsedUri
+
+        KlaviyoTrampolineActivity.handleTrampolineIntent(intent, mockTrampolineContext)
+
+        verify { Klaviyo.handlePush(intent) }
+        verify { DeepLinking.makeExternalIntent(parsedUri) }
+        verify { mockTrampolineContext.startActivity(mockBrowserIntent) }
     }
 }


### PR DESCRIPTION
## Summary
Loosen the open_url action's http/https gate to an allowlist supporting mailto:, tel:, sms:, smsto: in addition to web schemes. Dispatch (DeepLinking.makeExternalIntent) is now scheme-aware and only applies CATEGORY_BROWSABLE for web schemes.

## Changes
- Rename makeBrowserIntent → makeExternalIntent; CATEGORY_BROWSABLE only for http/https
- Replace isWebUrl() with allowlist check (http, https, mailto, tel, sms, smsto)
- Block intent:, android-app:, javascript:, file:, content:, data: (scheme validation)
- On blocked scheme: drop silently + log (graceful degrade, no crash)
- Declare `<queries>` in sdk/core for DIAL/tel and SENDTO/mailto,sms,smsto so resolveActivity() can see the dialer/SMS/mail handlers under Android 11+ package visibility (without this the tap silently no-ops on API 30+). Merges into host apps automatically.

## Test Plan
- Module test suite passes (gradlew :sdk:push-fcm:testDebugUnitTest, etc.)
- 5 new tests: makeExternalIntent BROWSABLE/FLAG flags, allowlisted schemes accepted, blocked rejected
- Existing tests updated for renamed makeBrowserIntent

### Manual testing (real device, Android 11+)
Verified end to end by sending push notifications through the production web interface and tapping on a physical device:

| web_url value | Result |
|---|---|
| `tel:+18005551234` | Opens dialer (pre-filled, not auto-dialed) via ACTION_DIAL ✅ |
| `mailto:support@example.com?subject=Hi&body=Hello` | Opens email composer via ACTION_SENDTO ✅ |
| `sms:+18005551234?body=Test%20message` | Opens messaging app via ACTION_SENDTO ✅ |
| `smsto:+18005551234` | Opens messaging app via ACTION_SENDTO ✅ |
| `https://example.com` | Opens browser via ACTION_VIEW + BROWSABLE ✅ |

$opened_push tracking fires on the allowed cases. The `<queries>` declaration was required to make the non-web schemes resolve on the test device (API 30+); before it, tel/mailto/sms tapped to a silent no-op.

## Related
Part of PUSH-834 (multi-repo). Also see iOS and fender PRs, plus app backend PR klaviyo/app#123425 (loosens the server-side web_url validation that would otherwise reject these schemes at save time).

https://linear.app/klaviyo/issue/PUSH-834


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added scheme-aware external URL handling for `open_url`/deep links (e.g., `tel`, `mailto`, `sms`, `smsto`, and web URLs) using the appropriate platform action per scheme.
  * Web URLs now use web-compatible intent categorization, while communication schemes route externally without browser-only assumptions.
* **Bug Fixes**
  * Tightened `webUrl` and `open_url` action-button validation to an allowlist; disallowed schemes are ignored and no longer dispatched.
  * Improved Android app visibility for dialer and messaging handlers via explicit intent queries.
* **Tests**
  * Updated unit tests and coverage to reflect the new scheme-based intent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
