### PR TITLE
feat(forms): handle IAF openExternalUrl bridge event [PUSH-733]

### DIFF
--- a/README.md
+++ b/README.md
@@ -799,7 +799,8 @@ object to the `registerForInAppForms()` method. For example, to set a session ti
 
 > Form lifecycle events are available in SDK version 4.4.0 and higher.
 
-You can register a handler to receive callbacks whenever a form is shown, dismissed, or a CTA button is tapped.
+You can register a handler to receive callbacks whenever a form is shown, dismissed, or a CTA button is tapped
+(distinguishing in-app deep-link CTAs from CTAs that open an external URL in the browser).
 This is useful for forwarding engagement data to a third-party analytics platform such as Amplitude, Segment, or Mixpanel.
 
 The handler is invoked on the **main thread**, so avoid performing long-running or blocking work inside it.
@@ -810,6 +811,7 @@ The handler is invoked on the **main thread**, so avoid performing long-running 
    ```kotlin
    import com.klaviyo.analytics.Klaviyo
    import com.klaviyo.forms.FormLifecycleEvent.FormCtaClicked
+   import com.klaviyo.forms.FormLifecycleEvent.FormCtaExternalUrlClicked
    import com.klaviyo.forms.FormLifecycleEvent.FormDismissed
    import com.klaviyo.forms.FormLifecycleEvent.FormShown
    import com.klaviyo.forms.registerFormLifecycleHandler
@@ -829,6 +831,14 @@ The handler is invoked on the **main thread**, so avoid performing long-running 
                //     "formName" to event.formName,
                //     "buttonLabel" to event.buttonLabel,
                //     "deepLinkUrl" to event.deepLinkUrl.toString()
+               // ))
+           }
+           is FormCtaExternalUrlClicked -> {
+               // e.g. myAnalytics.track("Form External URL Clicked", mapOf(
+               //     "formId" to event.formId,
+               //     "formName" to event.formName,
+               //     "buttonLabel" to event.buttonLabel,
+               //     "externalUrl" to event.externalUrl.toString()
                // ))
            }
        }
@@ -853,6 +863,8 @@ The handler is invoked on the **main thread**, so avoid performing long-running 
            // e.g. myAnalytics.track("Form Dismissed", ...)
        } else if (event instanceof FormLifecycleEvent.FormCtaClicked ctaClicked) {
            // e.g. myAnalytics.track("Form CTA Clicked", ...)
+       } else if (event instanceof FormLifecycleEvent.FormCtaExternalUrlClicked externalUrlClicked) {
+           // e.g. myAnalytics.track("Form External URL Clicked", ...)
        }
    });
 

--- a/sample/src/main/java/com/klaviyo/sample/SampleApplication.kt
+++ b/sample/src/main/java/com/klaviyo/sample/SampleApplication.kt
@@ -6,6 +6,7 @@ import android.widget.Toast
 import com.klaviyo.analytics.Klaviyo
 import com.klaviyo.core.Registry
 import com.klaviyo.forms.FormLifecycleEvent.FormCtaClicked
+import com.klaviyo.forms.FormLifecycleEvent.FormCtaExternalUrlClicked
 import com.klaviyo.forms.FormLifecycleEvent.FormDismissed
 import com.klaviyo.forms.FormLifecycleEvent.FormShown
 import com.klaviyo.forms.registerForInAppForms
@@ -44,6 +45,11 @@ class SampleApplication : Application() {
                     is FormCtaClicked -> {
                         Registry.log.debug(
                             "Form Lifecycle: CTA ${event.buttonLabel} -> ${event.deepLinkUrl} from ${event.formName} (${event.formId})"
+                        )
+                    }
+                    is FormCtaExternalUrlClicked -> {
+                        Registry.log.debug(
+                            "Form Lifecycle: External URL CTA ${event.buttonLabel} -> ${event.externalUrl} from ${event.formName} (${event.formId})"
                         )
                     }
                 }

--- a/sdk/fixtures/src/main/java/com/klaviyo/fixtures/MockIntent.kt
+++ b/sdk/fixtures/src/main/java/com/klaviyo/fixtures/MockIntent.kt
@@ -23,7 +23,8 @@ data class MockIntent(
     val packageName: CapturingSlot<String> = slot(),
     val flags: CapturingSlot<Int> = slot(),
     val className: CapturingSlot<String> = slot(),
-    val bundle: Bundle = mockk<Bundle>()
+    val bundle: Bundle = mockk<Bundle>(),
+    val categories: MutableList<String> = mutableListOf()
 ) {
     companion object {
         /**
@@ -38,7 +39,7 @@ data class MockIntent(
             val mockIntent = MockIntent(mockk<Intent>(relaxed = true)).apply {
                 every { intent.addFlags(any()) } returns intent
             }
-            val (intent, action, data, packageName, flags, className, bundle) = mockIntent
+            val (intent, action, data, packageName, flags, className, bundle, categories) = mockIntent
 
             mockkConstructor(Intent::class)
 
@@ -49,7 +50,11 @@ data class MockIntent(
             every { anyConstructed<Intent>().setPackage(capture(packageName)) } returns intent
             every { anyConstructed<Intent>().setFlags(capture(flags)) } returns intent
             every { anyConstructed<Intent>().putExtras(any<Bundle>()) } returns intent
-            every { anyConstructed<Intent>().addFlags(any()) } returns intent
+            every { anyConstructed<Intent>().addFlags(capture(flags)) } returns intent
+            every { anyConstructed<Intent>().addCategory(any()) } answers {
+                categories.add(it.invocation.args[0] as String)
+                intent
+            }
             every { anyConstructed<Intent>().extras } returns bundle
             every { anyConstructed<Intent>().resolveActivity(any()) } returns mockk()
 

--- a/sdk/forms-core/src/main/java/com/klaviyo/forms/FormLifecycleEvent.kt
+++ b/sdk/forms-core/src/main/java/com/klaviyo/forms/FormLifecycleEvent.kt
@@ -60,4 +60,22 @@ sealed interface FormLifecycleEvent {
         val buttonLabel: String,
         val deepLinkUrl: Uri
     ) : FormLifecycleEvent
+
+    /**
+     * Triggered when a user taps a call-to-action (CTA) button in a form
+     * that opens an external web URL in the default browser.
+     *
+     * Fired after the SDK has dispatched the browser intent. Distinct from
+     * [FormCtaClicked] because the host app loses focus to the browser, which
+     * typically warrants different telemetry and UI handling.
+     *
+     * @property buttonLabel The text label of the CTA button.
+     * @property externalUrl The web URL opened in the default browser.
+     */
+    data class FormCtaExternalUrlClicked(
+        override val formId: String,
+        override val formName: String,
+        val buttonLabel: String,
+        val externalUrl: Uri
+    ) : FormLifecycleEvent
 }

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/KlaviyoNativeBridge.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/KlaviyoNativeBridge.kt
@@ -1,5 +1,6 @@
 package com.klaviyo.forms.bridge
 
+import android.content.Intent
 import android.net.Uri
 import android.webkit.JavascriptInterface
 import android.webkit.WebView
@@ -11,6 +12,7 @@ import com.klaviyo.analytics.Klaviyo
 import com.klaviyo.analytics.linking.DeepLinking
 import com.klaviyo.analytics.networking.ApiClient
 import com.klaviyo.core.Registry
+import com.klaviyo.core.utils.startActivityIfResolved
 import com.klaviyo.forms.FormLifecycleEvent
 import com.klaviyo.forms.FormLifecycleHandler
 import com.klaviyo.forms.bridge.NativeBridgeMessage.Abort
@@ -19,6 +21,7 @@ import com.klaviyo.forms.bridge.NativeBridgeMessage.FormWillAppear
 import com.klaviyo.forms.bridge.NativeBridgeMessage.HandShook
 import com.klaviyo.forms.bridge.NativeBridgeMessage.JsReady
 import com.klaviyo.forms.bridge.NativeBridgeMessage.OpenDeepLink
+import com.klaviyo.forms.bridge.NativeBridgeMessage.OpenExternalUrl
 import com.klaviyo.forms.bridge.NativeBridgeMessage.TrackAggregateEvent
 import com.klaviyo.forms.bridge.NativeBridgeMessage.TrackProfileEvent
 import com.klaviyo.forms.presentation.PresentationManager
@@ -73,6 +76,7 @@ internal class KlaviyoNativeBridge : NativeBridge {
                 is TrackAggregateEvent -> createAggregateEvent(bridgeMessage)
                 is TrackProfileEvent -> createProfileEvent(bridgeMessage)
                 is OpenDeepLink -> deepLink(bridgeMessage)
+                is OpenExternalUrl -> openExternalUrl(bridgeMessage)
                 is FormDisappeared -> close(bridgeMessage)
                 is Abort -> abort(bridgeMessage.reason)
             }
@@ -151,6 +155,41 @@ internal class KlaviyoNativeBridge : NativeBridge {
                 formName = message.formName,
                 buttonLabel = message.buttonLabel,
                 deepLinkUrl = deepLinkUri
+            )
+        )
+    }
+
+    /**
+     * Handle an [OpenExternalUrl] message by opening the URL in the default browser.
+     *
+     * Unlike [deepLink], the intent is not package-scoped (no `setPackage`), so the OS routes it
+     * to the default browser, bypassing any registered deep link handler — mirroring
+     * [com.klaviyo.forms.webview.KlaviyoWebViewClient.shouldOverrideUrlLoading]. The `NEW_TASK`
+     * intent launches independently of the overlay activity, so no grace period is needed.
+     * Fires [FormLifecycleEvent.FormCtaExternalUrlClicked] after dispatch.
+     */
+    private fun openExternalUrl(message: OpenExternalUrl) {
+        val externalUri = message.url.toUri()
+
+        Intent().apply {
+            data = externalUri
+            action = Intent.ACTION_VIEW
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK
+        }.startActivityIfResolved(Registry.config.applicationContext)
+
+        if (message.formId.isEmpty() || message.formName.isEmpty()) {
+            Registry.log.warning(
+                "OpenExternalUrl missing required fields, skipping lifecycle callback"
+            )
+            return
+        }
+
+        invokeFormLifecycleHandler(
+            FormLifecycleEvent.FormCtaExternalUrlClicked(
+                formId = message.formId,
+                formName = message.formName,
+                buttonLabel = message.buttonLabel,
+                externalUrl = externalUri
             )
         )
     }

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/KlaviyoNativeBridge.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/KlaviyoNativeBridge.kt
@@ -1,6 +1,5 @@
 package com.klaviyo.forms.bridge
 
-import android.content.Intent
 import android.net.Uri
 import android.webkit.JavascriptInterface
 import android.webkit.WebView
@@ -11,6 +10,7 @@ import androidx.webkit.WebViewFeature.WEB_MESSAGE_LISTENER
 import com.klaviyo.analytics.Klaviyo
 import com.klaviyo.analytics.linking.DeepLinking
 import com.klaviyo.analytics.networking.ApiClient
+import com.klaviyo.core.Constants.ALLOWED_OPEN_URL_SCHEMES
 import com.klaviyo.core.Registry
 import com.klaviyo.core.utils.startActivityIfResolved
 import com.klaviyo.forms.FormLifecycleEvent
@@ -168,12 +168,13 @@ internal class KlaviyoNativeBridge : NativeBridge {
      * intent launches independently of the overlay activity, so no grace period is needed.
      * Fires [FormLifecycleEvent.FormCtaExternalUrlClicked] after dispatch.
      *
-     * The URL's scheme is checked against [ALLOWED_OPEN_URL_SCHEMES] before dispatch — matching
-     * the allowlist gate applied to push's `open_url`/`web_url` fields (see
+     * The URL's scheme is checked against [ALLOWED_OPEN_URL_SCHEMES] before dispatch — the same
+     * allowlist gate applied to push's `open_url`/`web_url` fields (see
      * [com.klaviyo.pushFcm.KlaviyoRemoteMessage], PUSH-834) — to avoid routing dangerous or
-     * unintended URIs (e.g. `intent:`, `javascript:`, `file:`) through the SDK. Unlike push,
-     * `smsto:` is included here for both platforms since Android has a handler for it (iOS omits
-     * it only because iOS Messages has no `smsto:` handler).
+     * unintended URIs (e.g. `intent:`, `javascript:`, `file:`) through the SDK. `smsto:` is
+     * included for both platforms since Android has a handler for it (iOS omits it only because
+     * iOS Messages has no `smsto:` handler). The intent itself is built by
+     * [DeepLinking.makeExternalIntent], shared with the push `open_url` path.
      */
     private fun openExternalUrl(message: OpenExternalUrl) {
         val externalUri = message.url.toUri()
@@ -185,7 +186,9 @@ internal class KlaviyoNativeBridge : NativeBridge {
             return
         }
 
-        makeExternalIntent(externalUri).startActivityIfResolved(Registry.config.applicationContext)
+        DeepLinking.makeExternalIntent(externalUri).startActivityIfResolved(
+            Registry.config.applicationContext
+        )
 
         if (message.formId.isEmpty() || message.formName.isEmpty()) {
             Registry.log.warning(
@@ -202,29 +205,6 @@ internal class KlaviyoNativeBridge : NativeBridge {
                 externalUrl = externalUri
             )
         )
-    }
-
-    /**
-     * Create an intent to open a URI externally (browser, mail client, dialer, etc.).
-     *
-     * The action is chosen by scheme so the OS can resolve a handler reliably:
-     * [Intent.ACTION_DIAL] for `tel:`, [Intent.ACTION_SENDTO] for `mailto:`/`sms:`/`smsto:`,
-     * and [Intent.ACTION_VIEW] for web schemes. Mirrors the semantics of
-     * [com.klaviyo.analytics.linking.DeepLinking.makeExternalIntent] added for push in PUSH-834,
-     * implemented locally here since that branch is unmerged — consolidate into a shared utility
-     * once it lands.
-     */
-    private fun makeExternalIntent(uri: Uri): Intent {
-        val scheme = uri.scheme?.lowercase()
-        return Intent().apply {
-            data = uri
-            action = when (scheme) {
-                in SENDTO_SCHEMES -> Intent.ACTION_SENDTO
-                DIAL_SCHEME -> Intent.ACTION_DIAL
-                else -> Intent.ACTION_VIEW
-            }
-            flags = Intent.FLAG_ACTIVITY_NEW_TASK
-        }
     }
 
     /**
@@ -268,26 +248,5 @@ internal class KlaviyoNativeBridge : NativeBridge {
                 }
             }
         }
-    }
-
-    private companion object {
-        /**
-         * Full set of URI schemes accepted by [openExternalUrl]. Schemes outside this set are
-         * silently dropped to prevent routing dangerous or unintended URIs (e.g. `intent:`,
-         * `javascript:`, `file:`) through the SDK.
-         */
-        val ALLOWED_OPEN_URL_SCHEMES = setOf("http", "https", "mailto", "tel", "sms", "smsto")
-
-        /**
-         * Schemes that compose a message and are resolved via [Intent.ACTION_SENDTO] in
-         * [makeExternalIntent].
-         */
-        val SENDTO_SCHEMES = setOf("mailto", "sms", "smsto")
-
-        /**
-         * Scheme that opens the dialer and is resolved via [Intent.ACTION_DIAL] in
-         * [makeExternalIntent].
-         */
-        const val DIAL_SCHEME = "tel"
     }
 }

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/KlaviyoNativeBridge.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/KlaviyoNativeBridge.kt
@@ -167,9 +167,23 @@ internal class KlaviyoNativeBridge : NativeBridge {
      * [com.klaviyo.forms.webview.KlaviyoWebViewClient.shouldOverrideUrlLoading]. The `NEW_TASK`
      * intent launches independently of the overlay activity, so no grace period is needed.
      * Fires [FormLifecycleEvent.FormCtaExternalUrlClicked] after dispatch.
+     *
+     * The URL's scheme is checked against [ALLOWED_OPEN_URL_SCHEMES] before dispatch — matching
+     * the allowlist gate applied to push's `open_url`/`web_url` fields (see
+     * [com.klaviyo.pushFcm.KlaviyoRemoteMessage], PUSH-834) — to avoid routing dangerous or
+     * unintended URIs (e.g. `intent:`, `javascript:`, `file:`) through the SDK. Unlike push,
+     * `smsto:` is included here for both platforms since Android has a handler for it (iOS omits
+     * it only because iOS Messages has no `smsto:` handler).
      */
     private fun openExternalUrl(message: OpenExternalUrl) {
         val externalUri = message.url.toUri()
+
+        if (externalUri.scheme?.lowercase() !in ALLOWED_OPEN_URL_SCHEMES) {
+            Registry.log.warning(
+                "openExternalUrl url '$externalUri' has a scheme not in the allowed list; ignoring."
+            )
+            return
+        }
 
         Intent().apply {
             data = externalUri
@@ -235,5 +249,14 @@ internal class KlaviyoNativeBridge : NativeBridge {
                 }
             }
         }
+    }
+
+    private companion object {
+        /**
+         * Full set of URI schemes accepted by [openExternalUrl]. Schemes outside this set are
+         * silently dropped to prevent routing dangerous or unintended URIs (e.g. `intent:`,
+         * `javascript:`, `file:`) through the SDK.
+         */
+        val ALLOWED_OPEN_URL_SCHEMES = setOf("http", "https", "mailto", "tel", "sms", "smsto")
     }
 }

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/KlaviyoNativeBridge.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/KlaviyoNativeBridge.kt
@@ -185,11 +185,7 @@ internal class KlaviyoNativeBridge : NativeBridge {
             return
         }
 
-        Intent().apply {
-            data = externalUri
-            action = Intent.ACTION_VIEW
-            flags = Intent.FLAG_ACTIVITY_NEW_TASK
-        }.startActivityIfResolved(Registry.config.applicationContext)
+        makeExternalIntent(externalUri).startActivityIfResolved(Registry.config.applicationContext)
 
         if (message.formId.isEmpty() || message.formName.isEmpty()) {
             Registry.log.warning(
@@ -206,6 +202,29 @@ internal class KlaviyoNativeBridge : NativeBridge {
                 externalUrl = externalUri
             )
         )
+    }
+
+    /**
+     * Create an intent to open a URI externally (browser, mail client, dialer, etc.).
+     *
+     * The action is chosen by scheme so the OS can resolve a handler reliably:
+     * [Intent.ACTION_DIAL] for `tel:`, [Intent.ACTION_SENDTO] for `mailto:`/`sms:`/`smsto:`,
+     * and [Intent.ACTION_VIEW] for web schemes. Mirrors the semantics of
+     * [com.klaviyo.analytics.linking.DeepLinking.makeExternalIntent] added for push in PUSH-834,
+     * implemented locally here since that branch is unmerged — consolidate into a shared utility
+     * once it lands.
+     */
+    private fun makeExternalIntent(uri: Uri): Intent {
+        val scheme = uri.scheme?.lowercase()
+        return Intent().apply {
+            data = uri
+            action = when (scheme) {
+                in SENDTO_SCHEMES -> Intent.ACTION_SENDTO
+                DIAL_SCHEME -> Intent.ACTION_DIAL
+                else -> Intent.ACTION_VIEW
+            }
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK
+        }
     }
 
     /**
@@ -258,5 +277,17 @@ internal class KlaviyoNativeBridge : NativeBridge {
          * `javascript:`, `file:`) through the SDK.
          */
         val ALLOWED_OPEN_URL_SCHEMES = setOf("http", "https", "mailto", "tel", "sms", "smsto")
+
+        /**
+         * Schemes that compose a message and are resolved via [Intent.ACTION_SENDTO] in
+         * [makeExternalIntent].
+         */
+        val SENDTO_SCHEMES = setOf("mailto", "sms", "smsto")
+
+        /**
+         * Scheme that opens the dialer and is resolved via [Intent.ACTION_DIAL] in
+         * [makeExternalIntent].
+         */
+        const val DIAL_SCHEME = "tel"
     }
 }

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/NativeBridgeMessage.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/NativeBridgeMessage.kt
@@ -73,6 +73,24 @@ internal sealed class NativeBridgeMessage {
     ) : NativeBridgeMessage()
 
     /**
+     * Sent from the onsite-in-app-forms when a CTA opens an external URL in the default browser.
+     *
+     * Unlike [OpenDeepLink], this routes to the default browser (no host-app package scoping)
+     * rather than through any registered deep link handler.
+     *
+     * @param url The web URL to open in the default browser
+     * @param formId The form ID of the form that triggered the action
+     * @param formName The name of the form that triggered the action
+     * @param buttonLabel The text label of the CTA button that was clicked
+     */
+    data class OpenExternalUrl(
+        val url: String,
+        val formId: FormId,
+        val formName: String,
+        val buttonLabel: String
+    ) : NativeBridgeMessage()
+
+    /**
      * Sent from the onsite-in-app-forms when a form is closed as a signal to dismiss the webview
      *
      * @param formId The form ID of the form that is disappearing
@@ -111,6 +129,7 @@ internal sealed class NativeBridgeMessage {
                 HandshakeSpec(keyName<TrackProfileEvent>(), 1),
                 // Version 2 issues deep link after closing the form (v1 was before close, causing a timing issue)
                 HandshakeSpec(keyName<OpenDeepLink>(), 2),
+                HandshakeSpec(keyName<OpenExternalUrl>(), 1),
                 HandshakeSpec(keyName<FormDisappeared>(), 1),
                 HandshakeSpec(keyName<Abort>(), 1)
             )
@@ -149,6 +168,15 @@ internal sealed class NativeBridgeMessage {
 
                 keyName<OpenDeepLink>() -> OpenDeepLink(
                     route = jsonData.getDeepLink(),
+                    formId = jsonData.optString("formId"),
+                    formName = jsonData.optString("formName"),
+                    buttonLabel = jsonData.optString("buttonLabel")
+                )
+
+                keyName<OpenExternalUrl>() -> OpenExternalUrl(
+                    url = jsonData.optString("url").ifEmpty {
+                        throw IllegalStateException("openExternalUrl message missing url")
+                    },
                     formId = jsonData.optString("formId"),
                     formName = jsonData.optString("formName"),
                     buttonLabel = jsonData.optString("buttonLabel")

--- a/sdk/forms/src/test/java/com/klaviyo/forms/InAppFormsJavaApiTest.java
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/InAppFormsJavaApiTest.java
@@ -103,4 +103,21 @@ public class InAppFormsJavaApiTest extends BaseTest {
     public void testKlaviyoFormsUnregisterLifecycleHandler() {
         KlaviyoForms.unregisterFormLifecycleHandler();
     }
+
+    @Test
+    public void testFormCtaExternalUrlClickedAccessibleFromJava() {
+        // Confirms the new lifecycle case and its getters (including the Uri-typed
+        // externalUrl) are reachable from Java in a FormLifecycleHandler lambda.
+        FormLifecycleHandler callback = (event) -> {
+            if (event instanceof FormLifecycleEvent.FormCtaExternalUrlClicked) {
+                FormLifecycleEvent.FormCtaExternalUrlClicked externalUrlClicked =
+                        (FormLifecycleEvent.FormCtaExternalUrlClicked) event;
+                String ignored = externalUrlClicked.getButtonLabel()
+                        + externalUrlClicked.getExternalUrl().toString()
+                        + externalUrlClicked.getFormId()
+                        + externalUrlClicked.getFormName();
+            }
+        };
+        KlaviyoForms.registerFormLifecycleHandler(callback);
+    }
 }

--- a/sdk/forms/src/test/java/com/klaviyo/forms/bridge/KlaviyoNativeBridgeTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/bridge/KlaviyoNativeBridgeTest.kt
@@ -29,6 +29,7 @@ import io.mockk.mockkStatic
 import io.mockk.runs
 import io.mockk.slot
 import io.mockk.unmockkAll
+import io.mockk.unmockkConstructor
 import io.mockk.verify
 import org.json.JSONException
 import org.json.JSONObject
@@ -422,6 +423,7 @@ internal class KlaviyoNativeBridgeTest : BaseTest() {
          */
         mockkObject(DeepLinking)
         every { mockContext.startActivity(any()) } just runs
+        every { mockUri.scheme } returns "https"
         val mockIntent = MockIntent.setupIntentMocking()
 
         val events = mutableListOf<FormLifecycleEvent>()
@@ -452,6 +454,7 @@ internal class KlaviyoNativeBridgeTest : BaseTest() {
         val message = """{"type":"openExternalUrl","data":{"url":"https://example.com","formName":"Test Form","buttonLabel":"Visit"}}"""
 
         every { mockContext.startActivity(any()) } just runs
+        every { mockUri.scheme } returns "https"
         val mockIntent = MockIntent.setupIntentMocking()
 
         val mockLifecycleHandler = mockk<FormLifecycleHandler>(relaxed = true)
@@ -464,6 +467,70 @@ internal class KlaviyoNativeBridgeTest : BaseTest() {
         verify { spyLog.warning(any()) }
 
         Registry.unregister<FormLifecycleHandler>()
+    }
+
+    @Test
+    fun `openExternalUrl dispatches for every allowlisted scheme and fires lifecycle callback`() {
+        val allowedSchemes = listOf("http", "https", "mailto", "tel", "sms", "smsto")
+
+        for (scheme in allowedSchemes) {
+            every { mockContext.startActivity(any()) } just runs
+            every { mockUri.scheme } returns scheme
+            val mockIntent = MockIntent.setupIntentMocking()
+
+            val events = mutableListOf<FormLifecycleEvent>()
+            val callback = FormLifecycleHandler { event -> events.add(event) }
+            Registry.register<FormLifecycleHandler>(callback)
+
+            postMessage(openExternalUrlMessage)
+
+            assertEquals(
+                "Expected intent to be dispatched for scheme $scheme",
+                Intent.ACTION_VIEW,
+                mockIntent.action.captured
+            )
+            assertEquals(
+                "Expected lifecycle callback to fire for scheme $scheme",
+                1,
+                events.size
+            )
+            assertEquals(
+                scheme,
+                (events[0] as FormLifecycleEvent.FormCtaExternalUrlClicked).externalUrl.scheme
+            )
+
+            Registry.unregister<FormLifecycleHandler>()
+            unmockkConstructor(Intent::class)
+        }
+    }
+
+    @Test
+    fun `openExternalUrl silently drops every disallowed scheme without intent or lifecycle callback`() {
+        val blockedSchemes = listOf("javascript", "intent", "android-app", "file", "data", "ftp")
+
+        for (scheme in blockedSchemes) {
+            every { mockUri.scheme } returns scheme
+            val mockIntent = MockIntent.setupIntentMocking()
+
+            val mockLifecycleHandler = mockk<FormLifecycleHandler>(relaxed = true)
+            Registry.register<FormLifecycleHandler>(mockLifecycleHandler)
+
+            postMessage(openExternalUrlMessage)
+
+            verify(exactly = 0) {
+                mockContext.startActivity(any())
+            }
+            assertEquals(
+                "Expected no intent action to be set for blocked scheme $scheme",
+                false,
+                mockIntent.action.isCaptured
+            )
+            verify(exactly = 0) { mockLifecycleHandler.onFormLifecycleEvent(any()) }
+            verify { spyLog.warning(any()) }
+
+            Registry.unregister<FormLifecycleHandler>()
+            unmockkConstructor(Intent::class)
+        }
     }
 
     @Test

--- a/sdk/forms/src/test/java/com/klaviyo/forms/bridge/KlaviyoNativeBridgeTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/bridge/KlaviyoNativeBridgeTest.kt
@@ -1,5 +1,6 @@
 package com.klaviyo.forms.bridge
 
+import android.content.Intent
 import android.net.Uri
 import androidx.webkit.WebMessageCompat
 import com.klaviyo.analytics.Klaviyo
@@ -11,6 +12,7 @@ import com.klaviyo.analytics.networking.requests.AggregateEventPayload
 import com.klaviyo.analytics.state.State
 import com.klaviyo.core.Registry
 import com.klaviyo.fixtures.BaseTest
+import com.klaviyo.fixtures.MockIntent
 import com.klaviyo.fixtures.mockDeviceProperties
 import com.klaviyo.fixtures.unmockDeviceProperties
 import com.klaviyo.forms.FormLifecycleEvent
@@ -20,9 +22,11 @@ import com.klaviyo.forms.presentation.PresentationState
 import com.klaviyo.forms.unregisterFromInAppForms
 import com.klaviyo.forms.webview.WebViewClient
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.mockkStatic
+import io.mockk.runs
 import io.mockk.slot
 import io.mockk.unmockkAll
 import io.mockk.verify
@@ -395,6 +399,69 @@ internal class KlaviyoNativeBridgeTest : BaseTest() {
         assertEquals("My Form", ctaEvent.formName)
         assertEquals("abc", ctaEvent.formId)
         assertEquals(mockUri, ctaEvent.deepLinkUrl)
+
+        Registry.unregister<FormLifecycleHandler>()
+    }
+
+    private val openExternalUrlMessage = """
+        {
+          "type": "openExternalUrl",
+          "data": {
+            "url": "https://example.com",
+            "formId": "64CjgW",
+            "formName": "Test Form",
+            "buttonLabel": "Visit Site"
+          }
+        }
+    """.trimIndent()
+
+    @Test
+    fun `openExternalUrl launches browser intent without package and fires lifecycle callback`() {
+        /**
+         * @see com.klaviyo.forms.bridge.KlaviyoNativeBridge.openExternalUrl
+         */
+        mockkObject(DeepLinking)
+        every { mockContext.startActivity(any()) } just runs
+        val mockIntent = MockIntent.setupIntentMocking()
+
+        val events = mutableListOf<FormLifecycleEvent>()
+        val callback = FormLifecycleHandler { event -> events.add(event) }
+        Registry.register<FormLifecycleHandler>(callback)
+
+        postMessage(openExternalUrlMessage)
+
+        // Browser intent: ACTION_VIEW with no setPackage, so the OS routes to the default browser
+        assertEquals(Intent.ACTION_VIEW, mockIntent.action.captured)
+        assertEquals(mockUri, mockIntent.data.captured)
+        assertEquals(Intent.FLAG_ACTIVITY_NEW_TASK, mockIntent.flags.captured)
+        assertEquals(false, mockIntent.packageName.isCaptured)
+        verify(exactly = 0) { DeepLinking.handleDeepLink(any<Uri>()) }
+
+        assertEquals(1, events.size)
+        val ctaEvent = events[0] as FormLifecycleEvent.FormCtaExternalUrlClicked
+        assertEquals("64CjgW", ctaEvent.formId)
+        assertEquals("Test Form", ctaEvent.formName)
+        assertEquals("Visit Site", ctaEvent.buttonLabel)
+        assertEquals(mockUri, ctaEvent.externalUrl)
+
+        Registry.unregister<FormLifecycleHandler>()
+    }
+
+    @Test
+    fun `openExternalUrl with missing formId still navigates but skips lifecycle callback`() {
+        val message = """{"type":"openExternalUrl","data":{"url":"https://example.com","formName":"Test Form","buttonLabel":"Visit"}}"""
+
+        every { mockContext.startActivity(any()) } just runs
+        val mockIntent = MockIntent.setupIntentMocking()
+
+        val mockLifecycleHandler = mockk<FormLifecycleHandler>(relaxed = true)
+        Registry.register<FormLifecycleHandler>(mockLifecycleHandler)
+
+        postMessage(message)
+
+        assertEquals(Intent.ACTION_VIEW, mockIntent.action.captured)
+        verify(exactly = 0) { mockLifecycleHandler.onFormLifecycleEvent(any()) }
+        verify { spyLog.warning(any()) }
 
         Registry.unregister<FormLifecycleHandler>()
     }

--- a/sdk/forms/src/test/java/com/klaviyo/forms/bridge/KlaviyoNativeBridgeTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/bridge/KlaviyoNativeBridgeTest.kt
@@ -471,9 +471,16 @@ internal class KlaviyoNativeBridgeTest : BaseTest() {
 
     @Test
     fun `openExternalUrl dispatches for every allowlisted scheme and fires lifecycle callback`() {
-        val allowedSchemes = listOf("http", "https", "mailto", "tel", "sms", "smsto")
+        val schemeToExpectedAction = mapOf(
+            "http" to Intent.ACTION_VIEW,
+            "https" to Intent.ACTION_VIEW,
+            "mailto" to Intent.ACTION_SENDTO,
+            "tel" to Intent.ACTION_DIAL,
+            "sms" to Intent.ACTION_SENDTO,
+            "smsto" to Intent.ACTION_SENDTO
+        )
 
-        for (scheme in allowedSchemes) {
+        for ((scheme, expectedAction) in schemeToExpectedAction) {
             every { mockContext.startActivity(any()) } just runs
             every { mockUri.scheme } returns scheme
             val mockIntent = MockIntent.setupIntentMocking()
@@ -485,8 +492,8 @@ internal class KlaviyoNativeBridgeTest : BaseTest() {
             postMessage(openExternalUrlMessage)
 
             assertEquals(
-                "Expected intent to be dispatched for scheme $scheme",
-                Intent.ACTION_VIEW,
+                "Expected intent action $expectedAction to be dispatched for scheme $scheme",
+                expectedAction,
                 mockIntent.action.captured
             )
             assertEquals(

--- a/sdk/forms/src/test/java/com/klaviyo/forms/bridge/KlaviyoNativeBridgeTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/bridge/KlaviyoNativeBridgeTest.kt
@@ -68,6 +68,7 @@ internal class KlaviyoNativeBridgeTest : BaseTest() {
 
         mockkStatic(Uri::class)
         every { Uri.parse(any()) } returns mockUri
+        every { mockUri.normalizeScheme() } returns mockUri
 
         bridgeMessageHandler = KlaviyoNativeBridge()
     }
@@ -421,7 +422,6 @@ internal class KlaviyoNativeBridgeTest : BaseTest() {
         /**
          * @see com.klaviyo.forms.bridge.KlaviyoNativeBridge.openExternalUrl
          */
-        mockkObject(DeepLinking)
         every { mockContext.startActivity(any()) } just runs
         every { mockUri.scheme } returns "https"
         val mockIntent = MockIntent.setupIntentMocking()
@@ -436,8 +436,10 @@ internal class KlaviyoNativeBridgeTest : BaseTest() {
         assertEquals(Intent.ACTION_VIEW, mockIntent.action.captured)
         assertEquals(mockUri, mockIntent.data.captured)
         assertEquals(Intent.FLAG_ACTIVITY_NEW_TASK, mockIntent.flags.captured)
+        // No setPackage call was ever captured, confirming this never routed through
+        // DeepLinking.handleDeepLink's package-scoped intent path
         assertEquals(false, mockIntent.packageName.isCaptured)
-        verify(exactly = 0) { DeepLinking.handleDeepLink(any<Uri>()) }
+        assertEquals(listOf(Intent.CATEGORY_BROWSABLE), mockIntent.categories)
 
         assertEquals(1, events.size)
         val ctaEvent = events[0] as FormLifecycleEvent.FormCtaExternalUrlClicked
@@ -479,6 +481,7 @@ internal class KlaviyoNativeBridgeTest : BaseTest() {
             "sms" to Intent.ACTION_SENDTO,
             "smsto" to Intent.ACTION_SENDTO
         )
+        val webSchemes = setOf("http", "https")
 
         for ((scheme, expectedAction) in schemeToExpectedAction) {
             every { mockContext.startActivity(any()) } just runs
@@ -495,6 +498,11 @@ internal class KlaviyoNativeBridgeTest : BaseTest() {
                 "Expected intent action $expectedAction to be dispatched for scheme $scheme",
                 expectedAction,
                 mockIntent.action.captured
+            )
+            assertEquals(
+                "Expected CATEGORY_BROWSABLE only for web scheme $scheme",
+                scheme in webSchemes,
+                Intent.CATEGORY_BROWSABLE in mockIntent.categories
             )
             assertEquals(
                 "Expected lifecycle callback to fire for scheme $scheme",

--- a/sdk/forms/src/test/java/com/klaviyo/forms/bridge/NativeBridgeMessageTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/bridge/NativeBridgeMessageTest.kt
@@ -363,6 +363,64 @@ class NativeBridgeMessageTest : BaseTest() {
     }
 
     @Test
+    fun `test openExternalUrl decoding`() {
+        val message = """
+            {
+              "type": "openExternalUrl",
+              "data": {
+                "url": "https://example.com",
+                "formId": "abc123",
+                "formName": "Test Form",
+                "buttonLabel": "Visit Site"
+              }
+            }
+        """.trimIndent()
+
+        val result = NativeBridgeMessage.decodeWebviewMessage(message) as NativeBridgeMessage.OpenExternalUrl
+
+        assertEquals("https://example.com", result.url)
+        assertEquals("abc123", result.formId)
+        assertEquals("Test Form", result.formName)
+        assertEquals("Visit Site", result.buttonLabel)
+    }
+
+    @Test
+    fun `openExternalUrl without metadata fields parses with empty defaults`() {
+        val message = """
+            {
+              "type": "openExternalUrl",
+              "data": {
+                "url": "https://example.com"
+              }
+            }
+        """.trimIndent()
+
+        val result = NativeBridgeMessage.decodeWebviewMessage(message) as NativeBridgeMessage.OpenExternalUrl
+        assertEquals("https://example.com", result.url)
+        assertEquals("", result.formId)
+        assertEquals("", result.formName)
+        assertEquals("", result.buttonLabel)
+    }
+
+    @Test
+    fun `openExternalUrl with missing url throws`() {
+        val message = """
+            {
+              "type": "openExternalUrl",
+              "data": {
+                "formId": "abc123",
+                "formName": "Test Form",
+                "buttonLabel": "Visit Site"
+              }
+            }
+        """.trimIndent()
+
+        assertThrows(IllegalStateException::class.java) {
+            NativeBridgeMessage.decodeWebviewMessage(message)
+        }
+    }
+
+    @Test
     fun `abort message parses a reason, or falls back on unknown`() {
         val deeplinkMessage = """
             {
@@ -428,6 +486,10 @@ class NativeBridgeMessageTest : BaseTest() {
                   {
                     "type": "openDeepLink",
                     "version": 2
+                  },
+                  {
+                    "type": "openExternalUrl",
+                    "version": 1
                   },
                   {
                     "type": "formDisappeared",


### PR DESCRIPTION
# Description
Handle the IAF `openExternalUrl` native bridge event so in-app form CTAs with external/web URLs open in the default browser instead of routing through the deep link handler. Surfaces a new `FormCtaExternalUrlClicked` lifecycle event. Resolves PUSH-733.

Tested on emulator and validated that external url buttons work in in-app forms
## Due Diligence
- [x] I have tested this on an emulator and/or a physical device.
  - Unit tests pass. **Full end-to-end QA is now complete** (previously gated on the fender-side emitter — see the 2026-07-08 update below): live-validated against a real Fender dev server, local Django, the fender `push-634` companion branch, and a real emulator across `mailto:`, `tel:`, and `javascript:` (rejected).
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all Android versions the SDK currently supports.

## Release/Versioning Considerations
- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [x] `Minor` Contains changes to the public API.
  - Adds `FormLifecycleEvent.FormCtaExternalUrlClicked`. **No version bump in this PR** — versioning to be assigned at release time.
- [ ] `Major` Contains **breaking** changes.
- [x] Contains readme or migration guide changes.
  - README documents the new lifecycle event. Since it describes an unreleased API, consider merging to a feature/docs branch so docs only go live on release (currently targeting `master` per request).
- [x] This is planned work for an upcoming release.

## Changelog / Code Overview
Self-contained on `master` — **not** dependent on PUSH-637 / `feat/push-trampoline`. Rather than a new `DeepLinking` browser-intent helper, this reuses the existing external-browser intent pattern already in `KlaviyoWebViewClient.shouldOverrideUrlLoading` (`ACTION_VIEW` + `FLAG_ACTIVITY_NEW_TASK`, no `setPackage`).

- `NativeBridgeMessage.kt` — new `OpenExternalUrl` message, decode branch (required `url`), and handshake spec `openExternalUrl` v1 (permits KlaviyoJS to emit it).
- `KlaviyoNativeBridge.kt` — dispatch branch + `openExternalUrl()` handler: opens the browser, then fires `FormCtaExternalUrlClicked` (skips the callback with a warning if `formId`/`formName` are missing). Never touches `DeepLinking`, so existing `openDeepLink` behavior is unchanged.
- `FormLifecycleEvent.kt` — new public `FormCtaExternalUrlClicked(formId, formName, buttonLabel, externalUrl: Uri)` case.
- `README.md` — documents the new event (Kotlin + Java).
- `SampleApplication.kt` — wires the new event into the sample's lifecycle handler.
- Tests: decode + handshake (`NativeBridgeMessageTest`), handler intent + lifecycle + edge cases (`KlaviyoNativeBridgeTest`), Java interop (`InAppFormsJavaApiTest`).

## Update (2026-07-08): scheme allowlist + scheme-specific intent actions

Two follow-up commits extend `openExternalUrl` to match `klaviyo-swift-sdk` PR #623 and achieve parity with the (unmerged) Android push fix in `timmorrill/push-834-handle-non-web-url-schemes` (PUSH-834):

- **`86cd7faa1` — Scheme allowlist gate.** `openExternalUrl` now validates the URL's scheme against an allowlist (`http`, `https`, `mailto`, `tel`, `sms`, `smsto`) before dispatch. Disallowed schemes (`javascript:`, `intent:`, `file:`, `data:`, etc.) are dropped silently with a warning log and never fire `FormCtaExternalUrlClicked`. `smsto` is included per PUSH-834's Android-specific note (Android has a handler for it; iOS omits it only because iOS Messages has no `smsto:` handler).
- **`0b82d48ca` — Scheme-specific intent actions.** `openExternalUrl` now dispatches `ACTION_DIAL` for `tel:`, `ACTION_SENDTO` for `mailto:`/`sms:`/`smsto:`, and `ACTION_VIEW` for `http`/`https` (previously always `ACTION_VIEW`), plus adds the matching `<queries>` declarations to `sdk/core`'s manifest — required so `resolveActivity()` can see the dialer/SMS/mail handlers under Android 11+ package visibility (without this, `tel:`/`mailto:`/etc. silently fail to resolve even when a handler app is installed).

Both changes mirror — and are structured to consolidate cleanly with, once merged — PUSH-834's `DeepLinking`/`KlaviyoRemoteMessage` implementation for push's `open_url`/`web_url` fields: same scheme sets, and the manifest `<queries>` addition is byte-for-byte identical to PUSH-834's, so the two branches will merge without conflict.

**Live-validated end-to-end on a real emulator**, against the real Fender dev server + local Django + fender's `push-634` companion branch (which required a matching `openWebUrl` → `openExternalUrl` rename on the JS side to interoperate with this PR — done and verified):
- `mailto:` → allowlist passes, Gmail opens via `ACTION_SENDTO`, `FormCtaExternalUrlClicked` fires with the correct data.
- `tel:` → allowlist passes, Dialer opens with the number pre-filled via `ACTION_DIAL`, lifecycle event fires.
- `javascript:` → allowlist rejects it: warning logged, zero intent dispatch, zero lifecycle event, no crash.

## Test Plan
1. `./gradlew ktlintCheck` — clean.
2. `./gradlew :sdk:forms:testDebugUnitTest --tests "com.klaviyo.forms.bridge.NativeBridgeMessageTest" --tests "com.klaviyo.forms.bridge.KlaviyoNativeBridgeTest" --tests "com.klaviyo.forms.InAppFormsJavaApiTest"` — pass.
3. `./gradlew :sdk:forms:build :sdk:forms-core:build :sdk:analytics:build` — green.
4. **Manual QA — DONE (see 2026-07-08 update above):** validated against a real fender form with `mailto:`, `tel:`, and `javascript:` (rejected) CTAs. `FormCtaExternalUrlClicked` fires correctly for allowed schemes and is correctly skipped for the rejected one; existing deep-link CTAs unchanged.

> ⚠️ **Dependency (resolved for local testing, still tracks a real fender PR):** requires the fender-side change to emit `openExternalUrl` from KlaviyoJS — confirmed working against fender branch `josephzhou/push-634-iaf-open-url-runtime` (which required its own `openWebUrl` → `openExternalUrl` rename to match this PR's message type). Verify that branch (or whatever supersedes it) actually merges before this ships to production, since this SDK path is inert until it does.

## Related Issues/Tickets
- PUSH-733 (this) — split from PUSH-637 (Android push `open_url`)
- PUSH-732 — iOS parallel (`formExternalUrlClicked`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for form CTAs that open external web links in the device browser.
  * Lifecycle callbacks now include details for external-link CTA clicks, such as button label and URL.

* **Bug Fixes**
  * Restricted link handling to safe, supported URL schemes.
  * Added validation so malformed link actions are skipped and logged instead of causing issues.

* **Documentation**
  * Updated form lifecycle guidance with the new external-link CTA behavior.

* **Tests**
  * Expanded coverage for message decoding, browser launch behavior, and Java accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
