### PR TITLE
feat(forms): handle BadJWT native bridge message (MAGE-846)

### DIFF
--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/KlaviyoNativeBridge.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/KlaviyoNativeBridge.kt
@@ -14,6 +14,7 @@ import com.klaviyo.core.Registry
 import com.klaviyo.forms.FormLifecycleEvent
 import com.klaviyo.forms.FormLifecycleHandler
 import com.klaviyo.forms.bridge.NativeBridgeMessage.Abort
+import com.klaviyo.forms.bridge.NativeBridgeMessage.BadJwt
 import com.klaviyo.forms.bridge.NativeBridgeMessage.FormDisappeared
 import com.klaviyo.forms.bridge.NativeBridgeMessage.FormWillAppear
 import com.klaviyo.forms.bridge.NativeBridgeMessage.HandShook
@@ -75,6 +76,7 @@ internal class KlaviyoNativeBridge : NativeBridge {
                 is OpenDeepLink -> deepLink(bridgeMessage)
                 is FormDisappeared -> close(bridgeMessage)
                 is Abort -> abort(bridgeMessage.reason)
+                BadJwt -> badJwt()
             }
         } catch (e: Exception) {
             Registry.log.error("Failed to relay webview message: $message", e)
@@ -179,6 +181,14 @@ internal class KlaviyoNativeBridge : NativeBridge {
     private fun abort(reason: String) = Klaviyo.unregisterFromInAppForms().also {
         Registry.log.error("IAF aborted, reason: $reason")
     }
+
+    /**
+     * Handle a [BadJwt] message: the webview rejected the injected JWT (e.g. bad signature or a
+     * token that does not resolve to a profile). This is an expected outcome rather than an SDK
+     * error, so it degrades gracefully — the form continues unauthenticated — and we log at warning
+     * rather than throwing.
+     */
+    private fun badJwt() = Registry.log.warning("Webview rejected the injected JWT (BadJWT)")
 
     /**
      * Invoke the registered form lifecycle callback on the main thread, if one is registered.

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/NativeBridgeMessage.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/NativeBridgeMessage.kt
@@ -90,9 +90,25 @@ internal sealed class NativeBridgeMessage {
         val reason: String
     ) : NativeBridgeMessage()
 
+    /**
+     * Sent from the onsite-in-app-forms when it rejects an injected JWT — e.g. a bad signature, or
+     * a token that does not resolve to a profile for the account.
+     *
+     * A rejected token is a normal, expected outcome rather than an SDK error, so this is handled
+     * as a graceful no-op (logged at warning) instead of throwing.
+     */
+    data object BadJwt : NativeBridgeMessage()
+
     companion object {
         private const val MESSAGE_TYPE_KEY = HandshakeSpec.SPEC_TYPE_KEY
         private const val MESSAGE_DATA_KEY = "data"
+
+        /**
+         * Wire type for [BadJwt]. Fender sends this in PascalCase ("BadJWT"), which does not follow
+         * the lower-camelCase [keyName] convention used by the other message types, so it is matched
+         * against this literal instead.
+         */
+        private const val BAD_JWT_TYPE = "BadJWT"
 
         /**
          * Convert a [NativeBridgeMessage] subclass to its "type" by convention (lower camel case)
@@ -162,6 +178,8 @@ internal sealed class NativeBridgeMessage {
                 keyName<Abort>() -> Abort(
                     reason = jsonData.optString("reason").ifEmpty { "Unknown" }
                 )
+
+                BAD_JWT_TYPE -> BadJwt
 
                 else -> throw IllegalStateException("Unrecognized message type $type")
             }

--- a/sdk/forms/src/test/java/com/klaviyo/forms/bridge/KlaviyoNativeBridgeTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/bridge/KlaviyoNativeBridgeTest.kt
@@ -453,6 +453,19 @@ internal class KlaviyoNativeBridgeTest : BaseTest() {
     }
 
     @Test
+    fun `BadJWT logs a warning and does not throw`() {
+        /**
+         * A rejected JWT is a normal outcome, so it should degrade gracefully rather than
+         * hitting the error-level catch block.
+         *
+         * @see com.klaviyo.forms.bridge.KlaviyoNativeBridge.badJwt
+         */
+        postMessage("""{"type":"BadJWT","data":{}}""")
+        verify { spyLog.warning(any()) }
+        verify(exactly = 0) { spyLog.error(any(), any<Throwable>()) }
+    }
+
+    @Test
     fun `malformed message throws an error`() {
         postMessage("sawr a warewolf with a chinese menu inhis hands")
         verify { spyLog.error(any(), any<JSONException>()) }

--- a/sdk/forms/src/test/java/com/klaviyo/forms/bridge/KlaviyoNativeBridgeTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/bridge/KlaviyoNativeBridgeTest.kt
@@ -454,12 +454,8 @@ internal class KlaviyoNativeBridgeTest : BaseTest() {
 
     @Test
     fun `BadJWT logs a warning and does not throw`() {
-        /**
-         * A rejected JWT is a normal outcome, so it should degrade gracefully rather than
-         * hitting the error-level catch block.
-         *
-         * @see com.klaviyo.forms.bridge.KlaviyoNativeBridge.badJwt
-         */
+        // A rejected JWT is a normal outcome, so it should degrade gracefully rather than
+        // hitting the error-level catch block. See KlaviyoNativeBridge.badJwt.
         postMessage("""{"type":"BadJWT","data":{}}""")
         verify { spyLog.warning(any()) }
         verify(exactly = 0) { spyLog.error(any(), any<Throwable>()) }

--- a/sdk/forms/src/test/java/com/klaviyo/forms/bridge/NativeBridgeMessageTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/bridge/NativeBridgeMessageTest.kt
@@ -390,6 +390,28 @@ class NativeBridgeMessageTest : BaseTest() {
     }
 
     @Test
+    fun `test decodeWebviewMessage decodes BadJWT type`() {
+        val badJwtMessage = """{"type": "BadJWT", "data": {}}"""
+
+        assertEquals(
+            NativeBridgeMessage.BadJwt,
+            NativeBridgeMessage.decodeWebviewMessage(badJwtMessage)
+        )
+    }
+
+    @Test
+    fun `test decodeWebviewMessage BadJWT match is case-sensitive`() {
+        // Fender sends the exact PascalCase "BadJWT" wire type, which deliberately breaks the
+        // lower-camelCase keyName convention. A differently-cased variant must fall through to the
+        // unrecognized-type branch rather than silently matching.
+        listOf("badJWT", "badJwt", "BADJWT").forEach { type ->
+            assertThrows(IllegalStateException::class.java) {
+                NativeBridgeMessage.decodeWebviewMessage("""{"type": "$type", "data": {}}""")
+            }
+        }
+    }
+
+    @Test
     fun `handshake field sends proper type`() {
         val deeplinkMessage = """
             {


### PR DESCRIPTION
# Description
Fender's forms webview posts `{"type":"BadJWT","data":{}}` over the native bridge when it rejects an injected JWT (e.g. bad signature, or a token that doesn't resolve to a profile). The Android SDK had no case for it, so it threw `IllegalStateException` which got caught and logged at **error** level — misleading, since a rejected JWT is a normal outcome. This handles it gracefully as a warning-level no-op.

## Due Diligence
- [x] I have tested this on an emulator and/or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all Android versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.
  - Part of the JWT-for-personalized-forms feature; this PR targets the `feat/jwts-for-personalized-forms` feature branch.

## Changelog / Code Overview
- **`NativeBridgeMessage.kt`** — added a `BadJwt` message type to the sealed class; `decodeWebviewMessage` now maps it instead of throwing. The wire type is PascalCase (`"BadJWT"`), which breaks the lower-camelCase `keyName` convention used by every other type, so it's matched against an explicit `BAD_JWT_TYPE` literal (documented inline).
- **`KlaviyoNativeBridge.kt`** — added the `BadJwt` branch to the dispatch `when`; `badJwt()` logs at **warning** and no-ops, matching iOS's degrade-don't-throw behavior and the repo's logging-severity guidelines.
- **Tests** — decode maps `"BadJWT"` → `BadJwt`; a case-sensitivity regression test asserts near-miss casings still throw; and a dispatch-level test asserts `BadJWT` logs a warning and does **not** hit the error-level catch.

**Not added to the handshake (`handShakeData`), by design.** Verified against fender (`onsite-in-app-forms`, MAGE-553 on master): BadJWT delivery is gated on the SDK advertising `jwtMutation` (`native/index.ts`), never on `BadJWT` itself — `postNativeMessage` does no per-type gating and nothing calls `getSpecVersion(..., 'BadJWT')`. A handshake entry would have zero effect and would force the PascalCase exception into a second location.

**Follow-up (out of scope):** `BadJwt` is currently a terminal log-only no-op — there's no host-app-facing signal or `AuthTokenManager` re-fetch path, so a rejected token leaves the form unauthenticated for the session. Worth a separate ticket alongside the wider fender-protocol audit noted in MAGE-846.

## Test Plan
- `./gradlew :sdk:forms:testDebugUnitTest --tests "com.klaviyo.forms.bridge.NativeBridgeMessageTest" --tests "com.klaviyo.forms.bridge.KlaviyoNativeBridgeTest"` — pass
- `./gradlew :sdk:forms:ktlintCheck` — pass
- Manual repro (from MAGE-846): register an auth-token provider returning a well-formed-but-unsigned JWT, trigger a personalized form; fender rejects it and posts `BadJWT`. Previously logged an error+stacktrace; now logs a single warning and the form continues unauthenticated. _(Emulator repro checkbox left unchecked pending a device pass.)_

## Related Issues/Tickets
Resolves MAGE-846

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added handling for a new bridge message indicating an invalid/rejected JWT.
  * The form bridge now logs this as a warning (not an error) and continues without crashing.
* **Tests**
  * Added unit tests confirming the new message type is decoded correctly.
  * Added coverage to ensure type matching is case-sensitive and mismatches throw as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->