### PR TITLE
chore: sync feat/push-trampoline with feat/auto-push-tracking

### DIFF
--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -28,6 +28,7 @@ import com.klaviyo.core.config.Config
 import com.klaviyo.core.config.LifecycleException
 import com.klaviyo.core.safeApply
 import com.klaviyo.core.safeCall
+import com.klaviyo.core.utils.BoundedIdSet
 import com.klaviyo.core.utils.JSONUtil.toHashMap
 import com.klaviyo.core.utils.takeIf
 import java.io.Serializable
@@ -46,6 +47,17 @@ object Klaviyo {
      * Queue of failed operations attempted prior to [initialize]
      */
     private val preInitQueue: Queue<Operation<Unit>> = LinkedList()
+
+    /**
+     * Push delivery IDs already handled within this process, so a single tap records one
+     * `$opened_push`. See [handlePush] for how entries are matched and added.
+     */
+    private val handledPushDeliveries = BoundedIdSet()
+
+    /**
+     * Key within the `_k` tracking payload whose value uniquely identifies a single push delivery.
+     */
+    private const val PUSH_DELIVERY_KEY = "tm"
 
     /**
      * This method is provided for apps that are unable to register their API key immediately
@@ -324,38 +336,56 @@ object Klaviyo {
      * @param intent the [Intent] from opening a notification
      */
     @JvmStatic
-    fun handlePush(intent: Intent?): Klaviyo = this
-        .takeIf { intent.isKlaviyoNotificationIntent }
-        ?.safeApply(preInitQueue) {
-            // Create and enqueue an $opened_push
+    fun handlePush(intent: Intent?): Klaviyo {
+        if (intent == null || !intent.isKlaviyoNotificationIntent) {
+            Registry.log.verbose("Non-Klaviyo intent ignored")
+            return this
+        }
+
+        // Dedup guard: track each push delivery at most once per process. The trampoline calls
+        // handlePush and forwards the same intent to the host, so a leftover manual handlePush call
+        // (or singleTask re-entry) would otherwise double-track one tap. The first call to see a
+        // delivery records it and proceeds; a later call for the same delivery short-circuits — no
+        // event, dismissal, or deep link.
+        val deliveryId = intent.pushDeliveryId
+        if (deliveryId != null && !handledPushDeliveries.markOnce(deliveryId)) {
+            Registry.log.verbose("Ignoring duplicate push open")
+            return this
+        }
+
+        // Create and enqueue an $opened_push. safeApply(preInitQueue) buffers this for replay if
+        // handlePush runs before initialize(), and guards against unexpected failures.
+        safeApply(preInitQueue) {
+            val state = Registry.get<State>()
             val event = Event(EventMetric.OPENED_PUSH)
             event.appendKlaviyoExtras(intent)
+            state.pushToken?.let { event[EventKey.PUSH_TOKEN] = it }
+            // Not using Klaviyo.createEvent here to avoid nesting safeApply calls
+            state.createEvent(event, state.getAsProfile())
+        }
 
-            Registry.get<State>().pushToken?.let { event[EventKey.PUSH_TOKEN] = it }
-
-            // Not using createEvent here to avoid nested safeApply calls
-            Registry.get<State>().createEvent(event, Registry.get<State>().getAsProfile())
-        }?.safeApply {
-            // Dismiss the notification if opened via an action button.
-            // Body taps are handled by setAutoCancel(true) on the notification builder,
-            // but action button taps don't trigger auto-cancel (standard Android behavior).
-            intent?.getStringExtra(Constants.NOTIFICATION_TAG_EXTRA)?.let { tag ->
+        // Dismiss the notification if opened via an action button. Body taps auto-cancel via
+        // setAutoCancel(true) on the builder; action button taps don't (standard Android behavior).
+        safeApply {
+            val notificationTag = intent.getStringExtra(Constants.NOTIFICATION_TAG_EXTRA)
+            if (notificationTag != null) {
                 NotificationManagerCompat
                     .from(Registry.config.applicationContext)
-                    .cancel(tag, Constants.NOTIFICATION_ID)
-            }
-        }?.safeApply {
-            // If a Klaviyo notification is deep linked, invoke the developer's deep link handler
-            // if registered. If not, do nothing. The host already received the appropriate intent.
-            intent?.data?.takeIf {
-                DeepLinking.isHandlerRegistered
-            }?.let { uri ->
-                DeepLinking.handleDeepLink(uri)
+                    .cancel(notificationTag, Constants.NOTIFICATION_ID)
             }
         }
-        ?: apply {
-            Registry.log.verbose("Non-Klaviyo intent ignored")
+
+        // If the notification carries a deep link and a handler is registered, invoke it. Otherwise
+        // do nothing — the host already received the appropriate intent.
+        safeApply {
+            val deepLink = intent.data
+            if (deepLink != null && DeepLinking.isHandlerRegistered) {
+                DeepLinking.handleDeepLink(deepLink)
+            }
         }
+
+        return this
+    }
 
     /**
      * Handles a universal link [Intent], by resolving the destination [Uri] asynchronously
@@ -425,6 +455,29 @@ object Klaviyo {
      */
     @JvmStatic
     fun isKlaviyoNotificationIntent(intent: Intent?): Boolean = intent.isKlaviyoNotificationIntent
+
+    /**
+     * Dedup key for this intent's push delivery, or `null` if none is available. Prefers the `tm`
+     * field of the `_k` payload (a per-delivery ULID on campaign sends), else the SDK-generated
+     * per-notification [Constants.NOTIFICATION_UID_EXTRA]. Both are copied forward to the host's
+     * intent, so a delivery handled by the trampoline and then a leftover manual call resolve to the
+     * same key, while distinct notifications stay distinct.
+     *
+     * Deliberately not the raw `_k`: minus `tm` it is per-message metadata shared across deliveries,
+     * so it would collapse distinct opens.
+     */
+    private val Intent?.pushDeliveryId: String?
+        get() {
+            val deliveryId = this?.getStringExtra(PACKAGE_PREFIX + TRACKING_PARAMETER)
+                ?.takeIf { it.isNotEmpty() }
+                ?.let { trackingPayload ->
+                    runCatching { JSONObject(trackingPayload).optString(PUSH_DELIVERY_KEY) }
+                        .getOrNull()
+                        ?.takeIf { it.isNotEmpty() }
+                }
+            return deliveryId ?: this?.getStringExtra(Constants.NOTIFICATION_UID_EXTRA)
+                ?.takeIf { it.isNotEmpty() }
+        }
 
     /**
      * Determine if an intent is a Klaviyo click-tracking universal/app link

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
@@ -18,6 +18,7 @@ import com.klaviyo.analytics.state.KlaviyoState
 import com.klaviyo.analytics.state.ProfileEventObserver
 import com.klaviyo.analytics.state.State
 import com.klaviyo.analytics.state.StateSideEffects
+import com.klaviyo.core.Constants
 import com.klaviyo.core.DeviceProperties
 import com.klaviyo.core.Registry
 import com.klaviyo.core.config.Config
@@ -702,6 +703,113 @@ internal class KlaviyoTest : BaseTest() {
 
         assertEquals(null, getCapturedUri())
         verify(inverse = true) { mockApiClient.enqueueEvent(any(), any()) }
+    }
+
+    // --- Push-open dedup guard (keyed on `_k.tm`, else the generated NOTIFICATION_UID_EXTRA) ---
+    // Note: Klaviyo is an object, so its in-memory dedup set persists across tests in this class.
+    // Each dedup test uses a distinct delivery ID to stay independent of execution order.
+
+    private fun deliveryExtras(deliveryId: String) = mapOf(
+        "com.klaviyo.body" to "Message body",
+        "com.klaviyo._k" to """{"m":"01GK4P5W6AV4V3APTJ727JKSKQ","tm":"$deliveryId"}"""
+    )
+
+    private fun deliveryIntent(deliveryId: String, uri: Uri? = null): Intent =
+        mockIntent(deliveryExtras(deliveryId), uri)
+
+    /** A Klaviyo intent whose `_k` payload omits `tm`, relying on the generated uid as the key. */
+    private fun tmLessIntent(notificationUid: String): Intent =
+        mockIntent(
+            mapOf(
+                "com.klaviyo._k" to """{"m":"01GK4P5W6AV4V3APTJ727JKSKQ"}""",
+                Constants.NOTIFICATION_UID_EXTRA to notificationUid
+            )
+        )
+
+    @Test
+    fun `handlePush tracks exactly one opened_push when a delivery is handled twice`() {
+        // The trampoline tracks first, then forwards the same intent (same tm) to a host that still
+        // calls handlePush manually; only one open, dismissal, and deep link result.
+        val (getCapturedUri) = setupDeepLinkHandler()
+        val testUri = mockk<Uri>()
+
+        Klaviyo.handlePush(deliveryIntent("dedup-twice-distinct-intents", testUri))
+        Klaviyo.handlePush(deliveryIntent("dedup-twice-distinct-intents", testUri))
+
+        verifyOpenedPushEventEnqueued()
+        assertEquals(testUri, getCapturedUri())
+        verify(exactly = 1) { DeepLinking.handleDeepLink(testUri) }
+    }
+
+    @Test
+    fun `handlePush short-circuits a repeat call with the same intent`() {
+        val intent = deliveryIntent("dedup-same-intent-object")
+
+        Klaviyo.handlePush(intent)
+        Klaviyo.handlePush(intent)
+
+        verifyOpenedPushEventEnqueued()
+    }
+
+    @Test
+    fun `handlePush tracks distinct deliveries independently`() {
+        Klaviyo.handlePush(deliveryIntent("dedup-distinct-A"))
+        Klaviyo.handlePush(deliveryIntent("dedup-distinct-B"))
+
+        verify(exactly = 2) {
+            mockApiClient.enqueueEvent(match { it.metric == EventMetric.OPENED_PUSH }, any())
+        }
+    }
+
+    @Test
+    fun `handlePush dedupes a tm-less delivery via the generated notification uid`() {
+        Klaviyo.handlePush(tmLessIntent("uid-fallback-same"))
+        Klaviyo.handlePush(tmLessIntent("uid-fallback-same"))
+
+        verifyOpenedPushEventEnqueued()
+    }
+
+    @Test
+    fun `handlePush tracks distinct tm-less notifications independently`() {
+        // Distinct notifications get distinct generated uids, so they must not collide.
+        Klaviyo.handlePush(tmLessIntent("uid-fallback-A"))
+        Klaviyo.handlePush(tmLessIntent("uid-fallback-B"))
+
+        verify(exactly = 2) {
+            mockApiClient.enqueueEvent(match { it.metric == EventMetric.OPENED_PUSH }, any())
+        }
+    }
+
+    @Test
+    fun `handlePush falls back to the generated uid when the _k payload is not valid JSON`() {
+        // A non-JSON _k must fail tm parsing gracefully and fall back to the generated uid.
+        val makeIntent = {
+            mockIntent(
+                mapOf(
+                    "com.klaviyo._k" to "not-json",
+                    Constants.NOTIFICATION_UID_EXTRA to "uid-malformed-k"
+                )
+            )
+        }
+
+        Klaviyo.handlePush(makeIntent())
+        Klaviyo.handlePush(makeIntent())
+
+        verifyOpenedPushEventEnqueued()
+    }
+
+    @Test
+    fun `handlePush does not dedupe when no delivery id is available`() {
+        // No `tm` and no generated uid: with no key to match on, each call tracks. We never fabricate
+        // a key from the shared `_k` metadata, which would collapse distinct deliveries.
+        val noKey = mapOf("com.klaviyo._k" to """{"m":"01GK4P5W6AV4V3APTJ727JKSKQ"}""")
+
+        Klaviyo.handlePush(mockIntent(noKey))
+        Klaviyo.handlePush(mockIntent(noKey))
+
+        verify(exactly = 2) {
+            mockApiClient.enqueueEvent(match { it.metric == EventMetric.OPENED_PUSH }, any())
+        }
     }
 
     @Test

--- a/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
@@ -30,6 +30,14 @@ object Constants {
     const val NOTIFICATION_TAG_EXTRA = INTERNAL_PREFIX + "notification_tag"
 
     /**
+     * Manifest `<meta-data>` key a host app sets to opt into automatic push open tracking.
+     *
+     * Lives in core (not push-fcm) because telemetry's push token request must read it, and core
+     * cannot depend on push-fcm.
+     */
+    const val AUTOMATIC_PUSH_TRACKING = PACKAGE_PREFIX + "automatic_push_tracking"
+
+    /**
      * Fixed notification ID used in all notify/cancel calls.
      * Notifications are uniquely identified by their string tag, not this ID.
      */

--- a/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
@@ -30,6 +30,14 @@ object Constants {
     const val NOTIFICATION_TAG_EXTRA = INTERNAL_PREFIX + "notification_tag"
 
     /**
+     * Intent extra carrying an SDK-generated, per-notification unique ID stamped on every Klaviyo
+     * notification's tap intents (body and each action button). Used by `Klaviyo.handlePush` as the
+     * dedup key when the `_k` tracking payload has no `tm`.
+     * Uses [INTERNAL_PREFIX] to stay out of analytics event properties, like [NOTIFICATION_TAG_EXTRA].
+     */
+    const val NOTIFICATION_UID_EXTRA = INTERNAL_PREFIX + "notification_uid"
+
+    /**
      * Manifest `<meta-data>` key a host app sets to opt into automatic push open tracking.
      *
      * Lives in core (not push-fcm) because telemetry's push token request must read it, and core

--- a/sdk/core/src/main/java/com/klaviyo/core/config/Config.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/config/Config.kt
@@ -28,6 +28,8 @@ interface Config {
 
     fun getManifestInt(key: String, defaultValue: Int): Int
 
+    fun getManifestBoolean(key: String, defaultValue: Boolean): Boolean
+
     interface Builder {
         fun apiKey(apiKey: String): Builder
         fun applicationContext(context: Context): Builder

--- a/sdk/core/src/main/java/com/klaviyo/core/config/KlaviyoConfig.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/config/KlaviyoConfig.kt
@@ -146,6 +146,13 @@ object KlaviyoConfig : Config {
             applicationContext.getManifestInt(key, defaultValue)
         }
 
+    override fun getManifestBoolean(key: String, defaultValue: Boolean): Boolean =
+        if (!this::applicationContext.isInitialized) {
+            defaultValue
+        } else {
+            applicationContext.getManifestBoolean(key, defaultValue)
+        }
+
     /**
      * Nested class to enable the builder pattern for easy declaration of custom configurations
      */
@@ -363,4 +370,15 @@ fun Context.getManifestInt(key: String, defaultValue: Int): Int {
     val appInfo = pkgManager.getApplicationInfoCompat(pkgName, PackageManager.GET_META_DATA)
     val manifestMetadata = appInfo?.metaData ?: Bundle.EMPTY
     return manifestMetadata.getInt(key, defaultValue)
+}
+
+/**
+ * Extension method to get a boolean value from the manifest metadata
+ */
+fun Context.getManifestBoolean(key: String, defaultValue: Boolean): Boolean {
+    val pkgName = packageName
+    val pkgManager = packageManager
+    val appInfo = pkgManager.getApplicationInfoCompat(pkgName, PackageManager.GET_META_DATA)
+    val manifestMetadata = appInfo?.metaData ?: Bundle.EMPTY
+    return manifestMetadata.getBoolean(key, defaultValue)
 }

--- a/sdk/core/src/main/java/com/klaviyo/core/utils/BoundedIdSet.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/utils/BoundedIdSet.kt
@@ -1,0 +1,61 @@
+package com.klaviyo.core.utils
+
+/**
+ * Thread-safe, fixed-capacity set of string IDs with FIFO eviction, used as an in-memory dedup
+ * guard for recently-seen identifiers.
+ *
+ * When the set is full, inserting a new ID evicts the oldest-inserted one. A duplicate insert is a
+ * no-op that does **not** refresh the ID's position in eviction order, so the set behaves as a
+ * sliding window over the most recently *first-seen* IDs.
+ *
+ * All operations are guarded by an intrinsic lock, so the set is safe to share across threads.
+ *
+ * @param capacity maximum number of IDs retained before the oldest is evicted.
+ */
+class BoundedIdSet(private val capacity: Int = DEFAULT_CAPACITY) {
+
+    init {
+        require(capacity > 0) { "capacity must be positive, was $capacity" }
+    }
+
+    // LinkedHashSet preserves insertion order, so the iterator's first element is always the oldest.
+    private val ids = LinkedHashSet<String>()
+
+    // Private monitor so external holders of this instance can't interfere with our locking.
+    private val lock = Any()
+
+    /**
+     * Atomically insert [id] and report whether it was newly added.
+     *
+     * Combining the check and the insert in one locked step is what makes this safe as a dedup
+     * guard: a caller can treat a `true` return as "I am the first to handle this ID" without
+     * racing a second caller for the same ID.
+     *
+     * @return `true` if [id] was not already present (now inserted), `false` if it was a duplicate.
+     */
+    fun markOnce(id: String): Boolean = synchronized(lock) {
+        if (!ids.add(id)) {
+            // Already present: no-op, and crucially we do not move it to the end, so its eviction
+            // order is unchanged.
+            return false
+        }
+        if (ids.size > capacity) {
+            val iterator = ids.iterator()
+            iterator.next()
+            iterator.remove()
+        }
+        return true
+    }
+
+    fun contains(id: String): Boolean = synchronized(lock) { ids.contains(id) }
+
+    val size: Int get() = synchronized(lock) { ids.size }
+
+    companion object {
+        /**
+         * Default retained-ID capacity: enough recent IDs to cover realistic dedup windows while
+         * bounding memory.
+         */
+        const val DEFAULT_CAPACITY = 256
+    }
+}

--- a/sdk/core/src/main/java/com/klaviyo/core/utils/IntentExtension.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/utils/IntentExtension.kt
@@ -12,7 +12,10 @@ fun Intent.startActivityIfResolved(context: Context) {
     if (activityResolved(context)) {
         context.startActivity(this)
     } else {
-        Registry.log.error("No activity found to handle intent: $this")
+        // Avoid logging the full intent — data/extras can carry deep-link URLs with PII.
+        Registry.log.error(
+            "No activity found to handle intent (action=$action, component=$component)"
+        )
     }
 }
 

--- a/sdk/core/src/test/java/com/klaviyo/core/config/KlaviyoConfigTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/config/KlaviyoConfigTest.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import android.os.Build
+import android.os.Bundle
 import com.klaviyo.core.BuildConfig
 import com.klaviyo.core.R
 import com.klaviyo.core.Registry
@@ -220,5 +221,51 @@ internal class KlaviyoConfigTest : BaseTest() {
             PackageManager.GET_PERMISSIONS
         )
         verify { mockPackageManager.getPackageInfo(BuildConfig.LIBRARY_PACKAGE_NAME, any<Int>()) }
+    }
+
+    @Test
+    fun `getManifestBoolean reads metadata value when present, else returns default`() {
+        // Back the Bundle with a real map so getBoolean has genuine present/absent semantics
+        // (stored value wins, missing key returns the supplied default) rather than echoing a
+        // stubbed return — the latter would only restate the assertion.
+        val metadata = mutableMapOf(
+            "com.klaviyo.present_true" to true,
+            "com.klaviyo.present_false" to false
+        )
+        val mockMetadata = mockk<Bundle> {
+            every { getBoolean(any(), any()) } answers {
+                metadata[firstArg<String>()] ?: secondArg<Boolean>()
+            }
+        }
+        mockApplicationInfo.metaData = mockMetadata
+
+        // Tiramisu+ path resolves application info via the ApplicationInfoFlags overload.
+        mockkStatic(PackageManager.ApplicationInfoFlags::class)
+        val mockApplicationInfoFlags = mockk<PackageManager.ApplicationInfoFlags>()
+        every { PackageManager.ApplicationInfoFlags.of(any()) } returns mockApplicationInfoFlags
+        setFinalStatic(Build.VERSION::class.java.getField("SDK_INT"), 33)
+        every {
+            mockPackageManager.getApplicationInfo(
+                BuildConfig.LIBRARY_PACKAGE_NAME,
+                mockApplicationInfoFlags
+            )
+        } returns mockApplicationInfo
+        // Reads the requested key from metadata, ignoring the (opposite) default.
+        assertEquals(true, mockContext.getManifestBoolean("com.klaviyo.present_true", false))
+
+        // Pre-Tiramisu path uses the simple getApplicationInfo(pkgName, flags) overload.
+        setFinalStatic(Build.VERSION::class.java.getField("SDK_INT"), 23)
+        every {
+            @Suppress("DEPRECATION")
+            mockPackageManager.getApplicationInfo(
+                BuildConfig.LIBRARY_PACKAGE_NAME,
+                PackageManager.GET_META_DATA
+            )
+        } returns mockApplicationInfo
+        // Stored false wins over a true default.
+        assertEquals(false, mockContext.getManifestBoolean("com.klaviyo.present_false", true))
+        // Absent key falls back to whichever default is supplied (both directions).
+        assertEquals(true, mockContext.getManifestBoolean("missing.key", true))
+        assertEquals(false, mockContext.getManifestBoolean("missing.key", false))
     }
 }

--- a/sdk/core/src/test/java/com/klaviyo/core/utils/BoundedIdSetTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/utils/BoundedIdSetTest.kt
@@ -1,0 +1,163 @@
+package com.klaviyo.core.utils
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BoundedIdSetTest {
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `constructor rejects a non-positive capacity`() {
+        BoundedIdSet(capacity = 0)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `constructor rejects a negative capacity`() {
+        BoundedIdSet(capacity = -1)
+    }
+
+    @Test
+    fun `markOnce inserts and contains reflects membership`() {
+        val set = BoundedIdSet()
+        assertFalse(set.contains("a"))
+        assertTrue(set.markOnce("a"))
+        assertTrue(set.contains("a"))
+    }
+
+    @Test
+    fun `markOnce returns true the first time and false thereafter`() {
+        val set = BoundedIdSet()
+        assertTrue(set.markOnce("a"))
+        assertFalse(set.markOnce("a"))
+        assertFalse(set.markOnce("a"))
+    }
+
+    @Test
+    fun `full set evicts the oldest inserted id first`() {
+        val set = BoundedIdSet(capacity = 3)
+        set.markOnce("a")
+        set.markOnce("b")
+        set.markOnce("c")
+        // Inserting a 4th id evicts "a" (oldest)
+        set.markOnce("d")
+
+        assertFalse(set.contains("a"))
+        assertTrue(set.contains("b"))
+        assertTrue(set.contains("c"))
+        assertTrue(set.contains("d"))
+        assertEquals(3, set.size)
+    }
+
+    @Test
+    fun `duplicate insert does not advance eviction order`() {
+        val set = BoundedIdSet(capacity = 3)
+        set.markOnce("a")
+        set.markOnce("b")
+        set.markOnce("c")
+        // Re-inserting "a" must NOT refresh its position; "a" is still the oldest.
+        assertFalse(set.markOnce("a"))
+        set.markOnce("d")
+
+        // If duplicate had advanced order, "b" would have been evicted instead of "a".
+        assertFalse(set.contains("a"))
+        assertTrue(set.contains("b"))
+        assertTrue(set.contains("c"))
+        assertTrue(set.contains("d"))
+    }
+
+    @Test
+    fun `evicted id can be re-inserted`() {
+        val set = BoundedIdSet(capacity = 2)
+        set.markOnce("a")
+        set.markOnce("b")
+        set.markOnce("c") // evicts "a"
+        assertFalse(set.contains("a"))
+
+        // "a" is treated as new again
+        assertTrue(set.markOnce("a")) // evicts "b"
+        assertTrue(set.contains("a"))
+        assertFalse(set.contains("b"))
+    }
+
+    @Test
+    fun `size never exceeds capacity`() {
+        val set = BoundedIdSet(capacity = 5)
+        repeat(100) { set.markOnce("id-$it") }
+        assertEquals(5, set.size)
+    }
+
+    @Test
+    fun `concurrent markOnce on the same id reports exactly one winner`() {
+        val set = BoundedIdSet()
+        val winners = ConcurrentHashMap.newKeySet<Int>()
+
+        runConcurrently(threadCount = 64, timeoutSeconds = 5) { i ->
+            if (set.markOnce("shared")) winners.add(i)
+        }
+
+        assertEquals(1, winners.size)
+    }
+
+    @Test
+    fun `concurrent access does not throw and stays within capacity`() {
+        val capacity = 128
+        val set = BoundedIdSet(capacity = capacity)
+        val perThread = 1000
+
+        runConcurrently(threadCount = 16, timeoutSeconds = 10) { t ->
+            repeat(perThread) { i ->
+                set.markOnce("t$t-$i")
+                set.contains("t$t-$i")
+            }
+        }
+
+        assertEquals(capacity, set.size)
+    }
+
+    /**
+     * Run [worker] on [threadCount] threads that all start together (via a latch) to maximize
+     * overlap/contention, wait up to [timeoutSeconds] for completion, and always shut the pool down.
+     * Test-specific assertions stay in the caller.
+     */
+    private fun runConcurrently(
+        threadCount: Int,
+        timeoutSeconds: Long,
+        worker: (index: Int) -> Unit
+    ) {
+        val pool = Executors.newFixedThreadPool(threadCount)
+        try {
+            val start = CountDownLatch(1)
+            val done = CountDownLatch(threadCount)
+            val failures = ConcurrentLinkedQueue<Throwable>()
+
+            repeat(threadCount) { i ->
+                pool.execute {
+                    try {
+                        start.await()
+                        worker(i)
+                    } catch (t: Throwable) {
+                        failures.add(t)
+                    } finally {
+                        // Always count down so a worker failure surfaces via the assertion below
+                        // rather than as a misleading await() timeout that hides the real cause.
+                        done.countDown()
+                    }
+                }
+            }
+            start.countDown()
+            assertTrue(done.await(timeoutSeconds, TimeUnit.SECONDS))
+            assertTrue(
+                failures.joinToString("\n") { it.stackTraceToString() },
+                failures.isEmpty()
+            )
+        } finally {
+            pool.shutdownNow()
+        }
+    }
+}

--- a/sdk/fixtures/src/main/java/com/klaviyo/fixtures/BaseTest.kt
+++ b/sdk/fixtures/src/main/java/com/klaviyo/fixtures/BaseTest.kt
@@ -96,6 +96,8 @@ abstract class BaseTest {
         every { sdkName } returns "klaviyo-android-sdk"
         every { sdkVersion } returns "4.20.69"
         every { formEnvironment } returns FormEnvironment.IN_APP
+        // Default to the passed default (e.g. automatic push tracking off); override per-test to flip on
+        every { getManifestBoolean(any(), any()) } answers { secondArg() }
     }
 
     protected val mockActivity: Activity = mockk(relaxed = true)

--- a/sdk/fixtures/src/main/java/com/klaviyo/fixtures/MockIntent.kt
+++ b/sdk/fixtures/src/main/java/com/klaviyo/fixtures/MockIntent.kt
@@ -2,6 +2,7 @@ package com.klaviyo.fixtures
 
 import android.annotation.SuppressLint
 import android.app.PendingIntent
+import android.content.ComponentName
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
@@ -65,6 +66,22 @@ data class MockIntent(
             }
             every { anyConstructed<Intent>().flags } answers {
                 if (flags.isCaptured) flags.captured else 0
+            }
+            // Mirror Android: setClassName(pkg, cls) makes getComponent() return the corresponding
+            // ComponentName. When only setPackage was used (e.g. deep-link intents), component is null.
+            every { anyConstructed<Intent>().component } answers {
+                if (className.isCaptured) {
+                    val capturedPkg = if (packageName.isCaptured) packageName.captured else ""
+                    val capturedCls = className.captured
+                    mockk<ComponentName>(relaxed = true) {
+                        every { getPackageName() } returns capturedPkg
+                        every { getClassName() } returns capturedCls
+                        every { flattenToShortString() } returns "$capturedPkg/$capturedCls"
+                        every { toString() } returns "ComponentInfo{$capturedPkg/$capturedCls}"
+                    }
+                } else {
+                    null
+                }
             }
 
             return mockIntent

--- a/sdk/push-fcm/src/main/AndroidManifest.xml
+++ b/sdk/push-fcm/src/main/AndroidManifest.xml
@@ -9,11 +9,23 @@
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />
             </intent-filter>
         </service>
+        <!--
+            Invisible, transient activity that routes notification taps (deep links, URLs, app opens).
+            Attribute reference:
+              exported="false"          - internal only; never launched by other apps
+              excludeFromRecents="true" - never appears in the recents/overview screen
+              launchMode="singleTask"   - reuses a single instance rather than stacking
+              noHistory="true"          - removed from the back stack as soon as it finishes
+              taskAffinity=""           - doesn't attach to or create the host app's task
+              theme="...Translucent..." - no visible UI while it runs
+        -->
         <activity
             android:name="com.klaviyo.pushFcm.KlaviyoTrampolineActivity"
             android:exported="false"
             android:excludeFromRecents="true"
+            android:launchMode="singleTask"
             android:noHistory="true"
+            android:taskAffinity=""
             android:theme="@android:style/Theme.Translucent.NoTitleBar" />
     </application>
 </manifest>

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoNotification.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoNotification.kt
@@ -20,6 +20,7 @@ import com.google.firebase.messaging.RemoteMessage
 import com.klaviyo.analytics.linking.DeepLinking
 import com.klaviyo.core.Constants
 import com.klaviyo.core.Registry
+import com.klaviyo.core.config.getManifestBoolean
 import com.klaviyo.core.utils.activityResolved
 import com.klaviyo.pushFcm.KlaviyoRemoteMessage.ActionButton
 import com.klaviyo.pushFcm.KlaviyoRemoteMessage.actionButtons
@@ -166,8 +167,16 @@ class KlaviyoNotification(private val message: RemoteMessage) {
         notificationTag: String
     ): NotificationCompat.Builder {
         val requestCodeBase = generateId()
+        // When the host opts into automatic push tracking, taps route through
+        // KlaviyoTrampolineActivity so it can call handlePush itself.
+        // Read the flag from the build-time context, not Registry.config, since FCM can build a
+        // notification before Klaviyo.initialize runs (e.g. init in an Activity, not Application).
+        val autoTracking = context.getManifestBoolean(
+            KlaviyoPushService.METADATA_AUTOMATIC_PUSH_TRACKING,
+            false
+        )
         return NotificationCompat.Builder(context, message.channel_id)
-            .setContentIntent(makePendingIntent(context, requestCodeBase))
+            .setContentIntent(makePendingIntent(context, requestCodeBase, autoTracking))
             .setSmallIcon(message.getSmallIcon(context))
             .also { message.getColor(context)?.let { color -> it.setColor(color) } }
             .setContentTitle(message.title)
@@ -177,7 +186,7 @@ class KlaviyoNotification(private val message: RemoteMessage) {
             .setNumber(message.notificationCount)
             .setPriority(message.notificationPriority)
             .setAutoCancel(true)
-            .addActionButtons(context, requestCodeBase, notificationTag)
+            .addActionButtons(context, requestCodeBase, notificationTag, autoTracking)
     }
 
     private fun URL.applyToNotification(builder: NotificationCompat.Builder) {
@@ -228,11 +237,11 @@ class KlaviyoNotification(private val message: RemoteMessage) {
      *
      * @return [PendingIntent]
      */
-    private fun makePendingIntent(context: Context, requestCode: Int) =
+    private fun makePendingIntent(context: Context, requestCode: Int, autoTracking: Boolean) =
         PendingIntent.getActivity(
             context,
             requestCode,
-            makeOpenedIntent(context),
+            makeOpenedIntent(context, autoTracking),
             PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_ONE_SHOT
         )
 
@@ -246,7 +255,7 @@ class KlaviyoNotification(private val message: RemoteMessage) {
      * creation, so this is only reachable via direct API calls or test tooling — we
      * warn so the misconfiguration is debuggable.
      */
-    private fun makeOpenedIntent(context: Context): Intent? {
+    private fun makeOpenedIntent(context: Context, autoTracking: Boolean): Intent? {
         val deepLink = message.deepLink
         val webUrl = message.webUrl
 
@@ -257,11 +266,23 @@ class KlaviyoNotification(private val message: RemoteMessage) {
         }
 
         if (deepLink != null) {
-            return makeResolvedDeepLinkIntent(
-                context,
-                deepLink,
-                "Push message contained unsupported deep link: $deepLink"
-            )?.apply {
+            // With automatic tracking on, route through the trampoline carrying the deep link as
+            // intent data so it calls handlePush; otherwise target the host directly as before.
+            //
+            // Unlike makeResolvedDeepLinkIntent, we keep the deep link on the intent even when no
+            // Activity resolves it: this is intentional so a registered DeepLinkHandler receives
+            // every link regardless of intent-filter resolution (the common single-Activity case).
+            // The trampoline only consults Activity resolvability when no handler is registered.
+            val intent = if (autoTracking) {
+                KlaviyoTrampolineActivity.forDestination(context, deepLink)
+            } else {
+                makeResolvedDeepLinkIntent(
+                    context,
+                    deepLink,
+                    "Push message contained unsupported deep link: $deepLink"
+                )
+            }
+            return intent?.apply {
                 addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
                 appendKlaviyoExtras(message)
             }
@@ -275,7 +296,13 @@ class KlaviyoNotification(private val message: RemoteMessage) {
             }
         }
 
-        return DeepLinking.makeLaunchIntent(context)?.apply {
+        // Plain open: route through the trampoline when auto-tracking, else launch the host directly.
+        val intent = if (autoTracking) {
+            KlaviyoTrampolineActivity.forDestination(context)
+        } else {
+            DeepLinking.makeLaunchIntent(context)
+        }
+        return intent?.apply {
             addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
             appendKlaviyoExtras(message)
         }
@@ -297,7 +324,8 @@ class KlaviyoNotification(private val message: RemoteMessage) {
     private fun NotificationCompat.Builder.addActionButtons(
         context: Context,
         requestCodeBase: Int,
-        notificationTag: String
+        notificationTag: String,
+        autoTracking: Boolean
     ): NotificationCompat.Builder {
         val actionButtons = message.actionButtons ?: return this
 
@@ -306,7 +334,15 @@ class KlaviyoNotification(private val message: RemoteMessage) {
             // request codes need to be unique, add index + offset to generate unique code
             // offset required due to zero index, so body and first button have unique codes
             val requestCode = requestCodeBase + index + ACTION_REQUEST_CODE_OFFSET
-            val action = createButtonAction(context, index, requestCode, button, notificationTag) ?: return@forEachIndexed
+            val action = createButtonAction(
+                context,
+                index,
+                requestCode,
+                button,
+                notificationTag,
+                autoTracking
+            )
+                ?: return@forEachIndexed
             addAction(action)
 
             val (actionType, destination) = when (button) {
@@ -329,16 +365,25 @@ class KlaviyoNotification(private val message: RemoteMessage) {
         index: Int,
         requestCode: Int,
         button: ActionButton,
-        notificationTag: String
+        notificationTag: String,
+        autoTracking: Boolean
     ): NotificationCompat.Action? {
         val intent = when (button) {
             is ActionButton.DeepLink -> {
                 val uri = button.url.toUri()
-                makeResolvedDeepLinkIntent(
-                    context,
-                    uri,
-                    "Action button $index contained unsupported deep link: $uri"
-                )
+                // With auto-tracking on, route through the trampoline carrying the deep link as
+                // intent data so it calls handlePush; otherwise target the host directly as before.
+                // See makeOpenedIntent: the deep link is deliberately kept even when unresolvable so
+                // a registered DeepLinkHandler still receives it.
+                if (autoTracking) {
+                    KlaviyoTrampolineActivity.forDestination(context, uri)
+                } else {
+                    makeResolvedDeepLinkIntent(
+                        context,
+                        uri,
+                        "Action button $index contained unsupported deep link: $uri"
+                    )
+                }
             }
             is ActionButton.OpenUrl -> {
                 // Route through the trampoline so handlePush tracks $opened_push
@@ -346,7 +391,11 @@ class KlaviyoNotification(private val message: RemoteMessage) {
                 KlaviyoTrampolineActivity.forBrowserUrl(context, button.url)
             }
             is ActionButton.OpenApp -> {
-                DeepLinking.makeLaunchIntent(context)
+                if (autoTracking) {
+                    KlaviyoTrampolineActivity.forDestination(context)
+                } else {
+                    DeepLinking.makeLaunchIntent(context)
+                }
             }
         }?.apply {
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoNotification.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoNotification.kt
@@ -43,6 +43,7 @@ import com.klaviyo.pushFcm.KlaviyoRemoteMessage.sound
 import com.klaviyo.pushFcm.KlaviyoRemoteMessage.title
 import com.klaviyo.pushFcm.KlaviyoRemoteMessage.webUrl
 import java.net.URL
+import java.util.UUID
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.Executors
 import java.util.concurrent.Future
@@ -175,8 +176,14 @@ class KlaviyoNotification(private val message: RemoteMessage) {
             KlaviyoPushService.METADATA_AUTOMATIC_PUSH_TRACKING,
             false
         )
+        // One id per notification, stamped on the body and every action-button intent, so
+        // handlePush can dedupe a notification's opens even when the `_k` payload carries no `tm`.
+        // Distinct notifications get distinct ids; body and buttons of one notification share it.
+        val notificationUid = UUID.randomUUID().toString()
         return NotificationCompat.Builder(context, message.channel_id)
-            .setContentIntent(makePendingIntent(context, requestCodeBase, autoTracking))
+            .setContentIntent(
+                makePendingIntent(context, requestCodeBase, autoTracking, notificationUid)
+            )
             .setSmallIcon(message.getSmallIcon(context))
             .also { message.getColor(context)?.let { color -> it.setColor(color) } }
             .setContentTitle(message.title)
@@ -186,7 +193,13 @@ class KlaviyoNotification(private val message: RemoteMessage) {
             .setNumber(message.notificationCount)
             .setPriority(message.notificationPriority)
             .setAutoCancel(true)
-            .addActionButtons(context, requestCodeBase, notificationTag, autoTracking)
+            .addActionButtons(
+                context,
+                requestCodeBase,
+                notificationTag,
+                autoTracking,
+                notificationUid
+            )
     }
 
     private fun URL.applyToNotification(builder: NotificationCompat.Builder) {
@@ -237,11 +250,16 @@ class KlaviyoNotification(private val message: RemoteMessage) {
      *
      * @return [PendingIntent]
      */
-    private fun makePendingIntent(context: Context, requestCode: Int, autoTracking: Boolean) =
+    private fun makePendingIntent(
+        context: Context,
+        requestCode: Int,
+        autoTracking: Boolean,
+        notificationUid: String
+    ) =
         PendingIntent.getActivity(
             context,
             requestCode,
-            makeOpenedIntent(context, autoTracking),
+            makeOpenedIntent(context, autoTracking, notificationUid),
             PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_ONE_SHOT
         )
 
@@ -255,7 +273,7 @@ class KlaviyoNotification(private val message: RemoteMessage) {
      * creation, so this is only reachable via direct API calls or test tooling — we
      * warn so the misconfiguration is debuggable.
      */
-    private fun makeOpenedIntent(context: Context, autoTracking: Boolean): Intent? {
+    private fun makeOpenedIntent(context: Context, autoTracking: Boolean, notificationUid: String): Intent? {
         val deepLink = message.deepLink
         val webUrl = message.webUrl
 
@@ -284,6 +302,7 @@ class KlaviyoNotification(private val message: RemoteMessage) {
             }
             return intent?.apply {
                 addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+                putExtra(Constants.NOTIFICATION_UID_EXTRA, notificationUid)
                 appendKlaviyoExtras(message)
             }
         }
@@ -292,6 +311,7 @@ class KlaviyoNotification(private val message: RemoteMessage) {
             // Route through the trampoline so handlePush tracks $opened_push
             // and dismisses the notification — the browser would otherwise swallow the intent.
             return KlaviyoTrampolineActivity.forBrowserUrl(context, webUrl).apply {
+                putExtra(Constants.NOTIFICATION_UID_EXTRA, notificationUid)
                 appendKlaviyoExtras(message)
             }
         }
@@ -304,6 +324,7 @@ class KlaviyoNotification(private val message: RemoteMessage) {
         }
         return intent?.apply {
             addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+            putExtra(Constants.NOTIFICATION_UID_EXTRA, notificationUid)
             appendKlaviyoExtras(message)
         }
     }
@@ -325,7 +346,8 @@ class KlaviyoNotification(private val message: RemoteMessage) {
         context: Context,
         requestCodeBase: Int,
         notificationTag: String,
-        autoTracking: Boolean
+        autoTracking: Boolean,
+        notificationUid: String
     ): NotificationCompat.Builder {
         val actionButtons = message.actionButtons ?: return this
 
@@ -340,7 +362,8 @@ class KlaviyoNotification(private val message: RemoteMessage) {
                 requestCode,
                 button,
                 notificationTag,
-                autoTracking
+                autoTracking,
+                notificationUid
             )
                 ?: return@forEachIndexed
             addAction(action)
@@ -366,7 +389,8 @@ class KlaviyoNotification(private val message: RemoteMessage) {
         requestCode: Int,
         button: ActionButton,
         notificationTag: String,
-        autoTracking: Boolean
+        autoTracking: Boolean,
+        notificationUid: String
     ): NotificationCompat.Action? {
         val intent = when (button) {
             is ActionButton.DeepLink -> {
@@ -400,6 +424,7 @@ class KlaviyoNotification(private val message: RemoteMessage) {
         }?.apply {
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             putExtra(Constants.NOTIFICATION_TAG_EXTRA, notificationTag)
+            putExtra(Constants.NOTIFICATION_UID_EXTRA, notificationUid)
         }?.appendKlaviyoExtras(message)
             ?.appendActionButtonExtras(button)
 

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoPushService.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoPushService.kt
@@ -3,6 +3,7 @@ package com.klaviyo.pushFcm
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import com.klaviyo.analytics.Klaviyo
+import com.klaviyo.core.Constants
 import com.klaviyo.core.Registry
 import com.klaviyo.pushFcm.KlaviyoRemoteMessage.hasKlaviyoKeyValuePairs
 import com.klaviyo.pushFcm.KlaviyoRemoteMessage.isKlaviyoMessage
@@ -21,6 +22,13 @@ open class KlaviyoPushService : FirebaseMessagingService() {
     companion object {
         const val METADATA_DEFAULT_ICON = "com.klaviyo.push.default_notification_icon"
         const val METADATA_DEFAULT_COLOR = "com.klaviyo.push.default_notification_color"
+
+        /**
+         * Manifest `<meta-data>` key (boolean) to opt into automatic push open tracking. When set to
+         * `true`, Klaviyo notification taps route through [KlaviyoTrampolineActivity], which tracks the
+         * open itself so the host app no longer needs to call `Klaviyo.handlePush(intent)` in its Activities.
+         */
+        const val METADATA_AUTOMATIC_PUSH_TRACKING = Constants.AUTOMATIC_PUSH_TRACKING
     }
 
     /**

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivity.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivity.kt
@@ -3,12 +3,14 @@ package com.klaviyo.pushFcm
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import androidx.core.net.toUri
 import com.klaviyo.analytics.Klaviyo
 import com.klaviyo.analytics.Klaviyo.isKlaviyoNotificationIntent
 import com.klaviyo.analytics.linking.DeepLinking
 import com.klaviyo.core.Registry
+import com.klaviyo.core.utils.activityResolved
 import com.klaviyo.core.utils.startActivityIfResolved
 
 /**
@@ -17,23 +19,38 @@ import com.klaviyo.core.utils.startActivityIfResolved
  * invoking the registered deep link handler) before forwarding the user to the actual
  * destination.
  *
- * Currently used for `open_url` push payloads — the destination is a browser intent
- * embedded as [BROWSER_URL_EXTRA]. Additional dispatch paths can be added to
- * [dispatchDestination] as new use cases (e.g. automatic open tracking) introduce
- * their own routing extras.
+ * Dispatch is driven by intent contents, not by any flag:
+ * - `open_url` payloads embed a browser URL as [BROWSER_URL_EXTRA] and route to the browser.
+ * - body / `deep_link` / `open_app` taps (when automatic push tracking is enabled at
+ *   notification-build time) carry the deep link as the intent `data` and route into the host app.
  *
- * Declared `android:exported="false"`, `android:noHistory="true"`, and
- * `android:excludeFromRecents="true"` with a translucent theme so it never appears
- * in the recents UI or flashes onscreen.
+ * Declared `android:exported="false"`, `android:noHistory="true"`,
+ * `android:excludeFromRecents="true"`, `android:launchMode="singleTask"`, and
+ * `android:taskAffinity=""` with a translucent theme so it never appears in the recents UI,
+ * flashes onscreen, or becomes the cold-start task root.
  */
 internal class KlaviyoTrampolineActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        process(intent)
+    }
+
+    /**
+     * `singleTask` re-entry: a tap while the trampoline instance already exists is delivered here
+     * rather than to a fresh [onCreate], so route it through the same handler.
+     */
+    override fun onNewIntent(intent: Intent?) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        process(intent)
+    }
+
+    private fun process(intent: Intent?) {
         try {
             handleTrampolineIntent(intent, this)
         } finally {
-            // Always finish — leaving a translucent activity onscreen after an exception
-            // would look like a stuck blank screen to the user.
+            // Always finish — leaving a translucent activity onscreen after an exception would look
+            // like a stuck blank screen to the user.
             finish()
         }
     }
@@ -61,6 +78,20 @@ internal class KlaviyoTrampolineActivity : Activity() {
         }
 
         /**
+         * Build a trampoline intent for a body tap or action button when automatic push tracking is
+         * enabled. The trampoline runs `Klaviyo.handlePush` then forwards to the host app, dispatching
+         * to [deepLink] (carried as the intent `data`) when present, otherwise to the launcher.
+         *
+         * Uses [Intent.setClassName] instead of the `Intent(Context, Class)` constructor — same test
+         * seam as [forBrowserUrl]. Callers append their own Klaviyo extras for parity with the
+         * non-trampoline intents they replace.
+         */
+        internal fun forDestination(context: Context, deepLink: Uri? = null): Intent = Intent().apply {
+            setClassName(context.packageName, KlaviyoTrampolineActivity::class.java.name)
+            deepLink?.let { data = it }
+        }
+
+        /**
          * Run the trampoline behavior: track `$opened_push`, dismiss the notification,
          * then dispatch to the destination. Extracted from [onCreate] so unit tests can
          * exercise it without instantiating an Android [Activity].
@@ -78,16 +109,64 @@ internal class KlaviyoTrampolineActivity : Activity() {
 
         private fun dispatchDestination(intent: Intent, context: Context) {
             intent.getStringExtra(BROWSER_URL_EXTRA)?.let { url ->
+                Registry.log.verbose("Trampoline dispatching browser intent")
                 DeepLinking.makeBrowserIntent(url.toUri()).startActivityIfResolved(context)
                 return
             }
-            // Add additional dispatch branches here as new routing extras are introduced.
-            // Reaching this point means a Klaviyo notification intent targeted the trampoline
-            // without any recognized dispatch extra — an internal SDK contract break, not
-            // graceful degradation. Log `wtf` to flag the bug.
-            Registry.log.wtf(
-                "KlaviyoTrampolineActivity launched without a recognized dispatch extra"
-            )
+            startDestination(intent, context)
+        }
+
+        /**
+         * Forward a body/`deep_link`/`open_app` tap into the host app.
+         *
+         * - Deep link present and no [DeepLinkHandler][com.klaviyo.analytics.linking.DeepLinkHandler]
+         *   registered → `ACTION_VIEW` into the host, falling back to the launcher if unresolvable.
+         * - Handler registered, or no deep link → launcher only. `handlePush` already dispatched the
+         *   handler, so an additional `ACTION_VIEW` would double-deliver navigation.
+         */
+        private fun startDestination(intent: Intent, context: Context) {
+            val deepLink = intent.data
+            val destination: Intent? = when {
+                deepLink != null && !DeepLinking.isHandlerRegistered -> {
+                    val viewIntent = DeepLinking.makeDeepLinkIntent(
+                        deepLink,
+                        context,
+                        copyIntent = intent
+                    )
+                    if (viewIntent.activityResolved(context)) {
+                        Registry.log.verbose("Trampoline dispatching deep link via VIEW")
+                        viewIntent
+                    } else {
+                        Registry.log.warning(
+                            "Trampoline could not resolve deep link; falling back to launcher"
+                        )
+                        DeepLinking.makeLaunchIntent(context, intent.extras)
+                    }
+                }
+                else -> {
+                    if (deepLink != null) {
+                        Registry.log.verbose(
+                            "Trampoline dispatching deep link via handler; launching host"
+                        )
+                    } else {
+                        Registry.log.verbose("Trampoline dispatching launch intent")
+                    }
+                    DeepLinking.makeLaunchIntent(context, intent.extras)
+                }
+            }
+
+            destination?.apply {
+                // CLEAR_TOP mirrors the non-trampoline path (KlaviyoNotification adds it to the
+                // contentIntent, but it's consumed launching the trampoline rather than forwarded),
+                // preserving back-stack behavior. NEW_TASK is required here since we launch from the
+                // trampoline's own (taskAffinity="") task.
+                addFlags(
+                    Intent.FLAG_ACTIVITY_NEW_TASK or
+                        Intent.FLAG_ACTIVITY_SINGLE_TOP or
+                        Intent.FLAG_ACTIVITY_CLEAR_TOP
+                )
+            }?.startActivityIfResolved(context)
+                ?: Registry.log.warning("No launch intent found for host app; nothing to start")
         }
     }
 }

--- a/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoNotificationTest.kt
+++ b/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoNotificationTest.kt
@@ -974,4 +974,68 @@ class KlaviyoNotificationTest : BaseTest() {
         verify { KlaviyoTrampolineActivity.forBrowserUrl(mockContext, "https://example.com") }
         verify(exactly = 0) { KlaviyoTrampolineActivity.forDestination(any(), any()) }
     }
+
+    @Test
+    fun `stamps a dedup uid on the body intent even when auto-tracking is off`() {
+        // Non-trampoline path: the host receives the intent directly, but it must still carry a
+        // per-notification dedup uid so handlePush can dedupe tm-less opens (e.g. a host calling
+        // handlePush twice for one tap).
+        val mockBodyIntent = mockk<Intent>(relaxed = true)
+        every { DeepLinking.makeLaunchIntent(mockContext) } returns mockBodyIntent
+        val intentSlot = slot<Intent>()
+        every {
+            PendingIntent.getActivity(any(), any(), capture(intentSlot), any())
+        } returns mockk(relaxed = true)
+
+        notification.displayNotification(mockContext)
+
+        assertEquals(mockBodyIntent, intentSlot.captured)
+        verify { mockBodyIntent.putExtra("_klaviyo.notification_uid", any<String>()) }
+    }
+
+    @Test
+    fun `body and action button share one dedup uid per notification`() {
+        // The dedup key must be per-notification, not per-intent: body and every action button
+        // carry the same uid so distinct targets on one notification collapse to a single open.
+        enableAutomaticTracking()
+        val bodyUri = mockk<Uri>(relaxed = true)
+        val buttonUri = mockk<Uri>(relaxed = true)
+        every { Uri.parse("klaviyotest://order/123") } returns buttonUri
+        val mockBodyIntent = mockk<Intent>(relaxed = true)
+        val mockButtonIntent = mockk<Intent>(relaxed = true)
+        val bodyUid = slot<String>()
+        val buttonUid = slot<String>()
+        every {
+            mockBodyIntent.putExtra("_klaviyo.notification_uid", capture(bodyUid))
+        } returns mockBodyIntent
+        every {
+            mockButtonIntent.putExtra("_klaviyo.notification_uid", capture(buttonUid))
+        } returns mockButtonIntent
+        every { KlaviyoTrampolineActivity.forDestination(mockContext, bodyUri) } returns mockBodyIntent
+        every { KlaviyoTrampolineActivity.forDestination(mockContext, buttonUri) } returns mockButtonIntent
+        every { PendingIntent.getActivity(any(), any(), any(), any()) } returns mockk(
+            relaxed = true
+        )
+        with(KlaviyoRemoteMessage) {
+            every { mockRemoteMessage.deepLink } returns bodyUri
+            every { mockRemoteMessage.actionButtons } returns listOf(
+                ActionButton.DeepLink(
+                    id = "com.klaviyo.test.view",
+                    label = "View Order",
+                    url = "klaviyotest://order/123"
+                )
+            )
+        }
+
+        notification.displayNotification(mockContext)
+
+        assertTrue("body intent should carry a dedup uid", bodyUid.isCaptured)
+        assertTrue("button intent should carry a dedup uid", buttonUid.isCaptured)
+        assertTrue("dedup uid should be non-empty", bodyUid.captured.isNotEmpty())
+        assertEquals(
+            "body and button should share one per-notification uid",
+            bodyUid.captured,
+            buttonUid.captured
+        )
+    }
 }

--- a/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoNotificationTest.kt
+++ b/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoNotificationTest.kt
@@ -9,6 +9,7 @@ import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import com.google.firebase.messaging.RemoteMessage
 import com.klaviyo.analytics.linking.DeepLinking
+import com.klaviyo.core.config.getManifestBoolean
 import com.klaviyo.fixtures.BaseTest
 import com.klaviyo.fixtures.MockIntent
 import com.klaviyo.pushFcm.KlaviyoNotification.Companion.BODY_KEY
@@ -111,6 +112,15 @@ class KlaviyoNotificationTest : BaseTest() {
         every {
             KlaviyoTrampolineActivity.forBrowserUrl(any(), any())
         } returns mockk(relaxed = true)
+        every {
+            KlaviyoTrampolineActivity.forDestination(any(), any())
+        } returns mockk(relaxed = true)
+        // buildNotification reads the auto-tracking flag from the build-time context via the
+        // Context.getManifestBoolean extension. Default to off (return the passed default);
+        // flag-on tests override via enableAutomaticTracking().
+        mockkStatic("com.klaviyo.core.config.KlaviyoConfigKt")
+        // Extension fn: receiver is the first arg, so the default value is the third arg.
+        every { mockContext.getManifestBoolean(any(), any()) } answers { thirdArg() }
 
         with(KlaviyoRemoteMessage) {
             every { mockRemoteMessage.webUrl } returns null
@@ -121,6 +131,7 @@ class KlaviyoNotificationTest : BaseTest() {
     override fun cleanup() {
         MockIntent.unmockPendingIntent()
         unmockkStatic(Uri::class)
+        unmockkStatic("com.klaviyo.core.config.KlaviyoConfigKt")
         super.cleanup()
     }
 
@@ -825,5 +836,142 @@ class KlaviyoNotificationTest : BaseTest() {
         verify { mockTrampolineIntent.putExtra("com.klaviyo.Button Label", "Open Website") }
         verify { mockTrampolineIntent.putExtra("com.klaviyo.Button Action", "Open URL") }
         verify { mockTrampolineIntent.putExtra("com.klaviyo.Button Link", "https://example.com") }
+    }
+
+    /** Opt into automatic push tracking for the duration of a test. */
+    private fun enableAutomaticTracking() {
+        // Overrides the flag-off default stubbed in setup(); buildNotification reads this off the
+        // build-time context (not Registry.config), so it works pre-init.
+        every {
+            mockContext.getManifestBoolean(
+                KlaviyoPushService.METADATA_AUTOMATIC_PUSH_TRACKING,
+                false
+            )
+        } returns true
+    }
+
+    @Test
+    fun `automatic tracking on - body deep link tap routes through trampoline`() {
+        enableAutomaticTracking()
+        val mockDeepLinkUri = mockk<Uri>(relaxed = true)
+        val mockTrampolineIntent = mockk<Intent>(relaxed = true)
+        val intentSlot = slot<Intent>()
+
+        with(KlaviyoRemoteMessage) {
+            every { mockRemoteMessage.deepLink } returns mockDeepLinkUri
+        }
+        every { KlaviyoTrampolineActivity.forDestination(mockContext, mockDeepLinkUri) } returns mockTrampolineIntent
+        every {
+            PendingIntent.getActivity(any(), any(), capture(intentSlot), any())
+        } returns mockk(relaxed = true)
+
+        notification.displayNotification(mockContext)
+
+        verify { KlaviyoTrampolineActivity.forDestination(mockContext, mockDeepLinkUri) }
+        // Deep link must NOT target the host directly when auto-tracking is on.
+        verify(exactly = 0) { DeepLinking.makeDeepLinkIntent(any(), any()) }
+        assertEquals(mockTrampolineIntent, intentSlot.captured)
+        // Extras parity: the trampoline intent still carries the Klaviyo extras.
+        verify { mockTrampolineIntent.putExtra("com.klaviyo._k", "test_tracking_id") }
+        verify { mockTrampolineIntent.putExtra("com.klaviyo.title", "Test Title") }
+    }
+
+    @Test
+    fun `automatic tracking on - plain body tap routes through trampoline launch`() {
+        enableAutomaticTracking()
+        val mockTrampolineIntent = mockk<Intent>(relaxed = true)
+        val intentSlot = slot<Intent>()
+
+        with(KlaviyoRemoteMessage) {
+            every { mockRemoteMessage.deepLink } returns null
+            every { mockRemoteMessage.webUrl } returns null
+        }
+        every { KlaviyoTrampolineActivity.forDestination(mockContext, null) } returns mockTrampolineIntent
+        every {
+            PendingIntent.getActivity(any(), any(), capture(intentSlot), any())
+        } returns mockk(relaxed = true)
+
+        notification.displayNotification(mockContext)
+
+        verify { KlaviyoTrampolineActivity.forDestination(mockContext, null) }
+        verify(exactly = 0) { DeepLinking.makeLaunchIntent(any()) }
+        assertEquals(mockTrampolineIntent, intentSlot.captured)
+    }
+
+    @Test
+    fun `automatic tracking on - deep_link action button routes through trampoline with extras`() {
+        enableAutomaticTracking()
+        val parsedUri = mockk<Uri>(relaxed = true)
+        every { Uri.parse("klaviyotest://order/123") } returns parsedUri
+        val mockButtonIntent = mockk<Intent>(relaxed = true)
+        every { KlaviyoTrampolineActivity.forDestination(mockContext, parsedUri) } returns mockButtonIntent
+
+        with(KlaviyoRemoteMessage) {
+            every { mockRemoteMessage.notificationTag } returns "test_tag"
+            every { mockRemoteMessage.actionButtons } returns listOf(
+                ActionButton.DeepLink(
+                    id = "com.klaviyo.test.view",
+                    label = "View Order",
+                    url = "klaviyotest://order/123"
+                )
+            )
+        }
+        every {
+            PendingIntent.getActivity(any(), any(), any(), any())
+        } returns mockk(relaxed = true)
+
+        notification.displayNotification(mockContext)
+
+        // Routed through the trampoline, not a direct ACTION_VIEW…
+        verify { KlaviyoTrampolineActivity.forDestination(mockContext, parsedUri) }
+        verify(exactly = 0) { DeepLinking.makeDeepLinkIntent(any(), any()) }
+        // …carrying the same extras the non-trampoline button intent does today.
+        verify { mockButtonIntent.putExtra("_klaviyo.notification_tag", "test_tag") }
+        verify { mockButtonIntent.putExtra("com.klaviyo._k", "test_tracking_id") }
+        verify { mockButtonIntent.putExtra("com.klaviyo.Button Label", "View Order") }
+        verify { mockButtonIntent.putExtra("com.klaviyo.Button Link", "klaviyotest://order/123") }
+    }
+
+    @Test
+    fun `automatic tracking on - open_app action button routes through trampoline with extras`() {
+        enableAutomaticTracking()
+        val mockButtonIntent = mockk<Intent>(relaxed = true)
+        every { KlaviyoTrampolineActivity.forDestination(mockContext, null) } returns mockButtonIntent
+
+        with(KlaviyoRemoteMessage) {
+            every { mockRemoteMessage.notificationTag } returns "test_tag"
+            every { mockRemoteMessage.actionButtons } returns listOf(
+                ActionButton.OpenApp(id = "open", label = "Open")
+            )
+        }
+        every {
+            PendingIntent.getActivity(any(), any(), any(), any())
+        } returns mockk(relaxed = true)
+
+        notification.displayNotification(mockContext)
+
+        verify { KlaviyoTrampolineActivity.forDestination(mockContext, null) }
+        verify(exactly = 0) { DeepLinking.makeLaunchIntent(any()) }
+        // Extras parity: notification tag (for dismissal) + Klaviyo extras still applied.
+        verify { mockButtonIntent.putExtra("_klaviyo.notification_tag", "test_tag") }
+        verify { mockButtonIntent.putExtra("com.klaviyo._k", "test_tracking_id") }
+    }
+
+    @Test
+    fun `open_url tap targets trampoline even with automatic tracking on`() {
+        enableAutomaticTracking()
+        with(KlaviyoRemoteMessage) {
+            every { mockRemoteMessage.webUrl } returns "https://example.com"
+            every { mockRemoteMessage.deepLink } returns null
+        }
+        every {
+            PendingIntent.getActivity(any(), any(), any(), any())
+        } returns mockk(relaxed = true)
+
+        notification.displayNotification(mockContext)
+
+        // open_url always uses the browser-URL trampoline factory, never the deep-link/launch one.
+        verify { KlaviyoTrampolineActivity.forBrowserUrl(mockContext, "https://example.com") }
+        verify(exactly = 0) { KlaviyoTrampolineActivity.forDestination(any(), any()) }
     }
 }

--- a/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivityTest.kt
+++ b/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivityTest.kt
@@ -23,6 +23,8 @@ import org.junit.Test
 class KlaviyoTrampolineActivityTest : BaseTest() {
 
     private val mockBrowserIntent = mockk<Intent>(relaxed = true)
+    private val mockDeepLinkIntent = mockk<Intent>(relaxed = true)
+    private val mockLaunchIntent = mockk<Intent>(relaxed = true)
     private val trampolineContextPackageManager = mockk<PackageManager>(relaxed = true)
     private val mockTrampolineContext = mockk<Context>(relaxed = true).apply {
         every { packageManager } returns trampolineContextPackageManager
@@ -41,9 +43,15 @@ class KlaviyoTrampolineActivityTest : BaseTest() {
         every { Uri.parse(any()) } returns mockk(relaxed = true)
         every { Klaviyo.handlePush(any()) } returns Klaviyo
         every { DeepLinking.makeBrowserIntent(any()) } returns mockBrowserIntent
-        // Make the browser intent appear resolvable so startActivityIfResolved
-        // actually dispatches to context.startActivity (vs logging an error).
+        every { DeepLinking.makeDeepLinkIntent(any(), any(), any()) } returns mockDeepLinkIntent
+        every { DeepLinking.makeLaunchIntent(any(), any()) } returns mockLaunchIntent
+        // No deep link handler registered by default; flip per-test for the handler branch.
+        every { DeepLinking.isHandlerRegistered } returns false
+        // Make intents appear resolvable so startActivityIfResolved actually dispatches to
+        // context.startActivity (vs logging an error). Override per-test for the unresolvable case.
         every { mockBrowserIntent.resolveActivity(any()) } returns mockk()
+        every { mockDeepLinkIntent.resolveActivity(any()) } returns mockk()
+        every { mockLaunchIntent.resolveActivity(any()) } returns mockk()
     }
 
     @After
@@ -61,6 +69,8 @@ class KlaviyoTrampolineActivityTest : BaseTest() {
      */
     private fun klaviyoIntent(): Intent = mockk(relaxed = true) {
         every { getStringExtra(PACKAGE_PREFIX + TRACKING_PARAMETER) } returns "tracking-id"
+        every { getStringExtra(KlaviyoTrampolineActivity.BROWSER_URL_EXTRA) } returns null
+        every { data } returns null
     }
 
     @Test
@@ -83,20 +93,80 @@ class KlaviyoTrampolineActivityTest : BaseTest() {
     }
 
     @Test
-    fun `handleTrampolineIntent with Klaviyo intent but no dispatch extra tracks open and logs wtf`() {
-        val intent = klaviyoIntent()
-        every {
-            intent.getStringExtra(KlaviyoTrampolineActivity.BROWSER_URL_EXTRA)
-        } returns null
+    fun `handleTrampolineIntent with no deep link launches the host app`() {
+        val intent = klaviyoIntent() // no browser extra, no deep link data
 
         KlaviyoTrampolineActivity.handleTrampolineIntent(intent, mockTrampolineContext)
 
-        // handlePush still runs for any Klaviyo notification intent — only dispatch is skipped.
         verify { Klaviyo.handlePush(intent) }
         verify(exactly = 0) { DeepLinking.makeBrowserIntent(any()) }
+        verify(exactly = 0) { DeepLinking.makeDeepLinkIntent(any(), any(), any()) }
+        verify { DeepLinking.makeLaunchIntent(mockTrampolineContext, any()) }
+        verify { mockTrampolineContext.startActivity(mockLaunchIntent) }
+    }
+
+    @Test
+    fun `handleTrampolineIntent with no launch intent warns and starts nothing`() {
+        val intent = klaviyoIntent() // no browser extra, no deep link data
+        // Host app has no launcher activity → makeLaunchIntent yields null.
+        every { DeepLinking.makeLaunchIntent(any(), any()) } returns null
+
+        KlaviyoTrampolineActivity.handleTrampolineIntent(intent, mockTrampolineContext)
+
+        verify { Klaviyo.handlePush(intent) }
         verify(exactly = 0) { mockTrampolineContext.startActivity(any()) }
-        // wtf, not warning: reaching this branch is an internal contract break.
-        verify { spyLog.wtf(any(), null) }
+        // Mirrors the non-trampoline diagnostic so a missing launcher is still debuggable.
+        verify { spyLog.warning(any(), null) }
+    }
+
+    @Test
+    fun `handleTrampolineIntent with deep link and no handler dispatches ACTION_VIEW into host`() {
+        val intent = klaviyoIntent()
+        val deepLink = mockk<Uri>(relaxed = true)
+        every { intent.data } returns deepLink
+        every { DeepLinking.isHandlerRegistered } returns false
+
+        KlaviyoTrampolineActivity.handleTrampolineIntent(intent, mockTrampolineContext)
+
+        verify { Klaviyo.handlePush(intent) }
+        verify { DeepLinking.makeDeepLinkIntent(deepLink, mockTrampolineContext, intent) }
+        verify { mockTrampolineContext.startActivity(mockDeepLinkIntent) }
+        verify(exactly = 0) { DeepLinking.makeLaunchIntent(any(), any()) }
+    }
+
+    @Test
+    fun `handleTrampolineIntent with deep link but handler registered launches host without ACTION_VIEW`() {
+        val intent = klaviyoIntent()
+        val deepLink = mockk<Uri>(relaxed = true)
+        every { intent.data } returns deepLink
+        // handlePush already dispatched the registered handler — a VIEW intent would double-deliver.
+        every { DeepLinking.isHandlerRegistered } returns true
+
+        KlaviyoTrampolineActivity.handleTrampolineIntent(intent, mockTrampolineContext)
+
+        verify { Klaviyo.handlePush(intent) }
+        verify(exactly = 0) { DeepLinking.makeDeepLinkIntent(any(), any(), any()) }
+        verify { DeepLinking.makeLaunchIntent(mockTrampolineContext, any()) }
+        verify { mockTrampolineContext.startActivity(mockLaunchIntent) }
+    }
+
+    @Test
+    fun `handleTrampolineIntent with unresolvable deep link falls back to launcher`() {
+        val intent = klaviyoIntent()
+        val deepLink = mockk<Uri>(relaxed = true)
+        every { intent.data } returns deepLink
+        every { DeepLinking.isHandlerRegistered } returns false
+        // Deep link target cannot be resolved → fall back to the launcher.
+        every { mockDeepLinkIntent.resolveActivity(any()) } returns null
+
+        KlaviyoTrampolineActivity.handleTrampolineIntent(intent, mockTrampolineContext)
+
+        verify { DeepLinking.makeDeepLinkIntent(deepLink, mockTrampolineContext, intent) }
+        verify { DeepLinking.makeLaunchIntent(mockTrampolineContext, any()) }
+        verify { mockTrampolineContext.startActivity(mockLaunchIntent) }
+        verify(exactly = 0) { mockTrampolineContext.startActivity(mockDeepLinkIntent) }
+        // Degraded-but-handled (fell back to launcher) → WARNING, not ERROR.
+        verify { spyLog.warning(any(), null) }
     }
 
     @Test


### PR DESCRIPTION
## Summary

Branch sync only, no new code. Brings the already-reviewed automatic push tracking work (#493, commit b08599dc) into `feat/push-trampoline`.

`feat/push-trampoline` is one commit behind `feat/auto-push-tracking`. A direct fast-forward push is blocked by repository rules, so this PR performs the same update. After merging, PR #494 (based on `feat/push-trampoline`) will show only its PUSH-834 changes instead of also including the trampoline/auto-tracking diff.

## Test Plan

No changes beyond what was already tested and approved in #493.

🤖 Generated with [Claude Code](https://claude.com/claude-code)