### PR TITLE
feat(push): decouple auto push tracking and token forwarding (MAGE-886)

### DIFF
--- a/sample/README.md
+++ b/sample/README.md
@@ -27,8 +27,8 @@ demonstrated side by side:
   (`com.klaviyo.push.automatic_push_tracking="true"` and `com.klaviyo.push.automatic_token_forwarding="true"`,
   see [src/automatic/AndroidManifest.xml](./src/automatic/AndroidManifest.xml)) and the SDK does both for you:
   `automatic_token_forwarding` auto-registers the push token at `initialize()` / every foreground, and
-  `automatic_push_tracking` routes notification taps through `KlaviyoTrampolineActivity` to track opens — so
-  the sample's `SampleActivity` contains **zero** push boilerplate. Compare the two `SampleActivity.kt` copies
+  `automatic_push_tracking` makes the SDK detect notification taps and report opens for you — so the
+  sample's `SampleActivity` contains **zero** push boilerplate. Compare the two `SampleActivity.kt` copies
   to see exactly what code disappears when you opt in.
 
 Everything except `SampleActivity.kt` is shared under `src/main`. To switch styles, pick the **Build Variants**

--- a/sample/README.md
+++ b/sample/README.md
@@ -23,12 +23,13 @@ demonstrated side by side:
 - **`manual`** — Manual integration (Option B). The app fetches the FCM token and calls `Klaviyo.setPushToken()`,
   and calls `Klaviyo.handlePush(intent)` on notification taps. This is the classic path and matches the
   behavior of prior sample releases.
-- **`automatic`** — Automatic integration (Option A). The app opts in with a single manifest flag
-  (`com.klaviyo.push.automatic_push_tracking="true"`, see [src/automatic/AndroidManifest.xml](./src/automatic/AndroidManifest.xml))
-  and the SDK does both for you: it auto-registers the push token at `initialize()` / every foreground, and
-  routes notification taps through `KlaviyoTrampolineActivity` to track opens — so the sample's `SampleActivity`
-  contains **zero** push boilerplate. Compare the two `SampleActivity.kt` copies to see exactly what code
-  disappears when you opt in.
+- **`automatic`** — Automatic integration (Option A). The app opts in with two independent manifest flags
+  (`com.klaviyo.push.automatic_push_tracking="true"` and `com.klaviyo.push.automatic_token_forwarding="true"`,
+  see [src/automatic/AndroidManifest.xml](./src/automatic/AndroidManifest.xml)) and the SDK does both for you:
+  `automatic_token_forwarding` auto-registers the push token at `initialize()` / every foreground, and
+  `automatic_push_tracking` routes notification taps through `KlaviyoTrampolineActivity` to track opens — so
+  the sample's `SampleActivity` contains **zero** push boilerplate. Compare the two `SampleActivity.kt` copies
+  to see exactly what code disappears when you opt in.
 
 Everything except `SampleActivity.kt` is shared under `src/main`. To switch styles, pick the **Build Variants**
 panel in Android Studio (`manualDebug` vs `automaticDebug`), or from the CLI:
@@ -40,8 +41,15 @@ panel in Android Studio (`manualDebug` vs `automaticDebug`), or from the CLI:
 
 Both flavors share the same `applicationId` and `google-services.json`, so only one installs at a time. The
 `automatic` flavor still relies on the auto-registered `KlaviyoPushService` (from `:sdk:push-fcm`) to *display*
-notifications. To keep automatic open tracking while owning your own token pipeline, add
-`com.klaviyo.push.disable_automatic_token_forwarding="true"` to the manifest.
+notifications. Because the two flags are independent, you can mix and match: set only
+`automatic_push_tracking="true"` to keep automatic open tracking while owning your own token pipeline (omit
+`automatic_token_forwarding`), or set only `automatic_token_forwarding="true"` to auto-forward tokens without
+automatic open tracking.
+
+Note that `KlaviyoPushService.onNewToken()` forwards token rotations to Klaviyo unconditionally whenever
+`KlaviyoPushService` is the registered `FirebaseMessagingService` — independent of both flags. To fully own
+the token pipeline, register your own `FirebaseMessagingService` instead of `KlaviyoPushService` (the same
+pattern used to integrate alongside Braze/Airship/Iterable).
 
 See the main [README](../README.md) "Push Notifications" section for the full Option A / Option B write-up.
 

--- a/sample/src/automatic/AndroidManifest.xml
+++ b/sample/src/automatic/AndroidManifest.xml
@@ -2,20 +2,24 @@
 
     <!--
         SETUP NOTE (Automatic / Option A): This overlay is the ONLY difference in the automatic flavor's
-        manifest. Setting com.klaviyo.push.automatic_push_tracking to "true" opts the app into:
-          - automatic push OPEN tracking: notification taps route through KlaviyoTrampolineActivity, which
-            calls Klaviyo.handlePush() for you (no handlePush() call in your Activity), and
-          - automatic push TOKEN registration: the SDK fetches and registers the token at Klaviyo.initialize()
-            and on every foreground (no FirebaseMessaging fetch / Klaviyo.setPushToken() in your app).
-        Note the key's "com.klaviyo.push." prefix is required — the bare "com.klaviyo.*" form silently no-ops.
-        The `manual` flavor omits this overlay entirely; absence of the flag is the manual (Option B) path.
-
-        Advanced: to keep automatic open tracking but own your token pipeline, also add
-        com.klaviyo.push.disable_automatic_token_forwarding="true" (see the main README).
+        manifest. It opts into both automatic behaviors via two independent flags:
+          - com.klaviyo.push.automatic_push_tracking="true" — automatic push OPEN tracking: notification
+            taps route through KlaviyoTrampolineActivity, which calls Klaviyo.handlePush() for you
+            (no handlePush() call in your Activity), and
+          - com.klaviyo.push.automatic_token_forwarding="true" — automatic push TOKEN registration: the SDK
+            fetches and registers the token at Klaviyo.initialize() and on every foreground (no
+            FirebaseMessaging fetch / Klaviyo.setPushToken() in your app).
+        The two flags are fully independent — set either one without the other to opt into just that
+        behavior. The `manual` flavor omits this overlay entirely; absence of both flags is the manual
+        (Option B) path.
+        Note the keys' "com.klaviyo.push." prefix is required — the bare "com.klaviyo.*" form silently no-ops.
     -->
     <application>
         <meta-data
             android:name="com.klaviyo.push.automatic_push_tracking"
+            android:value="true" />
+        <meta-data
+            android:name="com.klaviyo.push.automatic_token_forwarding"
             android:value="true" />
     </application>
 

--- a/sample/src/automatic/AndroidManifest.xml
+++ b/sample/src/automatic/AndroidManifest.xml
@@ -3,9 +3,9 @@
     <!--
         SETUP NOTE (Automatic / Option A): This overlay is the ONLY difference in the automatic flavor's
         manifest. It opts into both automatic behaviors via two independent flags:
-          - com.klaviyo.push.automatic_push_tracking="true" — automatic push OPEN tracking: notification
-            taps route through KlaviyoTrampolineActivity, which calls Klaviyo.handlePush() for you
-            (no handlePush() call in your Activity), and
+          - com.klaviyo.push.automatic_push_tracking="true" — automatic push OPEN tracking: the SDK
+            automatically detects notification taps and reports the open via Klaviyo.handlePush() for
+            you (no handlePush() call in your Activity), and
           - com.klaviyo.push.automatic_token_forwarding="true" — automatic push TOKEN registration: the SDK
             fetches and registers the token at Klaviyo.initialize() and on every foreground (no
             FirebaseMessaging fetch / Klaviyo.setPushToken() in your app).
@@ -17,10 +17,10 @@
     <application>
         <meta-data
             android:name="com.klaviyo.push.automatic_push_tracking"
-            android:value="true" />
+            android:value="false" />
         <meta-data
             android:name="com.klaviyo.push.automatic_token_forwarding"
-            android:value="true" />
+            android:value="false" />
     </application>
 
 </manifest>

--- a/sample/src/automatic/AndroidManifest.xml
+++ b/sample/src/automatic/AndroidManifest.xml
@@ -17,10 +17,10 @@
     <application>
         <meta-data
             android:name="com.klaviyo.push.automatic_push_tracking"
-            android:value="false" />
+            android:value="true" />
         <meta-data
             android:name="com.klaviyo.push.automatic_token_forwarding"
-            android:value="false" />
+            android:value="true" />
     </application>
 
 </manifest>

--- a/sample/src/automatic/java/com/klaviyo/sample/SampleActivity.kt
+++ b/sample/src/automatic/java/com/klaviyo/sample/SampleActivity.kt
@@ -21,8 +21,9 @@ import com.klaviyo.analytics.model.EventMetric
  * there is *zero* push boilerplate here:
  *  - Push token (automatic_token_forwarding): auto-registered at Klaviyo.initialize() and on every foreground
  *    (no FirebaseMessaging fetch, no Klaviyo.setPushToken() call). Contrast with the `manual` flavor's onCreate.
- *  - Push opens (automatic_push_tracking): KlaviyoTrampolineActivity intercepts taps and calls Klaviyo.handlePush()
- *    for you, so there is no handlePush() call in onNewIntent. Contrast with the `manual` flavor's onNewIntent.
+ *  - Push opens (automatic_push_tracking): the SDK automatically detects when a user taps a push notification
+ *    and reports the open event via Klaviyo.handlePush() for you, so there is no handlePush() call in
+ *    onNewIntent. Contrast with the `manual` flavor's onNewIntent.
  * Displaying notifications still relies on the auto-registered KlaviyoPushService from :sdk:push-fcm.
  * See the main README's "Push Notifications" section (Option A) and sample/README.md.
  */
@@ -66,8 +67,8 @@ class SampleActivity : ComponentActivity() {
         }
 
         // SETUP NOTE (Automatic / Option A): No Klaviyo.handlePush(intent) here.
-        // Because com.klaviyo.push.automatic_push_tracking is enabled, notification taps route through
-        // KlaviyoTrampolineActivity, which tracks the open and invokes your deep link handler for you.
+        // Because com.klaviyo.push.automatic_push_tracking is enabled, the SDK automatically detects
+        // notification taps, reports the open, and invokes your deep link handler for you.
     }
 
     private val requestPermissionLauncher = registerForActivityResult(

--- a/sample/src/automatic/java/com/klaviyo/sample/SampleActivity.kt
+++ b/sample/src/automatic/java/com/klaviyo/sample/SampleActivity.kt
@@ -16,12 +16,13 @@ import com.klaviyo.analytics.model.EventMetric
 
 /**
  * SETUP NOTE: This is the `automatic` flavor's Activity, demonstrating automatic push integration (Option A).
- * By setting com.klaviyo.push.automatic_push_tracking="true" in the manifest (see src/automatic/AndroidManifest.xml),
- * the SDK takes over both push responsibilities, so there is *zero* push boilerplate here:
- *  - Push token: auto-registered at Klaviyo.initialize() and on every foreground (no FirebaseMessaging fetch,
- *    no Klaviyo.setPushToken() call). Contrast with the `manual` flavor's onCreate under src/manual.
- *  - Push opens: KlaviyoTrampolineActivity intercepts taps and calls Klaviyo.handlePush() for you, so there is
- *    no handlePush() call in onNewIntent. Contrast with the `manual` flavor's onNewIntent.
+ * By setting com.klaviyo.push.automatic_token_forwarding="true" and com.klaviyo.push.automatic_push_tracking="true"
+ * in the manifest (see src/automatic/AndroidManifest.xml), the SDK takes over both push responsibilities, so
+ * there is *zero* push boilerplate here:
+ *  - Push token (automatic_token_forwarding): auto-registered at Klaviyo.initialize() and on every foreground
+ *    (no FirebaseMessaging fetch, no Klaviyo.setPushToken() call). Contrast with the `manual` flavor's onCreate.
+ *  - Push opens (automatic_push_tracking): KlaviyoTrampolineActivity intercepts taps and calls Klaviyo.handlePush()
+ *    for you, so there is no handlePush() call in onNewIntent. Contrast with the `manual` flavor's onNewIntent.
  * Displaying notifications still relies on the auto-registered KlaviyoPushService from :sdk:push-fcm.
  * See the main README's "Push Notifications" section (Option A) and sample/README.md.
  */

--- a/sample/src/manual/java/com/klaviyo/sample/SampleActivity.kt
+++ b/sample/src/manual/java/com/klaviyo/sample/SampleActivity.kt
@@ -35,7 +35,7 @@ class SampleActivity : ComponentActivity() {
 
         // SETUP NOTE (Manual / Option B): Fetch the current push token and register it with Klaviyo.
         // The `automatic` flavor omits this entirely — the SDK auto-registers the token at initialize()
-        // and on every foreground once com.klaviyo.push.automatic_push_tracking is enabled.
+        // and on every foreground once com.klaviyo.push.automatic_token_forwarding is enabled.
         FirebaseMessaging.getInstance().token.addOnSuccessListener { token ->
             // Dispatch to main for the UI update
             lifecycleScope.launch(Dispatchers.Main) {

--- a/sample/src/manual/java/com/klaviyo/sample/SampleActivity.kt
+++ b/sample/src/manual/java/com/klaviyo/sample/SampleActivity.kt
@@ -74,7 +74,7 @@ class SampleActivity : ComponentActivity() {
         // SETUP NOTE (Manual / Option B): Track an event when the user opens a notification.
         // If the notification is a deep link, the SDK will invoke your registered handler.
         // If not using a deep link handler, you should parse the URI from intent.data below.
-        // The `automatic` flavor omits this — KlaviyoTrampolineActivity calls handlePush() for you.
+        // The `automatic` flavor omits this — the SDK detects taps and calls handlePush() for you.
         if (intent.isKlaviyoNotificationIntent) {
             Klaviyo.handlePush(intent)
         }

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -118,25 +118,21 @@ object Klaviyo {
     }
 
     /**
-     * Opt-in automatic push token registration (via [Constants.AUTOMATIC_PUSH_TRACKING]): pull the
+     * Opt-in automatic push token registration (via [Constants.AUTOMATIC_TOKEN_FORWARDING]): pull the
      * current token and forward it to Klaviyo. Called from [initialize] and on each app foreground so
-     * rotations are picked up. No-op when the flag is off, when forwarding is opted out via
-     * [Constants.DISABLE_AUTOMATIC_TOKEN_FORWARDING], or when `push-fcm` is absent.
+     * rotations are picked up. No-op when the flag is off or when `push-fcm` is absent.
+     *
+     * Independent of [Constants.AUTOMATIC_PUSH_TRACKING] (which gates only automatic open tracking) —
+     * this flag alone controls token forwarding.
      */
     internal fun maybeAutoRegisterPushToken() {
-        val autoTrackingEnabled = Registry.config.getManifestBoolean(
-            Constants.AUTOMATIC_PUSH_TRACKING,
+        val tokenForwardingEnabled = Registry.config.getManifestBoolean(
+            Constants.AUTOMATIC_TOKEN_FORWARDING,
             false
         )
-        // Avoid a second manifest read on the common flag-off path
-        val tokenForwardingDisabled = autoTrackingEnabled && Registry.config.getManifestBoolean(
-            Constants.DISABLE_AUTOMATIC_TOKEN_FORWARDING,
-            false
-        )
-        if (!autoTrackingEnabled || tokenForwardingDisabled) {
+        if (!tokenForwardingEnabled) {
             Registry.log.verbose(
-                "Skipping automatic push token registration " +
-                    "(automaticPushTracking=$autoTrackingEnabled, tokenForwardingDisabled=$tokenForwardingDisabled)"
+                "Skipping automatic push token registration (automaticTokenForwarding=false)"
             )
             return
         }

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
@@ -596,17 +596,17 @@ internal class KlaviyoTest : BaseTest() {
         mockConfig.getManifestBoolean(Constants.AUTOMATIC_PUSH_TRACKING, false)
     } returns enabled
 
-    private fun setTokenForwardingDisabled(disabled: Boolean) = every {
-        mockConfig.getManifestBoolean(Constants.DISABLE_AUTOMATIC_TOKEN_FORWARDING, false)
-    } returns disabled
+    private fun setTokenForwardingEnabled(enabled: Boolean) = every {
+        mockConfig.getManifestBoolean(Constants.AUTOMATIC_TOKEN_FORWARDING, false)
+    } returns enabled
 
     private fun reinitialize() =
         Klaviyo.initialize(apiKey = API_KEY, applicationContext = mockContext)
 
     @Test
-    fun `initialize triggers automatic push token fetch when flag is on and fetcher is registered`() {
+    fun `initialize triggers automatic push token fetch when token forwarding is on and fetcher is registered`() {
         val mockFetcher = registerMockPushTokenFetcher()
-        setAutomaticPushTracking(true)
+        setTokenForwardingEnabled(true)
 
         reinitialize()
 
@@ -614,10 +614,21 @@ internal class KlaviyoTest : BaseTest() {
     }
 
     @Test
-    fun `initialize does not fetch push token when token forwarding is disabled`() {
+    fun `initialize fetches push token when token forwarding is on even if automatic push tracking is off`() {
+        // Independence: token forwarding no longer depends on the open-tracking flag
         val mockFetcher = registerMockPushTokenFetcher()
-        setAutomaticPushTracking(true)
-        setTokenForwardingDisabled(true)
+        setAutomaticPushTracking(false)
+        setTokenForwardingEnabled(true)
+
+        reinitialize()
+
+        verify(exactly = 1) { mockFetcher.fetchAndSetPushToken() }
+    }
+
+    @Test
+    fun `initialize does not fetch push token when token forwarding is off`() {
+        val mockFetcher = registerMockPushTokenFetcher()
+        setTokenForwardingEnabled(false)
 
         reinitialize()
 
@@ -625,9 +636,11 @@ internal class KlaviyoTest : BaseTest() {
     }
 
     @Test
-    fun `initialize does not fetch push token when automatic tracking flag is off`() {
+    fun `initialize does not fetch push token when only automatic push tracking is on`() {
+        // Independence: automatic push tracking alone must not trigger token forwarding
         val mockFetcher = registerMockPushTokenFetcher()
-        setAutomaticPushTracking(false)
+        setAutomaticPushTracking(true)
+        setTokenForwardingEnabled(false)
 
         reinitialize()
 
@@ -637,7 +650,7 @@ internal class KlaviyoTest : BaseTest() {
     @Test
     fun `initialize does not crash and logs a warning when the push token fetch throws`() {
         val mockFetcher = registerMockPushTokenFetcher()
-        setAutomaticPushTracking(true)
+        setTokenForwardingEnabled(true)
         every { mockFetcher.fetchAndSetPushToken() } throws RuntimeException("fetch blew up")
 
         // runCatching around the fetch must contain the failure so initialize still completes
@@ -650,7 +663,7 @@ internal class KlaviyoTest : BaseTest() {
     @Test
     fun `initialize does not crash when flag is on but no push token fetcher is registered`() {
         Registry.unregister<PushTokenFetcher>()
-        setAutomaticPushTracking(true)
+        setTokenForwardingEnabled(true)
 
         // push-fcm absent: lookup is null and automatic registration is a graceful no-op
         reinitialize()

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/EventApiRequestTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/EventApiRequestTest.kt
@@ -239,9 +239,9 @@ internal class EventApiRequestTest : BaseApiRequestTest<EventApiRequest>() {
     @Test
     fun `Does not include the SDK features header even when the flags that would trigger it on PushTokenApiRequest are set`() {
         every { mockConfig.hasManifestKey(Constants.AUTOMATIC_PUSH_TRACKING) } returns true
-        every { mockConfig.hasManifestKey(Constants.DISABLE_AUTOMATIC_TOKEN_FORWARDING) } returns true
+        every { mockConfig.hasManifestKey(Constants.AUTOMATIC_TOKEN_FORWARDING) } returns true
         every { mockConfig.getManifestBoolean(Constants.AUTOMATIC_PUSH_TRACKING, false) } returns true
-        every { mockConfig.getManifestBoolean(Constants.DISABLE_AUTOMATIC_TOKEN_FORWARDING, false) } returns true
+        every { mockConfig.getManifestBoolean(Constants.AUTOMATIC_TOKEN_FORWARDING, false) } returns true
         val request = EventApiRequest(stubEvent, stubProfile)
         assertNull(request.headers["X-Klaviyo-Sdk-Features"])
     }

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/PushTokenApiRequestTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/PushTokenApiRequestTest.kt
@@ -113,17 +113,18 @@ internal class PushTokenApiRequestTest : BaseApiRequestTest<PushTokenApiRequest>
 
     @Test
     fun `SDK features header includes only auto_push_token_forwarding when only that key is present`() {
-        every { mockConfig.hasManifestKey(Constants.DISABLE_AUTOMATIC_TOKEN_FORWARDING) } returns true
-        every { mockConfig.getManifestBoolean(Constants.DISABLE_AUTOMATIC_TOKEN_FORWARDING, false) } returns true
+        every { mockConfig.hasManifestKey(Constants.AUTOMATIC_TOKEN_FORWARDING) } returns true
+        every { mockConfig.getManifestBoolean(Constants.AUTOMATIC_TOKEN_FORWARDING, false) } returns true
         val request = PushTokenApiRequest(PUSH_TOKEN, stubProfile)
-        assertEquals("auto_push_token_forwarding=0;", request.headers["X-Klaviyo-Sdk-Features"])
+        assertEquals("auto_push_token_forwarding=1;", request.headers["X-Klaviyo-Sdk-Features"])
     }
 
     @Test
-    fun `SDK features header includes both attributes when both keys present and forwarding left at its default`() {
+    fun `SDK features header includes both attributes when both keys present and forwarding on`() {
         every { mockConfig.hasManifestKey(Constants.AUTOMATIC_PUSH_TRACKING) } returns true
-        every { mockConfig.hasManifestKey(Constants.DISABLE_AUTOMATIC_TOKEN_FORWARDING) } returns true
+        every { mockConfig.hasManifestKey(Constants.AUTOMATIC_TOKEN_FORWARDING) } returns true
         every { mockConfig.getManifestBoolean(Constants.AUTOMATIC_PUSH_TRACKING, false) } returns true
+        every { mockConfig.getManifestBoolean(Constants.AUTOMATIC_TOKEN_FORWARDING, false) } returns true
         val request = PushTokenApiRequest(PUSH_TOKEN, stubProfile)
         assertEquals(
             "auto_push_tracking=1; auto_push_token_forwarding=1;",
@@ -132,11 +133,11 @@ internal class PushTokenApiRequestTest : BaseApiRequestTest<PushTokenApiRequest>
     }
 
     @Test
-    fun `SDK features header includes both attributes when both keys present and forwarding explicitly disabled`() {
+    fun `SDK features header includes both attributes when both keys present and forwarding off`() {
         every { mockConfig.hasManifestKey(Constants.AUTOMATIC_PUSH_TRACKING) } returns true
-        every { mockConfig.hasManifestKey(Constants.DISABLE_AUTOMATIC_TOKEN_FORWARDING) } returns true
+        every { mockConfig.hasManifestKey(Constants.AUTOMATIC_TOKEN_FORWARDING) } returns true
         every { mockConfig.getManifestBoolean(Constants.AUTOMATIC_PUSH_TRACKING, false) } returns true
-        every { mockConfig.getManifestBoolean(Constants.DISABLE_AUTOMATIC_TOKEN_FORWARDING, false) } returns true
+        every { mockConfig.getManifestBoolean(Constants.AUTOMATIC_TOKEN_FORWARDING, false) } returns false
         val request = PushTokenApiRequest(PUSH_TOKEN, stubProfile)
         assertEquals(
             "auto_push_tracking=1; auto_push_token_forwarding=0;",

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/state/StateSideEffectsTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/state/StateSideEffectsTest.kt
@@ -419,7 +419,7 @@ class StateSideEffectsTest : BaseTest() {
 
     @Test
     fun `Resumed lifecycle event re-fetches push token when automatic forwarding is enabled`() {
-        every { mockConfig.getManifestBoolean(Constants.AUTOMATIC_PUSH_TRACKING, false) } returns true
+        every { mockConfig.getManifestBoolean(Constants.AUTOMATIC_TOKEN_FORWARDING, false) } returns true
         val mockFetcher = registerMockPushTokenFetcher()
 
         fireResumedEvent()
@@ -429,7 +429,7 @@ class StateSideEffectsTest : BaseTest() {
 
     @Test
     fun `Resumed lifecycle event does not re-fetch push token when automatic forwarding is disabled`() {
-        // Automatic push tracking flag defaults to false via BaseTest's getManifestBoolean stub
+        // Automatic token forwarding flag defaults to false via BaseTest's getManifestBoolean stub
         val mockFetcher = registerMockPushTokenFetcher()
 
         fireResumedEvent()

--- a/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
@@ -51,11 +51,15 @@ object Constants {
     const val AUTOMATIC_PUSH_TRACKING = PUSH_PREFIX + "automatic_push_tracking"
 
     /**
-     * Manifest `<meta-data>` boolean to opt out of automatic push token forwarding while keeping
-     * automatic open tracking. Only consulted when [AUTOMATIC_PUSH_TRACKING] is `true`; defaults to
-     * `false`. For hosts that own their own push-token pipeline.
+     * Manifest `<meta-data>` key a host app sets to opt into automatic push token forwarding: the
+     * SDK pulls the current push token at initialize and on each foreground and forwards it to
+     * Klaviyo. Opt-in, absent → `false`.
+     *
+     * Fully independent of [AUTOMATIC_PUSH_TRACKING] — either flag may be set without the other.
+     * Lives in core (not push-fcm) for the same reason as [AUTOMATIC_PUSH_TRACKING]: telemetry's
+     * push token request must read it, and core cannot depend on push-fcm.
      */
-    const val DISABLE_AUTOMATIC_TOKEN_FORWARDING = PUSH_PREFIX + "disable_automatic_token_forwarding"
+    const val AUTOMATIC_TOKEN_FORWARDING = PUSH_PREFIX + "automatic_token_forwarding"
 
     /**
      * Fixed notification ID used in all notify/cancel calls.

--- a/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
@@ -55,7 +55,6 @@ object Constants {
      * SDK pulls the current push token at initialize and on each foreground and forwards it to
      * Klaviyo. Opt-in, absent → `false`.
      *
-     * Fully independent of [AUTOMATIC_PUSH_TRACKING] — either flag may be set without the other.
      * Lives in core (not push-fcm) for the same reason as [AUTOMATIC_PUSH_TRACKING]: telemetry's
      * push token request must read it, and core cannot depend on push-fcm.
      */

--- a/sdk/core/src/main/java/com/klaviyo/core/SdkFeatures.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/SdkFeatures.kt
@@ -26,13 +26,12 @@ enum class SdkFeatureKey(
         scope = SdkFeatureScope.PUSH_TOKEN_REGISTRATION
     ),
 
-    // `disable_...` manifest key → reported as the inverse `auto_push_token_forwarding`. Reported
-    // independently of the master flag, so the backend sees how the host set each flag.
+    // `automatic_token_forwarding` opt-in flag, reported directly. Independent of the open-tracking
+    // flag, so the backend sees how the host set each flag.
     AUTO_PUSH_TOKEN_FORWARDING(
         wireName = "auto_push_token_forwarding",
-        manifestKey = Constants.DISABLE_AUTOMATIC_TOKEN_FORWARDING,
-        scope = SdkFeatureScope.PUSH_TOKEN_REGISTRATION,
-        reportedValue = { disabled -> !disabled }
+        manifestKey = Constants.AUTOMATIC_TOKEN_FORWARDING,
+        scope = SdkFeatureScope.PUSH_TOKEN_REGISTRATION
     )
 }
 

--- a/sdk/core/src/test/java/com/klaviyo/core/SdkFeaturesTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/SdkFeaturesTest.kt
@@ -42,19 +42,19 @@ internal class SdkFeaturesTest : BaseTest() {
     }
 
     @Test
-    fun `Reports auto_push_token_forwarding as inverse of the disable flag when disable is true`() {
+    fun `Reports auto_push_token_forwarding directly when the flag is true`() {
         stubManifestKey(SdkFeatureKey.AUTO_PUSH_TOKEN_FORWARDING.manifestKey, true)
         assertEquals(
-            "auto_push_token_forwarding=0;",
+            "auto_push_token_forwarding=1;",
             SdkFeatures.headerValue(SdkFeatureScope.PUSH_TOKEN_REGISTRATION)
         )
     }
 
     @Test
-    fun `Reports auto_push_token_forwarding as inverse of the disable flag when disable is false`() {
+    fun `Reports auto_push_token_forwarding directly when the flag is false`() {
         stubManifestKey(SdkFeatureKey.AUTO_PUSH_TOKEN_FORWARDING.manifestKey, false)
         assertEquals(
-            "auto_push_token_forwarding=1;",
+            "auto_push_token_forwarding=0;",
             SdkFeatures.headerValue(SdkFeatureScope.PUSH_TOKEN_REGISTRATION)
         )
     }
@@ -64,7 +64,7 @@ internal class SdkFeaturesTest : BaseTest() {
         stubManifestKey(SdkFeatureKey.AUTO_PUSH_TRACKING.manifestKey, true)
         stubManifestKey(SdkFeatureKey.AUTO_PUSH_TOKEN_FORWARDING.manifestKey, true)
         assertEquals(
-            "auto_push_tracking=1; auto_push_token_forwarding=0;",
+            "auto_push_tracking=1; auto_push_token_forwarding=1;",
             SdkFeatures.headerValue(SdkFeatureScope.PUSH_TOKEN_REGISTRATION)
         )
     }
@@ -72,7 +72,7 @@ internal class SdkFeaturesTest : BaseTest() {
     @Test
     fun `Omits an absent key even when the other in-scope key is present`() {
         stubManifestKey(SdkFeatureKey.AUTO_PUSH_TRACKING.manifestKey, false)
-        // Forwarding-disable key left absent
+        // Token-forwarding key left absent
         assertEquals(
             "auto_push_tracking=0;",
             SdkFeatures.headerValue(SdkFeatureScope.PUSH_TOKEN_REGISTRATION)

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoPushService.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoPushService.kt
@@ -34,6 +34,12 @@ open class KlaviyoPushService : FirebaseMessagingService() {
     /**
      * Called when FCM SDK receives a newly registered token
      *
+     * Forwards the token to Klaviyo unconditionally — independent of the
+     * [Constants.AUTOMATIC_TOKEN_FORWARDING] and [METADATA_AUTOMATIC_PUSH_TRACKING] manifest flags,
+     * which gate only the `Klaviyo`-side automatic fetch. A host that wants to opt out of this
+     * always-on rotation forwarding must register its own [FirebaseMessagingService] instead of
+     * [KlaviyoPushService] (the same pattern used to integrate alongside Braze/Airship/Iterable).
+     *
      * @param newToken
      */
     override fun onNewToken(newToken: String) {

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoPushService.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoPushService.kt
@@ -34,12 +34,6 @@ open class KlaviyoPushService : FirebaseMessagingService() {
     /**
      * Called when FCM SDK receives a newly registered token
      *
-     * Forwards the token to Klaviyo unconditionally — independent of the
-     * [Constants.AUTOMATIC_TOKEN_FORWARDING] and [METADATA_AUTOMATIC_PUSH_TRACKING] manifest flags,
-     * which gate only the `Klaviyo`-side automatic fetch. A host that wants to opt out of this
-     * always-on rotation forwarding must register its own [FirebaseMessagingService] instead of
-     * [KlaviyoPushService] (the same pattern used to integrate alongside Braze/Airship/Iterable).
-     *
      * @param newToken
      */
     override fun onNewToken(newToken: String) {


### PR DESCRIPTION
# Description
Decouples `automatic_push_tracking` and token forwarding into two independent manifest flags: deletes the nested `disable_automatic_token_forwarding` escape hatch and replaces it with a fully independent opt-in `automatic_token_forwarding` flag ([MAGE-886](https://linear.app/klaviyo/issue/MAGE-886)).

## Due Diligence
- [ ] I have tested this on an emulator and/or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all Android versions the SDK currently supports.

## Release/Versioning Considerations
- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [x] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [x] Contains readme or migration guide changes.
  - Sample README + sample manifest/comments only. Both flags are unshipped (feature branch only).
- [x] This is planned work for an upcoming release.

> [!NOTE]
> Both flags are **unshipped** (they exist only on `feat/auto-push-tracking`), so this restructure has **zero backward-compat cost**. This PR is stacked on `ab/mage-770-sample-app-product-flavors` (PR #508) because it edits the sample product-flavor files introduced there; retarget to `feat/auto-push-tracking` once #508 merges.

## Changelog / Code Overview
The two push behaviors are now orthogonal:

| Flag | Gates |
|---|---|
| `com.klaviyo.push.automatic_push_tracking` | automatic open tracking (trampoline) **only** |
| `com.klaviyo.push.automatic_token_forwarding` | automatic token fetch/forwarding **only** |

- **`Constants.kt`** — remove `DISABLE_AUTOMATIC_TOKEN_FORWARDING`, add `AUTOMATIC_TOKEN_FORWARDING` (opt-in, absent → `false`).
- **`Klaviyo.kt`** — `maybeAutoRegisterPushToken()` now gates on `automatic_token_forwarding` only; no longer reads `automatic_push_tracking`.
- **`SdkFeatures.kt`** — retarget the `auto_push_token_forwarding` telemetry entry to the new flag and drop the inverted `reportedValue`. **Wire name unchanged**, so the `X-Klaviyo-Sdk-Features` backend contract is preserved.
- **`KlaviyoPushService.onNewToken()`** — no code change; added KDoc noting it forwards unconditionally and that hosts opt out by registering their own `FirebaseMessagingService` (Braze/Airship/Iterable pattern).
- **Sample app** — `automatic` flavor sets **both** flags `true`; `manual` sets neither (both absent = both false). Updated sample README + `SampleActivity` comments.
- **Tests** — updated `KlaviyoTest` (proves independence across combinations), `SdkFeaturesTest`, `PushTokenApiRequestTest`, `EventApiRequestTest`, `StateSideEffectsTest`.

_Out of scope / N/A:_ no separate internal test app module exists in this repo (only `:sample`). Root README doesn't reference these flags (Option A write-up is MAGE-771's scope).

## Test Plan
Automated (all green locally, JDK 17):
- `:sdk:core:testDebugUnitTest` (`SdkFeaturesTest`), `:sdk:analytics:testDebugUnitTest` (`KlaviyoTest`, `StateSideEffectsTest`, `PushTokenApiRequestTest`, `EventApiRequestTest`)
- `ktlintCheck` clean; `git grep` confirms the old flag is fully removed; merged `automaticDebug` manifest contains both flags.

Manual matrix (pending device):

| `automatic_push_tracking` | `automatic_token_forwarding` | open tracking | token pull |
|---|---|---|---|
| false | false | no | no |
| true | false | yes | no |
| false | true | no | yes |
| true | true | yes | yes |

Plus confirm `onNewToken()` forwards token rotations in **all four** combinations (reads no flag).

## Related Issues/Tickets
- [MAGE-886](https://linear.app/klaviyo/issue/MAGE-886) — this ticket
- [MAGE-880](https://linear.app/klaviyo/issue/MAGE-880) — decision that motivated this
- [MAGE-884](https://linear.app/klaviyo/issue/MAGE-884) — **iOS companion**; must land together so flag meanings don't diverge
- Stacked on #508 (MAGE-770)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added independent configuration for automatic notification tap tracking and push token forwarding.
  * Push token forwarding is now explicitly opt-in and occurs during initialization and foreground events when enabled.

* **Documentation**
  * Updated integration guidance and sample app comments to explain configuration options, token ownership, and notification handling.
  * Clarified manifest key naming requirements and behavior when options are omitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->