### PR TITLE
feat(analytics): retry on greater of Retry-After and exponential backoff (MAGE-500)

### DIFF
--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequest.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequest.kt
@@ -489,7 +489,12 @@ internal open class KlaviyoApiRequest(
         )
 
         try {
-            val retryAfter = this.responseHeaders[HEADER_RETRY_AFTER]?.getOrNull(0)
+            // Look up Retry-After case-insensitively: HTTP header names are case-insensitive and an
+            // HTTP/2 stack may deliver it lowercased, so a case-sensitive map lookup could miss it.
+            // headerFields can contain a null key (the status line), so compare from the constant.
+            val retryAfter = this.responseHeaders.entries
+                .firstOrNull { HEADER_RETRY_AFTER.equals(it.key, ignoreCase = true) }
+                ?.value?.getOrNull(0)
 
             if (retryAfter?.isNotEmpty() == true) {
                 val retryAfterInterval = (retryAfter.toInt() + jitterSeconds).times(1_000L)

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequest.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequest.kt
@@ -468,32 +468,38 @@ internal open class KlaviyoApiRequest(
     /**
      * Compute a retry interval based on state of the request
      *
-     * If present, obey the Retry-After response header, plus some jitter.
-     * Absent the header, use an exponential backoff algorithm, with a
-     * floor set by current network connection, and ceiling set by the config.
+     * Always compute an exponential backoff interval, with a floor set by the
+     * current network connection and a ceiling set by the config. If the server
+     * sent a usable Retry-After response header, wait the GREATER of that header
+     * value and the exponential backoff (each plus the same jitter). Taking the
+     * greater of the two ensures a request deep in a rate-limit storm keeps
+     * backing off rather than retrying too soon just because the server's
+     * rate-limit window reset to a short Retry-After.
      */
     fun computeRetryInterval(): Long {
         val jitterSeconds = Registry.config.networkJitterRange.random()
-
-        try {
-            val retryAfter = this.responseHeaders[HEADER_RETRY_AFTER]?.getOrNull(0)
-
-            if (retryAfter?.isNotEmpty() == true) {
-                return (retryAfter.toInt() + jitterSeconds).times(1_000L)
-            }
-        } catch (e: NumberFormatException) {
-            Registry.log.warning("Invalid Retry-After header value", e)
-        }
 
         val networkType = Registry.networkMonitor.getNetworkType().position
         val minRetryInterval = Registry.config.networkFlushIntervals[networkType]
         val exponentialBackoff = (2.0.pow(attempts).toLong() + jitterSeconds).times(1_000L)
         val maxRetryInterval = Registry.config.networkMaxRetryInterval
-
-        return min(
+        val backoffInterval = min(
             max(minRetryInterval, exponentialBackoff),
             maxRetryInterval
         )
+
+        try {
+            val retryAfter = this.responseHeaders[HEADER_RETRY_AFTER]?.getOrNull(0)
+
+            if (retryAfter?.isNotEmpty() == true) {
+                val retryAfterInterval = (retryAfter.toInt() + jitterSeconds).times(1_000L)
+                return max(retryAfterInterval, backoffInterval)
+            }
+        } catch (e: NumberFormatException) {
+            Registry.log.warning("Invalid Retry-After header value", e)
+        }
+
+        return backoffInterval
     }
 
     /**

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/KlaviyoApiClientTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/KlaviyoApiClientTest.kt
@@ -735,7 +735,8 @@ internal class KlaviyoApiClientTest : BaseTest() {
 
         fun expectedBackoffInterval(startAttempts: Int) =
             expectedBackoffIntervals.getOrElse(startAttempts) {
-                300_000L // Max backoff time should be used from here on, because 512s > 300s
+                // Max backoff (cap) should be used from here on, because 512s > the configured cap
+                Registry.config.networkMaxRetryInterval
             }
 
         // First unsent request, which we will retry till max attempts
@@ -792,7 +793,7 @@ internal class KlaviyoApiClientTest : BaseTest() {
 
         // First request should have been retried exactly 50 times
         assertEquals(50, request1.attempts)
-        assertEquals(300_000L, scheduledIntervals.maxOrNull() ?: 0L)
+        assertEquals(Registry.config.networkMaxRetryInterval, scheduledIntervals.maxOrNull() ?: 0L)
 
         // Upon final failure, request 1 should have been dropped from the queue
         assertEquals(1, KlaviyoApiClient.getQueueSize())

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/KlaviyoApiClientTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/KlaviyoApiClientTest.kt
@@ -720,6 +720,23 @@ internal class KlaviyoApiClientTest : BaseTest() {
     fun `Rate limited requests are retried with backoff until max attempts in absence of Retry-After header`() {
         val defaultInterval =
             Registry.config.networkFlushIntervals[NetworkMonitor.NetworkType.Wifi.position]
+        val expectedBackoffIntervals = listOf(
+            defaultInterval, // First attempt starts after default interval
+            defaultInterval, // First RETRY starts after default interval bc 2s < 10s
+            defaultInterval, // Second RETRY starts after default interval bc 4s < 10s
+            defaultInterval, // Third RETRY starts after default interval bc 8s < 10s
+            16_000L, // Exp. backoff time should be used bc 16s > 10s
+            32_000L, // Exp. backoff time should be used bc 32s > 10s
+            64_000L, // Exp. backoff time should be used bc 64s > 10s
+            128_000L, // Exp. backoff time should be used bc 128s > 10s
+            256_000L // Exp. backoff time should be used bc 256s > 10s
+        )
+        val scheduledIntervals = mutableListOf<Long>()
+
+        fun expectedBackoffInterval(startAttempts: Int) =
+            expectedBackoffIntervals.getOrElse(startAttempts) {
+                300_000L // Max backoff time should be used from here on, because 512s > 300s
+            }
 
         // First unsent request, which we will retry till max attempts
         val request1 = mockRequest("uuid-retry", KlaviyoApiRequest.Status.Unsent).also {
@@ -732,6 +749,14 @@ internal class KlaviyoApiClientTest : BaseTest() {
                 50 -> KlaviyoApiRequest.Status.Failed.name
                 else -> KlaviyoApiRequest.Status.PendingRetry.name
             }
+        }
+        every { request1.computeRetryInterval() } answers {
+            expectedBackoffInterval(request1.attempts - 1)
+        }
+        every { mockHandler.postDelayed(any(), any()) } answers {
+            postedJob = firstArg<KlaviyoApiClient.NetworkRunnable>()
+            scheduledIntervals += secondArg<Long>()
+            true
         }
 
         // Second unset request in queue to ensure which shouldn't sent until first has failed
@@ -750,22 +775,16 @@ internal class KlaviyoApiClientTest : BaseTest() {
             val startAttempts = request1.attempts
 
             // Advance the time with our expected backoff interval
-            staticClock.time += listOf(
-                defaultInterval, // First attempt starts after default interval
-                defaultInterval, // First RETRY starts after default interval bc 2s < 10s
-                defaultInterval, // Second RETRY starts after default interval bc 4s < 10s
-                defaultInterval, // Third RETRY starts after default interval bc 8s < 10s
-                16_000L, // Exp. backoff time should be used bc 16s > 10s
-                32_000L, // Exp. backoff time should be used bc 32s > 10s
-                64_000L, // Exp. backoff time should be used bc 64s > 10s
-                128_000L // Exp. backoff time should be used bc 128s > 10s
-            ).getOrElse(startAttempts) { 180_000L } // Max backoff time should be used from here on, because 256s > 180s
+            staticClock.time += expectedBackoffInterval(startAttempts)
 
             // Run after advancing the clock (this mimics how handler.postDelay would run jobs)
             postedJob!!.run()
 
             // It should have attempted one send if the correct time elapsed
             assertEquals(startAttempts + 1, request1.attempts)
+            if (request1.state != KlaviyoApiRequest.Status.Failed.name) {
+                assertEquals(expectedBackoffInterval(startAttempts), scheduledIntervals.last())
+            }
 
             // Fail test if we exceed max attempts
             assert(request1.attempts <= 50)
@@ -773,6 +792,7 @@ internal class KlaviyoApiClientTest : BaseTest() {
 
         // First request should have been retried exactly 50 times
         assertEquals(50, request1.attempts)
+        assertEquals(300_000L, scheduledIntervals.maxOrNull() ?: 0L)
 
         // Upon final failure, request 1 should have been dropped from the queue
         assertEquals(1, KlaviyoApiClient.getQueueSize())

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequestTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequestTest.kt
@@ -214,8 +214,10 @@ internal class KlaviyoApiRequestTest : BaseApiRequestTest<KlaviyoApiRequest>() {
     }
 
     @Test
-    fun `Parses Retry-After header if present and adds jitter`() {
+    fun `Uses Retry-After header plus jitter when greater than exponential backoff`() {
+        // Retry-After is 25s; Wifi backoff floor is 10s, so Retry-After wins. Jitter forced to 1s.
         val expectedHeaders = mapOf("Retry-After" to listOf("25"))
+        every { mockNetworkMonitor.getNetworkType() } returns NetworkMonitor.NetworkType.Wifi
         every { mockConfig.networkJitterRange } returns 1..1
         withConnectionMock(URL(expectedFullUrl)).also {
             every { it.headerFields } returns expectedHeaders
@@ -224,6 +226,21 @@ internal class KlaviyoApiRequestTest : BaseApiRequestTest<KlaviyoApiRequest>() {
         val request = makeTestRequest()
         request.send()
         assertEquals(26_000L, request.computeRetryInterval())
+    }
+
+    @Test
+    fun `Uses exponential backoff interval when greater than Retry-After header`() {
+        // Retry-After is 2s but the Wifi backoff floor is 10s, so backoff wins. Jitter forced to 1s.
+        val expectedHeaders = mapOf("Retry-After" to listOf("2"))
+        every { mockNetworkMonitor.getNetworkType() } returns NetworkMonitor.NetworkType.Wifi
+        every { mockConfig.networkJitterRange } returns 1..1
+        withConnectionMock(URL(expectedFullUrl)).also {
+            every { it.headerFields } returns expectedHeaders
+        }
+
+        val request = makeTestRequest()
+        request.send()
+        assertEquals(10_000L, request.computeRetryInterval())
     }
 
     @Test

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequestTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequestTest.kt
@@ -256,7 +256,7 @@ internal class KlaviyoApiRequestTest : BaseApiRequestTest<KlaviyoApiRequest>() {
         repeat(9) {
             request.send()
         }
-        assertEquals(300_000L, request.computeRetryInterval())
+        assertEquals(mockConfig.networkMaxRetryInterval, request.computeRetryInterval())
     }
 
     @Test

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequestTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequestTest.kt
@@ -244,6 +244,21 @@ internal class KlaviyoApiRequestTest : BaseApiRequestTest<KlaviyoApiRequest>() {
     }
 
     @Test
+    fun `Reads Retry-After header case-insensitively`() {
+        // An HTTP/2 stack may deliver the header lowercased; the lookup must still find it.
+        val expectedHeaders = mapOf("retry-after" to listOf("25"))
+        every { mockNetworkMonitor.getNetworkType() } returns NetworkMonitor.NetworkType.Wifi
+        every { mockConfig.networkJitterRange } returns 1..1
+        withConnectionMock(URL(expectedFullUrl)).also {
+            every { it.headerFields } returns expectedHeaders
+        }
+
+        val request = makeTestRequest()
+        request.send()
+        assertEquals(26_000L, request.computeRetryInterval())
+    }
+
+    @Test
     fun `Falls back on network interval without jitter when Retry-After header is missing or invalid`() {
         // Wifi interval is 10s, force jitter to be 1s
         every { mockNetworkMonitor.getNetworkType() } returns NetworkMonitor.NetworkType.Wifi

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequestTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequestTest.kt
@@ -230,17 +230,33 @@ internal class KlaviyoApiRequestTest : BaseApiRequestTest<KlaviyoApiRequest>() {
 
     @Test
     fun `Uses exponential backoff interval when greater than Retry-After header`() {
-        // Retry-After is 2s but the Wifi backoff floor is 10s, so backoff wins. Jitter forced to 1s.
+        // Retry-After is 2s and the Wifi backoff floor is 10s; after 4 attempts,
+        // 16s exponential backoff wins.
         val expectedHeaders = mapOf("Retry-After" to listOf("2"))
         every { mockNetworkMonitor.getNetworkType() } returns NetworkMonitor.NetworkType.Wifi
-        every { mockConfig.networkJitterRange } returns 1..1
+        every { mockConfig.networkJitterRange } returns 0..0
         withConnectionMock(URL(expectedFullUrl)).also {
             every { it.headerFields } returns expectedHeaders
         }
 
         val request = makeTestRequest()
-        request.send()
-        assertEquals(10_000L, request.computeRetryInterval())
+        repeat(4) {
+            request.send()
+        }
+        assertEquals(16_000L, request.computeRetryInterval())
+    }
+
+    @Test
+    fun `Caps exponential backoff interval at configured maximum`() {
+        every { mockNetworkMonitor.getNetworkType() } returns NetworkMonitor.NetworkType.Wifi
+        every { mockConfig.networkJitterRange } returns 0..0
+        withConnectionMock(URL(expectedFullUrl))
+
+        val request = makeTestRequest()
+        repeat(9) {
+            request.send()
+        }
+        assertEquals(300_000L, request.computeRetryInterval())
     }
 
     @Test

--- a/sdk/core/src/main/java/com/klaviyo/core/config/KlaviyoConfig.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/config/KlaviyoConfig.kt
@@ -82,11 +82,12 @@ object KlaviyoConfig : Config {
     private const val NETWORK_MAX_ATTEMPTS_DEFAULT: Int = 50
 
     /**
-     * Maximum interval between retries for the exponential backoff, in milliseconds (3 minutes)
+     * Maximum interval between retries for the exponential backoff, in milliseconds (5 minutes)
      *
-     * Reasoning: We don't want to wait so long that the user has left the app.
+     * Reasoning: We don't want to wait so long that the user has left the app, but 180s was more
+     * aggressive than comparable SDKs (Segment caps at 300s), so we align with 300s (MAGE-500).
      */
-    private const val NETWORK_MAX_RETRY_INTERVAL_DEFAULT: Long = 180_000
+    private const val NETWORK_MAX_RETRY_INTERVAL_DEFAULT: Long = 300_000
 
     override val isDebugBuild = BuildConfig.DEBUG
 

--- a/sdk/core/src/test/java/com/klaviyo/core/config/KlaviyoConfigTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/config/KlaviyoConfigTest.kt
@@ -126,7 +126,7 @@ internal class KlaviyoConfigTest : BaseTest() {
             KlaviyoConfig.networkFlushIntervals[NetworkMonitor.NetworkType.Offline.position]
         )
         assertEquals(50, KlaviyoConfig.networkMaxAttempts)
-        assertEquals(180_000L, KlaviyoConfig.networkMaxRetryInterval)
+        assertEquals(300_000L, KlaviyoConfig.networkMaxRetryInterval)
         assertEquals("android", KlaviyoConfig.sdkName)
         assertEquals("9.9.9", KlaviyoConfig.sdkVersion)
     }
@@ -162,7 +162,7 @@ internal class KlaviyoConfigTest : BaseTest() {
             KlaviyoConfig.networkFlushIntervals[NetworkMonitor.NetworkType.Offline.position]
         )
         assertEquals(50, KlaviyoConfig.networkMaxAttempts)
-        assertEquals(180_000, KlaviyoConfig.networkMaxRetryInterval)
+        assertEquals(300_000, KlaviyoConfig.networkMaxRetryInterval)
         assertEquals("android", KlaviyoConfig.sdkName)
         assertEquals("9.9.9", KlaviyoConfig.sdkVersion)
         // Each bad call should have generated an error log

--- a/sdk/fixtures/src/main/java/com/klaviyo/fixtures/BaseTest.kt
+++ b/sdk/fixtures/src/main/java/com/klaviyo/fixtures/BaseTest.kt
@@ -86,7 +86,7 @@ abstract class BaseTest {
         every { networkMaxAttempts } returns 50
         every { networkTimeout } returns 1000
         every { uxNetworkTimeout } returns 100
-        every { networkMaxRetryInterval } returns 180_000L
+        every { networkMaxRetryInterval } returns 300_000L
         every { networkFlushIntervals } returns longArrayOf(10_000, 30_000, 60_000)
         every { networkJitterRange } returns 0..0
         every { baseUrl } returns "https://test.fake-klaviyo.com"


### PR DESCRIPTION
## What
Implements MAGE-500 retry scheduling updates for analytics requests:
- When a retryable response includes a usable `Retry-After` header, the SDK now waits the greater of that server-provided interval and the SDK exponential backoff interval.
- Raises the default exponential-backoff ceiling from 180s to 300s.
- Looks up `Retry-After` case-insensitively so lowercase HTTP/2 header names are honored.

## Why
Previously, `KlaviyoApiRequest.computeRetryInterval()` returned `Retry-After` directly whenever the header was present and only fell back to exponential backoff when it was absent or invalid. A device deep in a rate-limit storm could therefore retry too soon if the server returned a short `Retry-After`, even though the SDK backoff had grown larger.

The 300s cap aligns the default exponential-backoff ceiling with MAGE-500 proposal #1 and keeps retry pressure lower during extended failures.

## Change
- Always compute the network-floored, config-capped exponential backoff interval.
- When `Retry-After` is present and parseable, return `max(retryAfterInterval, backoffInterval)`.
- Preserve existing jitter behavior and the existing behavior that a large `Retry-After` value is not capped by `networkMaxRetryInterval`.
- Read `Retry-After` with a case-insensitive header-key comparison.
- Update config defaults and tests for the new 300s retry cap.

## Tests
- `./gradlew :sdk:analytics:testDebugUnitTest --tests "com.klaviyo.analytics.networking.requests.KlaviyoApiRequestTest" --tests "com.klaviyo.analytics.networking.KlaviyoApiClientTest" :sdk:core:testDebugUnitTest --tests "com.klaviyo.core.config.KlaviyoConfigTest"`

## Scope
MAGE-500 retry interval behavior only. Total retry-duration limits and applying the config cap to large `Retry-After` values remain follow-ups.

🔗 [View this job in Reca Studio](https://kiosk.klaviyo-dev.com/remote-coding-agent/flow/546ee672-2202-4b28-a0b8-93a2b7f0f3b0)
🤖 Generated with Reca

Reca job ID: 546ee672-2202-4b28-a0b8-93a2b7f0f3b0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network retry timing by honoring server-provided `Retry-After` alongside exponential backoff, using the longer delay when both apply.
  * `Retry-After` lookup is now case-insensitive; invalid values fall back to exponential backoff.
  * Retry delay maximum increased to **5 minutes** to better control retry behavior.
* **Tests**
  * Expanded and refined retry-interval assertions for `Retry-After` precedence, jitter, backoff capping, and case-insensitive header handling.
  * Updated tests/fixtures to reflect the new default retry maximum.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->