### PR TITLE
fix(core): notify token refresh observers on any successful fetch (MAGE-875)

### DIFF
--- a/sdk/core/src/main/java/com/klaviyo/core/auth/AuthTokenManager.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/AuthTokenManager.kt
@@ -1,7 +1,8 @@
 package com.klaviyo.core.auth
 
 /**
- * Callback invoked whenever the auth token is proactively refreshed.
+ * Callback invoked whenever the auth token is acquired or refreshed — both the initial demand
+ * fetch and each subsequent proactive refresh.
  *
  * Receives the raw JWT string. Observers must not retain the string beyond their immediate use —
  * for the full [ValidatedToken] wrapper (exp/iat metadata) callers should use
@@ -82,7 +83,9 @@ interface AuthTokenManager {
     suspend fun currentToken(timeoutMs: Long = BACKGROUND_FETCH_TIMEOUT_MS): ValidatedToken
 
     /**
-     * Register an observer that will be invoked each time the auth token is proactively refreshed.
+     * Register an observer that will be invoked each time the auth token is acquired or refreshed,
+     * including the initial fetch — so a consumer that subscribes while the first fetch is still in
+     * flight (e.g. a form displayed before the token resolves) still receives it once it lands.
      *
      * Multiple observers are supported. Each is invoked on the manager's internal dispatcher
      * (IO); the observer is responsible for any thread handoff it needs (e.g. hopping to the UI

--- a/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
@@ -93,10 +93,10 @@ internal class KlaviyoAuthTokenManager(
     private val resetGeneration = AtomicLong(0L)
 
     // Set to true by invalidate() and reset to false by registerProvider() and clearTokenState().
-    // Read by performScheduledRefresh just before notifying observers: if a profile reset is
-    // pending (i.e. invalidate() was called but clearTokenState() hasn't finished yet), the
-    // refresh must not broadcast the now-stale token. @Volatile because it is written on the
-    // calling thread (main) and read on the dispatcher (IO) with no other synchronisation.
+    // Read by doFetch() just before notifying observers: if a profile reset is pending (i.e.
+    // invalidate() was called but clearTokenState() hasn't finished yet), the fetch must not
+    // broadcast the now-stale token. @Volatile because it is written on the calling thread (main)
+    // and read on the dispatcher (IO) with no other synchronisation.
     @Volatile private var profileResetPending = false
 
     // CopyOnWriteArrayList for thread-safe iteration while observers add/remove on arbitrary threads
@@ -183,12 +183,12 @@ internal class KlaviyoAuthTokenManager(
         // was in-flight when this ran will see a generation mismatch in shouldArmConnectivityRetry
         // and skip arming a connectivity retry for the now-cleared session.
         resetGeneration.incrementAndGet()
-        // Null the cache BEFORE clearing profileResetPending. An in-flight performScheduledRefresh
-        // that has already fetched its token checks `cachedToken?.rawToken == token.rawToken &&
+        // Null the cache BEFORE clearing profileResetPending. An in-flight doFetch() that has
+        // already fetched its token checks `cachedToken?.rawToken == token.rawToken &&
         // !profileResetPending` before notifying observers. If invalidate() was called just before
         // unregister (typical logout: resetProfile → unregisterAuthTokenProvider), profileResetPending
         // is true — the suppression flag. Clearing it before nulling the cache opens a window where
-        // the in-flight refresh passes both guards and delivers a now-invalid JWT to observers.
+        // the in-flight fetch passes both guards and delivers a now-invalid JWT to observers.
         // Nulling the cache first closes that window: the rawToken comparison fails (null != token),
         // so the notify path is skipped regardless of profileResetPending. This matches the ordering
         // in clearTokenState(), which also nulls cachedToken before clearing profileResetPending.

--- a/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
@@ -343,9 +343,15 @@ internal class KlaviyoAuthTokenManager(
     }
 
     /**
-     * Invoke the provider, validate the returned JWT, write to the cache, and return the token.
-     * Runs inside [scope].async so failures (provider error, validation error) are captured by
-     * the Deferred and re-thrown to all awaiting callers.
+     * Invoke the provider, validate the returned JWT, write to the cache, notify refresh
+     * observers, and return the token. Runs inside [scope].async so failures (provider error,
+     * validation error) are captured by the Deferred and re-thrown to all awaiting callers.
+     *
+     * Every token acquisition funnels through here — the initial demand fetch as well as a
+     * proactive refresh — so notifying observers here (rather than only from
+     * [performScheduledRefresh]) guarantees consumers such as the forms WebView pick up a token
+     * that resolves *after* their own interactive-timeout fetch already gave up. Fetch dedup means
+     * a single [doFetch] shared by multiple callers still notifies exactly once.
      */
     private suspend fun doFetch(): ValidatedToken {
         val jwt = invokeProvider()
@@ -362,6 +368,20 @@ internal class KlaviyoAuthTokenManager(
         Registry.log.info(
             "Auth token acquired (exp=${token.expiresAtEpochSeconds}, iat=${token.issuedAtEpochSeconds})"
         )
+        // Notify observers of the freshly acquired token, outside the mutex — an observer may
+        // re-enter the manager and the lock is non-reentrant. Two-part stale guard (both @Volatile
+        // reads):
+        // 1. Cache check: clearTokenState() may have nulled cachedToken while the fetch was
+        //    suspended; skip if this token is no longer the live value.
+        // 2. Reset-pending check: invalidate() sets profileResetPending synchronously (from
+        //    resetProfile()) before the async clearTokenState() runs. A fetch that completes while
+        //    a logout reset is pending must not broadcast to observers, regardless of whether it
+        //    started before or after invalidate(). The flag is cleared by clearTokenState() and
+        //    registerProvider(). Dispatch is best-effort; the small TOCTOU window on these volatile
+        //    reads is acceptable (see notifyRefreshObservers KDoc).
+        if (cachedToken?.rawToken == token.rawToken && !profileResetPending) {
+            notifyRefreshObservers(token.rawToken)
+        }
         return token
     }
 
@@ -441,12 +461,9 @@ internal class KlaviyoAuthTokenManager(
      * even if the refresh attempt fails; any concurrent caller that arrives while refresh is
      * in-flight shares the single in-flight Deferred automatically.
      *
-     * On success, notifies registered [TokenRefreshObserver]s with the new JWT, subject to two
-     * guards: (1) the returned token is still the live cached value (clears can null the cache
-     * mid-flight), and (2) no profile reset is pending ([profileResetPending] is false). The
-     * reset-pending flag is set synchronously by [invalidate] so that any refresh completing
-     * in the window between [invalidate] and [clearTokenState] is suppressed. Dispatch is
-     * best-effort — see [notifyRefreshObservers].
+     * On success, registered [TokenRefreshObserver]s are notified with the new JWT from within
+     * [doFetch] (the shared acquisition path this call resolves through), under its stale guard —
+     * so notification is not repeated here.
      *
      * Logs at WARNING on failure — the still-valid cached token remains for live consumers.
      * On failure does NOT reschedule; one foreground-transition retry is possible if
@@ -466,23 +483,13 @@ internal class KlaviyoAuthTokenManager(
         if (provider == null) return
         Registry.log.info("Proactive token refresh fired")
         try {
-            val token = getOrFetchToken(
+            // allowCachedToken = false always resolves through a doFetch (a fresh one, or a shared
+            // in-flight one), which broadcasts the refreshed token to observers under its stale
+            // guard — so there is no separate notify step here.
+            getOrFetchToken(
                 timeoutMs = AuthTokenManager.BACKGROUND_FETCH_TIMEOUT_MS,
                 allowCachedToken = false
             )
-            // Two-part stale guard before notifying observers:
-            // 1. Cache check (@Volatile read): clearTokenState() may have nulled cachedToken
-            //    while the fetch was suspended; skip if this token is no longer the live value.
-            // 2. Reset-pending check (@Volatile read): invalidate() sets this flag synchronously
-            //    from resetProfile() before the async clearTokenState() runs. Any refresh that
-            //    completes while a logout reset is pending must not broadcast to observers —
-            //    regardless of whether the refresh started before or after invalidate() was called.
-            //    The flag is cleared by clearTokenState() and registerProvider().
-            // Dispatch is best-effort; the small TOCTOU window on these volatile reads is
-            // acceptable (see notifyRefreshObservers KDoc).
-            if (cachedToken?.rawToken == token.rawToken && !profileResetPending) {
-                notifyRefreshObservers(token.rawToken)
-            }
             Registry.log.info("Proactive token refresh succeeded")
         } catch (e: CancellationException) {
             throw e

--- a/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerRefreshTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerRefreshTest.kt
@@ -11,6 +11,7 @@ import io.mockk.verify
 import java.util.Base64
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.json.JSONObject
@@ -565,15 +566,23 @@ class KlaviyoAuthTokenManagerRefreshTest : BaseTest() {
 
         manager.registerProvider(provider)
         dispatcher.scheduler.advanceUntilIdle()
-        assertEquals("eager fetch should not notify observers", 0, receivedTokens.size)
+        assertEquals(
+            "eager fetch notifies observers with the acquired token",
+            1,
+            receivedTokens.size
+        )
 
         // Fire the scheduled refresh
         val timerTask = staticClock.scheduledTasks.first()
         staticClock.execute(timerTask.time - staticClock.time)
         dispatcher.scheduler.advanceUntilIdle()
 
-        assertEquals("observer should receive jwt after proactive refresh", 1, receivedTokens.size)
-        assertEquals(jwt, receivedTokens[0])
+        assertEquals(
+            "observer should receive jwt again after proactive refresh",
+            2,
+            receivedTokens.size
+        )
+        assertEquals(jwt, receivedTokens.last())
     }
 
     @Test
@@ -594,26 +603,82 @@ class KlaviyoAuthTokenManagerRefreshTest : BaseTest() {
         staticClock.execute(timerTask.time - staticClock.time)
         dispatcher.scheduler.advanceUntilIdle()
 
-        assertEquals("observer A should receive jwt", 1, receivedA.size)
-        assertEquals("observer B should receive jwt", 1, receivedB.size)
-        assertEquals(jwt, receivedA[0])
-        assertEquals(jwt, receivedB[0])
+        assertEquals("observer A should receive jwt on eager fetch and refresh", 2, receivedA.size)
+        assertEquals("observer B should receive jwt on eager fetch and refresh", 2, receivedB.size)
+        assertEquals(jwt, receivedA.last())
+        assertEquals(jwt, receivedB.last())
     }
 
     @Test
-    fun `refresh observer not called on initial eager fetch`() = runTest(dispatcher) {
-        val provider = CountingSuccessProvider(makeJwt())
+    fun `refresh observer notified on initial eager fetch`() = runTest(dispatcher) {
+        val jwt = makeJwt()
+        val provider = CountingSuccessProvider(jwt)
         val manager = KlaviyoAuthTokenManager()
 
-        var notified = false
-        manager.onTokenRefresh { notified = true }
+        val received = mutableListOf<String>()
+        manager.onTokenRefresh { received.add(it) }
 
         manager.registerProvider(provider)
         dispatcher.scheduler.advanceUntilIdle()
         assertEquals(1, provider.callCount)
 
-        assertEquals("eager fetch must not invoke observers", false, notified)
+        assertEquals(
+            "eager fetch notifies observers once it acquires a token, so a consumer that " +
+                "subscribed before the token resolved still receives it",
+            listOf(jwt),
+            received
+        )
     }
+
+    @Test
+    fun `observer notified when initial fetch completes after interactive timeout`() =
+        runTest(dispatcher) {
+            // Reproduces the forms scenario: a slow initial fetch is still in flight when a form
+            // subscribes and issues a short interactive-timeout fetch. That caller times out and
+            // the form shows without a JWT, but the underlying fetch is not cancelled — when it
+            // finally resolves, the observer must be notified so the webview can inject the token.
+            val jwt = makeJwt()
+            val provider = ResolvableProvider()
+            val manager = KlaviyoAuthTokenManager()
+
+            val received = mutableListOf<String>()
+            manager.onTokenRefresh { received.add(it) }
+
+            manager.registerProvider(provider)
+            dispatcher.scheduler.runCurrent() // eager fetch starts and suspends on the provider
+
+            // A form subscribes and requests the token with the short interactive budget, which
+            // times out (via the shared in-flight fetch) while the provider is still pending.
+            var timedOut = false
+            val demandCaller = launch {
+                try {
+                    manager.currentToken(AuthTokenManager.INTERACTIVE_FETCH_TIMEOUT_MS)
+                } catch (_: AuthTokenException.TimedOut) {
+                    timedOut = true
+                }
+            }
+            dispatcher.scheduler.runCurrent()
+            dispatcher.scheduler.advanceTimeBy(AuthTokenManager.INTERACTIVE_FETCH_TIMEOUT_MS + 1)
+            dispatcher.scheduler.runCurrent()
+            demandCaller.join()
+            assertEquals("interactive fetch should have timed out", true, timedOut)
+            assertEquals("no token delivered while the fetch is still in flight", 0, received.size)
+
+            // The provider finally responds after the timeout — observer must now be notified.
+            provider.resolve(jwt)
+            dispatcher.scheduler.advanceUntilIdle()
+
+            assertEquals(
+                "observer must receive the token once the slow initial fetch completes",
+                listOf(jwt),
+                received
+            )
+            assertEquals(
+                "provider invoked exactly once for the shared fetch",
+                1,
+                provider.callCount
+            )
+        }
 
     @Test
     fun `observer throwing does not prevent other observers`() = runTest(dispatcher) {
@@ -633,7 +698,11 @@ class KlaviyoAuthTokenManagerRefreshTest : BaseTest() {
         dispatcher.scheduler.advanceUntilIdle()
 
         verify { spyLog.warning(any(), any()) }
-        assertEquals("second observer should still receive jwt", 1, receivedBySecond.size)
+        assertEquals(
+            "second observer should still receive jwt on eager fetch and refresh",
+            2,
+            receivedBySecond.size
+        )
     }
 
     @Test
@@ -720,13 +789,16 @@ class KlaviyoAuthTokenManagerRefreshTest : BaseTest() {
         dispatcher.scheduler.advanceUntilIdle()
         assertEquals("retained provider should serve the next fetch", 2, provider.callCount)
 
-        // Observer is retained: fire a new proactive refresh and verify it fires
+        // Observer is retained: fire a new proactive refresh and verify it still fires. The eager
+        // fetch and the post-reset currentToken() above already notified, so assert the retained
+        // observer picks up one further notification rather than an absolute count.
+        val countBeforeRefresh = received.size
         val timerTask = staticClock.scheduledTasks.first()
         staticClock.execute(timerTask.time - staticClock.time)
         dispatcher.scheduler.advanceUntilIdle()
         assertEquals(
             "retained observer should receive jwt from post-reset refresh",
-            1,
+            countBeforeRefresh + 1,
             received.size
         )
     }
@@ -756,6 +828,9 @@ class KlaviyoAuthTokenManagerRefreshTest : BaseTest() {
             manager.registerProvider(provider)
             dispatcher.scheduler.advanceUntilIdle()
             assertEquals(1, provider.callCount)
+            // Eager fetch notified the observer with the initial token; the stale-refresh guard
+            // below must prevent any further notification beyond this baseline.
+            val notificationsAfterEagerFetch = received.size
 
             // Fire the refresh timer — provider hangs on call #2, inFlightFetch is live
             val timerTask = staticClock.scheduledTasks.first()
@@ -772,8 +847,13 @@ class KlaviyoAuthTokenManagerRefreshTest : BaseTest() {
 
             assertEquals(
                 "observer must not receive a stale-profile token after clearTokenState",
-                0,
+                notificationsAfterEagerFetch,
                 received.size
+            )
+            assertEquals(
+                "refreshed (stale-profile) token must never be delivered",
+                false,
+                received.contains(refreshedToken)
             )
         }
 
@@ -857,6 +937,9 @@ class KlaviyoAuthTokenManagerRefreshTest : BaseTest() {
             manager.registerProvider(provider)
             dispatcher.scheduler.advanceUntilIdle()
             assertEquals(1, provider.callCount)
+            // Eager fetch already notified with the initial token; the invalidate guard must
+            // suppress any further notification beyond this baseline.
+            val notificationsAfterEagerFetch = received.size
 
             // Fire the scheduled refresh; provider hangs on call #2 while fetch is suspended
             val timerTask = staticClock.scheduledTasks.first()
@@ -874,7 +957,7 @@ class KlaviyoAuthTokenManagerRefreshTest : BaseTest() {
 
             assertEquals(
                 "observer must not fire after invalidate() even before clearTokenState runs",
-                0,
+                notificationsAfterEagerFetch,
                 received.size
             )
         }
@@ -897,6 +980,9 @@ class KlaviyoAuthTokenManagerRefreshTest : BaseTest() {
             manager.registerProvider(provider)
             dispatcher.scheduler.advanceUntilIdle()
             assertEquals(1, provider.callCount)
+            // Eager fetch already notified with the acquired token; the invalidate guard must
+            // suppress any further notification beyond this baseline.
+            val notificationsAfterEagerFetch = received.size
 
             // Synchronous invalidate() fires BEFORE the refresh timer
             manager.invalidate()
@@ -908,7 +994,7 @@ class KlaviyoAuthTokenManagerRefreshTest : BaseTest() {
 
             assertEquals(
                 "observer must not fire when refresh starts after invalidate()",
-                0,
+                notificationsAfterEagerFetch,
                 received.size
             )
         }
@@ -965,6 +1051,24 @@ class KlaviyoAuthTokenManagerRefreshTest : BaseTest() {
             callCount++
             callback.onSuccess(jwt)
         }
+    }
+
+    /**
+     * Captures every callback so tests can resolve them manually, modelling a provider whose
+     * initial fetch stays in flight past a caller's timeout.
+     */
+    private class ResolvableProvider : AuthTokenProvider {
+        var callCount = 0
+            private set
+
+        private val pendingCallbacks = ArrayDeque<AuthTokenProvider.Callback>()
+
+        override fun fetchToken(callback: AuthTokenProvider.Callback) {
+            callCount++
+            pendingCallbacks.addLast(callback)
+        }
+
+        fun resolve(jwt: String) = pendingCallbacks.removeFirstOrNull()?.onSuccess(jwt)
     }
 
     private class InitialThenResolvableProvider(private val initialJwt: String) : AuthTokenProvider {

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/JwtObserver.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/JwtObserver.kt
@@ -62,16 +62,29 @@ internal class JwtObserver : JsBridgeObserver {
     private var lastInjectedSequence = 0L
 
     /**
-     * Last token value actually injected. Guards against re-injecting an identical token: a fast
-     * initial fetch that resolves within the interactive budget delivers the same token both as its
-     * own result and via the [AuthTokenManager.onTokenRefresh] broadcast that now fires on every
-     * acquisition. Null until the first injection, so an initial empty ("unauthenticated") token is
-     * still delivered. Only read/written on the UI thread.
+     * Last token value injected into the *current* webview. Guards against re-injecting an
+     * identical token within a session: a fast initial fetch that resolves within the interactive
+     * budget delivers the same value both as its own result and via the
+     * [AuthTokenManager.onTokenRefresh] echo that now fires on every acquisition. Null until the
+     * first injection of a session, so an initial empty ("unauthenticated") token is still
+     * delivered. Only read/written on the UI thread.
      */
     private var lastInjectedToken: String? = null
 
+    /**
+     * Set by [startObserver] so the next injection clears [lastInjectedToken] first. Each session
+     * loads a fresh webview with no JWT, so the value-dedup must not carry over from a previous
+     * session — otherwise a form reopened with an unchanged (still-valid) token would never receive
+     * it. `@Volatile` because [startObserver] may run off the UI thread while injections run on it;
+     * the flag is consumed on the UI thread so [lastInjectedToken] stays single-threaded.
+     */
+    @Volatile private var resetDedupOnNextInjection = false
+
     override fun startObserver() {
         stopped = false
+        // A new session loads a fresh webview; forget the previous session's injected value so an
+        // unchanged token is re-delivered rather than deduped away. Consumed on the UI thread.
+        resetDedupOnNextInjection = true
         val thisFetch = Any()
         latestFetch = thisFetch
         // Reserve the initial fetch's place in the injection order now, at request time, so any
@@ -140,12 +153,17 @@ internal class JwtObserver : JsBridgeObserver {
     /**
      * Inject [token] only if [sequence] is newer than any already applied, so an out-of-order
      * initial-fetch callback cannot overwrite a fresher token delivered via the refresh stream.
-     * Skips the bridge call when the value is unchanged from the last injection, so a token
-     * delivered twice (e.g. a fast initial fetch plus its refresh-stream echo) hits the webview
-     * once. Must be called on the UI thread, where [lastInjectedSequence] and [lastInjectedToken]
-     * are exclusively accessed.
+     * Within a session, skips the bridge call when the value is unchanged from the last injection,
+     * so a token delivered twice (e.g. a fast initial fetch plus its refresh-stream echo) hits the
+     * webview once; a new session first clears that baseline (see [resetDedupOnNextInjection]) so a
+     * reopened form still receives an unchanged token. Must be called on the UI thread, where
+     * [lastInjectedSequence] and [lastInjectedToken] are exclusively accessed.
      */
     private fun injectIfLatest(sequence: Long, token: String) {
+        if (resetDedupOnNextInjection) {
+            resetDedupOnNextInjection = false
+            lastInjectedToken = null
+        }
         if (sequence > lastInjectedSequence) {
             lastInjectedSequence = sequence
             if (token != lastInjectedToken) {

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/JwtObserver.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/JwtObserver.kt
@@ -61,6 +61,15 @@ internal class JwtObserver : JsBridgeObserver {
     /** Highest sequence applied to the webview. Only read/written on the UI thread. */
     private var lastInjectedSequence = 0L
 
+    /**
+     * Last token value actually injected. Guards against re-injecting an identical token: a fast
+     * initial fetch that resolves within the interactive budget delivers the same token both as its
+     * own result and via the [AuthTokenManager.onTokenRefresh] broadcast that now fires on every
+     * acquisition. Null until the first injection, so an initial empty ("unauthenticated") token is
+     * still delivered. Only read/written on the UI thread.
+     */
+    private var lastInjectedToken: String? = null
+
     override fun startObserver() {
         stopped = false
         val thisFetch = Any()
@@ -131,12 +140,18 @@ internal class JwtObserver : JsBridgeObserver {
     /**
      * Inject [token] only if [sequence] is newer than any already applied, so an out-of-order
      * initial-fetch callback cannot overwrite a fresher token delivered via the refresh stream.
-     * Must be called on the UI thread, where [lastInjectedSequence] is exclusively accessed.
+     * Skips the bridge call when the value is unchanged from the last injection, so a token
+     * delivered twice (e.g. a fast initial fetch plus its refresh-stream echo) hits the webview
+     * once. Must be called on the UI thread, where [lastInjectedSequence] and [lastInjectedToken]
+     * are exclusively accessed.
      */
     private fun injectIfLatest(sequence: Long, token: String) {
         if (sequence > lastInjectedSequence) {
             lastInjectedSequence = sequence
-            Registry.get<JsBridge>().jwtMutation(token)
+            if (token != lastInjectedToken) {
+                lastInjectedToken = token
+                Registry.get<JsBridge>().jwtMutation(token)
+            }
         }
     }
 }

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/JwtObserver.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/JwtObserver.kt
@@ -36,6 +36,13 @@ internal class JwtObserver : JsBridgeObserver {
 
     @Volatile private var stopped = false
 
+    /**
+     * Identity token for the current session, replaced on each [startObserver]. Both injection
+     * paths capture it and re-check it once they reach the UI thread, so a callback queued in a
+     * previous session (its fetch result, or a proactive-refresh echo) cannot inject into the fresh
+     * webview a later session loaded. `@Volatile` because it is written off the UI thread by
+     * [startObserver] and read on it.
+     */
     @Volatile private var latestFetch: Any? = null
 
     private val scope = CoroutineScope(SupervisorJob() + Registry.dispatcher)
@@ -138,13 +145,16 @@ internal class JwtObserver : JsBridgeObserver {
 
     /**
      * Re-inject a proactively-refreshed token into the webview. The manager only notifies on a
-     * successful fetch, so [jwt] is always a real (non-empty) token here. Skips if the observer has
-     * been stopped to avoid touching a torn-down webview.
+     * successful fetch, so [jwt] is always a real (non-empty) token here. Captures the current
+     * [latestFetch] and re-checks it (plus [stopped]) on the UI thread: a refresh dispatched during
+     * a previous session could otherwise run after a stop/start cycle flipped [stopped] back to
+     * false and inject a stale token into the freshly loaded webview.
      */
     private fun onTokenRefreshed(jwt: String) {
         val sequence = injectionSequence.incrementAndGet()
+        val session = latestFetch
         Registry.threadHelper.runOnUiThread {
-            if (!stopped) {
+            if (!stopped && latestFetch === session) {
                 injectIfLatest(sequence, jwt)
             }
         }

--- a/sdk/forms/src/test/java/com/klaviyo/forms/bridge/JwtObserverTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/bridge/JwtObserverTest.kt
@@ -262,6 +262,33 @@ class JwtObserverTest : BaseTest() {
     }
 
     @Test
+    fun `a refresh queued in a previous session does not inject into the new webview`() {
+        // A proactive refresh dispatched during session 1 queues its UI callback, then the form is
+        // closed and reopened (session 2) before that callback runs. The stale refresh must not
+        // reach the fresh webview even though stopObserver/startObserver flipped `stopped` back.
+        val uiQueue = mutableListOf<() -> Unit>()
+        every { mockThreadHelper.runOnUiThread(any()) } answers { uiQueue.add(firstArg()) }
+
+        val refreshObserver = captureRefreshObserver()
+        coEvery { mockAuthTokenManager.currentToken(any()) } returns validatedToken("session-1")
+
+        val observer = JwtObserver()
+        observer.startObserver() // session 1
+        dispatcher.scheduler.advanceUntilIdle() // session-1 fetch queues its inject
+        refreshObserver.captured.invoke("stale-refresh") // session-1 refresh queues its inject
+
+        observer.stopObserver()
+        coEvery { mockAuthTokenManager.currentToken(any()) } returns validatedToken("session-2")
+        observer.startObserver() // session 2 (fresh webview)
+        dispatcher.scheduler.advanceUntilIdle() // session-2 fetch queues its inject
+
+        uiQueue.forEach { it.invoke() }
+
+        verify(inverse = true) { mockJsBridge.jwtMutation("stale-refresh") }
+        verify(exactly = 1) { mockJsBridge.jwtMutation("session-2") }
+    }
+
+    @Test
     fun `unchanged token is re-injected into a fresh webview after a form restart`() {
         // JwtObserver is a shared instance across form sessions, but each session loads a new
         // webview with no JWT. The value-dedup must be scoped to the current webview: reopening a

--- a/sdk/forms/src/test/java/com/klaviyo/forms/bridge/JwtObserverTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/bridge/JwtObserverTest.kt
@@ -262,6 +262,25 @@ class JwtObserverTest : BaseTest() {
     }
 
     @Test
+    fun `unchanged token is re-injected into a fresh webview after a form restart`() {
+        // JwtObserver is a shared instance across form sessions, but each session loads a new
+        // webview with no JWT. The value-dedup must be scoped to the current webview: reopening a
+        // form while the same token is still valid must re-deliver it rather than skip it.
+        val token = "header.payload.signature"
+        coEvery { mockAuthTokenManager.currentToken(any()) } returns validatedToken(token)
+
+        val observer = JwtObserver()
+        observer.startObserver()
+        dispatcher.scheduler.advanceUntilIdle()
+        observer.stopObserver()
+
+        observer.startObserver()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        verify(exactly = 2) { mockJsBridge.jwtMutation(token) }
+    }
+
+    @Test
     fun `refresh after stopObserver does not inject the stale token`() {
         val refreshObserver = captureRefreshObserver()
         coEvery { mockAuthTokenManager.currentToken(any()) } returns validatedToken("initial")

--- a/sdk/forms/src/test/java/com/klaviyo/forms/bridge/JwtObserverTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/bridge/JwtObserverTest.kt
@@ -244,6 +244,24 @@ class JwtObserverTest : BaseTest() {
     }
 
     @Test
+    fun `identical token from initial fetch and refresh stream is injected only once`() {
+        // A fast initial fetch resolves within the interactive budget, and the manager also echoes
+        // the same value on its onTokenRefresh broadcast (which now fires on every acquisition).
+        // The webview should see the unchanged token only once.
+        val refreshObserver = captureRefreshObserver()
+        val token = "same.token.value"
+        coEvery { mockAuthTokenManager.currentToken(any()) } returns validatedToken(token)
+
+        val observer = JwtObserver()
+        observer.startObserver()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        refreshObserver.captured.invoke(token)
+
+        verify(exactly = 1) { mockJsBridge.jwtMutation(token) }
+    }
+
+    @Test
     fun `refresh after stopObserver does not inject the stale token`() {
         val refreshObserver = captureRefreshObserver()
         coEvery { mockAuthTokenManager.currentToken(any()) } returns validatedToken("initial")


### PR DESCRIPTION
# Description
When an auth token fetch is still in flight and a caller's interactive-timeout fetch gives up, the token that eventually resolves was cached silently and never broadcast to `TokenRefreshObserver`s. A form displayed while the initial fetch was in flight kept its empty JWT until a far-future proactive refresh. This moves observer notification into the shared `doFetch` path so any successful acquisition re-injects the token.

## Due Diligence
- [ ] I have tested this on an emulator and/or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all Android versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.
  - Part of the JWT / personalized-forms effort; targets the `feat/jwts-for-personalized-forms` feature branch.

## Changelog / Code Overview
Follow-up to MAGE-864 (#502). That change had `JwtObserver` subscribe to `onTokenRefresh` so a refreshed token re-injects into the webview — but the stream only fired from `performScheduledRefresh`. A slow **initial** fetch that completed after the interactive timeout resolved in `doFetch()`, which cached the token and scheduled a proactive refresh but never notified observers. So the webview kept its empty JWT until that far-future refresh (effectively never for a short-lived form).

- **`KlaviyoAuthTokenManager.doFetch()`** now notifies observers on every successful acquisition, outside the mutex, under the existing two-part stale guard (`cachedToken` match + `!profileResetPending`). Every acquisition path (initial demand fetch and proactive refresh) funnels through `doFetch`, and fetches are deduped, so this broadcasts exactly once per fetch — including the late-completing initial fetch.
- **`performScheduledRefresh()`** no longer notifies — it always resolves through a `doFetch`, so keeping its own notify would double-fire.
- **`onTokenRefresh` / `TokenRefreshObserver` docs** updated: the contract is now "acquired **or** refreshed," not "proactively refreshed."
- **`JwtObserver.injectIfLatest()`** now dedups by value. With the manager broadcasting on every acquisition, a fast initial fetch that resolves within the interactive budget would otherwise deliver the identical token twice — once as its own `currentToken()` result, once via the `onTokenRefresh` echo. `JwtObserver` tracks the last injected value and skips the bridge call when it's unchanged, so onsite sees each distinct token exactly once (the empty "unauthenticated" token is still delivered, since the tracked value starts null).
- Tests: revised the observer tests that asserted the eager fetch stayed silent (this intentionally changes that contract), and added `observer notified when initial fetch completes after interactive timeout` (core) reproducing the reported scenario, plus `identical token from initial fetch and refresh stream is injected only once` (forms) covering the dedup.

## Test Plan
- `./gradlew :sdk:core:testDebugUnitTest :sdk:forms:testDebugUnitTest` — green.
- `./gradlew :sdk:core:ktlintCheck :sdk:forms:ktlintCheck` — green.
- New regression test asserts an observer that subscribes while a slow initial fetch is in flight, then times out its own interactive fetch, is notified once the underlying fetch resolves.
- Manual on-device verification of the webview re-injection still to be done (unchecked above).

## Related Issues/Tickets
- Part of MAGE-875 — https://linear.app/klaviyo/issue/MAGE-875 (links without auto-closing, since this targets the feature branch rather than `master`)
- Follow-up to MAGE-864 (#502)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Token observers now fire both on initial auth token acquisition and on subsequent refreshes.
  * Form JWT updates are deduplicated within a webview session, with unchanged tokens re-injected after a form restart.
* **Bug Fixes**
  * Prevented stale auth-token notifications from reaching observers during reset/invalidation and in-flight refresh timing scenarios.
  * Reduced duplicate JWT injections by avoiding repeated injection of the same token value in a single session.
* **Tests**
  * Updated and expanded coverage for observer timing, eager/proactive refresh flows, and JWT injection deduplication across session lifecycles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->