### PR TITLE
feat(push): add X-Klaviyo-Sdk-Features header to push-token-register (MAGE-765)

### DIFF
--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/PushTokenApiRequest.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/PushTokenApiRequest.kt
@@ -39,17 +39,25 @@ internal class PushTokenApiRequest(
     }
 
     init {
-        val autoTrackingEnabled = Registry.config.getManifestBoolean(
-            Constants.AUTOMATIC_PUSH_TRACKING,
-            false
-        )
-        val tokenForwardingEnabled = !Registry.config.getManifestBoolean(
-            Constants.DISABLE_AUTOMATIC_TOKEN_FORWARDING,
-            false
-        )
-        headers[HEADER_SDK_FEATURES] =
-            "auto_push_tracking=${autoTrackingEnabled.toFeatureFlag()}; " +
-            "auto_push_token_forwarding=${tokenForwardingEnabled.toFeatureFlag()};"
+        val features = buildList {
+            if (Registry.config.hasManifestKey(Constants.AUTOMATIC_PUSH_TRACKING)) {
+                val autoTrackingEnabled = Registry.config.getManifestBoolean(
+                    Constants.AUTOMATIC_PUSH_TRACKING,
+                    false
+                )
+                add("auto_push_tracking=${autoTrackingEnabled.toFeatureFlag()};")
+            }
+            if (Registry.config.hasManifestKey(Constants.DISABLE_AUTOMATIC_TOKEN_FORWARDING)) {
+                val tokenForwardingEnabled = !Registry.config.getManifestBoolean(
+                    Constants.DISABLE_AUTOMATIC_TOKEN_FORWARDING,
+                    false
+                )
+                add("auto_push_token_forwarding=${tokenForwardingEnabled.toFeatureFlag()};")
+            }
+        }
+        if (features.isNotEmpty()) {
+            headers[HEADER_SDK_FEATURES] = features.joinToString(" ")
+        }
     }
 
     override val type: String = "Push Token"

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/PushTokenApiRequest.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/PushTokenApiRequest.kt
@@ -43,13 +43,13 @@ internal class PushTokenApiRequest(
             Constants.AUTOMATIC_PUSH_TRACKING,
             false
         )
-        val tokenForwardingDisabled = autoTrackingEnabled && Registry.config.getManifestBoolean(
+        val tokenForwardingEnabled = !Registry.config.getManifestBoolean(
             Constants.DISABLE_AUTOMATIC_TOKEN_FORWARDING,
             false
         )
-        if (tokenForwardingDisabled) {
-            headers[HEADER_SDK_FEATURES] = "auto_push_token_forwarding=0;"
-        }
+        headers[HEADER_SDK_FEATURES] =
+            "auto_push_tracking=${autoTrackingEnabled.toFeatureFlag()}; " +
+            "auto_push_token_forwarding=${tokenForwardingEnabled.toFeatureFlag()};"
     }
 
     override val type: String = "Push Token"
@@ -104,6 +104,8 @@ internal class PushTokenApiRequest(
         return body.toString().hashCode()
     }
 }
+
+private fun Boolean.toFeatureFlag(): String = if (this) "1" else "0"
 
 fun DeviceProperties.buildMetaData(): Map<String, String?> = mapOf(
     "device_id" to deviceId,

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/PushTokenApiRequest.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/PushTokenApiRequest.kt
@@ -1,9 +1,10 @@
 package com.klaviyo.analytics.networking.requests
 
 import com.klaviyo.analytics.model.Profile
-import com.klaviyo.core.Constants
 import com.klaviyo.core.DeviceProperties
 import com.klaviyo.core.Registry
+import com.klaviyo.core.SdkFeatureScope
+import com.klaviyo.core.SdkFeatures
 import org.json.JSONObject
 
 /**
@@ -34,30 +35,11 @@ internal class PushTokenApiRequest(
         const val BACKGROUND = "background"
         const val BG_AVAILABLE = "AVAILABLE"
         const val BG_UNAVAILABLE = "DENIED"
-
-        const val HEADER_SDK_FEATURES = "X-Klaviyo-Sdk-Features"
     }
 
     init {
-        val features = buildList {
-            if (Registry.config.hasManifestKey(Constants.AUTOMATIC_PUSH_TRACKING)) {
-                val autoTrackingEnabled = Registry.config.getManifestBoolean(
-                    Constants.AUTOMATIC_PUSH_TRACKING,
-                    false
-                )
-                add("auto_push_tracking=${autoTrackingEnabled.toFeatureFlag()};")
-            }
-            if (Registry.config.hasManifestKey(Constants.DISABLE_AUTOMATIC_TOKEN_FORWARDING)) {
-                val tokenForwardingEnabled = !Registry.config.getManifestBoolean(
-                    Constants.DISABLE_AUTOMATIC_TOKEN_FORWARDING,
-                    false
-                )
-                add("auto_push_token_forwarding=${tokenForwardingEnabled.toFeatureFlag()};")
-            }
-        }
-        if (features.isNotEmpty()) {
-            headers[HEADER_SDK_FEATURES] = features.joinToString(" ")
-        }
+        SdkFeatures.headerValue(SdkFeatureScope.PUSH_TOKEN_REGISTRATION)
+            ?.let { headers[SdkFeatures.HEADER_NAME] = it }
     }
 
     override val type: String = "Push Token"
@@ -112,8 +94,6 @@ internal class PushTokenApiRequest(
         return body.toString().hashCode()
     }
 }
-
-private fun Boolean.toFeatureFlag(): String = if (this) "1" else "0"
 
 fun DeviceProperties.buildMetaData(): Map<String, String?> = mapOf(
     "device_id" to deviceId,

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/PushTokenApiRequest.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/PushTokenApiRequest.kt
@@ -1,6 +1,7 @@
 package com.klaviyo.analytics.networking.requests
 
 import com.klaviyo.analytics.model.Profile
+import com.klaviyo.core.Constants
 import com.klaviyo.core.DeviceProperties
 import com.klaviyo.core.Registry
 import org.json.JSONObject
@@ -33,6 +34,22 @@ internal class PushTokenApiRequest(
         const val BACKGROUND = "background"
         const val BG_AVAILABLE = "AVAILABLE"
         const val BG_UNAVAILABLE = "DENIED"
+
+        const val HEADER_SDK_FEATURES = "X-Klaviyo-Sdk-Features"
+    }
+
+    init {
+        val autoTrackingEnabled = Registry.config.getManifestBoolean(
+            Constants.AUTOMATIC_PUSH_TRACKING,
+            false
+        )
+        val tokenForwardingDisabled = autoTrackingEnabled && Registry.config.getManifestBoolean(
+            Constants.DISABLE_AUTOMATIC_TOKEN_FORWARDING,
+            false
+        )
+        if (tokenForwardingDisabled) {
+            headers[HEADER_SDK_FEATURES] = "auto_push_token_forwarding=0;"
+        }
     }
 
     override val type: String = "Push Token"

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/EventApiRequestTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/EventApiRequestTest.kt
@@ -4,6 +4,7 @@ import com.klaviyo.analytics.Klaviyo
 import com.klaviyo.analytics.model.Event
 import com.klaviyo.analytics.model.EventKey
 import com.klaviyo.analytics.model.EventMetric
+import com.klaviyo.core.Constants
 import com.klaviyo.fixtures.mockDeviceProperties
 import com.klaviyo.fixtures.unmockDeviceProperties
 import io.mockk.every
@@ -14,6 +15,7 @@ import io.mockk.unmockkStatic
 import java.util.UUID
 import org.json.JSONObject
 import org.junit.After
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 
@@ -232,5 +234,13 @@ internal class EventApiRequestTest : BaseApiRequestTest<EventApiRequest>() {
         stubEvent.setProperty("custom_value", "100")
 
         compareJson(JSONObject(expectJson), JSONObject(request.requestBody!!))
+    }
+
+    @Test
+    fun `Does not include the SDK features header even when the flags that would trigger it on PushTokenApiRequest are set`() {
+        every { mockConfig.getManifestBoolean(Constants.AUTOMATIC_PUSH_TRACKING, false) } returns true
+        every { mockConfig.getManifestBoolean(Constants.DISABLE_AUTOMATIC_TOKEN_FORWARDING, false) } returns true
+        val request = EventApiRequest(stubEvent, stubProfile)
+        assertNull(request.headers["X-Klaviyo-Sdk-Features"])
     }
 }

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/EventApiRequestTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/EventApiRequestTest.kt
@@ -238,6 +238,8 @@ internal class EventApiRequestTest : BaseApiRequestTest<EventApiRequest>() {
 
     @Test
     fun `Does not include the SDK features header even when the flags that would trigger it on PushTokenApiRequest are set`() {
+        every { mockConfig.hasManifestKey(Constants.AUTOMATIC_PUSH_TRACKING) } returns true
+        every { mockConfig.hasManifestKey(Constants.DISABLE_AUTOMATIC_TOKEN_FORWARDING) } returns true
         every { mockConfig.getManifestBoolean(Constants.AUTOMATIC_PUSH_TRACKING, false) } returns true
         every { mockConfig.getManifestBoolean(Constants.DISABLE_AUTOMATIC_TOKEN_FORWARDING, false) } returns true
         val request = EventApiRequest(stubEvent, stubProfile)

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/PushTokenApiRequestTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/PushTokenApiRequestTest.kt
@@ -1,9 +1,11 @@
 package com.klaviyo.analytics.networking.requests
 
+import com.klaviyo.core.Constants
 import io.mockk.every
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 internal class PushTokenApiRequestTest : BaseApiRequestTest<PushTokenApiRequest>() {
@@ -93,5 +95,33 @@ internal class PushTokenApiRequestTest : BaseApiRequestTest<PushTokenApiRequest>
 
         val request = PushTokenApiRequest(PUSH_TOKEN, stubProfile)
         compareJson(JSONObject(expectJson), JSONObject(request.requestBody!!))
+    }
+
+    @Test
+    fun `Does not include SDK features header when automatic push tracking is off`() {
+        val request = PushTokenApiRequest(PUSH_TOKEN, stubProfile)
+        assertNull(request.headers["X-Klaviyo-Sdk-Features"])
+    }
+
+    @Test
+    fun `Does not include SDK features header when tracking is on but forwarding is not disabled`() {
+        every { mockConfig.getManifestBoolean(Constants.AUTOMATIC_PUSH_TRACKING, false) } returns true
+        val request = PushTokenApiRequest(PUSH_TOKEN, stubProfile)
+        assertNull(request.headers["X-Klaviyo-Sdk-Features"])
+    }
+
+    @Test
+    fun `Does not include SDK features header when forwarding is disabled but tracking is off`() {
+        every { mockConfig.getManifestBoolean(Constants.DISABLE_AUTOMATIC_TOKEN_FORWARDING, false) } returns true
+        val request = PushTokenApiRequest(PUSH_TOKEN, stubProfile)
+        assertNull(request.headers["X-Klaviyo-Sdk-Features"])
+    }
+
+    @Test
+    fun `Includes SDK features header when tracking is on and forwarding is disabled`() {
+        every { mockConfig.getManifestBoolean(Constants.AUTOMATIC_PUSH_TRACKING, false) } returns true
+        every { mockConfig.getManifestBoolean(Constants.DISABLE_AUTOMATIC_TOKEN_FORWARDING, false) } returns true
+        val request = PushTokenApiRequest(PUSH_TOKEN, stubProfile)
+        assertEquals("auto_push_token_forwarding=0;", request.headers["X-Klaviyo-Sdk-Features"])
     }
 }

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/PushTokenApiRequestTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/PushTokenApiRequestTest.kt
@@ -5,15 +5,12 @@ import io.mockk.every
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 internal class PushTokenApiRequestTest : BaseApiRequestTest<PushTokenApiRequest>() {
 
     override val expectedPath = "client/push-tokens"
-
-    override val expectedHeaders = super.expectedHeaders + mapOf(
-        "X-Klaviyo-Sdk-Features" to "auto_push_tracking=0; auto_push_token_forwarding=1;"
-    )
 
     override fun makeTestRequest(): PushTokenApiRequest =
         PushTokenApiRequest(PUSH_TOKEN, stubProfile)
@@ -101,26 +98,31 @@ internal class PushTokenApiRequestTest : BaseApiRequestTest<PushTokenApiRequest>
     }
 
     @Test
-    fun `SDK features header reflects tracking off and forwarding disable flag off`() {
+    fun `Does not include SDK features header when neither manifest key is present`() {
         val request = PushTokenApiRequest(PUSH_TOKEN, stubProfile)
-        assertEquals(
-            "auto_push_tracking=0; auto_push_token_forwarding=1;",
-            request.headers["X-Klaviyo-Sdk-Features"]
-        )
+        assertNull(request.headers["X-Klaviyo-Sdk-Features"])
     }
 
     @Test
-    fun `SDK features header reflects tracking off and forwarding disable flag on`() {
+    fun `SDK features header includes only auto_push_tracking when only that key is present`() {
+        every { mockConfig.hasManifestKey(Constants.AUTOMATIC_PUSH_TRACKING) } returns true
+        every { mockConfig.getManifestBoolean(Constants.AUTOMATIC_PUSH_TRACKING, false) } returns true
+        val request = PushTokenApiRequest(PUSH_TOKEN, stubProfile)
+        assertEquals("auto_push_tracking=1;", request.headers["X-Klaviyo-Sdk-Features"])
+    }
+
+    @Test
+    fun `SDK features header includes only auto_push_token_forwarding when only that key is present`() {
+        every { mockConfig.hasManifestKey(Constants.DISABLE_AUTOMATIC_TOKEN_FORWARDING) } returns true
         every { mockConfig.getManifestBoolean(Constants.DISABLE_AUTOMATIC_TOKEN_FORWARDING, false) } returns true
         val request = PushTokenApiRequest(PUSH_TOKEN, stubProfile)
-        assertEquals(
-            "auto_push_tracking=0; auto_push_token_forwarding=0;",
-            request.headers["X-Klaviyo-Sdk-Features"]
-        )
+        assertEquals("auto_push_token_forwarding=0;", request.headers["X-Klaviyo-Sdk-Features"])
     }
 
     @Test
-    fun `SDK features header reflects tracking on with forwarding left at its default`() {
+    fun `SDK features header includes both attributes when both keys present and forwarding left at its default`() {
+        every { mockConfig.hasManifestKey(Constants.AUTOMATIC_PUSH_TRACKING) } returns true
+        every { mockConfig.hasManifestKey(Constants.DISABLE_AUTOMATIC_TOKEN_FORWARDING) } returns true
         every { mockConfig.getManifestBoolean(Constants.AUTOMATIC_PUSH_TRACKING, false) } returns true
         val request = PushTokenApiRequest(PUSH_TOKEN, stubProfile)
         assertEquals(
@@ -130,7 +132,9 @@ internal class PushTokenApiRequestTest : BaseApiRequestTest<PushTokenApiRequest>
     }
 
     @Test
-    fun `SDK features header reflects tracking on with forwarding explicitly disabled`() {
+    fun `SDK features header includes both attributes when both keys present and forwarding explicitly disabled`() {
+        every { mockConfig.hasManifestKey(Constants.AUTOMATIC_PUSH_TRACKING) } returns true
+        every { mockConfig.hasManifestKey(Constants.DISABLE_AUTOMATIC_TOKEN_FORWARDING) } returns true
         every { mockConfig.getManifestBoolean(Constants.AUTOMATIC_PUSH_TRACKING, false) } returns true
         every { mockConfig.getManifestBoolean(Constants.DISABLE_AUTOMATIC_TOKEN_FORWARDING, false) } returns true
         val request = PushTokenApiRequest(PUSH_TOKEN, stubProfile)

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/PushTokenApiRequestTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/PushTokenApiRequestTest.kt
@@ -5,12 +5,15 @@ import io.mockk.every
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
-import org.junit.Assert.assertNull
 import org.junit.Test
 
 internal class PushTokenApiRequestTest : BaseApiRequestTest<PushTokenApiRequest>() {
 
     override val expectedPath = "client/push-tokens"
+
+    override val expectedHeaders = super.expectedHeaders + mapOf(
+        "X-Klaviyo-Sdk-Features" to "auto_push_tracking=0; auto_push_token_forwarding=1;"
+    )
 
     override fun makeTestRequest(): PushTokenApiRequest =
         PushTokenApiRequest(PUSH_TOKEN, stubProfile)
@@ -98,30 +101,42 @@ internal class PushTokenApiRequestTest : BaseApiRequestTest<PushTokenApiRequest>
     }
 
     @Test
-    fun `Does not include SDK features header when automatic push tracking is off`() {
+    fun `SDK features header reflects tracking off and forwarding disable flag off`() {
         val request = PushTokenApiRequest(PUSH_TOKEN, stubProfile)
-        assertNull(request.headers["X-Klaviyo-Sdk-Features"])
+        assertEquals(
+            "auto_push_tracking=0; auto_push_token_forwarding=1;",
+            request.headers["X-Klaviyo-Sdk-Features"]
+        )
     }
 
     @Test
-    fun `Does not include SDK features header when tracking is on but forwarding is not disabled`() {
-        every { mockConfig.getManifestBoolean(Constants.AUTOMATIC_PUSH_TRACKING, false) } returns true
-        val request = PushTokenApiRequest(PUSH_TOKEN, stubProfile)
-        assertNull(request.headers["X-Klaviyo-Sdk-Features"])
-    }
-
-    @Test
-    fun `Does not include SDK features header when forwarding is disabled but tracking is off`() {
+    fun `SDK features header reflects tracking off and forwarding disable flag on`() {
         every { mockConfig.getManifestBoolean(Constants.DISABLE_AUTOMATIC_TOKEN_FORWARDING, false) } returns true
         val request = PushTokenApiRequest(PUSH_TOKEN, stubProfile)
-        assertNull(request.headers["X-Klaviyo-Sdk-Features"])
+        assertEquals(
+            "auto_push_tracking=0; auto_push_token_forwarding=0;",
+            request.headers["X-Klaviyo-Sdk-Features"]
+        )
     }
 
     @Test
-    fun `Includes SDK features header when tracking is on and forwarding is disabled`() {
+    fun `SDK features header reflects tracking on with forwarding left at its default`() {
+        every { mockConfig.getManifestBoolean(Constants.AUTOMATIC_PUSH_TRACKING, false) } returns true
+        val request = PushTokenApiRequest(PUSH_TOKEN, stubProfile)
+        assertEquals(
+            "auto_push_tracking=1; auto_push_token_forwarding=1;",
+            request.headers["X-Klaviyo-Sdk-Features"]
+        )
+    }
+
+    @Test
+    fun `SDK features header reflects tracking on with forwarding explicitly disabled`() {
         every { mockConfig.getManifestBoolean(Constants.AUTOMATIC_PUSH_TRACKING, false) } returns true
         every { mockConfig.getManifestBoolean(Constants.DISABLE_AUTOMATIC_TOKEN_FORWARDING, false) } returns true
         val request = PushTokenApiRequest(PUSH_TOKEN, stubProfile)
-        assertEquals("auto_push_token_forwarding=0;", request.headers["X-Klaviyo-Sdk-Features"])
+        assertEquals(
+            "auto_push_tracking=1; auto_push_token_forwarding=0;",
+            request.headers["X-Klaviyo-Sdk-Features"]
+        )
     }
 }

--- a/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
@@ -58,13 +58,6 @@ object Constants {
     const val DISABLE_AUTOMATIC_TOKEN_FORWARDING = PUSH_PREFIX + "disable_automatic_token_forwarding"
 
     /**
-     * Manifest `<meta-data>` key to opt out of automatic push token forwarding while keeping
-     * automatic push tracking enabled. Only meaningful when [AUTOMATIC_PUSH_TRACKING] is also
-     * enabled; has no effect otherwise. Defaults to `false` (forwarding stays on).
-     */
-    const val DISABLE_AUTOMATIC_TOKEN_FORWARDING = PACKAGE_PREFIX + "disable_automatic_token_forwarding"
-
-    /**
      * Fixed notification ID used in all notify/cancel calls.
      * Notifications are uniquely identified by their string tag, not this ID.
      */

--- a/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
@@ -46,6 +46,13 @@ object Constants {
     const val AUTOMATIC_PUSH_TRACKING = PACKAGE_PREFIX + "automatic_push_tracking"
 
     /**
+     * Manifest `<meta-data>` key to opt out of automatic push token forwarding while keeping
+     * automatic push tracking enabled. Only meaningful when [AUTOMATIC_PUSH_TRACKING] is also
+     * enabled; has no effect otherwise. Defaults to `false` (forwarding stays on).
+     */
+    const val DISABLE_AUTOMATIC_TOKEN_FORWARDING = PACKAGE_PREFIX + "disable_automatic_token_forwarding"
+
+    /**
      * Fixed notification ID used in all notify/cancel calls.
      * Notifications are uniquely identified by their string tag, not this ID.
      */

--- a/sdk/core/src/main/java/com/klaviyo/core/SdkFeatures.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/SdkFeatures.kt
@@ -1,0 +1,71 @@
+package com.klaviyo.core
+
+/**
+ * The request surface a feature is reported on. Each request carrying the `X-Klaviyo-Sdk-Features`
+ * header reports only the features in its scope, so unrelated domains never share a request.
+ */
+enum class SdkFeatureScope {
+    PUSH_TOKEN_REGISTRATION
+}
+
+/**
+ * Central catalog of reportable SDK features. Each entry pairs its wire name (serialized into the
+ * header) with the manifest key it reads, its [scope], and how the raw manifest value maps to the
+ * reported value. Adding a feature — including one reported on a different request — is a new entry
+ * here; a feature is never serialized outside its [scope].
+ */
+enum class SdkFeatureKey(
+    val wireName: String,
+    val manifestKey: String,
+    val scope: SdkFeatureScope,
+    val reportedValue: (manifestValue: Boolean) -> Boolean = { it }
+) {
+    AUTO_PUSH_TRACKING(
+        wireName = "auto_push_tracking",
+        manifestKey = Constants.AUTOMATIC_PUSH_TRACKING,
+        scope = SdkFeatureScope.PUSH_TOKEN_REGISTRATION
+    ),
+
+    // `disable_...` manifest key → reported as the inverse `auto_push_token_forwarding`. Reported
+    // independently of the master flag, so the backend sees how the host set each flag.
+    AUTO_PUSH_TOKEN_FORWARDING(
+        wireName = "auto_push_token_forwarding",
+        manifestKey = Constants.DISABLE_AUTOMATIC_TOKEN_FORWARDING,
+        scope = SdkFeatureScope.PUSH_TOKEN_REGISTRATION,
+        reportedValue = { disabled -> !disabled }
+    )
+}
+
+/**
+ * Serializes SDK feature-adoption flags into the `X-Klaviyo-Sdk-Features` header, used for SDK
+ * adoption telemetry.
+ *
+ * Each flag is sourced from a manifest `<meta-data>` boolean and reported only when the host
+ * actually declared that key, so the backend can distinguish "configured false" from "not
+ * configured" (absent keys are omitted from the header).
+ */
+object SdkFeatures {
+    /** Name of the HTTP header these features are serialized into. */
+    const val HEADER_NAME = "X-Klaviyo-Sdk-Features"
+
+    /**
+     * Header value for the given [scope], e.g. `auto_push_tracking=1; auto_push_token_forwarding=0;`.
+     * Includes only in-scope features whose manifest key is present; returns `null` (so callers omit
+     * the header) when none are configured.
+     */
+    fun headerValue(scope: SdkFeatureScope): String? =
+        SdkFeatureKey.entries
+            .filter { it.scope == scope }
+            .mapNotNull { key ->
+                if (Registry.config.hasManifestKey(key.manifestKey)) {
+                    val value = key.reportedValue(
+                        Registry.config.getManifestBoolean(key.manifestKey, false)
+                    )
+                    "${key.wireName}=${if (value) "1" else "0"};"
+                } else {
+                    null
+                }
+            }
+            .takeIf { it.isNotEmpty() }
+            ?.joinToString(" ")
+}

--- a/sdk/core/src/main/java/com/klaviyo/core/config/Config.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/config/Config.kt
@@ -30,6 +30,8 @@ interface Config {
 
     fun getManifestBoolean(key: String, defaultValue: Boolean): Boolean
 
+    fun hasManifestKey(key: String): Boolean
+
     interface Builder {
         fun apiKey(apiKey: String): Builder
         fun applicationContext(context: Context): Builder

--- a/sdk/core/src/main/java/com/klaviyo/core/config/KlaviyoConfig.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/config/KlaviyoConfig.kt
@@ -153,6 +153,9 @@ object KlaviyoConfig : Config {
             applicationContext.getManifestBoolean(key, defaultValue)
         }
 
+    override fun hasManifestKey(key: String): Boolean =
+        this::applicationContext.isInitialized && applicationContext.hasManifestKey(key)
+
     /**
      * Nested class to enable the builder pattern for easy declaration of custom configurations
      */
@@ -381,4 +384,16 @@ fun Context.getManifestBoolean(key: String, defaultValue: Boolean): Boolean {
     val appInfo = pkgManager.getApplicationInfoCompat(pkgName, PackageManager.GET_META_DATA)
     val manifestMetadata = appInfo?.metaData ?: Bundle.EMPTY
     return manifestMetadata.getBoolean(key, defaultValue)
+}
+
+/**
+ * Extension method to check whether a key is present in the manifest metadata at all,
+ * regardless of its value
+ */
+fun Context.hasManifestKey(key: String): Boolean {
+    val pkgName = packageName
+    val pkgManager = packageManager
+    val appInfo = pkgManager.getApplicationInfoCompat(pkgName, PackageManager.GET_META_DATA)
+    val manifestMetadata = appInfo?.metaData ?: Bundle.EMPTY
+    return manifestMetadata.containsKey(key)
 }

--- a/sdk/core/src/test/java/com/klaviyo/core/SdkFeaturesTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/SdkFeaturesTest.kt
@@ -1,0 +1,95 @@
+package com.klaviyo.core
+
+import com.klaviyo.fixtures.BaseTest
+import io.mockk.every
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+internal class SdkFeaturesTest : BaseTest() {
+
+    /**
+     * Simulate a host declaring [manifestKey] in the manifest with the given boolean [value].
+     * Absent keys are left at BaseTest's defaults (hasManifestKey → false).
+     */
+    private fun stubManifestKey(manifestKey: String, value: Boolean) {
+        every { mockConfig.hasManifestKey(manifestKey) } returns true
+        every { mockConfig.getManifestBoolean(manifestKey, false) } returns value
+    }
+
+    @Test
+    fun `Header omitted when no manifest keys are present`() {
+        assertNull(SdkFeatures.headerValue(SdkFeatureScope.PUSH_TOKEN_REGISTRATION))
+    }
+
+    @Test
+    fun `Reports only auto_push_tracking when only that key is present and true`() {
+        stubManifestKey(SdkFeatureKey.AUTO_PUSH_TRACKING.manifestKey, true)
+        assertEquals(
+            "auto_push_tracking=1;",
+            SdkFeatures.headerValue(SdkFeatureScope.PUSH_TOKEN_REGISTRATION)
+        )
+    }
+
+    @Test
+    fun `Reports only auto_push_tracking when only that key is present and false`() {
+        stubManifestKey(SdkFeatureKey.AUTO_PUSH_TRACKING.manifestKey, false)
+        assertEquals(
+            "auto_push_tracking=0;",
+            SdkFeatures.headerValue(SdkFeatureScope.PUSH_TOKEN_REGISTRATION)
+        )
+    }
+
+    @Test
+    fun `Reports auto_push_token_forwarding as inverse of the disable flag when disable is true`() {
+        stubManifestKey(SdkFeatureKey.AUTO_PUSH_TOKEN_FORWARDING.manifestKey, true)
+        assertEquals(
+            "auto_push_token_forwarding=0;",
+            SdkFeatures.headerValue(SdkFeatureScope.PUSH_TOKEN_REGISTRATION)
+        )
+    }
+
+    @Test
+    fun `Reports auto_push_token_forwarding as inverse of the disable flag when disable is false`() {
+        stubManifestKey(SdkFeatureKey.AUTO_PUSH_TOKEN_FORWARDING.manifestKey, false)
+        assertEquals(
+            "auto_push_token_forwarding=1;",
+            SdkFeatures.headerValue(SdkFeatureScope.PUSH_TOKEN_REGISTRATION)
+        )
+    }
+
+    @Test
+    fun `Reports both attributes in deterministic order when both keys are present`() {
+        stubManifestKey(SdkFeatureKey.AUTO_PUSH_TRACKING.manifestKey, true)
+        stubManifestKey(SdkFeatureKey.AUTO_PUSH_TOKEN_FORWARDING.manifestKey, true)
+        assertEquals(
+            "auto_push_tracking=1; auto_push_token_forwarding=0;",
+            SdkFeatures.headerValue(SdkFeatureScope.PUSH_TOKEN_REGISTRATION)
+        )
+    }
+
+    @Test
+    fun `Omits an absent key even when the other in-scope key is present`() {
+        stubManifestKey(SdkFeatureKey.AUTO_PUSH_TRACKING.manifestKey, false)
+        // Forwarding-disable key left absent
+        assertEquals(
+            "auto_push_tracking=0;",
+            SdkFeatures.headerValue(SdkFeatureScope.PUSH_TOKEN_REGISTRATION)
+        )
+    }
+
+    @Test
+    fun `Every feature key resolves exactly one scope`() {
+        // Guard: a future entry cannot be added without a (non-null) scope, so it can't silently
+        // escape the scope filter.
+        SdkFeatureKey.entries.forEach { key ->
+            assertNotNull(key.scope)
+        }
+    }
+
+    @Test
+    fun `Header name matches the agreed wire contract`() {
+        assertEquals("X-Klaviyo-Sdk-Features", SdkFeatures.HEADER_NAME)
+    }
+}

--- a/sdk/core/src/test/java/com/klaviyo/core/config/KlaviyoConfigTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/config/KlaviyoConfigTest.kt
@@ -268,4 +268,35 @@ internal class KlaviyoConfigTest : BaseTest() {
         assertEquals(true, mockContext.getManifestBoolean("missing.key", true))
         assertEquals(false, mockContext.getManifestBoolean("missing.key", false))
     }
+
+    @Test
+    fun `hasManifestKey reflects presence of the key, regardless of its value`() {
+        // Back the Bundle with a real map so containsKey has genuine present/absent semantics
+        // rather than echoing a stubbed return.
+        val metadata = mutableMapOf(
+            "com.klaviyo.present_true" to true,
+            "com.klaviyo.present_false" to false
+        )
+        val mockMetadata = mockk<Bundle> {
+            every { containsKey(any()) } answers { metadata.containsKey(firstArg()) }
+        }
+        mockApplicationInfo.metaData = mockMetadata
+
+        mockkStatic(PackageManager.ApplicationInfoFlags::class)
+        val mockApplicationInfoFlags = mockk<PackageManager.ApplicationInfoFlags>()
+        every { PackageManager.ApplicationInfoFlags.of(any()) } returns mockApplicationInfoFlags
+        setFinalStatic(Build.VERSION::class.java.getField("SDK_INT"), 33)
+        every {
+            mockPackageManager.getApplicationInfo(
+                BuildConfig.LIBRARY_PACKAGE_NAME,
+                mockApplicationInfoFlags
+            )
+        } returns mockApplicationInfo
+
+        // Present regardless of whether the value is true or false.
+        assertEquals(true, mockContext.hasManifestKey("com.klaviyo.present_true"))
+        assertEquals(true, mockContext.hasManifestKey("com.klaviyo.present_false"))
+        // Absent key is reported as absent.
+        assertEquals(false, mockContext.hasManifestKey("missing.key"))
+    }
 }

--- a/sdk/fixtures/src/main/java/com/klaviyo/fixtures/BaseTest.kt
+++ b/sdk/fixtures/src/main/java/com/klaviyo/fixtures/BaseTest.kt
@@ -98,6 +98,8 @@ abstract class BaseTest {
         every { formEnvironment } returns FormEnvironment.IN_APP
         // Default to the passed default (e.g. automatic push tracking off); override per-test to flip on
         every { getManifestBoolean(any(), any()) } answers { secondArg() }
+        // Default to no manifest keys present; override per-test to simulate a host declaring one
+        every { hasManifestKey(any()) } returns false
     }
 
     protected val mockActivity: Activity = mockk(relaxed = true)


### PR DESCRIPTION
# Description
Adds an `X-Klaviyo-Sdk-Features` header to `PushTokenApiRequest` only, carrying SDK feature-adoption flags for backend telemetry ([MAGE-766](https://linear.app/klaviyo/issue/MAGE-766)).

## Due Diligence
- [x] I have tested this on an emulator and/or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all Android versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

## Changelog / Code Overview
- `Config`/`KlaviyoConfig`: added `hasManifestKey(key): Boolean` (mirrors `getManifestInt`/`getManifestBoolean`) to distinguish "manifest key absent" from "present and false" — `getManifestBoolean`'s single default-value return can't tell those apart.
- `Constants`: added `DISABLE_AUTOMATIC_TOKEN_FORWARDING` (`com.klaviyo.disable_automatic_token_forwarding`) alongside the existing `AUTOMATIC_PUSH_TRACKING`.
- `PushTokenApiRequest`: attaches `X-Klaviyo-Sdk-Features` with `auto_push_tracking` and/or `auto_push_token_forwarding`, **each included only if its manifest key is present** in the host's manifest. Header is omitted entirely if neither key is set.
  - `auto_push_tracking` reflects `com.klaviyo.automatic_push_tracking` directly.
  - `auto_push_token_forwarding` mirrors `!com.klaviyo.disable_automatic_token_forwarding` directly (independent of the tracking flag, per product decision — reports the disable flag as-is).
- Scoped to `PushTokenApiRequest` only, not the shared `KlaviyoApiRequest` base — verified via a dedicated `EventApiRequestTest` assertion that the header never leaks to other request types.

## Test Plan
- `./gradlew :sdk:core:testDebugUnitTest :sdk:analytics:testDebugUnitTest` — new coverage in `KlaviyoConfigTest`, `PushTokenApiRequestTest` (all manifest-key presence/value combinations), `EventApiRequestTest` (header does not leak to other request types).
- `./gradlew test` (full suite) and `./gradlew ktlintCheck` both pass.
- Manual: ran the sample app on an emulator with each combination of `com.klaviyo.automatic_push_tracking` / `com.klaviyo.disable_automatic_token_forwarding` present/absent/true/false in the manifest, confirmed via `adb logcat` that the outgoing `client/push-tokens` request carries exactly the expected `X-Klaviyo-Sdk-Features` value (or omits it) in each case.

## Related Issues/Tickets
[MAGE-765](https://linear.app/klaviyo/issue/MAGE-765)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for reporting SDK feature details in a request header when relevant manifest settings are present.
  * Improved manifest handling so the app can detect whether a setting exists, regardless of its value.

* **Bug Fixes**
  * Ensured only the intended request type includes the SDK feature header.
  * Added coverage for header generation across different manifest combinations and value states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->