### PR TITLE
feat(sample): product flavors for manual vs automatic push integration (MAGE-770)

### DIFF
--- a/sample/README.md
+++ b/sample/README.md
@@ -18,7 +18,7 @@ Key parts of the code are annotated with `SETUP NOTE` comments. Refer to the fol
 
 ## Integration styles (product flavors)
 The sample ships two product flavors (dimension `integration`) so both Klaviyo push integration styles are
-demonstrated side by side, mirroring the iOS examples (`SPMExample` alongside `SPMExampleAutomatic`):
+demonstrated side by side:
 
 - **`manual`** — Manual integration (Option B). The app fetches the FCM token and calls `Klaviyo.setPushToken()`,
   and calls `Klaviyo.handlePush(intent)` on notification taps. This is the classic path and matches the

--- a/sample/README.md
+++ b/sample/README.md
@@ -9,10 +9,41 @@ If you cannot isolate your issue and reproduce it with the sample app, the issue
 
 ## Code Reference
 Key parts of the code are annotated with `SETUP NOTE` comments. Refer to the following files in particular:
-- [build.gradle](./build.gradle) for installation, see `SETUP NOTE` comments.
+- [build.gradle](./build.gradle.kts) for installation, see `SETUP NOTE` comments.
 - [SampleApplication.kt](./src/main/java/com/klaviyo/sample/SampleApplication.kt) for initializing the Klaviyo SDK.
-- [SampleActivity.kt](./src/main/java/com/klaviyo/sample/SampleActivity.kt) for sample code to create/modify a profile, track events, and send push tokens to Klaviyo.
-- [Manifest](./src/main/AndroidManifest.xml) for push integration and other configurable settings. 
+- `SampleActivity.kt` for sample code to create/modify a profile, track events, and integrate push. This file
+  lives per product flavor — [manual](./src/manual/java/com/klaviyo/sample/SampleActivity.kt) and
+  [automatic](./src/automatic/java/com/klaviyo/sample/SampleActivity.kt) — see [Integration styles](#integration-styles-product-flavors) below.
+- [Manifest](./src/main/AndroidManifest.xml) for push integration and other configurable settings.
+
+## Integration styles (product flavors)
+The sample ships two product flavors (dimension `integration`) so both Klaviyo push integration styles are
+demonstrated side by side, mirroring the iOS examples (`SPMExample` alongside `SPMExampleAutomatic`):
+
+- **`manual`** — Manual integration (Option B). The app fetches the FCM token and calls `Klaviyo.setPushToken()`,
+  and calls `Klaviyo.handlePush(intent)` on notification taps. This is the classic path and matches the
+  behavior of prior sample releases.
+- **`automatic`** — Automatic integration (Option A). The app opts in with a single manifest flag
+  (`com.klaviyo.push.automatic_push_tracking="true"`, see [src/automatic/AndroidManifest.xml](./src/automatic/AndroidManifest.xml))
+  and the SDK does both for you: it auto-registers the push token at `initialize()` / every foreground, and
+  routes notification taps through `KlaviyoTrampolineActivity` to track opens — so the sample's `SampleActivity`
+  contains **zero** push boilerplate. Compare the two `SampleActivity.kt` copies to see exactly what code
+  disappears when you opt in.
+
+Everything except `SampleActivity.kt` is shared under `src/main`. To switch styles, pick the **Build Variants**
+panel in Android Studio (`manualDebug` vs `automaticDebug`), or from the CLI:
+
+```bash
+./gradlew :sample:installManualDebug
+./gradlew :sample:installAutomaticDebug
+```
+
+Both flavors share the same `applicationId` and `google-services.json`, so only one installs at a time. The
+`automatic` flavor still relies on the auto-registered `KlaviyoPushService` (from `:sdk:push-fcm`) to *display*
+notifications. To keep automatic open tracking while owning your own token pipeline, add
+`com.klaviyo.push.disable_automatic_token_forwarding="true"` to the manifest.
+
+See the main [README](../README.md) "Push Notifications" section for the full Option A / Option B write-up.
 
 ## Running the Sample App
 Follow these instructions to run the sample app on your own device or emulator.

--- a/sample/README.md
+++ b/sample/README.md
@@ -53,7 +53,7 @@ Follow these instructions to run the sample app on your own device or emulator.
   Or, replace `KLAVIYO_PUBLIC_KEY` in [SampleApplication.kt](./src/main/java/com/klaviyo/sample/SampleApplication.kt).
 - Add your `google-services.json` file to the [`sample`](.) directory. You can use the same file you use for your 
   own application, or register a new app in your project from the firebase console.
-- Open [build.gradle](./build.gradle) and replace `applicationId "${klaviyoGroupId}.sample"`
+- Open [build.gradle](./build.gradle.kts) and replace `applicationId "${klaviyoGroupId}.sample"`
   with your application ID as registered in the firebase console.
 - If you wish to send a test notification from Klaviyo, make sure you're using the correct authentication key
   in your account's [push settings](https://help.klaviyo.com/hc/en-us/articles/14750928993307).

--- a/sample/README.md
+++ b/sample/README.md
@@ -23,12 +23,13 @@ demonstrated side by side:
 - **`manual`** — Manual integration (Option B). The app fetches the FCM token and calls `Klaviyo.setPushToken()`,
   and calls `Klaviyo.handlePush(intent)` on notification taps. This is the classic path and matches the
   behavior of prior sample releases.
-- **`automatic`** — Automatic integration (Option A). The app opts in with a single manifest flag
-  (`com.klaviyo.push.automatic_push_tracking="true"`, see [src/automatic/AndroidManifest.xml](./src/automatic/AndroidManifest.xml))
-  and the SDK does both for you: it auto-registers the push token at `initialize()` / every foreground, and
-  routes notification taps through `KlaviyoTrampolineActivity` to track opens — so the sample's `SampleActivity`
-  contains **zero** push boilerplate. Compare the two `SampleActivity.kt` copies to see exactly what code
-  disappears when you opt in.
+- **`automatic`** — Automatic integration (Option A). The app opts in with two independent manifest flags
+  (`com.klaviyo.push.automatic_push_tracking="true"` and `com.klaviyo.push.automatic_token_forwarding="true"`,
+  see [src/automatic/AndroidManifest.xml](./src/automatic/AndroidManifest.xml)) and the SDK does both for you:
+  `automatic_token_forwarding` auto-registers the push token at `initialize()` / every foreground, and
+  `automatic_push_tracking` makes the SDK detect notification taps and report opens for you — so the
+  sample's `SampleActivity` contains **zero** push boilerplate. Compare the two `SampleActivity.kt` copies
+  to see exactly what code disappears when you opt in.
 
 Everything except `SampleActivity.kt` is shared under `src/main`. To switch styles, pick the **Build Variants**
 panel in Android Studio (`manualDebug` vs `automaticDebug`), or from the CLI:
@@ -40,8 +41,15 @@ panel in Android Studio (`manualDebug` vs `automaticDebug`), or from the CLI:
 
 Both flavors share the same `applicationId` and `google-services.json`, so only one installs at a time. The
 `automatic` flavor still relies on the auto-registered `KlaviyoPushService` (from `:sdk:push-fcm`) to *display*
-notifications. To keep automatic open tracking while owning your own token pipeline, add
-`com.klaviyo.push.disable_automatic_token_forwarding="true"` to the manifest.
+notifications. Because the two flags are independent, you can mix and match: set only
+`automatic_push_tracking="true"` to keep automatic open tracking while owning your own token pipeline (omit
+`automatic_token_forwarding`), or set only `automatic_token_forwarding="true"` to auto-forward tokens without
+automatic open tracking.
+
+Note that `KlaviyoPushService.onNewToken()` forwards token rotations to Klaviyo unconditionally whenever
+`KlaviyoPushService` is the registered `FirebaseMessagingService` — independent of both flags. To fully own
+the token pipeline, register your own `FirebaseMessagingService` instead of `KlaviyoPushService` (the same
+pattern used to integrate alongside Braze/Airship/Iterable).
 
 See the main [README](../README.md) "Push Notifications" section for the full Option A / Option B write-up.
 

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -87,6 +87,18 @@ android {
         }
     }
 
+    // SETUP NOTE: The sample ships two flavors so both Klaviyo push integration styles are demonstrated
+    // side by side. Select the `manualDebug` or `automaticDebug` build variant in Android Studio to run each.
+    //  - manual (Option B): the app fetches the push token and calls Klaviyo.handlePush() itself.
+    //  - automatic (Option A): the app opts in via a manifest flag and the SDK does both for you.
+    // The two flavors share the same applicationId, so they use the same google-services.json but install
+    // one at a time. See src/manual and src/automatic for the per-flavor SampleActivity, and sample/README.md.
+    flavorDimensions += "integration"
+    productFlavors {
+        create("manual") { dimension = "integration" }
+        create("automatic") { dimension = "integration" }
+    }
+
     compileOptions {
         sourceCompatibility = javaVersion
         targetCompatibility = javaVersion

--- a/sample/src/automatic/AndroidManifest.xml
+++ b/sample/src/automatic/AndroidManifest.xml
@@ -2,20 +2,24 @@
 
     <!--
         SETUP NOTE (Automatic / Option A): This overlay is the ONLY difference in the automatic flavor's
-        manifest. Setting com.klaviyo.push.automatic_push_tracking to "true" opts the app into:
-          - automatic push OPEN tracking: notification taps route through KlaviyoTrampolineActivity, which
-            calls Klaviyo.handlePush() for you (no handlePush() call in your Activity), and
-          - automatic push TOKEN registration: the SDK fetches and registers the token at Klaviyo.initialize()
-            and on every foreground (no FirebaseMessaging fetch / Klaviyo.setPushToken() in your app).
-        Note the key's "com.klaviyo.push." prefix is required — the bare "com.klaviyo.*" form silently no-ops.
-        The `manual` flavor omits this overlay entirely; absence of the flag is the manual (Option B) path.
-
-        Advanced: to keep automatic open tracking but own your token pipeline, also add
-        com.klaviyo.push.disable_automatic_token_forwarding="true" (see the main README).
+        manifest. It opts into both automatic behaviors via two independent flags:
+          - com.klaviyo.push.automatic_push_tracking="true" — automatic push OPEN tracking: the SDK
+            automatically detects notification taps and reports the open via Klaviyo.handlePush() for
+            you (no handlePush() call in your Activity), and
+          - com.klaviyo.push.automatic_token_forwarding="true" — automatic push TOKEN registration: the SDK
+            fetches and registers the token at Klaviyo.initialize() and on every foreground (no
+            FirebaseMessaging fetch / Klaviyo.setPushToken() in your app).
+        The two flags are fully independent — set either one without the other to opt into just that
+        behavior. The `manual` flavor omits this overlay entirely; absence of both flags is the manual
+        (Option B) path.
+        Note the keys' "com.klaviyo.push." prefix is required — the bare "com.klaviyo.*" form silently no-ops.
     -->
     <application>
         <meta-data
             android:name="com.klaviyo.push.automatic_push_tracking"
+            android:value="true" />
+        <meta-data
+            android:name="com.klaviyo.push.automatic_token_forwarding"
             android:value="true" />
     </application>
 

--- a/sample/src/automatic/AndroidManifest.xml
+++ b/sample/src/automatic/AndroidManifest.xml
@@ -1,0 +1,22 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <!--
+        SETUP NOTE (Automatic / Option A): This overlay is the ONLY difference in the automatic flavor's
+        manifest. Setting com.klaviyo.push.automatic_push_tracking to "true" opts the app into:
+          - automatic push OPEN tracking: notification taps route through KlaviyoTrampolineActivity, which
+            calls Klaviyo.handlePush() for you (no handlePush() call in your Activity), and
+          - automatic push TOKEN registration: the SDK fetches and registers the token at Klaviyo.initialize()
+            and on every foreground (no FirebaseMessaging fetch / Klaviyo.setPushToken() in your app).
+        Note the key's "com.klaviyo.push." prefix is required — the bare "com.klaviyo.*" form silently no-ops.
+        The `manual` flavor omits this overlay entirely; absence of the flag is the manual (Option B) path.
+
+        Advanced: to keep automatic open tracking but own your token pipeline, also add
+        com.klaviyo.push.disable_automatic_token_forwarding="true" (see the main README).
+    -->
+    <application>
+        <meta-data
+            android:name="com.klaviyo.push.automatic_push_tracking"
+            android:value="true" />
+    </application>
+
+</manifest>

--- a/sample/src/automatic/java/com/klaviyo/sample/SampleActivity.kt
+++ b/sample/src/automatic/java/com/klaviyo/sample/SampleActivity.kt
@@ -16,12 +16,14 @@ import com.klaviyo.analytics.model.EventMetric
 
 /**
  * SETUP NOTE: This is the `automatic` flavor's Activity, demonstrating automatic push integration (Option A).
- * By setting com.klaviyo.push.automatic_push_tracking="true" in the manifest (see src/automatic/AndroidManifest.xml),
- * the SDK takes over both push responsibilities, so there is *zero* push boilerplate here:
- *  - Push token: auto-registered at Klaviyo.initialize() and on every foreground (no FirebaseMessaging fetch,
- *    no Klaviyo.setPushToken() call). Contrast with the `manual` flavor's onCreate under src/manual.
- *  - Push opens: KlaviyoTrampolineActivity intercepts taps and calls Klaviyo.handlePush() for you, so there is
- *    no handlePush() call in onNewIntent. Contrast with the `manual` flavor's onNewIntent.
+ * By setting com.klaviyo.push.automatic_token_forwarding="true" and com.klaviyo.push.automatic_push_tracking="true"
+ * in the manifest (see src/automatic/AndroidManifest.xml), the SDK takes over both push responsibilities, so
+ * there is *zero* push boilerplate here:
+ *  - Push token (automatic_token_forwarding): auto-registered at Klaviyo.initialize() and on every foreground
+ *    (no FirebaseMessaging fetch, no Klaviyo.setPushToken() call). Contrast with the `manual` flavor's onCreate.
+ *  - Push opens (automatic_push_tracking): the SDK automatically detects when a user taps a push notification
+ *    and reports the open event via Klaviyo.handlePush() for you, so there is no handlePush() call in
+ *    onNewIntent. Contrast with the `manual` flavor's onNewIntent.
  * Displaying notifications still relies on the auto-registered KlaviyoPushService from :sdk:push-fcm.
  * See the main README's "Push Notifications" section (Option A) and sample/README.md.
  */
@@ -65,8 +67,8 @@ class SampleActivity : ComponentActivity() {
         }
 
         // SETUP NOTE (Automatic / Option A): No Klaviyo.handlePush(intent) here.
-        // Because com.klaviyo.push.automatic_push_tracking is enabled, notification taps route through
-        // KlaviyoTrampolineActivity, which tracks the open and invokes your deep link handler for you.
+        // Because com.klaviyo.push.automatic_push_tracking is enabled, the SDK automatically detects
+        // notification taps, reports the open, and invokes your deep link handler for you.
     }
 
     private val requestPermissionLauncher = registerForActivityResult(

--- a/sample/src/automatic/java/com/klaviyo/sample/SampleActivity.kt
+++ b/sample/src/automatic/java/com/klaviyo/sample/SampleActivity.kt
@@ -11,14 +11,20 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.core.content.ContextCompat
 import androidx.core.view.WindowCompat
-import androidx.lifecycle.lifecycleScope
-import com.google.firebase.messaging.FirebaseMessaging
 import com.klaviyo.analytics.Klaviyo
-import com.klaviyo.analytics.Klaviyo.isKlaviyoNotificationIntent
 import com.klaviyo.analytics.model.EventMetric
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 
+/**
+ * SETUP NOTE: This is the `automatic` flavor's Activity, demonstrating automatic push integration (Option A).
+ * By setting com.klaviyo.push.automatic_push_tracking="true" in the manifest (see src/automatic/AndroidManifest.xml),
+ * the SDK takes over both push responsibilities, so there is *zero* push boilerplate here:
+ *  - Push token: auto-registered at Klaviyo.initialize() and on every foreground (no FirebaseMessaging fetch,
+ *    no Klaviyo.setPushToken() call). Contrast with the `manual` flavor's onCreate under src/manual.
+ *  - Push opens: KlaviyoTrampolineActivity intercepts taps and calls Klaviyo.handlePush() for you, so there is
+ *    no handlePush() call in onNewIntent. Contrast with the `manual` flavor's onNewIntent.
+ * Displaying notifications still relies on the auto-registered KlaviyoPushService from :sdk:push-fcm.
+ * See the main README's "Push Notifications" section (Option A) and sample/README.md.
+ */
 class SampleActivity : ComponentActivity() {
     // Initialize ViewModel using the by viewModels() delegate
     private val viewModel: SampleViewModel by viewModels()
@@ -26,13 +32,8 @@ class SampleActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // SETUP NOTE: Fetch the current push token and register with Klaviyo Push-FCM
-        FirebaseMessaging.getInstance().token.addOnSuccessListener { token ->
-            // Dispatch to main for the UI update
-            lifecycleScope.launch(Dispatchers.Main) {
-                viewModel.updatePushToken(token)
-            }
-        }
+        // SETUP NOTE (Automatic / Option A): No push-token code here. The SDK auto-registers the token at
+        // initialize() and on every foreground. The UI reads it from Klaviyo.getPushToken().
 
         // Example analytics event to track "Opened App" event on launch
         Klaviyo.createEvent(EventMetric.OPENED_APP)
@@ -58,16 +59,14 @@ class SampleActivity : ComponentActivity() {
 
         // SETUP NOTE: Handle Universal Tracking Links. The SDK will resolve the destination URL
         // then either invoke your registered deep link handler or send another Intent to your app.
+        // (This is unrelated to push open tracking and is required in both integration styles.)
         if (Klaviyo.handleUniversalTrackingLink(intent)) {
             return
         }
 
-        // SETUP NOTE: Track an event when user opens a notification.
-        // If the notification is a deep link, the SDK will invoke your registered handler.
-        // If not using a deep link handler, you should parse the URI from intent.data below.
-        if (intent.isKlaviyoNotificationIntent) {
-            Klaviyo.handlePush(intent)
-        }
+        // SETUP NOTE (Automatic / Option A): No Klaviyo.handlePush(intent) here.
+        // Because com.klaviyo.push.automatic_push_tracking is enabled, notification taps route through
+        // KlaviyoTrampolineActivity, which tracks the open and invokes your deep link handler for you.
     }
 
     private val requestPermissionLauncher = registerForActivityResult(

--- a/sample/src/main/java/com/klaviyo/sample/SampleView.kt
+++ b/sample/src/main/java/com/klaviyo/sample/SampleView.kt
@@ -112,6 +112,10 @@ fun SampleView(
                     viewModel.updateNotificationPermission(areNotificationsEnabled())
                 }
 
+                // Refresh the push token from the SDK. The `automatic` flavor registers the token
+                // automatically (no updatePushToken call), so re-read it here to reflect it in the UI.
+                viewModel.refreshPushToken()
+
                 // Update location permission state
                 ContextCompat.checkSelfPermission(
                     context,

--- a/sample/src/main/java/com/klaviyo/sample/SampleViewModel.kt
+++ b/sample/src/main/java/com/klaviyo/sample/SampleViewModel.kt
@@ -170,6 +170,18 @@ class SampleViewModel : ViewModel() {
         pushToken = token
     }
 
+    /**
+     * Re-read the push token from the SDK to keep the UI in sync.
+     *
+     * The `automatic` flavor never calls [updatePushToken] — the SDK auto-registers the token
+     * asynchronously after launch — so the displayed token is refreshed from the SDK on resume.
+     * Only overwrite when the SDK has a token, to avoid clobbering a shown value with an empty one.
+     */
+    @UiThread
+    fun refreshPushToken() {
+        Klaviyo.getPushToken()?.let { pushToken = it }
+    }
+
     // Geofencing registration actions
     @UiThread
     fun registerForGeofencing() {

--- a/sample/src/manual/java/com/klaviyo/sample/SampleActivity.kt
+++ b/sample/src/manual/java/com/klaviyo/sample/SampleActivity.kt
@@ -1,0 +1,177 @@
+package com.klaviyo.sample
+
+import android.Manifest
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.activity.viewModels
+import androidx.core.content.ContextCompat
+import androidx.core.view.WindowCompat
+import androidx.lifecycle.lifecycleScope
+import com.google.firebase.messaging.FirebaseMessaging
+import com.klaviyo.analytics.Klaviyo
+import com.klaviyo.analytics.Klaviyo.isKlaviyoNotificationIntent
+import com.klaviyo.analytics.model.EventMetric
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+/**
+ * SETUP NOTE: This is the `manual` flavor's Activity, demonstrating manual push integration (Option B):
+ * the app fetches the push token and forwards it to Klaviyo, and calls [Klaviyo.handlePush] itself on
+ * notification taps. Compare with the `automatic` flavor's copy under `src/automatic`, where both of those
+ * responsibilities are handled by the SDK and this boilerplate simply disappears. See the main README's
+ * "Push Notifications" section (Option A vs Option B) and sample/README.md.
+ */
+class SampleActivity : ComponentActivity() {
+    // Initialize ViewModel using the by viewModels() delegate
+    private val viewModel: SampleViewModel by viewModels()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        // SETUP NOTE (Manual / Option B): Fetch the current push token and register it with Klaviyo.
+        // The `automatic` flavor omits this entirely — the SDK auto-registers the token at initialize()
+        // and on every foreground once com.klaviyo.push.automatic_push_tracking is enabled.
+        FirebaseMessaging.getInstance().token.addOnSuccessListener { token ->
+            // Dispatch to main for the UI update
+            lifecycleScope.launch(Dispatchers.Main) {
+                viewModel.updatePushToken(token)
+            }
+        }
+
+        // Example analytics event to track "Opened App" event on launch
+        Klaviyo.createEvent(EventMetric.OPENED_APP)
+
+        // Enable edge-to-edge display for all Android versions for consistency
+        WindowCompat.enableEdgeToEdge(window)
+
+        setContent {
+            SampleView(
+                viewModel = viewModel,
+                onRequestNotificationPermission = { askNotificationPermission() },
+                onRequestLocationPermission = { askLocationPermission() },
+                onRequestBackgroundLocationPermission = { askBackgroundLocationPermission() },
+                onShowToast = { message -> showToast(message) }
+            )
+        }
+
+        onNewIntent(intent)
+    }
+
+    override fun onNewIntent(intent: Intent?) {
+        super.onNewIntent(intent)
+
+        // SETUP NOTE: Handle Universal Tracking Links. The SDK will resolve the destination URL
+        // then either invoke your registered deep link handler or send another Intent to your app.
+        if (Klaviyo.handleUniversalTrackingLink(intent)) {
+            return
+        }
+
+        // SETUP NOTE (Manual / Option B): Track an event when the user opens a notification.
+        // If the notification is a deep link, the SDK will invoke your registered handler.
+        // If not using a deep link handler, you should parse the URI from intent.data below.
+        // The `automatic` flavor omits this — KlaviyoTrampolineActivity calls handlePush() for you.
+        if (intent.isKlaviyoNotificationIntent) {
+            Klaviyo.handlePush(intent)
+        }
+    }
+
+    private val requestPermissionLauncher = registerForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { isGranted: Boolean ->
+        // Note: you don't need to notify Klaviyo SDK after permission changes
+        showToast("Notification permission ${if (isGranted) "granted" else "denied"}")
+    }
+
+    /**
+     * Notification Permission Handling for Android 13+
+     */
+    private fun askNotificationPermission() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            if (ContextCompat.checkSelfPermission(
+                    this,
+                    Manifest.permission.POST_NOTIFICATIONS
+                ) == PackageManager.PERMISSION_GRANTED
+            ) {
+                // FCM SDK (and your app) can post notifications.
+            } else if (shouldShowRequestPermissionRationale(Manifest.permission.POST_NOTIFICATIONS)) {
+                // Note: It would be typical to show an educational UI here before, omitting in this sample app.
+                showToast("Please accept notifications to receive updates from Klaviyo")
+                requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+            } else {
+                // Directly ask for the permission
+                requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+            }
+        } else {
+            // FCM SDK (and your app) can post notifications.
+        }
+    }
+
+    private fun askLocationPermission() {
+        if (ContextCompat.checkSelfPermission(
+                this,
+                Manifest.permission.ACCESS_FINE_LOCATION
+            ) == PackageManager.PERMISSION_GRANTED
+        ) {
+            // Location permission already granted
+        } else if (shouldShowRequestPermissionRationale(Manifest.permission.ACCESS_FINE_LOCATION)) {
+            // Note: It would be typical to show an educational UI here before, omitting in this sample app.
+            requestLocationPermissionLauncher.launch(Manifest.permission.ACCESS_FINE_LOCATION)
+        } else {
+            // Directly ask for the permission
+            requestLocationPermissionLauncher.launch(Manifest.permission.ACCESS_FINE_LOCATION)
+        }
+    }
+
+    private val requestLocationPermissionLauncher = registerForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { isGranted: Boolean ->
+        if (isGranted) {
+            showToast("Location permission granted")
+        } else {
+            showToast("Location permission not granted")
+        }
+    }
+
+    private fun askBackgroundLocationPermission() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            if (ContextCompat.checkSelfPermission(
+                    this,
+                    Manifest.permission.ACCESS_BACKGROUND_LOCATION
+                ) == PackageManager.PERMISSION_GRANTED
+            ) {
+                // Background location permission already granted
+            } else if (shouldShowRequestPermissionRationale(
+                    Manifest.permission.ACCESS_BACKGROUND_LOCATION
+                )
+            ) {
+                // Show educational UI
+                showToast(
+                    "Please allow location access 'All the time' to enable geofencing features."
+                )
+                requestBackgroundLocationPermissionLauncher.launch(
+                    Manifest.permission.ACCESS_BACKGROUND_LOCATION
+                )
+            } else {
+                // Directly ask for the permission
+                requestBackgroundLocationPermissionLauncher.launch(
+                    Manifest.permission.ACCESS_BACKGROUND_LOCATION
+                )
+            }
+        }
+    }
+
+    private val requestBackgroundLocationPermissionLauncher = registerForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { isGranted: Boolean ->
+        if (isGranted) {
+            showToast("Background location permission granted")
+        } else {
+            showToast("Background location permission denied")
+        }
+    }
+}

--- a/sample/src/manual/java/com/klaviyo/sample/SampleActivity.kt
+++ b/sample/src/manual/java/com/klaviyo/sample/SampleActivity.kt
@@ -35,7 +35,7 @@ class SampleActivity : ComponentActivity() {
 
         // SETUP NOTE (Manual / Option B): Fetch the current push token and register it with Klaviyo.
         // The `automatic` flavor omits this entirely — the SDK auto-registers the token at initialize()
-        // and on every foreground once com.klaviyo.push.automatic_push_tracking is enabled.
+        // and on every foreground once com.klaviyo.push.automatic_token_forwarding is enabled.
         FirebaseMessaging.getInstance().token.addOnSuccessListener { token ->
             // Dispatch to main for the UI update
             lifecycleScope.launch(Dispatchers.Main) {
@@ -74,7 +74,7 @@ class SampleActivity : ComponentActivity() {
         // SETUP NOTE (Manual / Option B): Track an event when the user opens a notification.
         // If the notification is a deep link, the SDK will invoke your registered handler.
         // If not using a deep link handler, you should parse the URI from intent.data below.
-        // The `automatic` flavor omits this — KlaviyoTrampolineActivity calls handlePush() for you.
+        // The `automatic` flavor omits this — the SDK detects taps and calls handlePush() for you.
         if (intent.isKlaviyoNotificationIntent) {
             Klaviyo.handlePush(intent)
         }

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -118,25 +118,21 @@ object Klaviyo {
     }
 
     /**
-     * Opt-in automatic push token registration (via [Constants.AUTOMATIC_PUSH_TRACKING]): pull the
+     * Opt-in automatic push token registration (via [Constants.AUTOMATIC_TOKEN_FORWARDING]): pull the
      * current token and forward it to Klaviyo. Called from [initialize] and on each app foreground so
-     * rotations are picked up. No-op when the flag is off, when forwarding is opted out via
-     * [Constants.DISABLE_AUTOMATIC_TOKEN_FORWARDING], or when `push-fcm` is absent.
+     * rotations are picked up. No-op when the flag is off or when `push-fcm` is absent.
+     *
+     * Independent of [Constants.AUTOMATIC_PUSH_TRACKING] (which gates only automatic open tracking) —
+     * this flag alone controls token forwarding.
      */
     internal fun maybeAutoRegisterPushToken() {
-        val autoTrackingEnabled = Registry.config.getManifestBoolean(
-            Constants.AUTOMATIC_PUSH_TRACKING,
+        val tokenForwardingEnabled = Registry.config.getManifestBoolean(
+            Constants.AUTOMATIC_TOKEN_FORWARDING,
             false
         )
-        // Avoid a second manifest read on the common flag-off path
-        val tokenForwardingDisabled = autoTrackingEnabled && Registry.config.getManifestBoolean(
-            Constants.DISABLE_AUTOMATIC_TOKEN_FORWARDING,
-            false
-        )
-        if (!autoTrackingEnabled || tokenForwardingDisabled) {
+        if (!tokenForwardingEnabled) {
             Registry.log.verbose(
-                "Skipping automatic push token registration " +
-                    "(automaticPushTracking=$autoTrackingEnabled, tokenForwardingDisabled=$tokenForwardingDisabled)"
+                "Skipping automatic push token registration (automaticTokenForwarding=false)"
             )
             return
         }

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
@@ -596,17 +596,17 @@ internal class KlaviyoTest : BaseTest() {
         mockConfig.getManifestBoolean(Constants.AUTOMATIC_PUSH_TRACKING, false)
     } returns enabled
 
-    private fun setTokenForwardingDisabled(disabled: Boolean) = every {
-        mockConfig.getManifestBoolean(Constants.DISABLE_AUTOMATIC_TOKEN_FORWARDING, false)
-    } returns disabled
+    private fun setTokenForwardingEnabled(enabled: Boolean) = every {
+        mockConfig.getManifestBoolean(Constants.AUTOMATIC_TOKEN_FORWARDING, false)
+    } returns enabled
 
     private fun reinitialize() =
         Klaviyo.initialize(apiKey = API_KEY, applicationContext = mockContext)
 
     @Test
-    fun `initialize triggers automatic push token fetch when flag is on and fetcher is registered`() {
+    fun `initialize triggers automatic push token fetch when token forwarding is on and fetcher is registered`() {
         val mockFetcher = registerMockPushTokenFetcher()
-        setAutomaticPushTracking(true)
+        setTokenForwardingEnabled(true)
 
         reinitialize()
 
@@ -614,10 +614,21 @@ internal class KlaviyoTest : BaseTest() {
     }
 
     @Test
-    fun `initialize does not fetch push token when token forwarding is disabled`() {
+    fun `initialize fetches push token when token forwarding is on even if automatic push tracking is off`() {
+        // Independence: token forwarding no longer depends on the open-tracking flag
         val mockFetcher = registerMockPushTokenFetcher()
-        setAutomaticPushTracking(true)
-        setTokenForwardingDisabled(true)
+        setAutomaticPushTracking(false)
+        setTokenForwardingEnabled(true)
+
+        reinitialize()
+
+        verify(exactly = 1) { mockFetcher.fetchAndSetPushToken() }
+    }
+
+    @Test
+    fun `initialize does not fetch push token when token forwarding is off`() {
+        val mockFetcher = registerMockPushTokenFetcher()
+        setTokenForwardingEnabled(false)
 
         reinitialize()
 
@@ -625,9 +636,11 @@ internal class KlaviyoTest : BaseTest() {
     }
 
     @Test
-    fun `initialize does not fetch push token when automatic tracking flag is off`() {
+    fun `initialize does not fetch push token when only automatic push tracking is on`() {
+        // Independence: automatic push tracking alone must not trigger token forwarding
         val mockFetcher = registerMockPushTokenFetcher()
-        setAutomaticPushTracking(false)
+        setAutomaticPushTracking(true)
+        setTokenForwardingEnabled(false)
 
         reinitialize()
 
@@ -637,7 +650,7 @@ internal class KlaviyoTest : BaseTest() {
     @Test
     fun `initialize does not crash and logs a warning when the push token fetch throws`() {
         val mockFetcher = registerMockPushTokenFetcher()
-        setAutomaticPushTracking(true)
+        setTokenForwardingEnabled(true)
         every { mockFetcher.fetchAndSetPushToken() } throws RuntimeException("fetch blew up")
 
         // runCatching around the fetch must contain the failure so initialize still completes
@@ -650,7 +663,7 @@ internal class KlaviyoTest : BaseTest() {
     @Test
     fun `initialize does not crash when flag is on but no push token fetcher is registered`() {
         Registry.unregister<PushTokenFetcher>()
-        setAutomaticPushTracking(true)
+        setTokenForwardingEnabled(true)
 
         // push-fcm absent: lookup is null and automatic registration is a graceful no-op
         reinitialize()

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/EventApiRequestTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/EventApiRequestTest.kt
@@ -239,9 +239,9 @@ internal class EventApiRequestTest : BaseApiRequestTest<EventApiRequest>() {
     @Test
     fun `Does not include the SDK features header even when the flags that would trigger it on PushTokenApiRequest are set`() {
         every { mockConfig.hasManifestKey(Constants.AUTOMATIC_PUSH_TRACKING) } returns true
-        every { mockConfig.hasManifestKey(Constants.DISABLE_AUTOMATIC_TOKEN_FORWARDING) } returns true
+        every { mockConfig.hasManifestKey(Constants.AUTOMATIC_TOKEN_FORWARDING) } returns true
         every { mockConfig.getManifestBoolean(Constants.AUTOMATIC_PUSH_TRACKING, false) } returns true
-        every { mockConfig.getManifestBoolean(Constants.DISABLE_AUTOMATIC_TOKEN_FORWARDING, false) } returns true
+        every { mockConfig.getManifestBoolean(Constants.AUTOMATIC_TOKEN_FORWARDING, false) } returns true
         val request = EventApiRequest(stubEvent, stubProfile)
         assertNull(request.headers["X-Klaviyo-Sdk-Features"])
     }

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/PushTokenApiRequestTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/PushTokenApiRequestTest.kt
@@ -113,17 +113,18 @@ internal class PushTokenApiRequestTest : BaseApiRequestTest<PushTokenApiRequest>
 
     @Test
     fun `SDK features header includes only auto_push_token_forwarding when only that key is present`() {
-        every { mockConfig.hasManifestKey(Constants.DISABLE_AUTOMATIC_TOKEN_FORWARDING) } returns true
-        every { mockConfig.getManifestBoolean(Constants.DISABLE_AUTOMATIC_TOKEN_FORWARDING, false) } returns true
+        every { mockConfig.hasManifestKey(Constants.AUTOMATIC_TOKEN_FORWARDING) } returns true
+        every { mockConfig.getManifestBoolean(Constants.AUTOMATIC_TOKEN_FORWARDING, false) } returns true
         val request = PushTokenApiRequest(PUSH_TOKEN, stubProfile)
-        assertEquals("auto_push_token_forwarding=0;", request.headers["X-Klaviyo-Sdk-Features"])
+        assertEquals("auto_push_token_forwarding=1;", request.headers["X-Klaviyo-Sdk-Features"])
     }
 
     @Test
-    fun `SDK features header includes both attributes when both keys present and forwarding left at its default`() {
+    fun `SDK features header includes both attributes when both keys present and forwarding on`() {
         every { mockConfig.hasManifestKey(Constants.AUTOMATIC_PUSH_TRACKING) } returns true
-        every { mockConfig.hasManifestKey(Constants.DISABLE_AUTOMATIC_TOKEN_FORWARDING) } returns true
+        every { mockConfig.hasManifestKey(Constants.AUTOMATIC_TOKEN_FORWARDING) } returns true
         every { mockConfig.getManifestBoolean(Constants.AUTOMATIC_PUSH_TRACKING, false) } returns true
+        every { mockConfig.getManifestBoolean(Constants.AUTOMATIC_TOKEN_FORWARDING, false) } returns true
         val request = PushTokenApiRequest(PUSH_TOKEN, stubProfile)
         assertEquals(
             "auto_push_tracking=1; auto_push_token_forwarding=1;",
@@ -132,11 +133,11 @@ internal class PushTokenApiRequestTest : BaseApiRequestTest<PushTokenApiRequest>
     }
 
     @Test
-    fun `SDK features header includes both attributes when both keys present and forwarding explicitly disabled`() {
+    fun `SDK features header includes both attributes when both keys present and forwarding off`() {
         every { mockConfig.hasManifestKey(Constants.AUTOMATIC_PUSH_TRACKING) } returns true
-        every { mockConfig.hasManifestKey(Constants.DISABLE_AUTOMATIC_TOKEN_FORWARDING) } returns true
+        every { mockConfig.hasManifestKey(Constants.AUTOMATIC_TOKEN_FORWARDING) } returns true
         every { mockConfig.getManifestBoolean(Constants.AUTOMATIC_PUSH_TRACKING, false) } returns true
-        every { mockConfig.getManifestBoolean(Constants.DISABLE_AUTOMATIC_TOKEN_FORWARDING, false) } returns true
+        every { mockConfig.getManifestBoolean(Constants.AUTOMATIC_TOKEN_FORWARDING, false) } returns false
         val request = PushTokenApiRequest(PUSH_TOKEN, stubProfile)
         assertEquals(
             "auto_push_tracking=1; auto_push_token_forwarding=0;",

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/state/StateSideEffectsTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/state/StateSideEffectsTest.kt
@@ -419,7 +419,7 @@ class StateSideEffectsTest : BaseTest() {
 
     @Test
     fun `Resumed lifecycle event re-fetches push token when automatic forwarding is enabled`() {
-        every { mockConfig.getManifestBoolean(Constants.AUTOMATIC_PUSH_TRACKING, false) } returns true
+        every { mockConfig.getManifestBoolean(Constants.AUTOMATIC_TOKEN_FORWARDING, false) } returns true
         val mockFetcher = registerMockPushTokenFetcher()
 
         fireResumedEvent()
@@ -429,7 +429,7 @@ class StateSideEffectsTest : BaseTest() {
 
     @Test
     fun `Resumed lifecycle event does not re-fetch push token when automatic forwarding is disabled`() {
-        // Automatic push tracking flag defaults to false via BaseTest's getManifestBoolean stub
+        // Automatic token forwarding flag defaults to false via BaseTest's getManifestBoolean stub
         val mockFetcher = registerMockPushTokenFetcher()
 
         fireResumedEvent()

--- a/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
@@ -51,11 +51,14 @@ object Constants {
     const val AUTOMATIC_PUSH_TRACKING = PUSH_PREFIX + "automatic_push_tracking"
 
     /**
-     * Manifest `<meta-data>` boolean to opt out of automatic push token forwarding while keeping
-     * automatic open tracking. Only consulted when [AUTOMATIC_PUSH_TRACKING] is `true`; defaults to
-     * `false`. For hosts that own their own push-token pipeline.
+     * Manifest `<meta-data>` key a host app sets to opt into automatic push token forwarding: the
+     * SDK pulls the current push token at initialize and on each foreground and forwards it to
+     * Klaviyo. Opt-in, absent → `false`.
+     *
+     * Lives in core (not push-fcm) for the same reason as [AUTOMATIC_PUSH_TRACKING]: telemetry's
+     * push token request must read it, and core cannot depend on push-fcm.
      */
-    const val DISABLE_AUTOMATIC_TOKEN_FORWARDING = PUSH_PREFIX + "disable_automatic_token_forwarding"
+    const val AUTOMATIC_TOKEN_FORWARDING = PUSH_PREFIX + "automatic_token_forwarding"
 
     /**
      * Fixed notification ID used in all notify/cancel calls.

--- a/sdk/core/src/main/java/com/klaviyo/core/SdkFeatures.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/SdkFeatures.kt
@@ -26,13 +26,12 @@ enum class SdkFeatureKey(
         scope = SdkFeatureScope.PUSH_TOKEN_REGISTRATION
     ),
 
-    // `disable_...` manifest key → reported as the inverse `auto_push_token_forwarding`. Reported
-    // independently of the master flag, so the backend sees how the host set each flag.
+    // `automatic_token_forwarding` opt-in flag, reported directly. Independent of the open-tracking
+    // flag, so the backend sees how the host set each flag.
     AUTO_PUSH_TOKEN_FORWARDING(
         wireName = "auto_push_token_forwarding",
-        manifestKey = Constants.DISABLE_AUTOMATIC_TOKEN_FORWARDING,
-        scope = SdkFeatureScope.PUSH_TOKEN_REGISTRATION,
-        reportedValue = { disabled -> !disabled }
+        manifestKey = Constants.AUTOMATIC_TOKEN_FORWARDING,
+        scope = SdkFeatureScope.PUSH_TOKEN_REGISTRATION
     )
 }
 

--- a/sdk/core/src/test/java/com/klaviyo/core/SdkFeaturesTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/SdkFeaturesTest.kt
@@ -42,19 +42,19 @@ internal class SdkFeaturesTest : BaseTest() {
     }
 
     @Test
-    fun `Reports auto_push_token_forwarding as inverse of the disable flag when disable is true`() {
+    fun `Reports auto_push_token_forwarding directly when the flag is true`() {
         stubManifestKey(SdkFeatureKey.AUTO_PUSH_TOKEN_FORWARDING.manifestKey, true)
         assertEquals(
-            "auto_push_token_forwarding=0;",
+            "auto_push_token_forwarding=1;",
             SdkFeatures.headerValue(SdkFeatureScope.PUSH_TOKEN_REGISTRATION)
         )
     }
 
     @Test
-    fun `Reports auto_push_token_forwarding as inverse of the disable flag when disable is false`() {
+    fun `Reports auto_push_token_forwarding directly when the flag is false`() {
         stubManifestKey(SdkFeatureKey.AUTO_PUSH_TOKEN_FORWARDING.manifestKey, false)
         assertEquals(
-            "auto_push_token_forwarding=1;",
+            "auto_push_token_forwarding=0;",
             SdkFeatures.headerValue(SdkFeatureScope.PUSH_TOKEN_REGISTRATION)
         )
     }
@@ -64,7 +64,7 @@ internal class SdkFeaturesTest : BaseTest() {
         stubManifestKey(SdkFeatureKey.AUTO_PUSH_TRACKING.manifestKey, true)
         stubManifestKey(SdkFeatureKey.AUTO_PUSH_TOKEN_FORWARDING.manifestKey, true)
         assertEquals(
-            "auto_push_tracking=1; auto_push_token_forwarding=0;",
+            "auto_push_tracking=1; auto_push_token_forwarding=1;",
             SdkFeatures.headerValue(SdkFeatureScope.PUSH_TOKEN_REGISTRATION)
         )
     }
@@ -72,7 +72,7 @@ internal class SdkFeaturesTest : BaseTest() {
     @Test
     fun `Omits an absent key even when the other in-scope key is present`() {
         stubManifestKey(SdkFeatureKey.AUTO_PUSH_TRACKING.manifestKey, false)
-        // Forwarding-disable key left absent
+        // Token-forwarding key left absent
         assertEquals(
             "auto_push_tracking=0;",
             SdkFeatures.headerValue(SdkFeatureScope.PUSH_TOKEN_REGISTRATION)


### PR DESCRIPTION
# Description
Adds `manual` and `automatic` product flavors to the sample app so both Klaviyo push integration styles are demonstrated side by side, mirroring the iOS `SPMExample` / `SPMExampleAutomatic` split. (MAGE-770)

## Due Diligence
- [ ] I have tested this on an emulator and/or a physical device.
  - Both variants build/install (`assembleManualDebug`, `assembleAutomaticDebug`); the full on-device test plan below is still pending before this leaves draft.
- [ ] I have added sufficient unit/integration tests of my changes.
  - N/A — sample-app reference code only, no SDK logic changed.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all Android versions the SDK currently supports.
  - No version-specific code; only build config, a manifest `<meta-data>` overlay, and per-flavor `SampleActivity` copies.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
  - Sample app only — not part of the released SDK artifact.
- [x] Contains readme or migration guide changes (sample `README.md`).
  - Targeting the **`feat/auto-push-tracking`** feature branch accordingly.
- [x] This is planned work for an upcoming release (Auto Push Tracking milestone).

## Changelog / Code Overview
- `sample/build.gradle.kts`: new `integration` flavor dimension with `manual` and `automatic` flavors (shared `applicationId`, so both reuse the existing `google-services.json` and install one at a time).
- `SampleActivity.kt` moved out of `src/main` into each flavor source set — AGP compiles `main` into every variant, so a per-flavor class can't also live in `main`:
  - `src/manual/…/SampleActivity.kt`: unchanged Option B behavior (FCM token fetch → `setPushToken`, `handlePush(intent)` on taps), comments refreshed to point at the automatic flavor.
  - `src/automatic/…/SampleActivity.kt`: zero push boilerplate — both blocks removed, replaced with explanatory comments.
- `src/automatic/AndroidManifest.xml`: additive overlay adding `com.klaviyo.push.automatic_push_tracking="true"` (the only manifest difference; the `manual` flavor has no overlay). The SDK then auto-registers the token at `initialize()`/foreground and routes taps through `KlaviyoTrampolineActivity`.
- `sample/README.md`: documents the two flavors and how to switch build variants; cross-links the main README's Option A/B section.

Everything else (`SampleApplication`, `SampleViewModel`, `SampleView`, resources, etc.) stays shared under `src/main`.

## Test Plan
Per the ticket, run **each** flavor (`manualDebug`, `automaticDebug`) and send a Klaviyo push; tap the body and action buttons from foreground, background, and cold start, with and without a registered `DeepLinkHandler`. Verify:
- Exactly one `Opened Push` per tap.
- Correct destination foregrounded every time (deep link or launcher); trampoline never visible in recents/back stack (`automatic`).
- `automatic`: push token registered on launch with no manual token code.
- `manual`: behavior identical to the current release.

## Related Issues/Tickets
- MAGE-770 — https://linear.app/klaviyo/issue/MAGE-770
- iOS sibling: MAGE-661 (`SPMExampleAutomatic`)
- Blocks MAGE-771 (README documents Option A and will link this `automatic` flavor)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added manual and automatic push integration variants to the sample app.
  * Added support for switching integration styles through Android Studio build variants or Gradle commands.
  * Automatic integration now supports automatic push token registration and push open tracking.
  * Added optional configuration to disable automatic token forwarding while retaining automatic open tracking.

* **Documentation**
  * Expanded the sample app’s setup and code reference documentation with integration guidance and configuration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->