### PR TITLE
feat(push): in-memory dedup guard for auto-tracked push opens (MAGE-768)

### DIFF
--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -49,17 +49,8 @@ object Klaviyo {
     private val preInitQueue: Queue<Operation<Unit>> = LinkedList()
 
     /**
-     * In-memory dedup guard over push *delivery* IDs already auto-tracked by [handlePush].
-     *
-     * Only auto-tracking-path intents engage this guard: the trampoline stamps
-     * [Constants.NOTIFICATION_AUTO_TRACKED_EXTRA] on its targeted intents and forwards the
-     * destination intent (carrying that marker and the `_k` payload) to the host. The trampoline's
-     * own `handlePush` marks the delivery first; a host that also left a manual `handlePush` call in
-     * place then short-circuits instead of tracking a second `$opened_push` for the same tap. It
-     * also dedupes trampoline `singleTask` re-entry with the same intent.
-     *
-     * Manual-only integrations (auto-tracking disabled) never carry the marker, so they never engage
-     * the guard and behave exactly as before it existed.
+     * Push delivery IDs already auto-tracked within this process, so a single tap records one
+     * `$opened_push`. See [handlePush] for how entries are matched and added.
      */
     private val handledPushDeliveries = BoundedIdSet()
 
@@ -346,55 +337,58 @@ object Klaviyo {
      */
     @JvmStatic
     fun handlePush(intent: Intent?): Klaviyo {
-        // Dedup guard (top of function), scoped to the automatic-tracking path only: a push delivery
-        // we've already auto-tracked means this is a re-delivery of the same tap — a host's leftover
-        // manual handlePush after the trampoline already tracked, or singleTask re-entry.
-        // Short-circuit fully: no event, no dismissal, no deep link dispatch. The marker is absent on
-        // manual-only integrations, so their behavior is unchanged. Unseen delivery → atomically mark
-        // it and proceed.
-        if (intent.isAutoTrackedOpen) {
-            intent.pushDeliveryId?.let { deliveryId ->
-                if (!handledPushDeliveries.markOnce(deliveryId)) {
-                    Registry.log.verbose(
-                        "Ignoring duplicate auto-tracked push open for delivery $deliveryId"
-                    )
-                    return this
-                }
+        // Dedup guard for the automatic-tracking path. The trampoline calls handlePush and then
+        // forwards the same intent to the host, so a leftover manual handlePush call (or singleTask
+        // re-entry) would otherwise track a second open for one tap. Record each delivery the first
+        // time it's seen; if it's already recorded, drop this call entirely — no event, dismissal, or
+        // deep link. Manual-only integrations carry no auto-tracked marker, so they're unaffected.
+        val deliveryId = intent.pushDeliveryId
+        if (
+            intent.isAutoTrackedOpen &&
+            deliveryId != null &&
+            !handledPushDeliveries.markOnce(deliveryId)
+        ) {
+            Registry.log.verbose("Ignoring duplicate auto-tracked push open")
+            return this
+        }
+
+        if (intent == null || !intent.isKlaviyoNotificationIntent) {
+            Registry.log.verbose("Non-Klaviyo intent ignored")
+            return this
+        }
+
+        // Create and enqueue an $opened_push. safeApply(preInitQueue) buffers this for replay if
+        // handlePush runs before initialize(), and guards against unexpected failures.
+        safeApply(preInitQueue) {
+            val state = Registry.get<State>()
+            val event = Event(EventMetric.OPENED_PUSH)
+            event.appendKlaviyoExtras(intent)
+            state.pushToken?.let { event[EventKey.PUSH_TOKEN] = it }
+            // Not using Klaviyo.createEvent here to avoid nesting safeApply calls
+            state.createEvent(event, state.getAsProfile())
+        }
+
+        // Dismiss the notification if opened via an action button. Body taps auto-cancel via
+        // setAutoCancel(true) on the builder; action button taps don't (standard Android behavior).
+        safeApply {
+            val notificationTag = intent.getStringExtra(Constants.NOTIFICATION_TAG_EXTRA)
+            if (notificationTag != null) {
+                NotificationManagerCompat
+                    .from(Registry.config.applicationContext)
+                    .cancel(notificationTag, Constants.NOTIFICATION_ID)
+            }
+        }
+
+        // If the notification carries a deep link and a handler is registered, invoke it. Otherwise
+        // do nothing — the host already received the appropriate intent.
+        safeApply {
+            val deepLink = intent.data
+            if (deepLink != null && DeepLinking.isHandlerRegistered) {
+                DeepLinking.handleDeepLink(deepLink)
             }
         }
 
         return this
-            .takeIf { intent.isKlaviyoNotificationIntent }
-            ?.safeApply(preInitQueue) {
-                // Create and enqueue an $opened_push
-                val event = Event(EventMetric.OPENED_PUSH)
-                event.appendKlaviyoExtras(intent)
-
-                Registry.get<State>().pushToken?.let { event[EventKey.PUSH_TOKEN] = it }
-
-                // Not using createEvent here to avoid nested safeApply calls
-                Registry.get<State>().createEvent(event, Registry.get<State>().getAsProfile())
-            }?.safeApply {
-                // Dismiss the notification if opened via an action button.
-                // Body taps are handled by setAutoCancel(true) on the notification builder,
-                // but action button taps don't trigger auto-cancel (standard Android behavior).
-                intent?.getStringExtra(Constants.NOTIFICATION_TAG_EXTRA)?.let { tag ->
-                    NotificationManagerCompat
-                        .from(Registry.config.applicationContext)
-                        .cancel(tag, Constants.NOTIFICATION_ID)
-                }
-            }?.safeApply {
-                // If a Klaviyo notification is deep linked, invoke the developer's deep link handler
-                // if registered. If not, do nothing. The host already received the appropriate intent.
-                intent?.data?.takeIf {
-                    DeepLinking.isHandlerRegistered
-                }?.let { uri ->
-                    DeepLinking.handleDeepLink(uri)
-                }
-            }
-            ?: apply {
-                Registry.log.verbose("Non-Klaviyo intent ignored")
-            }
     }
 
     /**
@@ -475,20 +469,14 @@ object Klaviyo {
         get() = this?.getBooleanExtra(Constants.NOTIFICATION_AUTO_TRACKED_EXTRA, false) ?: false
 
     /**
-     * The dedup key identifying this intent's push delivery, or `null` if none is available.
+     * Dedup key for this intent's push delivery, or `null` if none is available. Prefers the `tm`
+     * field of the `_k` payload (a per-delivery ULID on campaign sends), else the SDK-generated
+     * [Constants.NOTIFICATION_UID_EXTRA]. Both are copied forward to the host's intent, so the
+     * trampoline call and a leftover manual call for the same tap resolve to the same key while
+     * distinct notifications stay distinct.
      *
-     * Prefers the `tm` field of the `_k` tracking payload — a ULID unique per delivery, present on
-     * real campaign sends. When `tm` is absent (local notifications, previews, non-campaign sends)
-     * it falls back to the SDK-generated [Constants.NOTIFICATION_UID_EXTRA] stamped on auto-tracked
-     * trampoline intents.
-     *
-     * Both keys are copied forward onto the host's destination intent, so the value is identical
-     * across the trampoline's `handlePush` call and a host's leftover manual call for the same tap —
-     * exactly what [handlePush]'s guard needs — while distinct notifications get distinct keys.
-     *
-     * There is deliberately no fallback to the raw `_k` payload: `_k` minus `tm` is per-message
-     * metadata shared by every delivery of the same campaign/message, so using it as a dedup key
-     * would drop legitimate opens across distinct deliveries.
+     * Deliberately not the raw `_k`: minus `tm` it is per-message metadata shared across deliveries,
+     * so it would collapse distinct opens.
      */
     private val Intent?.pushDeliveryId: String?
         get() {

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -49,7 +49,7 @@ object Klaviyo {
     private val preInitQueue: Queue<Operation<Unit>> = LinkedList()
 
     /**
-     * Push delivery IDs already auto-tracked within this process, so a single tap records one
+     * Push delivery IDs already handled within this process, so a single tap records one
      * `$opened_push`. See [handlePush] for how entries are matched and added.
      */
     private val handledPushDeliveries = BoundedIdSet()
@@ -337,23 +337,19 @@ object Klaviyo {
      */
     @JvmStatic
     fun handlePush(intent: Intent?): Klaviyo {
-        // Dedup guard for the automatic-tracking path. The trampoline calls handlePush and then
-        // forwards the same intent to the host, so a leftover manual handlePush call (or singleTask
-        // re-entry) would otherwise track a second open for one tap. Record each delivery the first
-        // time it's seen; if it's already recorded, drop this call entirely — no event, dismissal, or
-        // deep link. Manual-only integrations carry no auto-tracked marker, so they're unaffected.
-        val deliveryId = intent.pushDeliveryId
-        if (
-            intent.isAutoTrackedOpen &&
-            deliveryId != null &&
-            !handledPushDeliveries.markOnce(deliveryId)
-        ) {
-            Registry.log.verbose("Ignoring duplicate auto-tracked push open")
+        if (intent == null || !intent.isKlaviyoNotificationIntent) {
+            Registry.log.verbose("Non-Klaviyo intent ignored")
             return this
         }
 
-        if (intent == null || !intent.isKlaviyoNotificationIntent) {
-            Registry.log.verbose("Non-Klaviyo intent ignored")
+        // Dedup guard: track each push delivery at most once per process. The trampoline calls
+        // handlePush and forwards the same intent to the host, so a leftover manual handlePush call
+        // (or singleTask re-entry) would otherwise double-track one tap. The first call to see a
+        // delivery records it and proceeds; a later call for the same delivery short-circuits — no
+        // event, dismissal, or deep link.
+        val deliveryId = intent.pushDeliveryId
+        if (deliveryId != null && !handledPushDeliveries.markOnce(deliveryId)) {
+            Registry.log.verbose("Ignoring duplicate push open")
             return this
         }
 
@@ -461,19 +457,11 @@ object Klaviyo {
     fun isKlaviyoNotificationIntent(intent: Intent?): Boolean = intent.isKlaviyoNotificationIntent
 
     /**
-     * Whether this intent was routed through the automatic-open-tracking trampoline, i.e. carries
-     * [Constants.NOTIFICATION_AUTO_TRACKED_EXTRA]. Gates [handlePush]'s dedup guard so it never
-     * affects manual-only integrations.
-     */
-    private val Intent?.isAutoTrackedOpen: Boolean
-        get() = this?.getBooleanExtra(Constants.NOTIFICATION_AUTO_TRACKED_EXTRA, false) ?: false
-
-    /**
      * Dedup key for this intent's push delivery, or `null` if none is available. Prefers the `tm`
      * field of the `_k` payload (a per-delivery ULID on campaign sends), else the SDK-generated
-     * [Constants.NOTIFICATION_UID_EXTRA]. Both are copied forward to the host's intent, so the
-     * trampoline call and a leftover manual call for the same tap resolve to the same key while
-     * distinct notifications stay distinct.
+     * [Constants.NOTIFICATION_UID_EXTRA] stamped on trampoline intents. Both are copied forward to
+     * the host's intent, so the trampoline call and a leftover manual call for the same tap resolve
+     * to the same key while distinct notifications stay distinct.
      *
      * Deliberately not the raw `_k`: minus `tm` it is per-message metadata shared across deliveries,
      * so it would collapse distinct opens.

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -28,6 +28,7 @@ import com.klaviyo.core.config.Config
 import com.klaviyo.core.config.LifecycleException
 import com.klaviyo.core.safeApply
 import com.klaviyo.core.safeCall
+import com.klaviyo.core.utils.BoundedIdSet
 import com.klaviyo.core.utils.JSONUtil.toHashMap
 import com.klaviyo.core.utils.takeIf
 import java.io.Serializable
@@ -46,6 +47,26 @@ object Klaviyo {
      * Queue of failed operations attempted prior to [initialize]
      */
     private val preInitQueue: Queue<Operation<Unit>> = LinkedList()
+
+    /**
+     * In-memory dedup guard over push *delivery* IDs already auto-tracked by [handlePush].
+     *
+     * Only auto-tracking-path intents engage this guard: the trampoline stamps
+     * [Constants.NOTIFICATION_AUTO_TRACKED_EXTRA] on its targeted intents and forwards the
+     * destination intent (carrying that marker and the `_k` payload) to the host. The trampoline's
+     * own `handlePush` marks the delivery first; a host that also left a manual `handlePush` call in
+     * place then short-circuits instead of tracking a second `$opened_push` for the same tap. It
+     * also dedupes trampoline `singleTask` re-entry with the same intent.
+     *
+     * Manual-only integrations (auto-tracking disabled) never carry the marker, so they never engage
+     * the guard and behave exactly as before it existed.
+     */
+    private val handledPushDeliveries = BoundedIdSet()
+
+    /**
+     * Key within the `_k` tracking payload whose value uniquely identifies a single push delivery.
+     */
+    private const val PUSH_DELIVERY_KEY = "tm"
 
     /**
      * This method is provided for apps that are unable to register their API key immediately
@@ -324,38 +345,57 @@ object Klaviyo {
      * @param intent the [Intent] from opening a notification
      */
     @JvmStatic
-    fun handlePush(intent: Intent?): Klaviyo = this
-        .takeIf { intent.isKlaviyoNotificationIntent }
-        ?.safeApply(preInitQueue) {
-            // Create and enqueue an $opened_push
-            val event = Event(EventMetric.OPENED_PUSH)
-            event.appendKlaviyoExtras(intent)
-
-            Registry.get<State>().pushToken?.let { event[EventKey.PUSH_TOKEN] = it }
-
-            // Not using createEvent here to avoid nested safeApply calls
-            Registry.get<State>().createEvent(event, Registry.get<State>().getAsProfile())
-        }?.safeApply {
-            // Dismiss the notification if opened via an action button.
-            // Body taps are handled by setAutoCancel(true) on the notification builder,
-            // but action button taps don't trigger auto-cancel (standard Android behavior).
-            intent?.getStringExtra(Constants.NOTIFICATION_TAG_EXTRA)?.let { tag ->
-                NotificationManagerCompat
-                    .from(Registry.config.applicationContext)
-                    .cancel(tag, Constants.NOTIFICATION_ID)
-            }
-        }?.safeApply {
-            // If a Klaviyo notification is deep linked, invoke the developer's deep link handler
-            // if registered. If not, do nothing. The host already received the appropriate intent.
-            intent?.data?.takeIf {
-                DeepLinking.isHandlerRegistered
-            }?.let { uri ->
-                DeepLinking.handleDeepLink(uri)
+    fun handlePush(intent: Intent?): Klaviyo {
+        // Dedup guard (top of function), scoped to the automatic-tracking path only: a push delivery
+        // we've already auto-tracked means this is a re-delivery of the same tap — a host's leftover
+        // manual handlePush after the trampoline already tracked, or singleTask re-entry.
+        // Short-circuit fully: no event, no dismissal, no deep link dispatch. The marker is absent on
+        // manual-only integrations, so their behavior is unchanged. Unseen delivery → atomically mark
+        // it and proceed.
+        if (intent.isAutoTrackedOpen) {
+            intent.pushDeliveryId?.let { deliveryId ->
+                if (!handledPushDeliveries.markOnce(deliveryId)) {
+                    Registry.log.verbose(
+                        "Ignoring duplicate auto-tracked push open for delivery $deliveryId"
+                    )
+                    return this
+                }
             }
         }
-        ?: apply {
-            Registry.log.verbose("Non-Klaviyo intent ignored")
-        }
+
+        return this
+            .takeIf { intent.isKlaviyoNotificationIntent }
+            ?.safeApply(preInitQueue) {
+                // Create and enqueue an $opened_push
+                val event = Event(EventMetric.OPENED_PUSH)
+                event.appendKlaviyoExtras(intent)
+
+                Registry.get<State>().pushToken?.let { event[EventKey.PUSH_TOKEN] = it }
+
+                // Not using createEvent here to avoid nested safeApply calls
+                Registry.get<State>().createEvent(event, Registry.get<State>().getAsProfile())
+            }?.safeApply {
+                // Dismiss the notification if opened via an action button.
+                // Body taps are handled by setAutoCancel(true) on the notification builder,
+                // but action button taps don't trigger auto-cancel (standard Android behavior).
+                intent?.getStringExtra(Constants.NOTIFICATION_TAG_EXTRA)?.let { tag ->
+                    NotificationManagerCompat
+                        .from(Registry.config.applicationContext)
+                        .cancel(tag, Constants.NOTIFICATION_ID)
+                }
+            }?.safeApply {
+                // If a Klaviyo notification is deep linked, invoke the developer's deep link handler
+                // if registered. If not, do nothing. The host already received the appropriate intent.
+                intent?.data?.takeIf {
+                    DeepLinking.isHandlerRegistered
+                }?.let { uri ->
+                    DeepLinking.handleDeepLink(uri)
+                }
+            }
+            ?: apply {
+                Registry.log.verbose("Non-Klaviyo intent ignored")
+            }
+    }
 
     /**
      * Handles a universal link [Intent], by resolving the destination [Uri] asynchronously
@@ -425,6 +465,43 @@ object Klaviyo {
      */
     @JvmStatic
     fun isKlaviyoNotificationIntent(intent: Intent?): Boolean = intent.isKlaviyoNotificationIntent
+
+    /**
+     * Whether this intent was routed through the automatic-open-tracking trampoline, i.e. carries
+     * [Constants.NOTIFICATION_AUTO_TRACKED_EXTRA]. Gates [handlePush]'s dedup guard so it never
+     * affects manual-only integrations.
+     */
+    private val Intent?.isAutoTrackedOpen: Boolean
+        get() = this?.getBooleanExtra(Constants.NOTIFICATION_AUTO_TRACKED_EXTRA, false) ?: false
+
+    /**
+     * The dedup key identifying this intent's push delivery, or `null` if none is available.
+     *
+     * Prefers the `tm` field of the `_k` tracking payload — a ULID unique per delivery, present on
+     * real campaign sends. When `tm` is absent (local notifications, previews, non-campaign sends)
+     * it falls back to the SDK-generated [Constants.NOTIFICATION_UID_EXTRA] stamped on auto-tracked
+     * trampoline intents.
+     *
+     * Both keys are copied forward onto the host's destination intent, so the value is identical
+     * across the trampoline's `handlePush` call and a host's leftover manual call for the same tap —
+     * exactly what [handlePush]'s guard needs — while distinct notifications get distinct keys.
+     *
+     * There is deliberately no fallback to the raw `_k` payload: `_k` minus `tm` is per-message
+     * metadata shared by every delivery of the same campaign/message, so using it as a dedup key
+     * would drop legitimate opens across distinct deliveries.
+     */
+    private val Intent?.pushDeliveryId: String?
+        get() {
+            val deliveryId = this?.getStringExtra(PACKAGE_PREFIX + TRACKING_PARAMETER)
+                ?.takeIf { it.isNotEmpty() }
+                ?.let { trackingPayload ->
+                    runCatching { JSONObject(trackingPayload).optString(PUSH_DELIVERY_KEY) }
+                        .getOrNull()
+                        ?.takeIf { it.isNotEmpty() }
+                }
+            return deliveryId ?: this?.getStringExtra(Constants.NOTIFICATION_UID_EXTRA)
+                ?.takeIf { it.isNotEmpty() }
+        }
 
     /**
      * Determine if an intent is a Klaviyo click-tracking universal/app link

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -459,9 +459,9 @@ object Klaviyo {
     /**
      * Dedup key for this intent's push delivery, or `null` if none is available. Prefers the `tm`
      * field of the `_k` payload (a per-delivery ULID on campaign sends), else the SDK-generated
-     * [Constants.NOTIFICATION_UID_EXTRA] stamped on trampoline intents. Both are copied forward to
-     * the host's intent, so the trampoline call and a leftover manual call for the same tap resolve
-     * to the same key while distinct notifications stay distinct.
+     * per-notification [Constants.NOTIFICATION_UID_EXTRA]. Both are copied forward to the host's
+     * intent, so a delivery handled by the trampoline and then a leftover manual call resolve to the
+     * same key, while distinct notifications stay distinct.
      *
      * Deliberately not the raw `_k`: minus `tm` it is per-message metadata shared across deliveries,
      * so it would collapse distinct opens.

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
@@ -705,7 +705,7 @@ internal class KlaviyoTest : BaseTest() {
         verify(inverse = true) { mockApiClient.enqueueEvent(any(), any()) }
     }
 
-    // --- Auto-tracked push-open dedup guard (`_k.tm`, gated by NOTIFICATION_AUTO_TRACKED_EXTRA) ---
+    // --- Push-open dedup guard (keyed on `_k.tm`, else the generated NOTIFICATION_UID_EXTRA) ---
     // Note: Klaviyo is an object, so its in-memory dedup set persists across tests in this class.
     // Each dedup test uses a distinct delivery ID to stay independent of execution order.
 
@@ -714,21 +714,27 @@ internal class KlaviyoTest : BaseTest() {
         "com.klaviyo._k" to """{"m":"01GK4P5W6AV4V3APTJ727JKSKQ","tm":"$deliveryId"}"""
     )
 
-    /** A Klaviyo intent stamped as auto-tracked, as the trampoline forwards it to the host. */
-    private fun autoTrackedIntent(deliveryId: String, uri: Uri? = null): Intent =
-        mockIntent(deliveryExtras(deliveryId), uri).also {
-            every { it.getBooleanExtra(Constants.NOTIFICATION_AUTO_TRACKED_EXTRA, any()) } returns true
-        }
+    private fun deliveryIntent(deliveryId: String, uri: Uri? = null): Intent =
+        mockIntent(deliveryExtras(deliveryId), uri)
+
+    /** A Klaviyo intent whose `_k` payload omits `tm`, relying on the generated uid as the key. */
+    private fun tmLessIntent(notificationUid: String): Intent =
+        mockIntent(
+            mapOf(
+                "com.klaviyo._k" to """{"m":"01GK4P5W6AV4V3APTJ727JKSKQ"}""",
+                Constants.NOTIFICATION_UID_EXTRA to notificationUid
+            )
+        )
 
     @Test
-    fun `handlePush tracks exactly one opened_push when an auto-tracked delivery is handled twice`() {
-        // Legacy-integrator scenario: the trampoline tracks first, then forwards the destination
-        // intent (same _k/tm, same marker) to a host that still calls handlePush manually.
+    fun `handlePush tracks exactly one opened_push when a delivery is handled twice`() {
+        // The trampoline tracks first, then forwards the same intent (same tm) to a host that still
+        // calls handlePush manually; only one open, dismissal, and deep link result.
         val (getCapturedUri) = setupDeepLinkHandler()
         val testUri = mockk<Uri>()
 
-        Klaviyo.handlePush(autoTrackedIntent("dedup-twice-distinct-intents", testUri))
-        Klaviyo.handlePush(autoTrackedIntent("dedup-twice-distinct-intents", testUri))
+        Klaviyo.handlePush(deliveryIntent("dedup-twice-distinct-intents", testUri))
+        Klaviyo.handlePush(deliveryIntent("dedup-twice-distinct-intents", testUri))
 
         verifyOpenedPushEventEnqueued()
         assertEquals(testUri, getCapturedUri())
@@ -736,8 +742,8 @@ internal class KlaviyoTest : BaseTest() {
     }
 
     @Test
-    fun `handlePush short-circuits a repeat call with the same auto-tracked intent`() {
-        val intent = autoTrackedIntent("dedup-same-intent-object")
+    fun `handlePush short-circuits a repeat call with the same intent`() {
+        val intent = deliveryIntent("dedup-same-intent-object")
 
         Klaviyo.handlePush(intent)
         Klaviyo.handlePush(intent)
@@ -746,47 +752,28 @@ internal class KlaviyoTest : BaseTest() {
     }
 
     @Test
-    fun `handlePush tracks distinct auto-tracked deliveries independently`() {
-        Klaviyo.handlePush(autoTrackedIntent("dedup-distinct-A"))
-        Klaviyo.handlePush(autoTrackedIntent("dedup-distinct-B"))
+    fun `handlePush tracks distinct deliveries independently`() {
+        Klaviyo.handlePush(deliveryIntent("dedup-distinct-A"))
+        Klaviyo.handlePush(deliveryIntent("dedup-distinct-B"))
 
         verify(exactly = 2) {
             mockApiClient.enqueueEvent(match { it.metric == EventMetric.OPENED_PUSH }, any())
         }
     }
 
-    /**
-     * An auto-tracked intent whose `_k` payload has no `tm`, carrying the SDK-generated
-     * [Constants.NOTIFICATION_UID_EXTRA] fallback key the trampoline stamps (local notifications,
-     * previews, non-campaign sends).
-     */
-    private fun autoTrackedIntentNoTm(notificationUid: String): Intent =
-        mockIntent(
-            mapOf(
-                // Valid _k payload that simply omits `tm`, e.g. a non-campaign send.
-                "com.klaviyo._k" to """{"m":"01GK4P5W6AV4V3APTJ727JKSKQ"}""",
-                Constants.NOTIFICATION_UID_EXTRA to notificationUid
-            )
-        ).also {
-            every { it.getBooleanExtra(Constants.NOTIFICATION_AUTO_TRACKED_EXTRA, any()) } returns true
-        }
-
     @Test
     fun `handlePush dedupes a tm-less delivery via the generated notification uid`() {
-        // Trampoline call + a host's leftover manual call for the same tap carry the same generated
-        // uid, so only one $opened_push is tracked.
-        Klaviyo.handlePush(autoTrackedIntentNoTm("uid-fallback-same"))
-        Klaviyo.handlePush(autoTrackedIntentNoTm("uid-fallback-same"))
+        Klaviyo.handlePush(tmLessIntent("uid-fallback-same"))
+        Klaviyo.handlePush(tmLessIntent("uid-fallback-same"))
 
         verifyOpenedPushEventEnqueued()
     }
 
     @Test
     fun `handlePush tracks distinct tm-less notifications independently`() {
-        // Regression: distinct notifications get distinct generated uids, so they must NOT collide
-        // (they previously did when falling back to the shared raw _k payload).
-        Klaviyo.handlePush(autoTrackedIntentNoTm("uid-fallback-A"))
-        Klaviyo.handlePush(autoTrackedIntentNoTm("uid-fallback-B"))
+        // Distinct notifications get distinct generated uids, so they must not collide.
+        Klaviyo.handlePush(tmLessIntent("uid-fallback-A"))
+        Klaviyo.handlePush(tmLessIntent("uid-fallback-B"))
 
         verify(exactly = 2) {
             mockApiClient.enqueueEvent(match { it.metric == EventMetric.OPENED_PUSH }, any())
@@ -795,31 +782,30 @@ internal class KlaviyoTest : BaseTest() {
 
     @Test
     fun `handlePush falls back to the generated uid when the _k payload is not valid JSON`() {
-        // Some notifications (e.g. local notifications) carry a non-JSON _k; tm parsing must fail
-        // gracefully and fall back to the generated uid rather than throwing.
-        val malformedKIntent = {
+        // A non-JSON _k must fail tm parsing gracefully and fall back to the generated uid.
+        val makeIntent = {
             mockIntent(
                 mapOf(
                     "com.klaviyo._k" to "not-json",
                     Constants.NOTIFICATION_UID_EXTRA to "uid-malformed-k"
                 )
-            ).also {
-                every { it.getBooleanExtra(Constants.NOTIFICATION_AUTO_TRACKED_EXTRA, any()) } returns true
-            }
+            )
         }
 
-        Klaviyo.handlePush(malformedKIntent())
-        Klaviyo.handlePush(malformedKIntent())
+        Klaviyo.handlePush(makeIntent())
+        Klaviyo.handlePush(makeIntent())
 
         verifyOpenedPushEventEnqueued()
     }
 
     @Test
-    fun `handlePush never dedupes manual (non auto-tracked) intents even for the same delivery`() {
-        // No auto-tracked marker → manual integration → guard must not engage (byte-identical to
-        // pre-guard behavior), even though both intents share the same _k/tm.
-        Klaviyo.handlePush(mockIntent(deliveryExtras("manual-not-deduped")))
-        Klaviyo.handlePush(mockIntent(deliveryExtras("manual-not-deduped")))
+    fun `handlePush does not dedupe when no delivery id is available`() {
+        // No `tm` and no generated uid: with no key to match on, each call tracks. We never fabricate
+        // a key from the shared `_k` metadata, which would collapse distinct deliveries.
+        val noKey = mapOf("com.klaviyo._k" to """{"m":"01GK4P5W6AV4V3APTJ727JKSKQ"}""")
+
+        Klaviyo.handlePush(mockIntent(noKey))
+        Klaviyo.handlePush(mockIntent(noKey))
 
         verify(exactly = 2) {
             mockApiClient.enqueueEvent(match { it.metric == EventMetric.OPENED_PUSH }, any())

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
@@ -18,6 +18,7 @@ import com.klaviyo.analytics.state.KlaviyoState
 import com.klaviyo.analytics.state.ProfileEventObserver
 import com.klaviyo.analytics.state.State
 import com.klaviyo.analytics.state.StateSideEffects
+import com.klaviyo.core.Constants
 import com.klaviyo.core.DeviceProperties
 import com.klaviyo.core.Registry
 import com.klaviyo.core.config.Config
@@ -702,6 +703,127 @@ internal class KlaviyoTest : BaseTest() {
 
         assertEquals(null, getCapturedUri())
         verify(inverse = true) { mockApiClient.enqueueEvent(any(), any()) }
+    }
+
+    // --- Auto-tracked push-open dedup guard (`_k.tm`, gated by NOTIFICATION_AUTO_TRACKED_EXTRA) ---
+    // Note: Klaviyo is an object, so its in-memory dedup set persists across tests in this class.
+    // Each dedup test uses a distinct delivery ID to stay independent of execution order.
+
+    private fun deliveryExtras(deliveryId: String) = mapOf(
+        "com.klaviyo.body" to "Message body",
+        "com.klaviyo._k" to """{"m":"01GK4P5W6AV4V3APTJ727JKSKQ","tm":"$deliveryId"}"""
+    )
+
+    /** A Klaviyo intent stamped as auto-tracked, as the trampoline forwards it to the host. */
+    private fun autoTrackedIntent(deliveryId: String, uri: Uri? = null): Intent =
+        mockIntent(deliveryExtras(deliveryId), uri).also {
+            every { it.getBooleanExtra(Constants.NOTIFICATION_AUTO_TRACKED_EXTRA, any()) } returns true
+        }
+
+    @Test
+    fun `handlePush tracks exactly one opened_push when an auto-tracked delivery is handled twice`() {
+        // Legacy-integrator scenario: the trampoline tracks first, then forwards the destination
+        // intent (same _k/tm, same marker) to a host that still calls handlePush manually.
+        val (getCapturedUri) = setupDeepLinkHandler()
+        val testUri = mockk<Uri>()
+
+        Klaviyo.handlePush(autoTrackedIntent("dedup-twice-distinct-intents", testUri))
+        Klaviyo.handlePush(autoTrackedIntent("dedup-twice-distinct-intents", testUri))
+
+        verifyOpenedPushEventEnqueued()
+        assertEquals(testUri, getCapturedUri())
+        verify(exactly = 1) { DeepLinking.handleDeepLink(testUri) }
+    }
+
+    @Test
+    fun `handlePush short-circuits a repeat call with the same auto-tracked intent`() {
+        val intent = autoTrackedIntent("dedup-same-intent-object")
+
+        Klaviyo.handlePush(intent)
+        Klaviyo.handlePush(intent)
+
+        verifyOpenedPushEventEnqueued()
+    }
+
+    @Test
+    fun `handlePush tracks distinct auto-tracked deliveries independently`() {
+        Klaviyo.handlePush(autoTrackedIntent("dedup-distinct-A"))
+        Klaviyo.handlePush(autoTrackedIntent("dedup-distinct-B"))
+
+        verify(exactly = 2) {
+            mockApiClient.enqueueEvent(match { it.metric == EventMetric.OPENED_PUSH }, any())
+        }
+    }
+
+    /**
+     * An auto-tracked intent whose `_k` payload has no `tm`, carrying the SDK-generated
+     * [Constants.NOTIFICATION_UID_EXTRA] fallback key the trampoline stamps (local notifications,
+     * previews, non-campaign sends).
+     */
+    private fun autoTrackedIntentNoTm(notificationUid: String): Intent =
+        mockIntent(
+            mapOf(
+                // Valid _k payload that simply omits `tm`, e.g. a non-campaign send.
+                "com.klaviyo._k" to """{"m":"01GK4P5W6AV4V3APTJ727JKSKQ"}""",
+                Constants.NOTIFICATION_UID_EXTRA to notificationUid
+            )
+        ).also {
+            every { it.getBooleanExtra(Constants.NOTIFICATION_AUTO_TRACKED_EXTRA, any()) } returns true
+        }
+
+    @Test
+    fun `handlePush dedupes a tm-less delivery via the generated notification uid`() {
+        // Trampoline call + a host's leftover manual call for the same tap carry the same generated
+        // uid, so only one $opened_push is tracked.
+        Klaviyo.handlePush(autoTrackedIntentNoTm("uid-fallback-same"))
+        Klaviyo.handlePush(autoTrackedIntentNoTm("uid-fallback-same"))
+
+        verifyOpenedPushEventEnqueued()
+    }
+
+    @Test
+    fun `handlePush tracks distinct tm-less notifications independently`() {
+        // Regression: distinct notifications get distinct generated uids, so they must NOT collide
+        // (they previously did when falling back to the shared raw _k payload).
+        Klaviyo.handlePush(autoTrackedIntentNoTm("uid-fallback-A"))
+        Klaviyo.handlePush(autoTrackedIntentNoTm("uid-fallback-B"))
+
+        verify(exactly = 2) {
+            mockApiClient.enqueueEvent(match { it.metric == EventMetric.OPENED_PUSH }, any())
+        }
+    }
+
+    @Test
+    fun `handlePush falls back to the generated uid when the _k payload is not valid JSON`() {
+        // Some notifications (e.g. local notifications) carry a non-JSON _k; tm parsing must fail
+        // gracefully and fall back to the generated uid rather than throwing.
+        val malformedKIntent = {
+            mockIntent(
+                mapOf(
+                    "com.klaviyo._k" to "not-json",
+                    Constants.NOTIFICATION_UID_EXTRA to "uid-malformed-k"
+                )
+            ).also {
+                every { it.getBooleanExtra(Constants.NOTIFICATION_AUTO_TRACKED_EXTRA, any()) } returns true
+            }
+        }
+
+        Klaviyo.handlePush(malformedKIntent())
+        Klaviyo.handlePush(malformedKIntent())
+
+        verifyOpenedPushEventEnqueued()
+    }
+
+    @Test
+    fun `handlePush never dedupes manual (non auto-tracked) intents even for the same delivery`() {
+        // No auto-tracked marker → manual integration → guard must not engage (byte-identical to
+        // pre-guard behavior), even though both intents share the same _k/tm.
+        Klaviyo.handlePush(mockIntent(deliveryExtras("manual-not-deduped")))
+        Klaviyo.handlePush(mockIntent(deliveryExtras("manual-not-deduped")))
+
+        verify(exactly = 2) {
+            mockApiClient.enqueueEvent(match { it.metric == EventMetric.OPENED_PUSH }, any())
+        }
     }
 
     @Test

--- a/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
@@ -30,13 +30,6 @@ object Constants {
     const val NOTIFICATION_TAG_EXTRA = INTERNAL_PREFIX + "notification_tag"
 
     /**
-     * Intent extra marking a notification tap as routed through the automatic-open-tracking
-     * trampoline. Read by `Klaviyo.handlePush` to scope its dedup guard to auto-tracked opens.
-     * Uses [INTERNAL_PREFIX] to stay out of analytics event properties, like [NOTIFICATION_TAG_EXTRA].
-     */
-    const val NOTIFICATION_AUTO_TRACKED_EXTRA = INTERNAL_PREFIX + "auto_tracked"
-
-    /**
      * Intent extra carrying an SDK-generated, per-notification unique ID. Used by `Klaviyo.handlePush`
      * as the dedup key when the `_k` tracking payload has no `tm`.
      * Uses [INTERNAL_PREFIX] to stay out of analytics event properties, like [NOTIFICATION_TAG_EXTRA].

--- a/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
@@ -30,8 +30,9 @@ object Constants {
     const val NOTIFICATION_TAG_EXTRA = INTERNAL_PREFIX + "notification_tag"
 
     /**
-     * Intent extra carrying an SDK-generated, per-notification unique ID. Used by `Klaviyo.handlePush`
-     * as the dedup key when the `_k` tracking payload has no `tm`.
+     * Intent extra carrying an SDK-generated, per-notification unique ID stamped on every Klaviyo
+     * notification's tap intents (body and each action button). Used by `Klaviyo.handlePush` as the
+     * dedup key when the `_k` tracking payload has no `tm`.
      * Uses [INTERNAL_PREFIX] to stay out of analytics event properties, like [NOTIFICATION_TAG_EXTRA].
      */
     const val NOTIFICATION_UID_EXTRA = INTERNAL_PREFIX + "notification_uid"

--- a/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
@@ -31,32 +31,15 @@ object Constants {
 
     /**
      * Intent extra marking a notification tap as routed through the automatic-open-tracking
-     * trampoline. Stamped only on trampoline-targeted intents built on the auto-tracking path, and
-     * copied forward (alongside the rest of the Klaviyo extras) onto the destination intent the host
-     * receives.
-     *
-     * [handlePush] runs its in-memory dedup guard only when this marker is present, so manual-only
-     * integrations (auto-tracking disabled) never carry it and behave exactly as before the guard
-     * existed.
-     *
-     * Uses [INTERNAL_PREFIX] instead of [PACKAGE_PREFIX] to avoid being swept into analytics event
-     * properties by [appendKlaviyoExtras], same as [NOTIFICATION_TAG_EXTRA].
+     * trampoline. Read by `Klaviyo.handlePush` to scope its dedup guard to auto-tracked opens.
+     * Uses [INTERNAL_PREFIX] to stay out of analytics event properties, like [NOTIFICATION_TAG_EXTRA].
      */
     const val NOTIFICATION_AUTO_TRACKED_EXTRA = INTERNAL_PREFIX + "auto_tracked"
 
     /**
-     * Intent extra carrying an SDK-generated, per-notification unique ID, stamped on auto-tracked
-     * trampoline intents at notification-build time. [handlePush] uses it as the dedup-guard key when
-     * the `_k` tracking payload has no `tm` (e.g. local notifications, campaign previews, or other
-     * non-campaign sends), so a single tap still tracks exactly one `$opened_push` while distinct
-     * notifications never collide.
-     *
-     * The real per-delivery `tm` is preferred when present; this is the fallback for payloads that
-     * lack it. There is no stable per-notification ID on the forwarded intent to reuse, so the SDK
-     * generates one.
-     *
-     * Uses [INTERNAL_PREFIX] instead of [PACKAGE_PREFIX] to avoid being swept into analytics event
-     * properties by [appendKlaviyoExtras], same as [NOTIFICATION_TAG_EXTRA].
+     * Intent extra carrying an SDK-generated, per-notification unique ID. Used by `Klaviyo.handlePush`
+     * as the dedup key when the `_k` tracking payload has no `tm`.
+     * Uses [INTERNAL_PREFIX] to stay out of analytics event properties, like [NOTIFICATION_TAG_EXTRA].
      */
     const val NOTIFICATION_UID_EXTRA = INTERNAL_PREFIX + "notification_uid"
 

--- a/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
@@ -30,6 +30,37 @@ object Constants {
     const val NOTIFICATION_TAG_EXTRA = INTERNAL_PREFIX + "notification_tag"
 
     /**
+     * Intent extra marking a notification tap as routed through the automatic-open-tracking
+     * trampoline. Stamped only on trampoline-targeted intents built on the auto-tracking path, and
+     * copied forward (alongside the rest of the Klaviyo extras) onto the destination intent the host
+     * receives.
+     *
+     * [handlePush] runs its in-memory dedup guard only when this marker is present, so manual-only
+     * integrations (auto-tracking disabled) never carry it and behave exactly as before the guard
+     * existed.
+     *
+     * Uses [INTERNAL_PREFIX] instead of [PACKAGE_PREFIX] to avoid being swept into analytics event
+     * properties by [appendKlaviyoExtras], same as [NOTIFICATION_TAG_EXTRA].
+     */
+    const val NOTIFICATION_AUTO_TRACKED_EXTRA = INTERNAL_PREFIX + "auto_tracked"
+
+    /**
+     * Intent extra carrying an SDK-generated, per-notification unique ID, stamped on auto-tracked
+     * trampoline intents at notification-build time. [handlePush] uses it as the dedup-guard key when
+     * the `_k` tracking payload has no `tm` (e.g. local notifications, campaign previews, or other
+     * non-campaign sends), so a single tap still tracks exactly one `$opened_push` while distinct
+     * notifications never collide.
+     *
+     * The real per-delivery `tm` is preferred when present; this is the fallback for payloads that
+     * lack it. There is no stable per-notification ID on the forwarded intent to reuse, so the SDK
+     * generates one.
+     *
+     * Uses [INTERNAL_PREFIX] instead of [PACKAGE_PREFIX] to avoid being swept into analytics event
+     * properties by [appendKlaviyoExtras], same as [NOTIFICATION_TAG_EXTRA].
+     */
+    const val NOTIFICATION_UID_EXTRA = INTERNAL_PREFIX + "notification_uid"
+
+    /**
      * Manifest `<meta-data>` key a host app sets to opt into automatic push open tracking.
      *
      * Lives in core (not push-fcm) because telemetry's push token request must read it, and core

--- a/sdk/core/src/main/java/com/klaviyo/core/utils/BoundedIdSet.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/utils/BoundedIdSet.kt
@@ -21,6 +21,9 @@ class BoundedIdSet(private val capacity: Int = DEFAULT_CAPACITY) {
     // LinkedHashSet preserves insertion order, so the iterator's first element is always the oldest.
     private val ids = LinkedHashSet<String>()
 
+    // Private monitor so external holders of this instance can't interfere with our locking.
+    private val lock = Any()
+
     /**
      * Atomically insert [id] and report whether it was newly added.
      *
@@ -30,8 +33,7 @@ class BoundedIdSet(private val capacity: Int = DEFAULT_CAPACITY) {
      *
      * @return `true` if [id] was not already present (now inserted), `false` if it was a duplicate.
      */
-    @Synchronized
-    fun markOnce(id: String): Boolean {
+    fun markOnce(id: String): Boolean = synchronized(lock) {
         if (!ids.add(id)) {
             // Already present: no-op, and crucially we do not move it to the end, so its eviction
             // order is unchanged.
@@ -45,11 +47,9 @@ class BoundedIdSet(private val capacity: Int = DEFAULT_CAPACITY) {
         return true
     }
 
-    @Synchronized
-    fun contains(id: String): Boolean = ids.contains(id)
+    fun contains(id: String): Boolean = synchronized(lock) { ids.contains(id) }
 
-    @get:Synchronized
-    val size: Int get() = ids.size
+    val size: Int get() = synchronized(lock) { ids.size }
 
     companion object {
         /**

--- a/sdk/core/src/main/java/com/klaviyo/core/utils/BoundedIdSet.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/utils/BoundedIdSet.kt
@@ -1,0 +1,61 @@
+package com.klaviyo.core.utils
+
+/**
+ * Thread-safe, fixed-capacity set of string IDs with FIFO eviction, used as an in-memory dedup
+ * guard for recently-seen identifiers.
+ *
+ * When the set is full, inserting a new ID evicts the oldest-inserted one. A duplicate insert is a
+ * no-op that does **not** refresh the ID's position in eviction order, so the set behaves as a
+ * sliding window over the most recently *first-seen* IDs.
+ *
+ * All operations are guarded by an intrinsic lock, so the set is safe to share across threads.
+ *
+ * @param capacity maximum number of IDs retained before the oldest is evicted.
+ */
+class BoundedIdSet(private val capacity: Int = DEFAULT_CAPACITY) {
+
+    init {
+        require(capacity > 0) { "capacity must be positive, was $capacity" }
+    }
+
+    // LinkedHashSet preserves insertion order, so the iterator's first element is always the oldest.
+    private val ids = LinkedHashSet<String>()
+
+    /**
+     * Atomically insert [id] and report whether it was newly added.
+     *
+     * Combining the check and the insert in one locked step is what makes this safe as a dedup
+     * guard: a caller can treat a `true` return as "I am the first to handle this ID" without
+     * racing a second caller for the same ID.
+     *
+     * @return `true` if [id] was not already present (now inserted), `false` if it was a duplicate.
+     */
+    @Synchronized
+    fun markOnce(id: String): Boolean {
+        if (!ids.add(id)) {
+            // Already present: no-op, and crucially we do not move it to the end, so its eviction
+            // order is unchanged.
+            return false
+        }
+        if (ids.size > capacity) {
+            val iterator = ids.iterator()
+            iterator.next()
+            iterator.remove()
+        }
+        return true
+    }
+
+    @Synchronized
+    fun contains(id: String): Boolean = ids.contains(id)
+
+    @get:Synchronized
+    val size: Int get() = ids.size
+
+    companion object {
+        /**
+         * Default retained-ID capacity: enough recent IDs to cover realistic dedup windows while
+         * bounding memory.
+         */
+        const val DEFAULT_CAPACITY = 256
+    }
+}

--- a/sdk/core/src/test/java/com/klaviyo/core/utils/BoundedIdSetTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/utils/BoundedIdSetTest.kt
@@ -94,56 +94,55 @@ class BoundedIdSetTest {
     @Test
     fun `concurrent markOnce on the same id reports exactly one winner`() {
         val set = BoundedIdSet()
-        val threads = 64
-        val pool = Executors.newFixedThreadPool(threads)
-        try {
-            val start = CountDownLatch(1)
-            val done = CountDownLatch(threads)
-            val winners = ConcurrentHashMap.newKeySet<Int>()
+        val winners = ConcurrentHashMap.newKeySet<Int>()
 
-            repeat(threads) { i ->
-                pool.execute {
-                    start.await()
-                    if (set.markOnce("shared")) winners.add(i)
-                    done.countDown()
-                }
-            }
-            // Release all workers at once to maximize contention on the same id.
-            start.countDown()
-            assertTrue(done.await(5, TimeUnit.SECONDS))
-
-            assertEquals(1, winners.size)
-        } finally {
-            pool.shutdownNow()
+        runConcurrently(threadCount = 64, timeoutSeconds = 5) { i ->
+            if (set.markOnce("shared")) winners.add(i)
         }
+
+        assertEquals(1, winners.size)
     }
 
     @Test
     fun `concurrent access does not throw and stays within capacity`() {
         val capacity = 128
         val set = BoundedIdSet(capacity = capacity)
-        val threads = 16
         val perThread = 1000
-        val pool = Executors.newFixedThreadPool(threads)
+
+        runConcurrently(threadCount = 16, timeoutSeconds = 10) { t ->
+            repeat(perThread) { i ->
+                set.markOnce("t$t-$i")
+                set.contains("t$t-$i")
+            }
+        }
+
+        assertEquals(capacity, set.size)
+    }
+
+    /**
+     * Run [worker] on [threadCount] threads that all start together (via a latch) to maximize
+     * overlap/contention, wait up to [timeoutSeconds] for completion, and always shut the pool down.
+     * Test-specific assertions stay in the caller.
+     */
+    private fun runConcurrently(
+        threadCount: Int,
+        timeoutSeconds: Long,
+        worker: (index: Int) -> Unit
+    ) {
+        val pool = Executors.newFixedThreadPool(threadCount)
         try {
             val start = CountDownLatch(1)
-            val done = CountDownLatch(threads)
+            val done = CountDownLatch(threadCount)
 
-            repeat(threads) { t ->
+            repeat(threadCount) { i ->
                 pool.execute {
                     start.await()
-                    repeat(perThread) { i ->
-                        set.markOnce("t$t-$i")
-                        set.contains("t$t-$i")
-                    }
+                    worker(i)
                     done.countDown()
                 }
             }
-            // Release all workers together so the operations actually overlap.
             start.countDown()
-            assertTrue(done.await(10, TimeUnit.SECONDS))
-
-            assertEquals(capacity, set.size)
+            assertTrue(done.await(timeoutSeconds, TimeUnit.SECONDS))
         } finally {
             pool.shutdownNow()
         }

--- a/sdk/core/src/test/java/com/klaviyo/core/utils/BoundedIdSetTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/utils/BoundedIdSetTest.kt
@@ -1,6 +1,7 @@
 package com.klaviyo.core.utils
 
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
@@ -133,16 +134,28 @@ class BoundedIdSetTest {
         try {
             val start = CountDownLatch(1)
             val done = CountDownLatch(threadCount)
+            val failures = ConcurrentLinkedQueue<Throwable>()
 
             repeat(threadCount) { i ->
                 pool.execute {
-                    start.await()
-                    worker(i)
-                    done.countDown()
+                    try {
+                        start.await()
+                        worker(i)
+                    } catch (t: Throwable) {
+                        failures.add(t)
+                    } finally {
+                        // Always count down so a worker failure surfaces via the assertion below
+                        // rather than as a misleading await() timeout that hides the real cause.
+                        done.countDown()
+                    }
                 }
             }
             start.countDown()
             assertTrue(done.await(timeoutSeconds, TimeUnit.SECONDS))
+            assertTrue(
+                failures.joinToString("\n") { it.stackTraceToString() },
+                failures.isEmpty()
+            )
         } finally {
             pool.shutdownNow()
         }

--- a/sdk/core/src/test/java/com/klaviyo/core/utils/BoundedIdSetTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/utils/BoundedIdSetTest.kt
@@ -1,0 +1,151 @@
+package com.klaviyo.core.utils
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BoundedIdSetTest {
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `constructor rejects a non-positive capacity`() {
+        BoundedIdSet(capacity = 0)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `constructor rejects a negative capacity`() {
+        BoundedIdSet(capacity = -1)
+    }
+
+    @Test
+    fun `markOnce inserts and contains reflects membership`() {
+        val set = BoundedIdSet()
+        assertFalse(set.contains("a"))
+        assertTrue(set.markOnce("a"))
+        assertTrue(set.contains("a"))
+    }
+
+    @Test
+    fun `markOnce returns true the first time and false thereafter`() {
+        val set = BoundedIdSet()
+        assertTrue(set.markOnce("a"))
+        assertFalse(set.markOnce("a"))
+        assertFalse(set.markOnce("a"))
+    }
+
+    @Test
+    fun `full set evicts the oldest inserted id first`() {
+        val set = BoundedIdSet(capacity = 3)
+        set.markOnce("a")
+        set.markOnce("b")
+        set.markOnce("c")
+        // Inserting a 4th id evicts "a" (oldest)
+        set.markOnce("d")
+
+        assertFalse(set.contains("a"))
+        assertTrue(set.contains("b"))
+        assertTrue(set.contains("c"))
+        assertTrue(set.contains("d"))
+        assertEquals(3, set.size)
+    }
+
+    @Test
+    fun `duplicate insert does not advance eviction order`() {
+        val set = BoundedIdSet(capacity = 3)
+        set.markOnce("a")
+        set.markOnce("b")
+        set.markOnce("c")
+        // Re-inserting "a" must NOT refresh its position; "a" is still the oldest.
+        assertFalse(set.markOnce("a"))
+        set.markOnce("d")
+
+        // If duplicate had advanced order, "b" would have been evicted instead of "a".
+        assertFalse(set.contains("a"))
+        assertTrue(set.contains("b"))
+        assertTrue(set.contains("c"))
+        assertTrue(set.contains("d"))
+    }
+
+    @Test
+    fun `evicted id can be re-inserted`() {
+        val set = BoundedIdSet(capacity = 2)
+        set.markOnce("a")
+        set.markOnce("b")
+        set.markOnce("c") // evicts "a"
+        assertFalse(set.contains("a"))
+
+        // "a" is treated as new again
+        assertTrue(set.markOnce("a")) // evicts "b"
+        assertTrue(set.contains("a"))
+        assertFalse(set.contains("b"))
+    }
+
+    @Test
+    fun `size never exceeds capacity`() {
+        val set = BoundedIdSet(capacity = 5)
+        repeat(100) { set.markOnce("id-$it") }
+        assertEquals(5, set.size)
+    }
+
+    @Test
+    fun `concurrent markOnce on the same id reports exactly one winner`() {
+        val set = BoundedIdSet()
+        val threads = 64
+        val pool = Executors.newFixedThreadPool(threads)
+        try {
+            val start = CountDownLatch(1)
+            val done = CountDownLatch(threads)
+            val winners = ConcurrentHashMap.newKeySet<Int>()
+
+            repeat(threads) { i ->
+                pool.execute {
+                    start.await()
+                    if (set.markOnce("shared")) winners.add(i)
+                    done.countDown()
+                }
+            }
+            // Release all workers at once to maximize contention on the same id.
+            start.countDown()
+            assertTrue(done.await(5, TimeUnit.SECONDS))
+
+            assertEquals(1, winners.size)
+        } finally {
+            pool.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `concurrent access does not throw and stays within capacity`() {
+        val capacity = 128
+        val set = BoundedIdSet(capacity = capacity)
+        val threads = 16
+        val perThread = 1000
+        val pool = Executors.newFixedThreadPool(threads)
+        try {
+            val start = CountDownLatch(1)
+            val done = CountDownLatch(threads)
+
+            repeat(threads) { t ->
+                pool.execute {
+                    start.await()
+                    repeat(perThread) { i ->
+                        set.markOnce("t$t-$i")
+                        set.contains("t$t-$i")
+                    }
+                    done.countDown()
+                }
+            }
+            // Release all workers together so the operations actually overlap.
+            start.countDown()
+            assertTrue(done.await(10, TimeUnit.SECONDS))
+
+            assertEquals(capacity, set.size)
+        } finally {
+            pool.shutdownNow()
+        }
+    }
+}

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoNotification.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoNotification.kt
@@ -43,6 +43,7 @@ import com.klaviyo.pushFcm.KlaviyoRemoteMessage.sound
 import com.klaviyo.pushFcm.KlaviyoRemoteMessage.title
 import com.klaviyo.pushFcm.KlaviyoRemoteMessage.webUrl
 import java.net.URL
+import java.util.UUID
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.Executors
 import java.util.concurrent.Future
@@ -175,8 +176,14 @@ class KlaviyoNotification(private val message: RemoteMessage) {
             KlaviyoPushService.METADATA_AUTOMATIC_PUSH_TRACKING,
             false
         )
+        // One id per notification, stamped on the body and every action-button intent, so
+        // handlePush can dedupe a notification's opens even when the `_k` payload carries no `tm`.
+        // Distinct notifications get distinct ids; body and buttons of one notification share it.
+        val notificationUid = UUID.randomUUID().toString()
         return NotificationCompat.Builder(context, message.channel_id)
-            .setContentIntent(makePendingIntent(context, requestCodeBase, autoTracking))
+            .setContentIntent(
+                makePendingIntent(context, requestCodeBase, autoTracking, notificationUid)
+            )
             .setSmallIcon(message.getSmallIcon(context))
             .also { message.getColor(context)?.let { color -> it.setColor(color) } }
             .setContentTitle(message.title)
@@ -186,7 +193,13 @@ class KlaviyoNotification(private val message: RemoteMessage) {
             .setNumber(message.notificationCount)
             .setPriority(message.notificationPriority)
             .setAutoCancel(true)
-            .addActionButtons(context, requestCodeBase, notificationTag, autoTracking)
+            .addActionButtons(
+                context,
+                requestCodeBase,
+                notificationTag,
+                autoTracking,
+                notificationUid
+            )
     }
 
     private fun URL.applyToNotification(builder: NotificationCompat.Builder) {
@@ -237,11 +250,16 @@ class KlaviyoNotification(private val message: RemoteMessage) {
      *
      * @return [PendingIntent]
      */
-    private fun makePendingIntent(context: Context, requestCode: Int, autoTracking: Boolean) =
+    private fun makePendingIntent(
+        context: Context,
+        requestCode: Int,
+        autoTracking: Boolean,
+        notificationUid: String
+    ) =
         PendingIntent.getActivity(
             context,
             requestCode,
-            makeOpenedIntent(context, autoTracking),
+            makeOpenedIntent(context, autoTracking, notificationUid),
             PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_ONE_SHOT
         )
 
@@ -255,7 +273,7 @@ class KlaviyoNotification(private val message: RemoteMessage) {
      * creation, so this is only reachable via direct API calls or test tooling — we
      * warn so the misconfiguration is debuggable.
      */
-    private fun makeOpenedIntent(context: Context, autoTracking: Boolean): Intent? {
+    private fun makeOpenedIntent(context: Context, autoTracking: Boolean, notificationUid: String): Intent? {
         val deepLink = message.deepLink
         val webUrl = message.webUrl
 
@@ -284,6 +302,7 @@ class KlaviyoNotification(private val message: RemoteMessage) {
             }
             return intent?.apply {
                 addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+                putExtra(Constants.NOTIFICATION_UID_EXTRA, notificationUid)
                 appendKlaviyoExtras(message)
             }
         }
@@ -292,6 +311,7 @@ class KlaviyoNotification(private val message: RemoteMessage) {
             // Route through the trampoline so handlePush tracks $opened_push
             // and dismisses the notification — the browser would otherwise swallow the intent.
             return KlaviyoTrampolineActivity.forBrowserUrl(context, webUrl).apply {
+                putExtra(Constants.NOTIFICATION_UID_EXTRA, notificationUid)
                 appendKlaviyoExtras(message)
             }
         }
@@ -304,6 +324,7 @@ class KlaviyoNotification(private val message: RemoteMessage) {
         }
         return intent?.apply {
             addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+            putExtra(Constants.NOTIFICATION_UID_EXTRA, notificationUid)
             appendKlaviyoExtras(message)
         }
     }
@@ -325,7 +346,8 @@ class KlaviyoNotification(private val message: RemoteMessage) {
         context: Context,
         requestCodeBase: Int,
         notificationTag: String,
-        autoTracking: Boolean
+        autoTracking: Boolean,
+        notificationUid: String
     ): NotificationCompat.Builder {
         val actionButtons = message.actionButtons ?: return this
 
@@ -340,7 +362,8 @@ class KlaviyoNotification(private val message: RemoteMessage) {
                 requestCode,
                 button,
                 notificationTag,
-                autoTracking
+                autoTracking,
+                notificationUid
             )
                 ?: return@forEachIndexed
             addAction(action)
@@ -366,7 +389,8 @@ class KlaviyoNotification(private val message: RemoteMessage) {
         requestCode: Int,
         button: ActionButton,
         notificationTag: String,
-        autoTracking: Boolean
+        autoTracking: Boolean,
+        notificationUid: String
     ): NotificationCompat.Action? {
         val intent = when (button) {
             is ActionButton.DeepLink -> {
@@ -400,6 +424,7 @@ class KlaviyoNotification(private val message: RemoteMessage) {
         }?.apply {
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             putExtra(Constants.NOTIFICATION_TAG_EXTRA, notificationTag)
+            putExtra(Constants.NOTIFICATION_UID_EXTRA, notificationUid)
         }?.appendKlaviyoExtras(message)
             ?.appendActionButtonExtras(button)
 

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivity.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivity.kt
@@ -88,15 +88,12 @@ internal class KlaviyoTrampolineActivity : Activity() {
          * seam as [forBrowserUrl]. Callers append their own Klaviyo extras for parity with the
          * non-trampoline intents they replace.
          *
-         * Stamps the dedup extras read by `handlePush`: [Constants.NOTIFICATION_AUTO_TRACKED_EXTRA]
-         * to mark the auto-tracking path, and a fresh per-intent [Constants.NOTIFICATION_UID_EXTRA]
-         * as a fallback dedup key for payloads without a `tm`. `open_url` ([forBrowserUrl]) is left
-         * unmarked — the host never receives a forwarded `open_url` tap, so nothing to dedupe.
+         * Stamps a fresh per-intent [Constants.NOTIFICATION_UID_EXTRA] that `handlePush` uses as a
+         * fallback dedup key for payloads without a `tm` (e.g. local notifications, previews).
          */
         internal fun forDestination(context: Context, deepLink: Uri? = null): Intent = Intent().apply {
             setClassName(context.packageName, KlaviyoTrampolineActivity::class.java.name)
             deepLink?.let { data = it }
-            putExtra(Constants.NOTIFICATION_AUTO_TRACKED_EXTRA, true)
             putExtra(Constants.NOTIFICATION_UID_EXTRA, UUID.randomUUID().toString())
         }
 

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivity.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivity.kt
@@ -88,17 +88,10 @@ internal class KlaviyoTrampolineActivity : Activity() {
          * seam as [forBrowserUrl]. Callers append their own Klaviyo extras for parity with the
          * non-trampoline intents they replace.
          *
-         * Only ever called on the auto-tracking path (body / `deep_link` / `open_app` taps when the
-         * feature is enabled), so it stamps [Constants.NOTIFICATION_AUTO_TRACKED_EXTRA] to scope
-         * `handlePush`'s dedup guard to auto-tracked opens. `open_url` uses [forBrowserUrl] (which
-         * trampolines regardless of the flag) and is intentionally left unmarked — the host never
-         * receives a forwarded `open_url` tap, so there is nothing to deduplicate there.
-         *
-         * Also stamps a fresh [Constants.NOTIFICATION_UID_EXTRA] so the dedup guard has a
-         * per-notification key even when the `_k` payload carries no `tm` (local notifications,
-         * previews, non-campaign sends). A fresh UUID per built intent means distinct notifications
-         * never collide, while the value rides forward onto the host's destination intent so the
-         * trampoline's `handlePush` and a host's leftover manual call still dedupe to one open.
+         * Stamps the dedup extras read by `handlePush`: [Constants.NOTIFICATION_AUTO_TRACKED_EXTRA]
+         * to mark the auto-tracking path, and a fresh per-intent [Constants.NOTIFICATION_UID_EXTRA]
+         * as a fallback dedup key for payloads without a `tm`. `open_url` ([forBrowserUrl]) is left
+         * unmarked — the host never receives a forwarded `open_url` tap, so nothing to dedupe.
          */
         internal fun forDestination(context: Context, deepLink: Uri? = null): Intent = Intent().apply {
             setClassName(context.packageName, KlaviyoTrampolineActivity::class.java.name)

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivity.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivity.kt
@@ -9,9 +9,11 @@ import androidx.core.net.toUri
 import com.klaviyo.analytics.Klaviyo
 import com.klaviyo.analytics.Klaviyo.isKlaviyoNotificationIntent
 import com.klaviyo.analytics.linking.DeepLinking
+import com.klaviyo.core.Constants
 import com.klaviyo.core.Registry
 import com.klaviyo.core.utils.activityResolved
 import com.klaviyo.core.utils.startActivityIfResolved
+import java.util.UUID
 
 /**
  * Transparent trampoline [Activity] used to intercept Klaviyo notification taps so the
@@ -85,10 +87,24 @@ internal class KlaviyoTrampolineActivity : Activity() {
          * Uses [Intent.setClassName] instead of the `Intent(Context, Class)` constructor — same test
          * seam as [forBrowserUrl]. Callers append their own Klaviyo extras for parity with the
          * non-trampoline intents they replace.
+         *
+         * Only ever called on the auto-tracking path (body / `deep_link` / `open_app` taps when the
+         * feature is enabled), so it stamps [Constants.NOTIFICATION_AUTO_TRACKED_EXTRA] to scope
+         * `handlePush`'s dedup guard to auto-tracked opens. `open_url` uses [forBrowserUrl] (which
+         * trampolines regardless of the flag) and is intentionally left unmarked — the host never
+         * receives a forwarded `open_url` tap, so there is nothing to deduplicate there.
+         *
+         * Also stamps a fresh [Constants.NOTIFICATION_UID_EXTRA] so the dedup guard has a
+         * per-notification key even when the `_k` payload carries no `tm` (local notifications,
+         * previews, non-campaign sends). A fresh UUID per built intent means distinct notifications
+         * never collide, while the value rides forward onto the host's destination intent so the
+         * trampoline's `handlePush` and a host's leftover manual call still dedupe to one open.
          */
         internal fun forDestination(context: Context, deepLink: Uri? = null): Intent = Intent().apply {
             setClassName(context.packageName, KlaviyoTrampolineActivity::class.java.name)
             deepLink?.let { data = it }
+            putExtra(Constants.NOTIFICATION_AUTO_TRACKED_EXTRA, true)
+            putExtra(Constants.NOTIFICATION_UID_EXTRA, UUID.randomUUID().toString())
         }
 
         /**

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivity.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivity.kt
@@ -9,11 +9,9 @@ import androidx.core.net.toUri
 import com.klaviyo.analytics.Klaviyo
 import com.klaviyo.analytics.Klaviyo.isKlaviyoNotificationIntent
 import com.klaviyo.analytics.linking.DeepLinking
-import com.klaviyo.core.Constants
 import com.klaviyo.core.Registry
 import com.klaviyo.core.utils.activityResolved
 import com.klaviyo.core.utils.startActivityIfResolved
-import java.util.UUID
 
 /**
  * Transparent trampoline [Activity] used to intercept Klaviyo notification taps so the
@@ -87,14 +85,10 @@ internal class KlaviyoTrampolineActivity : Activity() {
          * Uses [Intent.setClassName] instead of the `Intent(Context, Class)` constructor — same test
          * seam as [forBrowserUrl]. Callers append their own Klaviyo extras for parity with the
          * non-trampoline intents they replace.
-         *
-         * Stamps a fresh per-intent [Constants.NOTIFICATION_UID_EXTRA] that `handlePush` uses as a
-         * fallback dedup key for payloads without a `tm` (e.g. local notifications, previews).
          */
         internal fun forDestination(context: Context, deepLink: Uri? = null): Intent = Intent().apply {
             setClassName(context.packageName, KlaviyoTrampolineActivity::class.java.name)
             deepLink?.let { data = it }
-            putExtra(Constants.NOTIFICATION_UID_EXTRA, UUID.randomUUID().toString())
         }
 
         /**

--- a/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoNotificationTest.kt
+++ b/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoNotificationTest.kt
@@ -974,4 +974,68 @@ class KlaviyoNotificationTest : BaseTest() {
         verify { KlaviyoTrampolineActivity.forBrowserUrl(mockContext, "https://example.com") }
         verify(exactly = 0) { KlaviyoTrampolineActivity.forDestination(any(), any()) }
     }
+
+    @Test
+    fun `stamps a dedup uid on the body intent even when auto-tracking is off`() {
+        // Non-trampoline path: the host receives the intent directly, but it must still carry a
+        // per-notification dedup uid so handlePush can dedupe tm-less opens (e.g. a host calling
+        // handlePush twice for one tap).
+        val mockBodyIntent = mockk<Intent>(relaxed = true)
+        every { DeepLinking.makeLaunchIntent(mockContext) } returns mockBodyIntent
+        val intentSlot = slot<Intent>()
+        every {
+            PendingIntent.getActivity(any(), any(), capture(intentSlot), any())
+        } returns mockk(relaxed = true)
+
+        notification.displayNotification(mockContext)
+
+        assertEquals(mockBodyIntent, intentSlot.captured)
+        verify { mockBodyIntent.putExtra("_klaviyo.notification_uid", any<String>()) }
+    }
+
+    @Test
+    fun `body and action button share one dedup uid per notification`() {
+        // The dedup key must be per-notification, not per-intent: body and every action button
+        // carry the same uid so distinct targets on one notification collapse to a single open.
+        enableAutomaticTracking()
+        val bodyUri = mockk<Uri>(relaxed = true)
+        val buttonUri = mockk<Uri>(relaxed = true)
+        every { Uri.parse("klaviyotest://order/123") } returns buttonUri
+        val mockBodyIntent = mockk<Intent>(relaxed = true)
+        val mockButtonIntent = mockk<Intent>(relaxed = true)
+        val bodyUid = slot<String>()
+        val buttonUid = slot<String>()
+        every {
+            mockBodyIntent.putExtra("_klaviyo.notification_uid", capture(bodyUid))
+        } returns mockBodyIntent
+        every {
+            mockButtonIntent.putExtra("_klaviyo.notification_uid", capture(buttonUid))
+        } returns mockButtonIntent
+        every { KlaviyoTrampolineActivity.forDestination(mockContext, bodyUri) } returns mockBodyIntent
+        every { KlaviyoTrampolineActivity.forDestination(mockContext, buttonUri) } returns mockButtonIntent
+        every { PendingIntent.getActivity(any(), any(), any(), any()) } returns mockk(
+            relaxed = true
+        )
+        with(KlaviyoRemoteMessage) {
+            every { mockRemoteMessage.deepLink } returns bodyUri
+            every { mockRemoteMessage.actionButtons } returns listOf(
+                ActionButton.DeepLink(
+                    id = "com.klaviyo.test.view",
+                    label = "View Order",
+                    url = "klaviyotest://order/123"
+                )
+            )
+        }
+
+        notification.displayNotification(mockContext)
+
+        assertTrue("body intent should carry a dedup uid", bodyUid.isCaptured)
+        assertTrue("button intent should carry a dedup uid", buttonUid.isCaptured)
+        assertTrue("dedup uid should be non-empty", bodyUid.captured.isNotEmpty())
+        assertEquals(
+            "body and button should share one per-notification uid",
+            bodyUid.captured,
+            buttonUid.captured
+        )
+    }
 }


### PR DESCRIPTION
# Description
In-memory dedup guard so a single notification tap tracks exactly one `Opened Push`, even when a host opts into automatic push tracking (the `KlaviyoTrampolineActivity` from #493) but leaves a manual `Klaviyo.handlePush(intent)` call in an Activity. The trampoline tracks first, then forwards the destination intent (carrying the same Klaviyo extras) to the host, whose manual call would otherwise track a second event — this guard short-circuits that second call. Safety net that makes a future default-on flip safe for existing integrators.

## Due Diligence
- [x] I have tested this on an emulator and/or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all Android versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [x] This is planned work for an upcoming release.

> Stacked on #493 (`feat/mage-767-trampoline`). Review/merge that first; base will retarget to the default branch once it lands.

## Changelog / Code Overview
- **`sdk/core/.../utils/BoundedIdSet.kt`** (new) — thread-safe, fixed-capacity (default 256) set with FIFO eviction and an atomic `markOnce(id): Boolean` (combined check-and-insert). Duplicate inserts are a no-op that does not advance eviction order.
- **`sdk/core/.../Constants.kt`** — two internal-prefixed intent extras: `NOTIFICATION_AUTO_TRACKED_EXTRA` (marks an intent as routed through the auto-tracking trampoline) and `NOTIFICATION_UID_EXTRA` (SDK-generated per-notification fallback dedup key). Internal prefix keeps both out of analytics event payloads.
- **`sdk/push-fcm/.../KlaviyoTrampolineActivity.kt`** — `forDestination` (the auto-tracking-path intent factory) stamps the auto-tracked marker and a fresh per-notification UUID. `forBrowserUrl` (`open_url`) is intentionally left unmarked — it always trampolines regardless of the flag and the host never receives a forwarded `open_url` tap, so there is nothing to deduplicate.
- **`sdk/analytics/.../Klaviyo.kt#handlePush`** — top-of-function guard, scoped to auto-tracked intents only. Dedup key prefers the per-delivery `tm` from the `_k` payload, falling back to the generated per-notification UUID when `tm` is absent. Both keys ride forward onto the host's destination intent, so the trampoline's call and the host's manual call resolve to the same key. Manual-only integrations carry no marker, so their behavior is unchanged.

### Design notes
- **Flag-off is byte-identical.** The guard engages only when the auto-tracked marker is present, which only the trampoline (auto path) stamps. Manual-only integrations never carry it.
- **Dedup key.** `tm` is a per-delivery ULID present on campaign sends and is the same value the backend associates with the open. When absent (local notifications, previews, non-campaign sends) the generated per-notification UUID is used. The raw `_k` payload is deliberately not used as a fallback — minus `tm` it is per-message metadata shared across deliveries, so it would collide and drop legitimate opens.

## Test Plan
- `BoundedIdSetTest` (core): insert/contains round-trip, `markOnce` true-then-false, FIFO eviction removes oldest, duplicate insert does not advance eviction order, evicted IDs re-insertable, capacity bound, constructor rejects non-positive capacity, concurrent-access safety.
- `KlaviyoTest` (analytics): one event when an auto-tracked delivery is handled twice (distinct intents + same intent object); distinct deliveries tracked independently; `tm`-less dedup via the generated UID with distinct notifications independent; malformed `_k` falls back gracefully; manual (non-auto-tracked) intents never deduped.
- Manual: sample/test app with auto-tracking on + a leftover manual `handlePush` — single `Opened Push` per tap; distinct notifications each track.

## Related Issues/Tickets
- MAGE-768
- Stacked on #493 (MAGE-767)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bounded in-process deduplication for auto-tracked push notification opens to prevent repeated processing.
  * Updated destination trampoline intents to include a per-notification fallback ID to support consistent “handled once” behavior.

* **Bug Fixes**
  * Prevented duplicate `$opened_push` events for the same delivery, while still performing deep-link handling and dismissal for the first occurrence.
  * Gracefully falls back when delivery metadata is missing or malformed, and only dedups when a dedup key is available.

* **Tests / Quality**
  * Expanded coverage for deduplication, fallback behavior, and bounded set eviction/concurrency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->