### PR TITLE
fix(forms): re-inject refreshed auth token into webview (MAGE-864)

### DIFF
--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/JwtObserver.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/JwtObserver.kt
@@ -3,7 +3,9 @@ package com.klaviyo.forms.bridge
 import com.klaviyo.core.Registry
 import com.klaviyo.core.auth.AuthTokenException
 import com.klaviyo.core.auth.AuthTokenManager
+import com.klaviyo.core.auth.TokenRefreshObserver
 import com.klaviyo.core.safeLaunch
+import java.util.concurrent.atomic.AtomicLong
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
@@ -16,6 +18,10 @@ import kotlinx.coroutines.SupervisorJob
  *
  * The onsite personalization module only triggers the authenticated profile fetch when both a JWT
  * and profile identifiers are present, so the JWT must land first.
+ *
+ * Beyond the initial delivery, this observer subscribes to [AuthTokenManager.onTokenRefresh] so that
+ * a token proactively refreshed while a form is displayed is re-injected into the webview, keeping
+ * onsite from acting on a stale (eventually expired) JWT.
  */
 internal class JwtObserver : JsBridgeObserver {
 
@@ -35,6 +41,24 @@ internal class JwtObserver : JsBridgeObserver {
     private val scope = CoroutineScope(SupervisorJob() + Registry.dispatcher)
     private var fetchJob: Job? = null
 
+    /**
+     * Stable instance so it can be unregistered by reference via [AuthTokenManager.offTokenRefresh].
+     * Invoked on the manager's IO dispatcher, so it hops to the UI thread before touching the bridge.
+     */
+    private val refreshObserver: TokenRefreshObserver = { jwt -> onTokenRefreshed(jwt) }
+
+    /**
+     * Monotonic sequence assigned to each token as it becomes ready to inject. The initial one-shot
+     * fetch and the refresh stream inject on the UI thread independently, so without an ordering
+     * guard a slow initial fetch could resolve after a proactive refresh and clobber the fresher
+     * token with a stale cached one. Each injection applies only if it carries the highest sequence
+     * seen so far, so the newest token always wins regardless of UI-callback ordering.
+     */
+    private val injectionSequence = AtomicLong(0L)
+
+    /** Highest sequence applied to the webview. Only read/written on the UI thread. */
+    private var lastInjectedSequence = 0L
+
     override fun startObserver() {
         stopped = false
         val thisFetch = Any()
@@ -43,6 +67,13 @@ internal class JwtObserver : JsBridgeObserver {
             CompletableDeferred<Unit>().also { jwtReady = it }
         } else {
             jwtReady
+        }
+
+        // off-then-on guarantees a single registration across re-entrant starts (duplicate
+        // registrations would inject the refreshed token more than once).
+        Registry.get<AuthTokenManager>().apply {
+            offTokenRefresh(refreshObserver)
+            onTokenRefresh(refreshObserver)
         }
 
         fetchJob?.cancel()
@@ -61,9 +92,10 @@ internal class JwtObserver : JsBridgeObserver {
                 null
             }
 
+            val sequence = injectionSequence.incrementAndGet()
             Registry.threadHelper.runOnUiThread {
                 if (latestFetch === thisFetch && !stopped) {
-                    Registry.get<JsBridge>().jwtMutation(token ?: "")
+                    injectIfLatest(sequence, token ?: "")
                     currentJwtReady.complete(Unit)
                 }
             }
@@ -72,7 +104,34 @@ internal class JwtObserver : JsBridgeObserver {
 
     override fun stopObserver() {
         stopped = true
+        Registry.get<AuthTokenManager>().offTokenRefresh(refreshObserver)
         fetchJob?.cancel()
         fetchJob = null
+    }
+
+    /**
+     * Re-inject a proactively-refreshed token into the webview. The manager only notifies on a
+     * successful fetch, so [jwt] is always a real (non-empty) token here. Skips if the observer has
+     * been stopped to avoid touching a torn-down webview.
+     */
+    private fun onTokenRefreshed(jwt: String) {
+        val sequence = injectionSequence.incrementAndGet()
+        Registry.threadHelper.runOnUiThread {
+            if (!stopped) {
+                injectIfLatest(sequence, jwt)
+            }
+        }
+    }
+
+    /**
+     * Inject [token] only if [sequence] is newer than any already applied, so an out-of-order
+     * initial-fetch callback cannot overwrite a fresher token delivered via the refresh stream.
+     * Must be called on the UI thread, where [lastInjectedSequence] is exclusively accessed.
+     */
+    private fun injectIfLatest(sequence: Long, token: String) {
+        if (sequence > lastInjectedSequence) {
+            lastInjectedSequence = sequence
+            Registry.get<JsBridge>().jwtMutation(token)
+        }
     }
 }

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/JwtObserver.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/JwtObserver.kt
@@ -48,11 +48,13 @@ internal class JwtObserver : JsBridgeObserver {
     private val refreshObserver: TokenRefreshObserver = { jwt -> onTokenRefreshed(jwt) }
 
     /**
-     * Monotonic sequence assigned to each token as it becomes ready to inject. The initial one-shot
-     * fetch and the refresh stream inject on the UI thread independently, so without an ordering
-     * guard a slow initial fetch could resolve after a proactive refresh and clobber the fresher
-     * token with a stale cached one. Each injection applies only if it carries the highest sequence
-     * seen so far, so the newest token always wins regardless of UI-callback ordering.
+     * Monotonic sequence claimed by each token source when its injection is *requested*, not when it
+     * resolves. The initial one-shot fetch reserves its slot up front in [startObserver]; the refresh
+     * stream claims one each time it fires. Because the initial fetch takes its (lower) sequence
+     * before it awaits, a proactive refresh that lands while the fetch is still in flight always
+     * outranks it — so a slow or failed initial fetch can never clobber a fresher refreshed token.
+     * Each injection applies only if it carries the highest sequence seen so far, so the newest token
+     * always wins regardless of UI-callback ordering.
      */
     private val injectionSequence = AtomicLong(0L)
 
@@ -63,6 +65,10 @@ internal class JwtObserver : JsBridgeObserver {
         stopped = false
         val thisFetch = Any()
         latestFetch = thisFetch
+        // Reserve the initial fetch's place in the injection order now, at request time, so any
+        // refresh that fires while the fetch is still in flight outranks it. Assigning the sequence
+        // only once the token resolved let a slow or failed fetch clobber a fresher refreshed token.
+        val fetchSequence = injectionSequence.incrementAndGet()
         val currentJwtReady = if (jwtReady.isCompleted) {
             CompletableDeferred<Unit>().also { jwtReady = it }
         } else {
@@ -92,10 +98,9 @@ internal class JwtObserver : JsBridgeObserver {
                 null
             }
 
-            val sequence = injectionSequence.incrementAndGet()
             Registry.threadHelper.runOnUiThread {
                 if (latestFetch === thisFetch && !stopped) {
-                    injectIfLatest(sequence, token ?: "")
+                    injectIfLatest(fetchSequence, token ?: "")
                     currentJwtReady.complete(Unit)
                 }
             }

--- a/sdk/forms/src/test/java/com/klaviyo/forms/bridge/JwtObserverTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/bridge/JwtObserverTest.kt
@@ -3,13 +3,18 @@ package com.klaviyo.forms.bridge
 import com.klaviyo.core.Registry
 import com.klaviyo.core.auth.AuthTokenException
 import com.klaviyo.core.auth.AuthTokenManager
+import com.klaviyo.core.auth.TokenRefreshObserver
 import com.klaviyo.core.auth.ValidatedToken
 import com.klaviyo.fixtures.BaseTest
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.slot
 import io.mockk.verify
+import io.mockk.verifyOrder
 import kotlinx.coroutines.CompletableDeferred
 import org.junit.After
 import org.junit.Assert.assertFalse
@@ -32,6 +37,8 @@ class JwtObserverTest : BaseTest() {
         super.setup()
         Registry.register<AuthTokenManager>(mockAuthTokenManager)
         Registry.register<JsBridge>(mockJsBridge)
+        every { mockAuthTokenManager.onTokenRefresh(any()) } just runs
+        every { mockAuthTokenManager.offTokenRefresh(any()) } just runs
     }
 
     @After
@@ -212,5 +219,87 @@ class JwtObserverTest : BaseTest() {
 
         verify(inverse = true) { mockJsBridge.jwtMutation("stale") }
         verify(exactly = 1) { mockJsBridge.jwtMutation("fresh") }
+    }
+
+    @Test
+    fun `startObserver re-injects the token when it is proactively refreshed`() {
+        val refreshObserver = slot<TokenRefreshObserver>()
+        every { mockAuthTokenManager.onTokenRefresh(capture(refreshObserver)) } just runs
+        coEvery { mockAuthTokenManager.currentToken(any()) } returns validatedToken("initial")
+
+        val observer = JwtObserver()
+        observer.startObserver()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        refreshObserver.captured.invoke("refreshed.token")
+
+        verify(exactly = 1) { mockJsBridge.jwtMutation("initial") }
+        verify(exactly = 1) { mockJsBridge.jwtMutation("refreshed.token") }
+    }
+
+    @Test
+    fun `refresh after stopObserver does not inject the stale token`() {
+        val refreshObserver = slot<TokenRefreshObserver>()
+        every { mockAuthTokenManager.onTokenRefresh(capture(refreshObserver)) } just runs
+        coEvery { mockAuthTokenManager.currentToken(any()) } returns validatedToken("initial")
+
+        val observer = JwtObserver()
+        observer.startObserver()
+        dispatcher.scheduler.advanceUntilIdle()
+        val captured = refreshObserver.captured
+
+        observer.stopObserver()
+        captured.invoke("late.token")
+
+        verify { mockAuthTokenManager.offTokenRefresh(any()) }
+        verify(inverse = true) { mockJsBridge.jwtMutation("late.token") }
+    }
+
+    @Test
+    fun `a stale initial fetch does not clobber a token already delivered by refresh`() {
+        // Queue UI callbacks manually so the test can force the initial fetch's callback to run
+        // AFTER the refresh callback — the ordering that would let a stale cached token overwrite
+        // the fresher refreshed one without the sequence guard.
+        val uiQueue = mutableListOf<() -> Unit>()
+        every { mockThreadHelper.runOnUiThread(any()) } answers {
+            uiQueue.add(firstArg())
+        }
+
+        val refreshObserver = slot<TokenRefreshObserver>()
+        every { mockAuthTokenManager.onTokenRefresh(capture(refreshObserver)) } just runs
+        coEvery { mockAuthTokenManager.currentToken(any()) } returns validatedToken("stale-cached")
+
+        val observer = JwtObserver()
+        observer.startObserver()
+        dispatcher.scheduler.advanceUntilIdle() // initial fetch queues its UI callback (index 0)
+
+        refreshObserver.captured.invoke("fresh-refreshed") // refresh queues its callback (index 1)
+
+        // Run the refresh callback first, then the stale initial callback.
+        uiQueue[1].invoke()
+        uiQueue[0].invoke()
+
+        verify(exactly = 1) { mockJsBridge.jwtMutation("fresh-refreshed") }
+        verify(inverse = true) { mockJsBridge.jwtMutation("stale-cached") }
+        assertTrue(observer.jwtReady.isCompleted)
+    }
+
+    @Test
+    fun `startObserver deregisters before registering so the refresh observer is not duplicated`() {
+        val offObserver = slot<TokenRefreshObserver>()
+        val onObserver = slot<TokenRefreshObserver>()
+        every { mockAuthTokenManager.offTokenRefresh(capture(offObserver)) } just runs
+        every { mockAuthTokenManager.onTokenRefresh(capture(onObserver)) } just runs
+        coEvery { mockAuthTokenManager.currentToken(any()) } returns validatedToken("initial")
+
+        val observer = JwtObserver()
+        observer.startObserver()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        verifyOrder {
+            mockAuthTokenManager.offTokenRefresh(any())
+            mockAuthTokenManager.onTokenRefresh(any())
+        }
+        assertSame(offObserver.captured, onObserver.captured)
     }
 }

--- a/sdk/forms/src/test/java/com/klaviyo/forms/bridge/JwtObserverTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/bridge/JwtObserverTest.kt
@@ -6,6 +6,7 @@ import com.klaviyo.core.auth.AuthTokenManager
 import com.klaviyo.core.auth.TokenRefreshObserver
 import com.klaviyo.core.auth.ValidatedToken
 import com.klaviyo.fixtures.BaseTest
+import io.mockk.CapturingSlot
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -31,6 +32,12 @@ class JwtObserverTest : BaseTest() {
 
     private fun validatedToken(rawToken: String): ValidatedToken =
         ValidatedToken(rawToken = rawToken, expiresAtEpochSeconds = 0L, issuedAtEpochSeconds = 0L)
+
+    /** Registers a capturing [TokenRefreshObserver] so a test can drive proactive refreshes. */
+    private fun captureRefreshObserver(): CapturingSlot<TokenRefreshObserver> =
+        slot<TokenRefreshObserver>().also { slot ->
+            every { mockAuthTokenManager.onTokenRefresh(capture(slot)) } just runs
+        }
 
     @Before
     override fun setup() {
@@ -223,8 +230,7 @@ class JwtObserverTest : BaseTest() {
 
     @Test
     fun `startObserver re-injects the token when it is proactively refreshed`() {
-        val refreshObserver = slot<TokenRefreshObserver>()
-        every { mockAuthTokenManager.onTokenRefresh(capture(refreshObserver)) } just runs
+        val refreshObserver = captureRefreshObserver()
         coEvery { mockAuthTokenManager.currentToken(any()) } returns validatedToken("initial")
 
         val observer = JwtObserver()
@@ -239,8 +245,7 @@ class JwtObserverTest : BaseTest() {
 
     @Test
     fun `refresh after stopObserver does not inject the stale token`() {
-        val refreshObserver = slot<TokenRefreshObserver>()
-        every { mockAuthTokenManager.onTokenRefresh(capture(refreshObserver)) } just runs
+        val refreshObserver = captureRefreshObserver()
         coEvery { mockAuthTokenManager.currentToken(any()) } returns validatedToken("initial")
 
         val observer = JwtObserver()
@@ -265,8 +270,7 @@ class JwtObserverTest : BaseTest() {
             uiQueue.add(firstArg())
         }
 
-        val refreshObserver = slot<TokenRefreshObserver>()
-        every { mockAuthTokenManager.onTokenRefresh(capture(refreshObserver)) } just runs
+        val refreshObserver = captureRefreshObserver()
         coEvery { mockAuthTokenManager.currentToken(any()) } returns validatedToken("stale-cached")
 
         val observer = JwtObserver()
@@ -282,6 +286,30 @@ class JwtObserverTest : BaseTest() {
         verify(exactly = 1) { mockJsBridge.jwtMutation("fresh-refreshed") }
         verify(inverse = true) { mockJsBridge.jwtMutation("stale-cached") }
         assertTrue(observer.jwtReady.isCompleted)
+    }
+
+    @Test
+    fun `a failed initial fetch does not clobber a token delivered by an in-flight refresh`() {
+        // The initial fetch is still suspended when a proactive refresh delivers a fresh token.
+        // Because the fetch reserves its (lower) injection sequence at request time, its later
+        // empty-string injection is dropped rather than overwriting the fresher refreshed token.
+        val refreshObserver = captureRefreshObserver()
+        val fetchCompletion = CompletableDeferred<ValidatedToken>()
+        coEvery { mockAuthTokenManager.currentToken(any()) } coAnswers { fetchCompletion.await() }
+
+        val observer = JwtObserver()
+        observer.startObserver()
+        dispatcher.scheduler.runCurrent() // initial fetch launched and suspended on currentToken
+
+        // Refresh lands while the initial fetch is still in flight.
+        refreshObserver.captured.invoke("fresh-refreshed")
+
+        // Initial fetch then fails — its callback would inject an empty JWT.
+        fetchCompletion.completeExceptionally(AuthTokenException.ValidationFailed("Malformed"))
+        dispatcher.scheduler.advanceUntilIdle()
+
+        verify(exactly = 1) { mockJsBridge.jwtMutation("fresh-refreshed") }
+        verify(inverse = true) { mockJsBridge.jwtMutation("") }
     }
 
     @Test

--- a/sdk/forms/src/test/java/com/klaviyo/forms/bridge/ProfileMutationObserverAsyncTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/bridge/ProfileMutationObserverAsyncTest.kt
@@ -8,7 +8,9 @@ import com.klaviyo.core.auth.ValidatedToken
 import com.klaviyo.fixtures.BaseTest
 import io.mockk.coEvery
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.runs
 import io.mockk.verify
 import org.junit.After
 import org.junit.Assert.assertNotSame
@@ -111,6 +113,8 @@ class ProfileMutationObserverAsyncTest : BaseTest() {
             expiresAtEpochSeconds = 0L,
             issuedAtEpochSeconds = 0L
         )
+        every { mockAuth.onTokenRefresh(any()) } just runs
+        every { mockAuth.offTokenRefresh(any()) } just runs
         Registry.register<AuthTokenManager>(mockAuth)
         try {
             jwtObserver.startObserver()
@@ -121,6 +125,8 @@ class ProfileMutationObserverAsyncTest : BaseTest() {
             dispatcher.scheduler.advanceUntilIdle()
 
             verify(exactly = 1) { mockBridge.profileMutation(stubProfile) }
+
+            jwtObserver.stopObserver()
         } finally {
             Registry.unregister<AuthTokenManager>()
         }


### PR DESCRIPTION
# Description
In-App Forms only delivered the JWT to the webview once, at form load. When `AuthTokenManager` proactively refreshed the token while a form was displayed, the new JWT was broadcast to zero listeners and the webview kept the stale (eventually expired) token. This wires `JwtObserver` into the manager's refresh stream so refreshed tokens are re-injected.

## Due Diligence
- [ ] I have tested this on an emulator and/or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all Android versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

## Changelog / Code Overview
`JwtObserver` previously did a one-shot `currentToken()` fetch at `JsReady` and never subscribed to `AuthTokenManager.onTokenRefresh` — the refresh-observer plumbing built in MAGE-630 had no forms-side consumer.

- **Subscribe on start / unsubscribe on stop:** `startObserver()` registers a stable `TokenRefreshObserver` (via off-then-on to guarantee a single registration across re-entrant starts); `stopObserver()` deregisters it.
- **Re-inject on refresh:** the handler hops to the UI thread (the callback fires on the manager's IO dispatcher) and calls `jwtMutation` with the fresh token, guarded by the existing `stopped` flag so a late callback after teardown can't touch a torn-down webview.
- **Ordering guard:** a monotonic sequence ensures the newest token always wins, so a slow initial fetch that resolves after a proactive refresh can't clobber the fresher token with a stale cached one.
- The initial-delivery path and `jwtReady` completion are unchanged, preserving JWT-before-profile injection ordering.

## Test Plan
- `./gradlew :sdk:forms:testDebugUnitTest` — all pass (240 tests).
- `./gradlew ktlintCheck` — clean.
- New `JwtObserverTest` coverage: re-injection on refresh, no injection after `stopObserver`, off-then-on dedup, and the stale-initial-vs-fresh-refresh ordering guard.
- Not yet exercised on a device — a manual test with a short-TTL token while a form is displayed would confirm the end-to-end refresh injection.

## Related Issues/Tickets
Resolves MAGE-864
Related to MAGE-630, MAGE-849

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Proactively re-inject refreshed JWTs into the webview during an active form session.
  * Added ordering safeguards so stale initial-fetch results can’t overwrite newer refreshed tokens.
  * Strengthened shutdown by unregistering refresh callbacks and preventing in-flight stale injections.
  * Improved refresh listener setup to be idempotent and avoid duplicate registrations; suppressed empty-token injections.
* **Tests**
  * Expanded coverage for refresh-driven injection, stop behavior, delayed update ordering, and idempotent observer registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->