### PR TITLE
refactor(analytics): cap request queue at 200 evict-oldest + drop depth-triggered flush (MAGE-496)

### DIFF
--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/KlaviyoApiClient.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/KlaviyoApiClient.kt
@@ -220,12 +220,18 @@ internal object KlaviyoApiClient : ApiClient {
                 while (apiQueue.size >= MAX_QUEUE_SIZE) {
                     // Evict the oldest request by enqueue timestamp, not the front of the deque —
                     // head-of-line requests are inserted at the front but are the newest.
+                    // The minByOrNull + remove pair is not atomic on the ConcurrentLinkedDeque, so a
+                    // concurrent enqueue could target the same victim. We gate the side effects on
+                    // remove()'s boolean: if another thread already evicted this request, remove()
+                    // returns false and the while-loop simply re-scans — a best-effort, self-healing
+                    // soft bound rather than a hard guarantee.
                     val evicted = apiQueue.minByOrNull { it.queuedTime } ?: break
-                    apiQueue.remove(evicted)
-                    Registry.dataStore.clear(evicted.uuid)
-                    Registry.log.warning(
-                        "API queue at capacity ($MAX_QUEUE_SIZE), evicting oldest request: ${evicted.type}"
-                    )
+                    if (apiQueue.remove(evicted)) {
+                        Registry.dataStore.clear(evicted.uuid)
+                        Registry.log.warning(
+                            "API queue at capacity ($MAX_QUEUE_SIZE), evicting oldest request: ${evicted.type}"
+                        )
+                    }
                 }
                 Registry.dataStore.store(request.uuid, request.toString())
                 if (headOfLine) {

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/KlaviyoApiClient.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/KlaviyoApiClient.kt
@@ -42,8 +42,10 @@ internal object KlaviyoApiClient : ApiClient {
      * Maximum number of requests that can sit in the API queue at one time.
      *
      * Matches the iOS SDK cap (200) for behavioural parity across platforms.
-     * When the queue reaches this limit, the oldest request (front of deque) is evicted
-     * to make room for the incoming one. This prevents the queue from growing unbounded during
+     * When the queue reaches this limit, the oldest request (smallest [KlaviyoApiRequest.queuedTime])
+     * is evicted to make room for the incoming one. Evicting by enqueue timestamp — rather than
+     * the front of the deque — protects freshly-enqueued head-of-line requests, which are inserted
+     * at the front but are the newest. This prevents the queue from growing unbounded during
      * request storms — for example, a push-token registration loop that floods the queue and
      * blocks legitimate new requests from ever reaching the network.
      */
@@ -216,7 +218,10 @@ internal object KlaviyoApiClient : ApiClient {
         }.forEach { request ->
             if (!apiQueue.contains(request)) {
                 while (apiQueue.size >= MAX_QUEUE_SIZE) {
-                    val evicted = apiQueue.pollFirst() ?: break
+                    // Evict the oldest request by enqueue timestamp, not the front of the deque —
+                    // head-of-line requests are inserted at the front but are the newest.
+                    val evicted = apiQueue.minByOrNull { it.queuedTime } ?: break
+                    apiQueue.remove(evicted)
                     Registry.dataStore.clear(evicted.uuid)
                     Registry.log.warning(
                         "API queue at capacity ($MAX_QUEUE_SIZE), evicting oldest request: ${evicted.type}"

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/KlaviyoApiClient.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/KlaviyoApiClient.kt
@@ -41,13 +41,9 @@ internal object KlaviyoApiClient : ApiClient {
     /**
      * Maximum number of requests that can sit in the API queue at one time.
      *
-     * Matches the iOS SDK cap (200) for behavioural parity across platforms.
-     * When the queue reaches this limit, the oldest request (smallest [KlaviyoApiRequest.queuedTime])
-     * is evicted to make room for the incoming one. Evicting by enqueue timestamp — rather than
-     * the front of the deque — protects freshly-enqueued head-of-line requests, which are inserted
-     * at the front but are the newest. This prevents the queue from growing unbounded during
-     * request storms — for example, a push-token registration loop that floods the queue and
-     * blocks legitimate new requests from ever reaching the network.
+     * When the queue reaches this limit, the oldest request is evicted to make room.
+     * We evict by enqueued time, not simply queue position, to honor actual age.
+     * This prevents the queue from growing unbounded during request storms.
      */
     internal const val MAX_QUEUE_SIZE: Int = 200
 

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/KlaviyoApiClient.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/KlaviyoApiClient.kt
@@ -38,6 +38,17 @@ import org.json.JSONObject
 internal object KlaviyoApiClient : ApiClient {
     internal const val QUEUE_KEY = "klaviyo_api_request_queue"
 
+    /**
+     * Maximum number of requests that can sit in the API queue at one time.
+     *
+     * Matches the iOS SDK cap (200) for behavioural parity across platforms.
+     * When the queue reaches this limit, the oldest request (front of deque) is evicted
+     * to make room for the incoming one. This prevents the queue from growing unbounded during
+     * request storms — for example, a push-token registration loop that floods the queue and
+     * blocks legitimate new requests from ever reaching the network.
+     */
+    internal const val MAX_QUEUE_SIZE: Int = 200
+
     private var handlerThread = Registry.threadHelper.getHandlerThread(
         KlaviyoApiClient::class.simpleName
     )
@@ -204,6 +215,13 @@ internal object KlaviyoApiClient : ApiClient {
             }
         }.forEach { request ->
             if (!apiQueue.contains(request)) {
+                while (apiQueue.size >= MAX_QUEUE_SIZE) {
+                    val evicted = apiQueue.pollFirst() ?: break
+                    Registry.dataStore.clear(evicted.uuid)
+                    Registry.log.warning(
+                        "API queue at capacity ($MAX_QUEUE_SIZE), evicting oldest request: ${evicted.type}"
+                    )
+                }
                 Registry.dataStore.store(request.uuid, request.toString())
                 if (headOfLine) {
                     apiQueue.offerFirst(request)
@@ -489,8 +507,6 @@ internal object KlaviyoApiClient : ApiClient {
 
         private var flushInterval: Long = defaultFlushInterval
 
-        private val flushDepth: Int = Registry.config.networkFlushDepth
-
         /**
          * Send queued requests serially
          * The queue will flush whenever the triggers specified in config are met
@@ -499,7 +515,7 @@ internal object KlaviyoApiClient : ApiClient {
         override fun run() {
             val queueTimePassed = Registry.clock.currentTimeMillis() - enqueuedTime
 
-            if (getQueueSize() < flushDepth && queueTimePassed < flushInterval && !force) {
+            if (queueTimePassed < flushInterval && !force) {
                 return requeue()
             }
 

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/KlaviyoApiClientTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/KlaviyoApiClientTest.kt
@@ -69,7 +69,6 @@ internal class KlaviyoApiClientTest : BaseTest() {
     private val flushIntervalWifi = 10_000L
     private val flushIntervalCell = 20_000L
     private val flushIntervalOffline = 30_000L
-    private val queueDepth = 10
     private var postedJob: KlaviyoApiClient.NetworkRunnable? = null
     private val mockQueueScheduler = mockk<QueueScheduler>(relaxed = true)
 
@@ -97,7 +96,6 @@ internal class KlaviyoApiClientTest : BaseTest() {
             flushIntervalCell,
             flushIntervalOffline
         )
-        every { mockConfig.networkFlushDepth } returns queueDepth
         every { mockNetworkMonitor.isNetworkConnected() } returns false
         every { mockNetworkMonitor.getNetworkType() } returns NetworkMonitor.NetworkType.Wifi
         every { mockLifecycleMonitor.onActivityEvent(capture(slotOnActivityEvent)) } returns Unit
@@ -446,18 +444,6 @@ internal class KlaviyoApiClientTest : BaseTest() {
     }
 
     @Test
-    fun `Flushes queue when configured size is reached`() {
-        repeat(queueDepth) {
-            KlaviyoApiClient.enqueueRequest(mockRequest("uuid-$it"))
-            assertEquals(it + 1, KlaviyoApiClient.getQueueSize())
-        }
-
-        postedJob!!.run()
-
-        assertEquals(0, KlaviyoApiClient.getQueueSize())
-    }
-
-    @Test
     fun `Flushes queue when configured time has elapsed`() {
         val requestMock = mockRequest()
 
@@ -471,20 +457,19 @@ internal class KlaviyoApiClientTest : BaseTest() {
     }
 
     @Test
-    fun `Does not flush queue if no criteria is met`() {
-        repeat(queueDepth - 1) {
-            KlaviyoApiClient.enqueueRequest(mockRequest("uuid-$it"))
-            assertEquals(it + 1, KlaviyoApiClient.getQueueSize())
-        }
+    fun `Does not flush queue if flush interval has not elapsed`() {
+        KlaviyoApiClient.enqueueRequest(mockRequest("uuid-0"))
+        assertEquals(1, KlaviyoApiClient.getQueueSize())
 
+        // Time has not advanced, so flush interval has not elapsed
         postedJob!!.run()
 
-        assertEquals(queueDepth - 1, KlaviyoApiClient.getQueueSize())
+        assertEquals(1, KlaviyoApiClient.getQueueSize())
     }
 
     @Test
-    fun `Flushes queue if forced when no criteria is met`() {
-        repeat(queueDepth - 1) {
+    fun `Flushes queue if forced when flush interval has not elapsed`() {
+        repeat(5) {
             KlaviyoApiClient.enqueueRequest(mockRequest("uuid-$it"))
             assertEquals(it + 1, KlaviyoApiClient.getQueueSize())
         }
@@ -492,6 +477,35 @@ internal class KlaviyoApiClientTest : BaseTest() {
         KlaviyoApiClient.flushQueue()
 
         assertEquals(0, KlaviyoApiClient.getQueueSize())
+    }
+
+    @Test
+    fun `Queue cap evicts oldest request on overflow and emits warning log`() {
+        // Fill the queue to capacity
+        repeat(KlaviyoApiClient.MAX_QUEUE_SIZE) {
+            KlaviyoApiClient.enqueueRequest(mockRequest("uuid-$it"))
+        }
+        assertEquals(KlaviyoApiClient.MAX_QUEUE_SIZE, KlaviyoApiClient.getQueueSize())
+
+        // The oldest request (uuid-0) is at the front of the deque
+        val oldestUuid = "uuid-0"
+        assertNotNull(spyDataStore.fetch(oldestUuid))
+
+        // Enqueue one more request — should evict uuid-0
+        val newestRequest = mockRequest("uuid-newest")
+        KlaviyoApiClient.enqueueRequest(newestRequest)
+
+        // Queue size stays at the cap
+        assertEquals(KlaviyoApiClient.MAX_QUEUE_SIZE, KlaviyoApiClient.getQueueSize())
+
+        // Oldest was evicted from the datastore
+        assertNull(spyDataStore.fetch(oldestUuid))
+
+        // Newest request is present in the datastore
+        assertNotNull(spyDataStore.fetch("uuid-newest"))
+
+        // A warning log was emitted for the eviction
+        verify(atLeast = 1) { spyLog.warning(any(), null) }
     }
 
     @Test

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/KlaviyoApiClientTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/KlaviyoApiClientTest.kt
@@ -480,29 +480,69 @@ internal class KlaviyoApiClientTest : BaseTest() {
     }
 
     @Test
-    fun `Queue cap evicts oldest request on overflow and emits warning log`() {
-        // Fill the queue to capacity
+    fun `Queue cap evicts request with oldest queuedTime on overflow and emits warning log`() {
+        // Fill the queue to capacity, advancing the clock so each request captures a
+        // progressively later queuedTime — uuid-0 therefore holds the oldest queuedTime.
         repeat(KlaviyoApiClient.MAX_QUEUE_SIZE) {
-            KlaviyoApiClient.enqueueRequest(mockRequest("uuid-$it"))
+            val request = mockRequest("uuid-$it") // queuedTime is captured from staticClock here
+            KlaviyoApiClient.enqueueRequest(request)
+            staticClock.time += 1
         }
         assertEquals(KlaviyoApiClient.MAX_QUEUE_SIZE, KlaviyoApiClient.getQueueSize())
 
-        // The oldest request (uuid-0) is at the front of the deque
+        // uuid-0 has the oldest queuedTime
         val oldestUuid = "uuid-0"
         assertNotNull(spyDataStore.fetch(oldestUuid))
 
-        // Enqueue one more request — should evict uuid-0
+        // Enqueue one more request — should evict the request with the oldest queuedTime
         val newestRequest = mockRequest("uuid-newest")
         KlaviyoApiClient.enqueueRequest(newestRequest)
 
         // Queue size stays at the cap
         assertEquals(KlaviyoApiClient.MAX_QUEUE_SIZE, KlaviyoApiClient.getQueueSize())
 
-        // Oldest was evicted from the datastore
+        // The oldest request by queuedTime was evicted from the datastore
         assertNull(spyDataStore.fetch(oldestUuid))
 
         // Newest request is present in the datastore
         assertNotNull(spyDataStore.fetch("uuid-newest"))
+
+        // A warning log was emitted for the eviction
+        verify(atLeast = 1) { spyLog.warning(any(), null) }
+    }
+
+    @Test
+    fun `Queue cap protects freshly-enqueued head-of-line request and evicts oldest by queuedTime`() {
+        // Fill the queue with regular requests just under capacity, advancing the clock so
+        // uuid-0 holds the oldest queuedTime and sits at the front (head) of the deque.
+        repeat(KlaviyoApiClient.MAX_QUEUE_SIZE - 1) {
+            val request = mockRequest("uuid-$it") // queuedTime is captured from staticClock here
+            KlaviyoApiClient.enqueueRequest(request)
+            staticClock.time += 1
+        }
+        assertEquals(KlaviyoApiClient.MAX_QUEUE_SIZE - 1, KlaviyoApiClient.getQueueSize())
+
+        // A head-of-line request is enqueued last, so it has the NEWEST queuedTime, and it is
+        // inserted at the FRONT of the deque via offerFirst. This is the exact shape that used to
+        // break: blindly evicting the front would remove this freshly-enqueued priority request.
+        val headOfLineRequest = mockRequest("hol-newest")
+        KlaviyoApiClient.enqueueRequest(headOfLineRequest, headOfLine = true)
+        staticClock.time += 1
+        assertEquals(KlaviyoApiClient.MAX_QUEUE_SIZE, KlaviyoApiClient.getQueueSize())
+
+        // Enqueuing one more request overflows the cap and triggers eviction.
+        val incomingRequest = mockRequest("uuid-incoming")
+        KlaviyoApiClient.enqueueRequest(incomingRequest)
+
+        // The oldest request by queuedTime (uuid-0) is evicted — NOT the front of the deque.
+        assertNull(spyDataStore.fetch("uuid-0"))
+
+        // The freshly-enqueued head-of-line request is protected because it is the newest.
+        assertNotNull(spyDataStore.fetch("hol-newest"))
+
+        // The incoming request was accepted and the queue stays bounded at the cap.
+        assertNotNull(spyDataStore.fetch("uuid-incoming"))
+        assertEquals(KlaviyoApiClient.MAX_QUEUE_SIZE, KlaviyoApiClient.getQueueSize())
 
         // A warning log was emitted for the eviction
         verify(atLeast = 1) { spyLog.warning(any(), null) }

--- a/sdk/core/src/main/java/com/klaviyo/core/config/Config.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/config/Config.kt
@@ -43,9 +43,10 @@ interface Config {
         fun networkMaxRetryInterval(networkMaxRetryInterval: Long): Builder
 
         @Deprecated(
-            message = "Depth-triggered flushing has been removed. The queue now flushes only on " +
-                "the timer interval (see networkFlushInterval) and is internally bounded by a " +
-                "size cap. This setter has no effect and will be removed in a future major release.",
+            message = "Depth-triggered flushing has been removed. The queue now flushes on the " +
+                "timer interval (see networkFlushInterval) or when explicitly forced, and is " +
+                "internally bounded by a size cap. This setter has no effect and will be " +
+                "removed in a future major release.",
             level = DeprecationLevel.WARNING
         )
         fun networkFlushDepth(networkFlushDepth: Int): Builder

--- a/sdk/core/src/main/java/com/klaviyo/core/config/Config.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/config/Config.kt
@@ -41,6 +41,15 @@ interface Config {
         fun networkFlushInterval(networkFlushInterval: Long, type: NetworkMonitor.NetworkType): Builder
         fun networkMaxAttempts(networkMaxAttempts: Int): Builder
         fun networkMaxRetryInterval(networkMaxRetryInterval: Long): Builder
+
+        @Deprecated(
+            message = "Depth-triggered flushing has been removed. The queue now flushes only on " +
+                "the timer interval (see networkFlushInterval) and is internally bounded by a " +
+                "size cap. This setter has no effect and will be removed in a future major release.",
+            level = DeprecationLevel.WARNING
+        )
+        fun networkFlushDepth(networkFlushDepth: Int): Builder
+
         fun build(): Config
     }
 }

--- a/sdk/core/src/main/java/com/klaviyo/core/config/Config.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/config/Config.kt
@@ -21,7 +21,6 @@ interface Config {
     val networkTimeout: Int
     val uxNetworkTimeout: Int
     val networkFlushIntervals: LongArray
-    val networkFlushDepth: Int
     val networkMaxAttempts: Int
     val networkMaxRetryInterval: Long
     val networkJitterRange: IntRange
@@ -40,7 +39,6 @@ interface Config {
         fun networkTimeout(networkTimeout: Int): Builder
         fun uxNetworkTimeout(uxNetworkTimeout: Int): Builder
         fun networkFlushInterval(networkFlushInterval: Long, type: NetworkMonitor.NetworkType): Builder
-        fun networkFlushDepth(networkFlushDepth: Int): Builder
         fun networkMaxAttempts(networkMaxAttempts: Int): Builder
         fun networkMaxRetryInterval(networkMaxRetryInterval: Long): Builder
         fun build(): Config

--- a/sdk/core/src/main/java/com/klaviyo/core/config/KlaviyoConfig.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/config/KlaviyoConfig.kt
@@ -256,6 +256,17 @@ object KlaviyoConfig : Config {
             }
         }
 
+        @Deprecated(
+            message = "Depth-triggered flushing has been removed. The queue now flushes only on " +
+                "the timer interval (see networkFlushInterval) and is internally bounded by a " +
+                "size cap. This setter has no effect and will be removed in a future major release.",
+            level = DeprecationLevel.WARNING
+        )
+        override fun networkFlushDepth(networkFlushDepth: Int) = apply {
+            // No-op: depth-triggered flushing was removed; retained for one release as a
+            // deprecated setter so existing caller code keeps compiling.
+        }
+
         override fun build(): Config {
             val context = applicationContext ?: throw MissingContext()
             val packageInfo = context.packageManager.getPackageInfoCompat(

--- a/sdk/core/src/main/java/com/klaviyo/core/config/KlaviyoConfig.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/config/KlaviyoConfig.kt
@@ -75,14 +75,6 @@ object KlaviyoConfig : Config {
     private const val NETWORK_FLUSH_INTERVAL_OFFLINE_DEFAULT = 60_000L
 
     /**
-     * How many API requests can be enqueued before flush
-     *
-     * Reasoning: The goal of depth control is to limit duration that radios are active
-     * if a typical request takes 1-3 seconds, this should ideally limit us to 30-90 seconds
-     */
-    private const val NETWORK_FLUSH_DEPTH_DEFAULT: Int = 25
-
-    /**
      * How many retries to allow an API request before permanent failure
      *
      * Reasoning: Most likely the rate limit should be cleared within 2-3 retries with exp backoff.
@@ -131,8 +123,6 @@ object KlaviyoConfig : Config {
         NETWORK_FLUSH_INTERVAL_OFFLINE_DEFAULT
     )
         private set
-    override var networkFlushDepth = NETWORK_FLUSH_DEPTH_DEFAULT
-        private set
     override var networkMaxAttempts = NETWORK_MAX_ATTEMPTS_DEFAULT
         private set
     override var networkMaxRetryInterval = NETWORK_MAX_RETRY_INTERVAL_DEFAULT
@@ -167,7 +157,6 @@ object KlaviyoConfig : Config {
             NETWORK_FLUSH_INTERVAL_CELL_DEFAULT,
             NETWORK_FLUSH_INTERVAL_OFFLINE_DEFAULT
         )
-        private var networkFlushDepth = NETWORK_FLUSH_DEPTH_DEFAULT
         private var networkMaxAttempts = NETWORK_MAX_ATTEMPTS_DEFAULT
         private var networkMaxRetryInterval = NETWORK_MAX_RETRY_INTERVAL_DEFAULT
 
@@ -247,16 +236,6 @@ object KlaviyoConfig : Config {
             }
         }
 
-        override fun networkFlushDepth(networkFlushDepth: Int) = apply {
-            if (networkFlushDepth > 0) {
-                this.networkFlushDepth = networkFlushDepth
-            } else {
-                Registry.log.error(
-                    "${KlaviyoConfig::networkFlushDepth.name} must be greater than 0"
-                )
-            }
-        }
-
         override fun networkMaxAttempts(networkMaxAttempts: Int) = apply {
             if (networkMaxAttempts >= 0) {
                 this.networkMaxAttempts = networkMaxAttempts
@@ -305,7 +284,6 @@ object KlaviyoConfig : Config {
             KlaviyoConfig.networkTimeout = networkTimeout
             KlaviyoConfig.uxNetworkTimeout = uxNetworkTimeout
             KlaviyoConfig.networkFlushIntervals = networkFlushIntervals
-            KlaviyoConfig.networkFlushDepth = networkFlushDepth
             KlaviyoConfig.networkMaxAttempts = networkMaxAttempts
             KlaviyoConfig.networkMaxRetryInterval = networkMaxRetryInterval
 

--- a/sdk/core/src/main/java/com/klaviyo/core/config/KlaviyoConfig.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/config/KlaviyoConfig.kt
@@ -257,9 +257,10 @@ object KlaviyoConfig : Config {
         }
 
         @Deprecated(
-            message = "Depth-triggered flushing has been removed. The queue now flushes only on " +
-                "the timer interval (see networkFlushInterval) and is internally bounded by a " +
-                "size cap. This setter has no effect and will be removed in a future major release.",
+            message = "Depth-triggered flushing has been removed. The queue now flushes on the " +
+                "timer interval (see networkFlushInterval) or when explicitly forced, and is " +
+                "internally bounded by a size cap. This setter has no effect and will be " +
+                "removed in a future major release.",
             level = DeprecationLevel.WARNING
         )
         override fun networkFlushDepth(networkFlushDepth: Int) = apply {

--- a/sdk/core/src/test/java/com/klaviyo/core/config/KlaviyoConfigTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/config/KlaviyoConfigTest.kt
@@ -70,7 +70,6 @@ internal class KlaviyoConfigTest : BaseTest() {
             .networkFlushInterval(1, NetworkMonitor.NetworkType.Wifi)
             .networkFlushInterval(3, NetworkMonitor.NetworkType.Cell)
             .networkFlushInterval(6, NetworkMonitor.NetworkType.Offline)
-            .networkFlushDepth(4)
             .networkMaxAttempts(5)
             .networkMaxRetryInterval(7)
             .baseCdnUrl("spider-water.com")
@@ -95,7 +94,6 @@ internal class KlaviyoConfigTest : BaseTest() {
             6,
             KlaviyoConfig.networkFlushIntervals[NetworkMonitor.NetworkType.Offline.position]
         )
-        assertEquals(4, KlaviyoConfig.networkFlushDepth)
         assertEquals(5, KlaviyoConfig.networkMaxAttempts)
         assertEquals(7, KlaviyoConfig.networkMaxRetryInterval)
         assertEquals("android", KlaviyoConfig.sdkName)
@@ -127,7 +125,6 @@ internal class KlaviyoConfigTest : BaseTest() {
             60_000L,
             KlaviyoConfig.networkFlushIntervals[NetworkMonitor.NetworkType.Offline.position]
         )
-        assertEquals(25, KlaviyoConfig.networkFlushDepth)
         assertEquals(50, KlaviyoConfig.networkMaxAttempts)
         assertEquals(180_000L, KlaviyoConfig.networkMaxRetryInterval)
         assertEquals("android", KlaviyoConfig.sdkName)
@@ -145,7 +142,6 @@ internal class KlaviyoConfigTest : BaseTest() {
             .networkFlushInterval(-5000, NetworkMonitor.NetworkType.Wifi)
             .networkFlushInterval(-5000, NetworkMonitor.NetworkType.Cell)
             .networkFlushInterval(-5000, NetworkMonitor.NetworkType.Offline)
-            .networkFlushDepth(-10)
             .networkMaxAttempts(-10)
             .networkMaxRetryInterval(-1)
             .build()
@@ -165,13 +161,12 @@ internal class KlaviyoConfigTest : BaseTest() {
             60_000,
             KlaviyoConfig.networkFlushIntervals[NetworkMonitor.NetworkType.Offline.position]
         )
-        assertEquals(25, KlaviyoConfig.networkFlushDepth)
         assertEquals(50, KlaviyoConfig.networkMaxAttempts)
         assertEquals(180_000, KlaviyoConfig.networkMaxRetryInterval)
         assertEquals("android", KlaviyoConfig.sdkName)
         assertEquals("9.9.9", KlaviyoConfig.sdkVersion)
         // Each bad call should have generated an error log
-        verify(exactly = 9) { spyLog.error(any(), null) }
+        verify(exactly = 8) { spyLog.error(any(), null) }
     }
 
     @Test


### PR DESCRIPTION
Part of the **SDK Network Behavior Upgrades** stacked chain. **Base: `feat/mage-694-retry-all-5xx`.**

MAGE-496 — align queue-depth behavior across the Android & iOS SDKs.

## Changes
- Cap the API request queue at **200** (`MAX_QUEUE_SIZE`), matching the iOS cap. At capacity, evict the **oldest request by enqueue timestamp** (`queuedTime`) — *not* the front of the deque — clear it from the datastore, and warn. Priority / head-of-line requests are inserted at the front but are the *newest*, so evicting by timestamp naturally protects them. Eviction gates its `clear`/`warn` side effects on the boolean returned by `ConcurrentLinkedDeque.remove()`, so a concurrent enqueue targeting the same victim can't double-evict — the `while` loop just re-scans (best-effort, self-healing soft bound).
- Retire the depth-triggered flush: the internal machinery (`NETWORK_FLUSH_DEPTH_DEFAULT`, the config field, and the `getQueueSize() < flushDepth` trigger) is removed, so flushing is now purely interval/force-based.
- The public `Config.Builder.networkFlushDepth(Int)` setter is **kept as a `@Deprecated` no-op** for one release rather than hard-removed — existing caller code keeps compiling (no source/binary break, no forced major version bump). It has no effect and is slated for removal in a future major release.

## Behavior change
Under a sustained storm the queue drops the **oldest** request (by enqueue time) rather than the newest, and Android no longer flushes early purely due to queue depth. Intended per MAGE-496 (aligns with iOS + the MAGE-473 storm rationale). `networkFlushDepth` is a no-op deprecation, so no consumer code breaks.

## Tests
Updated `KlaviyoApiClientTest` — timestamp-based eviction with a mocked clock (FIFO eviction order + head-of-line protection + true 200-cap) — and `KlaviyoConfigTest` for the removed flush-depth machinery. Verified locally: `:sdk:core` + `:sdk:analytics` unit tests pass, ktlint clean.

🔗 Chain: retry-all-5xx (#485) → **align** → backoff (#497)
🤖 Generated with Reca

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced a hard maximum on the pending analytics queue; when full, the oldest items are evicted from storage (by queued time) and a warning is logged.
  * Updated queue flushing to rely solely on flush-interval timing, with explicit forced flush still able to clear the queue; removed queue-depth-based gating while keeping higher-priority items protected.
* **Chores**
  * Deprecated depth/queue-size flush configuration (`networkFlushDepth`); it is now effectively a no-op and related validation and tests were updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
