### PR TITLE
feat(push): automatic push token registration (MAGE-769)

### DIFF
--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -16,6 +16,7 @@ import com.klaviyo.analytics.networking.KlaviyoApiClient
 import com.klaviyo.analytics.state.KlaviyoState
 import com.klaviyo.analytics.state.State
 import com.klaviyo.analytics.state.StateSideEffects
+import com.klaviyo.core.Constants
 import com.klaviyo.core.Constants.PACKAGE_PREFIX
 import com.klaviyo.core.Constants.TRACKING_PARAMETER
 import com.klaviyo.core.Operation
@@ -113,7 +114,7 @@ object Klaviyo {
         }
 
         // Optional side effect, kept last so it can never interfere with core initialization
-        maybeRegisterPushTokenAutomatically()
+        maybeAutoRegisterPushToken()
     }
 
     /**
@@ -122,7 +123,7 @@ object Klaviyo {
      * rotations are picked up. No-op when the flag is off, when forwarding is opted out via
      * [Constants.DISABLE_AUTOMATIC_TOKEN_FORWARDING], or when `push-fcm` is absent.
      */
-    internal fun maybeRegisterPushTokenAutomatically() {
+    internal fun maybeAutoRegisterPushToken() {
         val autoTrackingEnabled = Registry.config.getManifestBoolean(
             Constants.AUTOMATIC_PUSH_TRACKING,
             false

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -19,6 +19,7 @@ import com.klaviyo.analytics.state.StateSideEffects
 import com.klaviyo.core.Constants.PACKAGE_PREFIX
 import com.klaviyo.core.Constants.TRACKING_PARAMETER
 import com.klaviyo.core.Operation
+import com.klaviyo.core.PushTokenFetcher
 import com.klaviyo.core.Registry
 import com.klaviyo.core.config.Config
 import com.klaviyo.core.config.LifecycleException
@@ -110,6 +111,43 @@ object Klaviyo {
                 preInitQueue.poll()?.let { safeCall(null, it) }
             }
         }
+
+        // Optional side effect, kept last so it can never interfere with core initialization
+        maybeRegisterPushTokenAutomatically()
+    }
+
+    /**
+     * Opt-in automatic push token registration (via [Constants.AUTOMATIC_PUSH_TRACKING]): pull the
+     * current token and forward it to Klaviyo. Called from [initialize] and on each app foreground so
+     * rotations are picked up. No-op when the flag is off, when forwarding is opted out via
+     * [Constants.DISABLE_AUTOMATIC_TOKEN_FORWARDING], or when `push-fcm` is absent.
+     */
+    internal fun maybeRegisterPushTokenAutomatically() {
+        val autoTrackingEnabled = Registry.config.getManifestBoolean(
+            Constants.AUTOMATIC_PUSH_TRACKING,
+            false
+        )
+        // Avoid a second manifest read on the common flag-off path
+        val tokenForwardingDisabled = autoTrackingEnabled && Registry.config.getManifestBoolean(
+            Constants.DISABLE_AUTOMATIC_TOKEN_FORWARDING,
+            false
+        )
+        if (!autoTrackingEnabled || tokenForwardingDisabled) {
+            Registry.log.verbose(
+                "Skipping automatic push token registration " +
+                    "(automaticPushTracking=$autoTrackingEnabled, tokenForwardingDisabled=$tokenForwardingDisabled)"
+            )
+            return
+        }
+
+        Registry.getOrNull<PushTokenFetcher>()?.also { fetcher ->
+            Registry.log.debug("Automatically fetching push token")
+            // Contain any fetcher failure so this optional side effect cannot disrupt the caller
+            runCatching { fetcher.fetchAndSetPushToken() }
+                .onFailure { Registry.log.warning("Automatic push token fetch failed", it) }
+        } ?: Registry.log.verbose(
+            "No push token fetcher registered; skipping automatic registration"
+        )
     }
 
     /**

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/state/StateSideEffects.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/state/StateSideEffects.kt
@@ -180,6 +180,8 @@ internal class StateSideEffects(
                 // Trigger the token in state to refresh overall push state, if changed
                 Klaviyo.setPushToken(it)
             }
+            // Re-pull the token on foreground so rotations while backgrounded are caught
+            Klaviyo.maybeRegisterPushTokenAutomatically()
         }
     }
 }

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/state/StateSideEffects.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/state/StateSideEffects.kt
@@ -181,7 +181,7 @@ internal class StateSideEffects(
                 Klaviyo.setPushToken(it)
             }
             // Re-pull the token on foreground so rotations while backgrounded are caught
-            Klaviyo.maybeRegisterPushTokenAutomatically()
+            Klaviyo.maybeAutoRegisterPushToken()
         }
     }
 }

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
@@ -592,9 +592,6 @@ internal class KlaviyoTest : BaseTest() {
         assertEquals(Klaviyo.getPushToken(), PUSH_TOKEN)
     }
 
-    private fun registerMockPushTokenFetcher(): PushTokenFetcher =
-        mockk<PushTokenFetcher>(relaxed = true).also { Registry.register<PushTokenFetcher>(it) }
-
     private fun setAutomaticPushTracking(enabled: Boolean) = every {
         mockConfig.getManifestBoolean(Constants.AUTOMATIC_PUSH_TRACKING, false)
     } returns enabled

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
@@ -19,6 +19,7 @@ import com.klaviyo.analytics.state.ProfileEventObserver
 import com.klaviyo.analytics.state.State
 import com.klaviyo.analytics.state.StateSideEffects
 import com.klaviyo.core.DeviceProperties
+import com.klaviyo.core.PushTokenFetcher
 import com.klaviyo.core.Registry
 import com.klaviyo.core.config.Config
 import com.klaviyo.core.config.MissingAPIKey
@@ -159,6 +160,7 @@ internal class KlaviyoTest : BaseTest() {
         Registry.unregister<State>()
         Registry.unregister<StateSideEffects>()
         Registry.unregister<ApiClient>()
+        Registry.unregister<PushTokenFetcher>()
         super.cleanup()
         Registry.unregister<Config>()
         unmockDeviceProperties()
@@ -587,6 +589,75 @@ internal class KlaviyoTest : BaseTest() {
     fun `Fetches push token from persistent store`() {
         spyDataStore.store("push_token", PUSH_TOKEN)
         assertEquals(Klaviyo.getPushToken(), PUSH_TOKEN)
+    }
+
+    private fun registerMockPushTokenFetcher(): PushTokenFetcher =
+        mockk<PushTokenFetcher>(relaxed = true).also { Registry.register<PushTokenFetcher>(it) }
+
+    private fun setAutomaticPushTracking(enabled: Boolean) = every {
+        mockConfig.getManifestBoolean(Constants.AUTOMATIC_PUSH_TRACKING, false)
+    } returns enabled
+
+    private fun setTokenForwardingDisabled(disabled: Boolean) = every {
+        mockConfig.getManifestBoolean(Constants.DISABLE_AUTOMATIC_TOKEN_FORWARDING, false)
+    } returns disabled
+
+    private fun reinitialize() =
+        Klaviyo.initialize(apiKey = API_KEY, applicationContext = mockContext)
+
+    @Test
+    fun `initialize triggers automatic push token fetch when flag is on and fetcher is registered`() {
+        val mockFetcher = registerMockPushTokenFetcher()
+        setAutomaticPushTracking(true)
+
+        reinitialize()
+
+        verify(exactly = 1) { mockFetcher.fetchAndSetPushToken() }
+    }
+
+    @Test
+    fun `initialize does not fetch push token when token forwarding is disabled`() {
+        val mockFetcher = registerMockPushTokenFetcher()
+        setAutomaticPushTracking(true)
+        setTokenForwardingDisabled(true)
+
+        reinitialize()
+
+        verify(inverse = true) { mockFetcher.fetchAndSetPushToken() }
+    }
+
+    @Test
+    fun `initialize does not fetch push token when automatic tracking flag is off`() {
+        val mockFetcher = registerMockPushTokenFetcher()
+        setAutomaticPushTracking(false)
+
+        reinitialize()
+
+        verify(inverse = true) { mockFetcher.fetchAndSetPushToken() }
+    }
+
+    @Test
+    fun `initialize does not crash and logs a warning when the push token fetch throws`() {
+        val mockFetcher = registerMockPushTokenFetcher()
+        setAutomaticPushTracking(true)
+        every { mockFetcher.fetchAndSetPushToken() } throws RuntimeException("fetch blew up")
+
+        // runCatching around the fetch must contain the failure so initialize still completes
+        reinitialize()
+
+        verify(exactly = 1) { mockFetcher.fetchAndSetPushToken() }
+        verify { spyLog.warning(any(), any()) }
+    }
+
+    @Test
+    fun `initialize does not crash when flag is on but no push token fetcher is registered`() {
+        Registry.unregister<PushTokenFetcher>()
+        setAutomaticPushTracking(true)
+
+        // push-fcm absent: lookup is null and automatic registration is a graceful no-op
+        reinitialize()
+
+        assertNull(Registry.getOrNull<PushTokenFetcher>())
     }
 
     @Test

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
@@ -18,6 +18,7 @@ import com.klaviyo.analytics.state.KlaviyoState
 import com.klaviyo.analytics.state.ProfileEventObserver
 import com.klaviyo.analytics.state.State
 import com.klaviyo.analytics.state.StateSideEffects
+import com.klaviyo.core.Constants
 import com.klaviyo.core.DeviceProperties
 import com.klaviyo.core.PushTokenFetcher
 import com.klaviyo.core.Registry

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/state/StateSideEffectsTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/state/StateSideEffectsTest.kt
@@ -12,6 +12,8 @@ import com.klaviyo.analytics.networking.requests.KlaviyoErrorResponse
 import com.klaviyo.analytics.networking.requests.KlaviyoErrorSource
 import com.klaviyo.analytics.networking.requests.ProfileApiRequest
 import com.klaviyo.analytics.networking.requests.PushTokenApiRequest
+import com.klaviyo.core.Constants
+import com.klaviyo.core.PushTokenFetcher
 import com.klaviyo.core.Registry
 import com.klaviyo.core.lifecycle.ActivityEvent
 import com.klaviyo.core.lifecycle.ActivityObserver
@@ -65,6 +67,7 @@ class StateSideEffectsTest : BaseTest() {
     @After
     override fun cleanup() {
         Registry.unregister<ApiClient>()
+        Registry.unregister<PushTokenFetcher>()
         super.cleanup()
     }
 
@@ -424,5 +427,49 @@ class StateSideEffectsTest : BaseTest() {
         capturedLifecycleObserver.captured(ActivityEvent.Resumed(mockk()))
 
         verify { stateMock.pushToken = "mocked_push_token" }
+    }
+
+    @Test
+    fun `Resumed lifecycle event re-fetches push token when automatic forwarding is enabled`() {
+        Registry.register<State>(stateMock)
+        every { stateMock.pushToken } returns "mocked_push_token"
+        every { stateMock.pushToken = any() } returns Unit
+        every { mockConfig.getManifestBoolean(Constants.AUTOMATIC_PUSH_TRACKING, false) } returns true
+        val mockFetcher = mockk<PushTokenFetcher>(relaxed = true)
+        Registry.register<PushTokenFetcher>(mockFetcher)
+        val capturedLifecycleObserver = slot<ActivityObserver>()
+        every { mockLifecycleMonitor.onActivityEvent(capture(capturedLifecycleObserver)) } returns Unit
+
+        StateSideEffects(
+            state = stateMock,
+            apiClient = apiClientMock,
+            lifecycleMonitor = mockLifecycleMonitor
+        )
+
+        capturedLifecycleObserver.captured(ActivityEvent.Resumed(mockk()))
+
+        verify(exactly = 1) { mockFetcher.fetchAndSetPushToken() }
+    }
+
+    @Test
+    fun `Resumed lifecycle event does not re-fetch push token when automatic forwarding is disabled`() {
+        Registry.register<State>(stateMock)
+        every { stateMock.pushToken } returns "mocked_push_token"
+        every { stateMock.pushToken = any() } returns Unit
+        // Automatic push tracking flag defaults to false via BaseTest's getManifestBoolean stub
+        val mockFetcher = mockk<PushTokenFetcher>(relaxed = true)
+        Registry.register<PushTokenFetcher>(mockFetcher)
+        val capturedLifecycleObserver = slot<ActivityObserver>()
+        every { mockLifecycleMonitor.onActivityEvent(capture(capturedLifecycleObserver)) } returns Unit
+
+        StateSideEffects(
+            state = stateMock,
+            apiClient = apiClientMock,
+            lifecycleMonitor = mockLifecycleMonitor
+        )
+
+        capturedLifecycleObserver.captured(ActivityEvent.Resumed(mockk()))
+
+        verify(inverse = true) { mockFetcher.fetchAndSetPushToken() }
     }
 }

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/state/StateSideEffectsTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/state/StateSideEffectsTest.kt
@@ -437,9 +437,6 @@ class StateSideEffectsTest : BaseTest() {
         verify(inverse = true) { mockFetcher.fetchAndSetPushToken() }
     }
 
-    private fun registerMockPushTokenFetcher(): PushTokenFetcher =
-        mockk<PushTokenFetcher>(relaxed = true).also { Registry.register<PushTokenFetcher>(it) }
-
     // Registers stateMock, captures the lifecycle observer via a new StateSideEffects, and fires Resumed
     private fun fireResumedEvent() {
         Registry.register<State>(stateMock)

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/state/StateSideEffectsTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/state/StateSideEffectsTest.kt
@@ -412,53 +412,39 @@ class StateSideEffectsTest : BaseTest() {
 
     @Test
     fun `Resumed lifecycle event triggers push permission refresh`() {
-        Registry.register<State>(stateMock)
-        every { stateMock.pushToken } returns "mocked_push_token"
-        every { stateMock.pushToken = any() } returns Unit
-        val capturedLifecycleObserver = slot<ActivityObserver>()
-        every { mockLifecycleMonitor.onActivityEvent(capture(capturedLifecycleObserver)) } returns Unit
-
-        StateSideEffects(
-            state = stateMock,
-            apiClient = apiClientMock,
-            lifecycleMonitor = mockLifecycleMonitor
-        )
-
-        capturedLifecycleObserver.captured(ActivityEvent.Resumed(mockk()))
+        fireResumedEvent()
 
         verify { stateMock.pushToken = "mocked_push_token" }
     }
 
     @Test
     fun `Resumed lifecycle event re-fetches push token when automatic forwarding is enabled`() {
-        Registry.register<State>(stateMock)
-        every { stateMock.pushToken } returns "mocked_push_token"
-        every { stateMock.pushToken = any() } returns Unit
         every { mockConfig.getManifestBoolean(Constants.AUTOMATIC_PUSH_TRACKING, false) } returns true
-        val mockFetcher = mockk<PushTokenFetcher>(relaxed = true)
-        Registry.register<PushTokenFetcher>(mockFetcher)
-        val capturedLifecycleObserver = slot<ActivityObserver>()
-        every { mockLifecycleMonitor.onActivityEvent(capture(capturedLifecycleObserver)) } returns Unit
+        val mockFetcher = registerMockPushTokenFetcher()
 
-        StateSideEffects(
-            state = stateMock,
-            apiClient = apiClientMock,
-            lifecycleMonitor = mockLifecycleMonitor
-        )
-
-        capturedLifecycleObserver.captured(ActivityEvent.Resumed(mockk()))
+        fireResumedEvent()
 
         verify(exactly = 1) { mockFetcher.fetchAndSetPushToken() }
     }
 
     @Test
     fun `Resumed lifecycle event does not re-fetch push token when automatic forwarding is disabled`() {
+        // Automatic push tracking flag defaults to false via BaseTest's getManifestBoolean stub
+        val mockFetcher = registerMockPushTokenFetcher()
+
+        fireResumedEvent()
+
+        verify(inverse = true) { mockFetcher.fetchAndSetPushToken() }
+    }
+
+    private fun registerMockPushTokenFetcher(): PushTokenFetcher =
+        mockk<PushTokenFetcher>(relaxed = true).also { Registry.register<PushTokenFetcher>(it) }
+
+    // Registers stateMock, captures the lifecycle observer via a new StateSideEffects, and fires Resumed
+    private fun fireResumedEvent() {
         Registry.register<State>(stateMock)
         every { stateMock.pushToken } returns "mocked_push_token"
         every { stateMock.pushToken = any() } returns Unit
-        // Automatic push tracking flag defaults to false via BaseTest's getManifestBoolean stub
-        val mockFetcher = mockk<PushTokenFetcher>(relaxed = true)
-        Registry.register<PushTokenFetcher>(mockFetcher)
         val capturedLifecycleObserver = slot<ActivityObserver>()
         every { mockLifecycleMonitor.onActivityEvent(capture(capturedLifecycleObserver)) } returns Unit
 
@@ -469,7 +455,5 @@ class StateSideEffectsTest : BaseTest() {
         )
 
         capturedLifecycleObserver.captured(ActivityEvent.Resumed(mockk()))
-
-        verify(inverse = true) { mockFetcher.fetchAndSetPushToken() }
     }
 }

--- a/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
@@ -10,8 +10,7 @@ object Constants {
     const val PACKAGE_PREFIX = "com.klaviyo."
 
     /**
-     * Prefix for push-related manifest `<meta-data>` keys, matching the existing
-     * `com.klaviyo.push.*` notification keys (e.g. default_notification_icon).
+     * Prefix for push-related manifest `<meta-data>` keys.
      */
     const val PUSH_PREFIX = PACKAGE_PREFIX + "push."
 

--- a/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
@@ -10,6 +10,12 @@ object Constants {
     const val PACKAGE_PREFIX = "com.klaviyo."
 
     /**
+     * Prefix for push-related manifest `<meta-data>` keys, matching the existing
+     * `com.klaviyo.push.*` notification keys (e.g. default_notification_icon).
+     */
+    const val PUSH_PREFIX = PACKAGE_PREFIX + "push."
+
+    /**
      * Key-value pairs get special treatment in a few places across multiple packages
      */
     const val KEY_VALUE_PAIRS = "key_value_pairs"
@@ -43,14 +49,14 @@ object Constants {
      * Lives in core (not push-fcm) because telemetry's push token request must read it, and core
      * cannot depend on push-fcm.
      */
-    const val AUTOMATIC_PUSH_TRACKING = PACKAGE_PREFIX + "automatic_push_tracking"
+    const val AUTOMATIC_PUSH_TRACKING = PUSH_PREFIX + "automatic_push_tracking"
 
     /**
      * Manifest `<meta-data>` boolean to opt out of automatic push token forwarding while keeping
      * automatic open tracking. Only consulted when [AUTOMATIC_PUSH_TRACKING] is `true`; defaults to
      * `false`. For hosts that own their own push-token pipeline.
      */
-    const val DISABLE_AUTOMATIC_TOKEN_FORWARDING = PACKAGE_PREFIX + "disable_automatic_token_forwarding"
+    const val DISABLE_AUTOMATIC_TOKEN_FORWARDING = PUSH_PREFIX + "disable_automatic_token_forwarding"
 
     /**
      * Fixed notification ID used in all notify/cancel calls.

--- a/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
@@ -46,6 +46,13 @@ object Constants {
     const val AUTOMATIC_PUSH_TRACKING = PACKAGE_PREFIX + "automatic_push_tracking"
 
     /**
+     * Manifest `<meta-data>` boolean to opt out of automatic push token forwarding while keeping
+     * automatic open tracking. Only consulted when [AUTOMATIC_PUSH_TRACKING] is `true`; defaults to
+     * `false`. For hosts that own their own push-token pipeline.
+     */
+    const val DISABLE_AUTOMATIC_TOKEN_FORWARDING = PACKAGE_PREFIX + "disable_automatic_token_forwarding"
+
+    /**
      * Fixed notification ID used in all notify/cancel calls.
      * Notifications are uniquely identified by their string tag, not this ID.
      */

--- a/sdk/core/src/main/java/com/klaviyo/core/PushTokenFetcher.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/PushTokenFetcher.kt
@@ -1,0 +1,14 @@
+package com.klaviyo.core
+
+/**
+ * Pulls the current push token from the device's push provider (e.g. FCM) and forwards it to
+ * Klaviyo. Implemented in `push-fcm` and resolved lazily via [Registry]; when that module is absent
+ * the lookup is null, so automatic token registration is a no-op for analytics-only integrators.
+ */
+interface PushTokenFetcher {
+    /**
+     * Pull the current push token and forward it to Klaviyo. Must not throw — failures (e.g.
+     * Firebase not configured) are logged and swallowed.
+     */
+    fun fetchAndSetPushToken()
+}

--- a/sdk/fixtures/src/main/java/com/klaviyo/fixtures/BaseTest.kt
+++ b/sdk/fixtures/src/main/java/com/klaviyo/fixtures/BaseTest.kt
@@ -9,6 +9,7 @@ import android.os.Build
 import android.os.Handler
 import android.os.HandlerThread
 import com.klaviyo.core.BuildConfig
+import com.klaviyo.core.PushTokenFetcher
 import com.klaviyo.core.Registry
 import com.klaviyo.core.config.Config
 import com.klaviyo.core.config.FormEnvironment
@@ -205,4 +206,7 @@ abstract class BaseTest {
             throw e
         }
     }
+
+    protected fun registerMockPushTokenFetcher(): PushTokenFetcher =
+        mockk<PushTokenFetcher>(relaxed = true).also { Registry.register<PushTokenFetcher>(it) }
 }

--- a/sdk/push-fcm/src/main/AndroidManifest.xml
+++ b/sdk/push-fcm/src/main/AndroidManifest.xml
@@ -27,5 +27,14 @@
             android:noHistory="true"
             android:taskAffinity=""
             android:theme="@android:style/Theme.Translucent.NoTitleBar" />
+        <!--
+            Registers the FCM-backed PushTokenFetcher at process start so analytics can pull the
+            current push token at initialize() without depending on push-fcm. Mirrors the forms
+            module's FormsInitProvider.
+        -->
+        <provider
+            android:name="com.klaviyo.pushFcm.KlaviyoPushTokenInitProvider"
+            android:authorities="${applicationId}.klaviyo.pushfcm.init"
+            android:exported="false" />
     </application>
 </manifest>

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoPushTokenFetcher.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoPushTokenFetcher.kt
@@ -1,0 +1,27 @@
+package com.klaviyo.pushFcm
+
+import com.google.firebase.messaging.FirebaseMessaging
+import com.klaviyo.analytics.Klaviyo
+import com.klaviyo.core.PushTokenFetcher
+import com.klaviyo.core.Registry
+
+/**
+ * [PushTokenFetcher] backed by Firebase Cloud Messaging.
+ */
+internal class KlaviyoPushTokenFetcher : PushTokenFetcher {
+    override fun fetchAndSetPushToken() {
+        try {
+            FirebaseMessaging.getInstance().token
+                .addOnSuccessListener { token -> Klaviyo.setPushToken(token) }
+                .addOnFailureListener { e ->
+                    Registry.log.warning("Failed to fetch push token for automatic registration", e)
+                }
+        } catch (e: IllegalStateException) {
+            // Thrown by getInstance() when no default FirebaseApp is configured in the host app
+            Registry.log.warning(
+                "Unable to access FirebaseMessaging for automatic push token registration",
+                e
+            )
+        }
+    }
+}

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoPushTokenFetcher.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoPushTokenFetcher.kt
@@ -16,8 +16,8 @@ internal class KlaviyoPushTokenFetcher : PushTokenFetcher {
                 .addOnFailureListener { e ->
                     Registry.log.warning("Failed to fetch push token for automatic registration", e)
                 }
-        } catch (e: IllegalStateException) {
-            // Thrown by getInstance() when no default FirebaseApp is configured in the host app
+        } catch (e: Exception) {
+            // Honor the must-not-throw contract (e.g. getInstance() with no default FirebaseApp)
             Registry.log.warning(
                 "Unable to access FirebaseMessaging for automatic push token registration",
                 e

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoPushTokenInitProvider.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoPushTokenInitProvider.kt
@@ -1,0 +1,26 @@
+package com.klaviyo.pushFcm
+
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.database.Cursor
+import android.net.Uri
+import com.klaviyo.core.PushTokenFetcher
+import com.klaviyo.core.Registry
+
+/**
+ * Manifest-merged init [ContentProvider] that registers [KlaviyoPushTokenFetcher] at process start,
+ * mirroring the forms module's `FormsInitProvider`. Lets analytics resolve a push-token fetcher
+ * lazily via [Registry] without analytics depending on `push-fcm` or Firebase.
+ */
+internal class KlaviyoPushTokenInitProvider : ContentProvider() {
+    override fun onCreate(): Boolean {
+        Registry.registerOnce<PushTokenFetcher> { KlaviyoPushTokenFetcher() }
+        return true
+    }
+
+    override fun query(u: Uri, p: Array<String>?, s: String?, a: Array<String>?, o: String?): Cursor? = null
+    override fun getType(uri: Uri): String? = null
+    override fun insert(uri: Uri, values: ContentValues?): Uri? = null
+    override fun delete(uri: Uri, s: String?, a: Array<String>?): Int = 0
+    override fun update(uri: Uri, v: ContentValues?, s: String?, a: Array<String>?): Int = 0
+}

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoPushTokenInitProvider.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoPushTokenInitProvider.kt
@@ -18,9 +18,24 @@ internal class KlaviyoPushTokenInitProvider : ContentProvider() {
         return true
     }
 
-    override fun query(u: Uri, p: Array<String>?, s: String?, a: Array<String>?, o: String?): Cursor? = null
+    override fun query(
+        uri: Uri,
+        projection: Array<String>?,
+        selection: String?,
+        selectionArgs: Array<String>?,
+        sortOrder: String?
+    ): Cursor? = null
+
     override fun getType(uri: Uri): String? = null
+
     override fun insert(uri: Uri, values: ContentValues?): Uri? = null
-    override fun delete(uri: Uri, s: String?, a: Array<String>?): Int = 0
-    override fun update(uri: Uri, v: ContentValues?, s: String?, a: Array<String>?): Int = 0
+
+    override fun delete(uri: Uri, selection: String?, selectionArgs: Array<String>?): Int = 0
+
+    override fun update(
+        uri: Uri,
+        values: ContentValues?,
+        selection: String?,
+        selectionArgs: Array<String>?
+    ): Int = 0
 }

--- a/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoPushTokenFetcherTest.kt
+++ b/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoPushTokenFetcherTest.kt
@@ -1,0 +1,89 @@
+package com.klaviyo.pushFcm
+
+import com.google.android.gms.tasks.OnFailureListener
+import com.google.android.gms.tasks.OnSuccessListener
+import com.google.android.gms.tasks.Task
+import com.google.firebase.messaging.FirebaseMessaging
+import com.klaviyo.analytics.Klaviyo
+import com.klaviyo.fixtures.BaseTest
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkObject
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+class KlaviyoPushTokenFetcherTest : BaseTest() {
+    private val stubToken = "fcm_stub_token"
+    private val mockTask = mockk<Task<String>>()
+    private val mockFirebaseMessaging = mockk<FirebaseMessaging>().apply {
+        every { token } returns mockTask
+    }
+
+    @Before
+    override fun setup() {
+        super.setup()
+        // mockkStatic is required for @JvmStatic methods on the Klaviyo facade
+        mockkStatic(Klaviyo::class)
+        mockkObject(Klaviyo)
+        every { Klaviyo.setPushToken(any()) } returns Klaviyo
+
+        mockkStatic(FirebaseMessaging::class)
+        every { FirebaseMessaging.getInstance() } returns mockFirebaseMessaging
+    }
+
+    @After
+    override fun cleanup() {
+        super.cleanup()
+        unmockkObject(Klaviyo)
+        unmockkStatic(Klaviyo::class)
+        unmockkStatic(FirebaseMessaging::class)
+    }
+
+    @Test
+    fun `fetchAndSetPushToken forwards the fetched token to Klaviyo on success`() {
+        val successSlot = slot<OnSuccessListener<String>>()
+        every { mockTask.addOnSuccessListener(capture(successSlot)) } answers {
+            successSlot.captured.onSuccess(stubToken)
+            mockTask
+        }
+        every { mockTask.addOnFailureListener(any()) } returns mockTask
+
+        KlaviyoPushTokenFetcher().fetchAndSetPushToken()
+
+        verify(exactly = 1) { Klaviyo.setPushToken(stubToken) }
+    }
+
+    @Test
+    fun `fetchAndSetPushToken logs a warning and does not crash when the fetch fails`() {
+        every { mockTask.addOnSuccessListener(any()) } returns mockTask
+        val failureSlot = slot<OnFailureListener>()
+        every { mockTask.addOnFailureListener(capture(failureSlot)) } answers {
+            failureSlot.captured.onFailure(RuntimeException("fetch failed"))
+            mockTask
+        }
+
+        KlaviyoPushTokenFetcher().fetchAndSetPushToken()
+
+        verify(inverse = true) { Klaviyo.setPushToken(any()) }
+        verify { spyLog.warning(any(), any()) }
+    }
+
+    @Test
+    fun `fetchAndSetPushToken survives when FirebaseMessaging is unavailable`() {
+        every {
+            FirebaseMessaging.getInstance()
+        } throws IllegalStateException("Firebase is not configured")
+
+        // Should swallow the synchronous failure rather than crash initialize
+        KlaviyoPushTokenFetcher().fetchAndSetPushToken()
+
+        verify(inverse = true) { Klaviyo.setPushToken(any()) }
+        verify { spyLog.warning(any(), any()) }
+    }
+}

--- a/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoPushTokenFetcherTest.kt
+++ b/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoPushTokenFetcherTest.kt
@@ -86,4 +86,16 @@ class KlaviyoPushTokenFetcherTest : BaseTest() {
         verify(inverse = true) { Klaviyo.setPushToken(any()) }
         verify { spyLog.warning(any(), any()) }
     }
+
+    @Test
+    fun `fetchAndSetPushToken swallows unexpected synchronous failures`() {
+        every {
+            FirebaseMessaging.getInstance()
+        } throws RuntimeException("unexpected Firebase failure")
+
+        KlaviyoPushTokenFetcher().fetchAndSetPushToken()
+
+        verify(inverse = true) { Klaviyo.setPushToken(any()) }
+        verify { spyLog.warning(any(), any()) }
+    }
 }

--- a/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoPushTokenInitProviderTest.kt
+++ b/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoPushTokenInitProviderTest.kt
@@ -1,0 +1,29 @@
+package com.klaviyo.pushFcm
+
+import com.klaviyo.core.PushTokenFetcher
+import com.klaviyo.core.Registry
+import com.klaviyo.fixtures.BaseTest
+import org.junit.After
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class KlaviyoPushTokenInitProviderTest : BaseTest() {
+
+    @After
+    override fun cleanup() {
+        super.cleanup()
+        Registry.unregister<PushTokenFetcher>()
+    }
+
+    @Test
+    fun `onCreate registers the FCM-backed PushTokenFetcher`() {
+        Registry.unregister<PushTokenFetcher>()
+        assertNull(Registry.getOrNull<PushTokenFetcher>())
+
+        val created = KlaviyoPushTokenInitProvider().onCreate()
+
+        assertTrue(created)
+        assertTrue(Registry.getOrNull<PushTokenFetcher>() is KlaviyoPushTokenFetcher)
+    }
+}


### PR DESCRIPTION
# Description
Opt-in automatic push-token registration: with the `com.klaviyo.push.automatic_push_tracking` manifest flag set, the SDK fetches the FCM token at `initialize()` (and refreshes on app foreground) and registers it with Klaviyo — no manual `setPushToken` wiring required, and it coexists with hosts running other push providers.

## Due Diligence
- [x] I have tested this on an emulator and/or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all Android versions the SDK currently supports.

## Release/Versioning Considerations
- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [x] `Minor` Contains changes to the public API. <!-- new opt-in manifest flag -->
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes. <!-- README handled separately in MAGE-771 -->
- [x] This is planned work for an upcoming release. <!-- targets the feat/auto-push-tracking feature branch; ships with the Automatic Push Tracking milestone -->

## Changelog / Code Overview
- **`sdk/core`** — new `PushTokenFetcher` interface + `PUSH_PREFIX`; `automatic_push_tracking` / `disable_automatic_token_forwarding` manifest keys namespaced under `com.klaviyo.push.` (consistent with the existing notification meta-data keys).
- **`sdk/push-fcm`** — `KlaviyoPushTokenFetcher` (pulls the FCM token via `getToken`, honors a must-not-throw contract), auto-registered at process start via the manifest-merged `KlaviyoPushTokenInitProvider` (mirrors `FormsInitProvider`).
- **`sdk/analytics`** — `Klaviyo.initialize` triggers `maybeAutoRegisterPushToken()`, and `StateSideEffects` re-runs it on app foreground to catch token rotations. Gated by the opt-in flag with a `disable_automatic_token_forwarding` opt-out. Graceful no-op when `push-fcm` is absent; idempotent via the existing `pushState` de-dup, so repeated calls make no redundant API requests.

## Test Plan
Validated on emulator **and** physical device against a test company:
- Flag on, no `KlaviyoPushService`, no manual code → token registers at launch.
- Foreground refresh fires and de-dupes (no duplicate token API calls).
- `disable_automatic_token_forwarding` → token fetch suppressed, open tracking unaffected.
- Opt-out + manual `onNewToken` integration → token registers via the service path; the two coexist cleanly.
- Renamed `com.klaviyo.push.*` keys confirmed read end-to-end.

Unit coverage: analytics gating (flag on/off, forwarding disabled, fetcher absent, fetch throws), foreground re-fetch (on/off), fetcher (success / async-fail / Firebase-unavailable / unexpected sync failure), and init-provider registration.

## Related Issues/Tickets
- MAGE-769 (this work)
- MAGE-770 (sample app flavors) and MAGE-771 (README docs) — follow-ups, already updated with the as-built keys.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic push-token registration during app start and when the app returns to the foreground.
  * Added support for a new push-token forwarding opt-out setting.
  * Introduced FCM-backed push-token initialization so token setup can happen automatically.

* **Bug Fixes**
  * Push-token setup now fails safely, with logging instead of interrupting app initialization.
  * Added handling for missing push-token providers and Firebase configuration issues.

* **Tests**
  * Expanded test coverage for startup, foreground refresh, and push-token fetch success and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->