### PR TITLE
feat(sample): add Push Log inbox POC + push data extraction guide

### DIFF
--- a/PUSH_NOTIFICATION_DATA_GUIDE.md
+++ b/PUSH_NOTIFICATION_DATA_GUIDE.md
@@ -7,10 +7,13 @@ messages in your app's own inbox.
 ## How Klaviyo delivers push on Android
 
 Klaviyo formats every push as an FCM [data message](https://firebase.google.com/docs/cloud-messaging/android/receive)
-to retain full control over display formatting. As a result **every** Klaviyo push — visible or
-silent — is delivered to your `FirebaseMessagingService.onMessageReceived`, regardless of whether
-the app is in the foreground, background, or terminated. There is no separate foreground/background
-delivery path like iOS.
+to retain full control over display formatting. As a result Klaviyo pushes — visible or silent —
+are normally delivered to your `FirebaseMessagingService.onMessageReceived` whether the app is in
+the foreground, background, or terminated, rather than only through the notification tap like a
+notification-payload message. Delivery is still subject to normal FCM/Android limits: a
+[force-stopped](https://firebase.google.com/docs/cloud-messaging/android/receive) app receives
+nothing until the user relaunches it, [hibernated](https://developer.android.com/topic/performance/app-hibernation)
+(unused) apps on Android 12+ aren't woken, and delivery can be delayed by Doze/App Standby.
 
 | Type | Visible alert? | Where it arrives |
 |---|---|---|

--- a/PUSH_NOTIFICATION_DATA_GUIDE.md
+++ b/PUSH_NOTIFICATION_DATA_GUIDE.md
@@ -1,0 +1,127 @@
+# Extracting Title, Body, Custom Data, and Media from Klaviyo Push Notifications (Android)
+
+This guide shows how to read the title, body, custom key-value pairs, and media from a push
+notification sent through Klaviyo, using the Klaviyo Android SDK — for example, to store received
+messages in your app's own inbox.
+
+## How Klaviyo delivers push on Android
+
+Klaviyo formats every push as an FCM [data message](https://firebase.google.com/docs/cloud-messaging/android/receive)
+to retain full control over display formatting. As a result **every** Klaviyo push — visible or
+silent — is delivered to your `FirebaseMessagingService.onMessageReceived`, regardless of whether
+the app is in the foreground, background, or terminated. There is no separate foreground/background
+delivery path like iOS.
+
+| Type | Visible alert? | Where it arrives |
+|---|---|---|
+| Standard push | Yes (`title`/`body`) | `onMessageReceived` |
+| Silent / data-only push | No | `onMessageReceived` |
+
+## Prerequisites
+
+- `Klaviyo.initialize(...)` called in `Application.onCreate()`.
+- Push token registered (`Klaviyo.setPushToken(...)`) and the `POST_NOTIFICATIONS` runtime
+  permission requested on Android 13+.
+
+## 1. Intercept received messages
+
+The SDK's `KlaviyoPushService` displays notifications for you with no extra code. To *also* capture
+each message (e.g. to save it to a custom inbox), provide your own service. The simplest option is
+to subclass `KlaviyoPushService` and call `super` so the SDK still displays the notification and
+tracks opens. Register it in your `AndroidManifest.xml`, where it takes precedence over the SDK's
+default service (see [README § Advanced Setup](README.md#advanced-setup)).
+
+```xml
+<!-- AndroidManifest.xml -->
+<service android:name=".YourPushService" android:exported="false">
+    <intent-filter>
+        <action android:name="com.google.firebase.MESSAGING_EVENT" />
+    </intent-filter>
+</service>
+```
+
+```kotlin
+import com.google.firebase.messaging.RemoteMessage
+import com.klaviyo.pushFcm.KlaviyoPushService
+import com.klaviyo.pushFcm.KlaviyoRemoteMessage.body
+import com.klaviyo.pushFcm.KlaviyoRemoteMessage.hasKlaviyoKeyValuePairs
+import com.klaviyo.pushFcm.KlaviyoRemoteMessage.isKlaviyoMessage
+import com.klaviyo.pushFcm.KlaviyoRemoteMessage.isKlaviyoNotification
+import com.klaviyo.pushFcm.KlaviyoRemoteMessage.keyValuePairs
+import com.klaviyo.pushFcm.KlaviyoRemoteMessage.title
+
+class YourPushService : KlaviyoPushService() {
+    override fun onMessageReceived(message: RemoteMessage) {
+        super.onMessageReceived(message) // let Klaviyo display the notification & track opens
+
+        if (!message.isKlaviyoMessage) return // route non-Klaviyo messages elsewhere
+
+        val title = message.title.orEmpty()
+        val body = message.body.orEmpty()
+        val isVisible = message.isKlaviyoNotification // false = silent / data-only
+        val customData = if (message.hasKlaviyoKeyValuePairs) {
+            message.keyValuePairs ?: emptyMap()
+        } else {
+            emptyMap()
+        }
+
+        // Store title/body/customData in your inbox here.
+    }
+}
+```
+
+## 2. Title & body
+
+The SDK exposes these as `RemoteMessage` extension properties:
+
+```kotlin
+import com.klaviyo.pushFcm.KlaviyoRemoteMessage.body
+import com.klaviyo.pushFcm.KlaviyoRemoteMessage.title
+
+val title = message.title // null on a silent push
+val body = message.body
+```
+
+## 3. Standard vs. silent push
+
+```kotlin
+if (message.isKlaviyoMessage) {
+    if (message.isKlaviyoNotification) {
+        // Standard visible push — title/body present
+    } else {
+        // Silent / data-only push — no visible alert
+    }
+}
+```
+
+## 4. Custom key-value pairs
+
+```kotlin
+import com.klaviyo.pushFcm.KlaviyoRemoteMessage.hasKlaviyoKeyValuePairs
+import com.klaviyo.pushFcm.KlaviyoRemoteMessage.keyValuePairs
+
+if (message.hasKlaviyoKeyValuePairs) {
+    val customData: Map<String, String> = message.keyValuePairs ?: emptyMap()
+    for ((key, value) in customData) {
+        // handle each key/value
+    }
+}
+```
+
+## 5. Media (rich push)
+
+Rich media is attached automatically by the Klaviyo push service when the notification is built —
+there is no separate extension setup like iOS. If you are building a fully custom notification UI,
+use the `RemoteMessage` extensions (the `com.klaviyo.pushFcm.KlaviyoRemoteMessage.*` family, e.g.
+`imageUrl`) to pull whatever fields you need and construct your own notification. Use
+`Intent.appendKlaviyoExtras(RemoteMessage)` so `Klaviyo.handlePush(intent)` can still track opens.
+
+## Reference implementation
+
+See the sample app's Push Log ("inbox") POC, which implements the pattern above:
+
+- [`SamplePushService.kt`](sample/src/main/java/com/klaviyo/sample/SamplePushService.kt) — captures each push
+- [`PushLogStore.kt`](sample/src/main/java/com/klaviyo/sample/PushLogStore.kt) — stores the history
+- [`PushLogView.kt`](sample/src/main/java/com/klaviyo/sample/PushLogView.kt) — displays it
+
+Full documentation: [README § Push Notifications](README.md#push-notifications)

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -53,6 +53,17 @@
             </intent-filter>
         </activity>
 
+        <!-- Sample App Only: Custom push service that subclasses KlaviyoPushService to capture
+             received notifications into the in-app Push Log (see SamplePushService). Declaring a
+             service here takes precedence over the SDK's default KlaviyoPushService. -->
+        <service
+                android:name=".SamplePushService"
+                android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT"/>
+            </intent-filter>
+        </service>
+
         <!-- Optional: Set the Klaviyo SDK logging level (1=verbose, 2=debug etc) -->
         <meta-data
                 android:name="com.klaviyo.core.log_level"

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -3,6 +3,8 @@
     <application
             android:name="SampleApplication"
             android:allowBackup="true"
+            android:dataExtractionRules="@xml/data_extraction_rules"
+            android:fullBackupContent="@xml/backup_rules"
             android:icon="@mipmap/ic_launcher"
             android:label="@string/app_name"
             android:supportsRtl="true"

--- a/sample/src/main/java/com/klaviyo/sample/PushLogEntry.kt
+++ b/sample/src/main/java/com/klaviyo/sample/PushLogEntry.kt
@@ -1,0 +1,28 @@
+package com.klaviyo.sample
+
+/**
+ * A single push notification captured for display in the sample app's Push Log screen — the
+ * Android counterpart to the iOS example app's Push Log ("mobile inbox") POC.
+ */
+data class PushLogEntry(
+    val id: String,
+    val receivedAt: Long,
+    val source: Source,
+    val title: String,
+    val body: String,
+    val customData: Map<String, String>
+) {
+    /**
+     * How the push reached the app. Unlike iOS — where the app state (foreground/background/tapped)
+     * dictates which delegate fires — Klaviyo formats every push as an FCM data message, so all of
+     * them arrive via [SamplePushService.onMessageReceived] regardless of app state. The meaningful
+     * distinction on Android is therefore whether the push carried a visible alert.
+     */
+    enum class Source(val label: String) {
+        /** Standard visible push: carries a title and/or body. */
+        NOTIFICATION("Notification"),
+
+        /** Silent / data-only push: no visible alert, custom data only. */
+        SILENT("Silent")
+    }
+}

--- a/sample/src/main/java/com/klaviyo/sample/PushLogStore.kt
+++ b/sample/src/main/java/com/klaviyo/sample/PushLogStore.kt
@@ -1,0 +1,116 @@
+package com.klaviyo.sample
+
+import android.content.Context
+import android.content.SharedPreferences
+import java.util.UUID
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * Keeps a lightly-persisted history of the push notifications the sample app has received, so the
+ * [PushLogView] screen can show each notification's title, body, and custom key-value pairs without
+ * needing to reproduce the push or dig through Logcat. Mirrors the iOS example app's PushLogStore.
+ *
+ * The list is exposed as a [StateFlow] so Compose can observe it. Entries are recorded from
+ * [SamplePushService] (a background FCM thread) and read from the UI thread; [MutableStateFlow]
+ * handles that hand-off safely.
+ */
+object PushLogStore {
+    private const val PREFS_NAME = "com.klaviyo.sample.pushLog"
+    private const val STORAGE_KEY = "entries"
+    private const val MAX_ENTRIES = 50
+
+    private val _entries = MutableStateFlow<List<PushLogEntry>>(emptyList())
+    val entries: StateFlow<List<PushLogEntry>> = _entries.asStateFlow()
+
+    private var prefs: SharedPreferences? = null
+
+    /**
+     * Call once from Application.onCreate. Hydrates the in-memory list from disk (debug builds only).
+     */
+    fun initialize(context: Context) {
+        if (prefs != null) return
+        prefs = context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        _entries.value = load()
+    }
+
+    fun record(
+        source: PushLogEntry.Source,
+        title: String,
+        body: String,
+        customData: Map<String, String>
+    ) {
+        val entry = PushLogEntry(
+            id = UUID.randomUUID().toString(),
+            receivedAt = System.currentTimeMillis(),
+            source = source,
+            title = title,
+            body = body,
+            customData = customData
+        )
+        _entries.update { current -> (listOf(entry) + current).take(MAX_ENTRIES) }
+        save()
+    }
+
+    fun clear() {
+        _entries.value = emptyList()
+        save()
+    }
+
+    private fun save() {
+        // Push payloads can carry sensitive custom data (promo codes, identifiers, etc.), so only
+        // persist across launches in debug builds. Release builds keep the log in memory for the
+        // current session only.
+        if (!BuildConfig.DEBUG) return
+        prefs?.edit()?.putString(STORAGE_KEY, encode(_entries.value))?.apply()
+    }
+
+    private fun load(): List<PushLogEntry> {
+        if (!BuildConfig.DEBUG) return emptyList()
+        val json = prefs?.getString(STORAGE_KEY, null) ?: return emptyList()
+        return decode(json)
+    }
+
+    // Serialize via org.json so the sample app needn't pull in a JSON/serialization dependency.
+
+    private fun encode(entries: List<PushLogEntry>): String {
+        val array = JSONArray()
+        entries.forEach { entry ->
+            val custom = JSONObject()
+            entry.customData.forEach { (key, value) -> custom.put(key, value) }
+            array.put(
+                JSONObject()
+                    .put("id", entry.id)
+                    .put("receivedAt", entry.receivedAt)
+                    .put("source", entry.source.name)
+                    .put("title", entry.title)
+                    .put("body", entry.body)
+                    .put("customData", custom)
+            )
+        }
+        return array.toString()
+    }
+
+    private fun decode(json: String): List<PushLogEntry> = runCatching {
+        val array = JSONArray(json)
+        (0 until array.length()).map { index ->
+            val obj = array.getJSONObject(index)
+            val customObj = obj.optJSONObject("customData") ?: JSONObject()
+            val customData = customObj.keys().asSequence()
+                .associateWith { key -> customObj.getString(key) }
+            PushLogEntry(
+                id = obj.getString("id"),
+                receivedAt = obj.getLong("receivedAt"),
+                source = runCatching { PushLogEntry.Source.valueOf(obj.getString("source")) }
+                    .getOrDefault(PushLogEntry.Source.NOTIFICATION),
+                title = obj.optString("title"),
+                body = obj.optString("body"),
+                customData = customData
+            )
+        }
+    }.getOrDefault(emptyList())
+}

--- a/sample/src/main/java/com/klaviyo/sample/PushLogStore.kt
+++ b/sample/src/main/java/com/klaviyo/sample/PushLogStore.kt
@@ -29,6 +29,10 @@ object PushLogStore {
 
     private var prefs: SharedPreferences? = null
 
+    // record() runs on a background FCM thread while clear() runs on the UI thread; serialize each
+    // update-plus-save so a slower save() can't overwrite a newer one and drop entries after restart.
+    private val persistenceLock = Any()
+
     /**
      * Call once from Application.onCreate. Hydrates the in-memory list from disk (debug builds only).
      */
@@ -52,13 +56,17 @@ object PushLogStore {
             body = body,
             customData = customData
         )
-        _entries.update { current -> (listOf(entry) + current).take(MAX_ENTRIES) }
-        save()
+        synchronized(persistenceLock) {
+            _entries.update { current -> (listOf(entry) + current).take(MAX_ENTRIES) }
+            save()
+        }
     }
 
     fun clear() {
-        _entries.value = emptyList()
-        save()
+        synchronized(persistenceLock) {
+            _entries.value = emptyList()
+            save()
+        }
     }
 
     private fun save() {

--- a/sample/src/main/java/com/klaviyo/sample/PushLogView.kt
+++ b/sample/src/main/java/com/klaviyo/sample/PushLogView.kt
@@ -37,6 +37,19 @@ import com.klaviyo.sample.ui.theme.KlaviyoAndroidSdkTheme
 import java.text.DateFormat
 import java.util.Date
 
+private object PushLogStrings {
+    const val TITLE = "Push Log"
+    const val CLOSE = "Close"
+    const val CLEAR = "Clear"
+    const val EMPTY_TITLE = "No Push Notifications Yet"
+    const val EMPTY_SUBTITLE =
+        "Received pushes will appear here with their title, body, and custom data."
+    const val NO_TITLE = "(no title)"
+    const val NO_BODY = "(no body)"
+}
+
+private fun formatKeyValue(key: String, value: String): String = "$key: $value"
+
 /**
  * Displays the list of push notifications the sample app has received — the title, body, and any
  * custom key-value pairs — matching the data extracted in [SamplePushService]. This is the Android
@@ -99,10 +112,10 @@ private fun PushLogHeader(
             onClick = onClose,
             modifier = Modifier.semantics { testTag = SampleTestTags.BTN_CLOSE_PUSH_LOG }
         ) {
-            Text("Close")
+            Text(PushLogStrings.CLOSE)
         }
         Text(
-            text = "Push Log",
+            text = PushLogStrings.TITLE,
             style = MaterialTheme.typography.titleLarge,
             textAlign = TextAlign.Center,
             modifier = Modifier.weight(1f)
@@ -112,7 +125,7 @@ private fun PushLogHeader(
             enabled = canClear,
             modifier = Modifier.semantics { testTag = SampleTestTags.BTN_CLEAR_PUSH_LOG }
         ) {
-            Text("Clear")
+            Text(PushLogStrings.CLEAR)
         }
     }
 }
@@ -133,12 +146,12 @@ private fun EmptyState() {
         )
         Spacer(Modifier.width(0.dp))
         Text(
-            text = "No Push Notifications Yet",
+            text = PushLogStrings.EMPTY_TITLE,
             style = MaterialTheme.typography.titleMedium,
             modifier = Modifier.padding(top = 12.dp)
         )
         Text(
-            text = "Received pushes will appear here with their title, body, and custom data.",
+            text = PushLogStrings.EMPTY_SUBTITLE,
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             textAlign = TextAlign.Center,
@@ -165,12 +178,12 @@ private fun PushLogRow(entry: PushLogEntry) {
             )
         }
         Text(
-            text = entry.title.ifEmpty { "(no title)" },
+            text = entry.title.ifEmpty { PushLogStrings.NO_TITLE },
             style = MaterialTheme.typography.titleMedium,
             modifier = Modifier.padding(top = 6.dp)
         )
         Text(
-            text = entry.body.ifEmpty { "(no body)" },
+            text = entry.body.ifEmpty { PushLogStrings.NO_BODY },
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )
@@ -178,7 +191,7 @@ private fun PushLogRow(entry: PushLogEntry) {
             Column(modifier = Modifier.padding(top = 6.dp)) {
                 entry.customData.toSortedMap().forEach { (key, value) ->
                     Text(
-                        text = "$key: $value",
+                        text = formatKeyValue(key, value),
                         style = MaterialTheme.typography.labelSmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )

--- a/sample/src/main/java/com/klaviyo/sample/PushLogView.kt
+++ b/sample/src/main/java/com/klaviyo/sample/PushLogView.kt
@@ -1,0 +1,242 @@
+package com.klaviyo.sample
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.NotificationsOff
+import androidx.compose.material3.DividerDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTag
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.klaviyo.sample.ui.theme.KlaviyoAndroidSdkTheme
+import java.text.DateFormat
+import java.util.Date
+
+/**
+ * Displays the list of push notifications the sample app has received — the title, body, and any
+ * custom key-value pairs — matching the data extracted in [SamplePushService]. This is the Android
+ * counterpart to the iOS example app's Push Log screen.
+ */
+@Composable
+fun PushLogView(
+    entries: List<PushLogEntry>,
+    onClear: () -> Unit,
+    onClose: () -> Unit
+) {
+    KlaviyoAndroidSdkTheme {
+        Surface(
+            modifier = Modifier
+                .fillMaxSize()
+                .windowInsetsPadding(WindowInsets.systemBars),
+            color = MaterialTheme.colorScheme.background
+        ) {
+            Column(modifier = Modifier.fillMaxSize()) {
+                PushLogHeader(
+                    canClear = entries.isNotEmpty(),
+                    onClear = onClear,
+                    onClose = onClose
+                )
+                HorizontalDivider(Modifier, DividerDefaults.Thickness, DividerDefaults.color)
+
+                if (entries.isEmpty()) {
+                    EmptyState()
+                } else {
+                    LazyColumn(modifier = Modifier.fillMaxSize()) {
+                        items(entries, key = { it.id }) { entry ->
+                            PushLogRow(entry)
+                            HorizontalDivider(
+                                Modifier,
+                                DividerDefaults.Thickness,
+                                DividerDefaults.color
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PushLogHeader(
+    canClear: Boolean,
+    onClear: () -> Unit,
+    onClose: () -> Unit
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.surface)
+            .padding(horizontal = 8.dp, vertical = 4.dp)
+    ) {
+        TextButton(
+            onClick = onClose,
+            modifier = Modifier.semantics { testTag = SampleTestTags.BTN_CLOSE_PUSH_LOG }
+        ) {
+            Text("Close")
+        }
+        Text(
+            text = "Push Log",
+            style = MaterialTheme.typography.titleLarge,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.weight(1f)
+        )
+        TextButton(
+            onClick = onClear,
+            enabled = canClear,
+            modifier = Modifier.semantics { testTag = SampleTestTags.BTN_CLEAR_PUSH_LOG }
+        ) {
+            Text("Clear")
+        }
+    }
+}
+
+@Composable
+private fun EmptyState() {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(32.dp)
+    ) {
+        Icon(
+            imageVector = Icons.Default.NotificationsOff,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(Modifier.width(0.dp))
+        Text(
+            text = "No Push Notifications Yet",
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.padding(top = 12.dp)
+        )
+        Text(
+            text = "Received pushes will appear here with their title, body, and custom data.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(top = 4.dp)
+        )
+    }
+}
+
+@Composable
+private fun PushLogRow(entry: PushLogEntry) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.surface)
+            .padding(16.dp)
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            SourceChip(entry.source)
+            Spacer(Modifier.weight(1f))
+            Text(
+                text = formatTime(entry.receivedAt),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        Text(
+            text = entry.title.ifEmpty { "(no title)" },
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.padding(top = 6.dp)
+        )
+        Text(
+            text = entry.body.ifEmpty { "(no body)" },
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        if (entry.customData.isNotEmpty()) {
+            Column(modifier = Modifier.padding(top = 6.dp)) {
+                entry.customData.toSortedMap().forEach { (key, value) ->
+                    Text(
+                        text = "$key: $value",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SourceChip(source: PushLogEntry.Source) {
+    Text(
+        text = source.label,
+        style = MaterialTheme.typography.labelSmall,
+        color = MaterialTheme.colorScheme.primary,
+        modifier = Modifier
+            .clip(RoundedCornerShape(50))
+            .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.12f))
+            .padding(horizontal = 8.dp, vertical = 2.dp)
+    )
+}
+
+private fun formatTime(epochMillis: Long): String =
+    DateFormat.getTimeInstance(DateFormat.MEDIUM).format(Date(epochMillis))
+
+@Preview(showBackground = true)
+@Composable
+private fun PushLogPreviewEmpty() {
+    KlaviyoAndroidSdkTheme {
+        PushLogView(entries = emptyList(), onClear = {}, onClose = {})
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PushLogPreviewFilled() {
+    KlaviyoAndroidSdkTheme {
+        PushLogView(
+            entries = listOf(
+                PushLogEntry(
+                    id = "1",
+                    receivedAt = System.currentTimeMillis(),
+                    source = PushLogEntry.Source.NOTIFICATION,
+                    title = "Sale is live!",
+                    body = "20% off everything today only",
+                    customData = mapOf("promo_code" to "SAVE20", "screen" to "sale")
+                ),
+                PushLogEntry(
+                    id = "2",
+                    receivedAt = System.currentTimeMillis(),
+                    source = PushLogEntry.Source.SILENT,
+                    title = "",
+                    body = "",
+                    customData = mapOf("sync" to "orders")
+                )
+            ),
+            onClear = {},
+            onClose = {}
+        )
+    }
+}

--- a/sample/src/main/java/com/klaviyo/sample/SampleApplication.kt
+++ b/sample/src/main/java/com/klaviyo/sample/SampleApplication.kt
@@ -16,6 +16,10 @@ class SampleApplication : Application() {
     override fun onCreate() {
         super.onCreate()
 
+        // Sample App Only: Hydrate the in-app Push Log store so received notifications can be
+        // displayed on the Push Log screen (see SamplePushService / PushLogView).
+        PushLogStore.initialize(applicationContext)
+
         // SETUP NOTE Initialize Klaviyo SDK: Add your public API key here or in the local.properties file
         val klaviyoPublicKey = validatePublicKey(BuildConfig.KLAVIYO_PUBLIC_KEY)
 

--- a/sample/src/main/java/com/klaviyo/sample/SamplePushService.kt
+++ b/sample/src/main/java/com/klaviyo/sample/SamplePushService.kt
@@ -1,0 +1,60 @@
+package com.klaviyo.sample
+
+import com.google.firebase.messaging.RemoteMessage
+import com.klaviyo.core.Registry
+import com.klaviyo.pushFcm.KlaviyoPushService
+import com.klaviyo.pushFcm.KlaviyoRemoteMessage.body
+import com.klaviyo.pushFcm.KlaviyoRemoteMessage.hasKlaviyoKeyValuePairs
+import com.klaviyo.pushFcm.KlaviyoRemoteMessage.isKlaviyoMessage
+import com.klaviyo.pushFcm.KlaviyoRemoteMessage.isKlaviyoNotification
+import com.klaviyo.pushFcm.KlaviyoRemoteMessage.keyValuePairs
+import com.klaviyo.pushFcm.KlaviyoRemoteMessage.title
+
+/**
+ * Sample custom push service demonstrating how to capture received notifications into a custom
+ * inbox — the Android counterpart to the iOS example app's Push Log POC.
+ *
+ * Subclassing [KlaviyoPushService] lets the sample intercept every Klaviyo push in
+ * [onMessageReceived], read its title/body/custom data via the SDK's `RemoteMessage` extensions,
+ * and store it in [PushLogStore] for display on the [PushLogView] screen — while still delegating
+ * to the SDK (via `super`) so the notification is displayed and open-tracking keeps working.
+ *
+ * Registered in the sample's AndroidManifest, which takes precedence over the SDK's default
+ * `KlaviyoPushService` (see README § Advanced Setup).
+ *
+ * Note: Klaviyo formats every push as an FCM data message, so this fires whether the app is in the
+ * foreground, background, or terminated — there is no separate foreground/background delivery path
+ * like iOS.
+ */
+class SamplePushService : KlaviyoPushService() {
+
+    override fun onMessageReceived(message: RemoteMessage) {
+        // Let the Klaviyo SDK display the notification and do its own bookkeeping first.
+        super.onMessageReceived(message)
+
+        // Only Klaviyo messages belong in this inbox; a real app would route others elsewhere.
+        if (!message.isKlaviyoMessage) return
+
+        val customData = if (message.hasKlaviyoKeyValuePairs) {
+            message.keyValuePairs ?: emptyMap()
+        } else {
+            emptyMap()
+        }
+
+        // A standard push carries a visible title/body; a data-only push (no alert) is "silent".
+        val source = if (message.isKlaviyoNotification) {
+            PushLogEntry.Source.NOTIFICATION
+        } else {
+            PushLogEntry.Source.SILENT
+        }
+
+        PushLogStore.record(
+            source = source,
+            title = message.title ?: "",
+            body = message.body ?: "",
+            customData = customData
+        )
+
+        Registry.log.info("Push Log recorded ${source.label} push: ${message.title}")
+    }
+}

--- a/sample/src/main/java/com/klaviyo/sample/SamplePushService.kt
+++ b/sample/src/main/java/com/klaviyo/sample/SamplePushService.kt
@@ -55,6 +55,7 @@ class SamplePushService : KlaviyoPushService() {
             customData = customData
         )
 
-        Registry.log.info("Push Log recorded ${source.label} push: ${message.title}")
+        // Log only the source/type — never the payload (title/body/custom data can be sensitive).
+        Registry.log.info("Push Log recorded ${source.label} push")
     }
 }

--- a/sample/src/main/java/com/klaviyo/sample/SampleView.kt
+++ b/sample/src/main/java/com/klaviyo/sample/SampleView.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.Science
 import androidx.compose.material.icons.filled.ShoppingCart
 import androidx.compose.material3.DividerDefaults
@@ -33,6 +34,11 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
@@ -84,6 +90,7 @@ private object UiConstants {
     const val UNREGISTER = "Unregister"
     const val REQUEST_PERMISSION = "Request Notification Permission"
     const val PERMISSION_GRANTED = "Notification Permission Granted"
+    const val VIEW_PUSH_LOG = "Push Log"
 }
 
 @Composable
@@ -151,7 +158,19 @@ fun SampleView(
         }
     }
 
+    val pushLogEntries by PushLogStore.entries.collectAsState()
+    var showPushLog by remember { mutableStateOf(false) }
+
     KlaviyoAndroidSdkTheme {
+        if (showPushLog) {
+            PushLogView(
+                entries = pushLogEntries,
+                onClear = { PushLogStore.clear() },
+                onClose = { showPushLog = false }
+            )
+            return@KlaviyoAndroidSdkTheme
+        }
+
         Surface(
             modifier = Modifier
                 .fillMaxSize()
@@ -159,6 +178,8 @@ fun SampleView(
             color = MaterialTheme.colorScheme.background
         ) {
             SampleViewContent(
+                pushLogCount = pushLogEntries.size,
+                onOpenPushLog = { showPushLog = true },
                 externalId = viewModel.externalId,
                 email = viewModel.email,
                 phoneNumber = viewModel.phoneNumber,
@@ -228,6 +249,8 @@ fun SampleView(
 
 @Composable
 private fun SampleViewContent(
+    pushLogCount: Int = 0,
+    onOpenPushLog: () -> Unit = {},
     externalId: String,
     email: String,
     phoneNumber: String,
@@ -409,6 +432,22 @@ private fun SampleViewContent(
                 text = pushToken,
                 style = MaterialTheme.typography.bodySmall,
                 modifier = Modifier.semantics { testTag = SampleTestTags.TEXT_PUSH_TOKEN }
+            )
+        }
+        ViewRow {
+            ActionButton(
+                text = "${UiConstants.VIEW_PUSH_LOG} ($pushLogCount)",
+                onClick = onOpenPushLog,
+                modifier = Modifier
+                    .weight(1f)
+                    .semantics { testTag = SampleTestTags.BTN_VIEW_PUSH_LOG },
+                icon = {
+                    Icon(
+                        imageVector = Icons.Default.Notifications,
+                        tint = MaterialTheme.colorScheme.primary,
+                        contentDescription = "Push Log"
+                    )
+                }
             )
         }
 

--- a/sample/src/main/java/com/klaviyo/sample/SampleView.kt
+++ b/sample/src/main/java/com/klaviyo/sample/SampleView.kt
@@ -445,7 +445,8 @@ private fun SampleViewContent(
                     Icon(
                         imageVector = Icons.Default.Notifications,
                         tint = MaterialTheme.colorScheme.primary,
-                        contentDescription = "Push Log"
+                        // Decorative: the button's text already announces the action.
+                        contentDescription = null
                     )
                 }
             )

--- a/sample/src/main/java/com/klaviyo/sample/TestTags.kt
+++ b/sample/src/main/java/com/klaviyo/sample/TestTags.kt
@@ -23,6 +23,11 @@ object SampleTestTags {
     const val BTN_REQUEST_NOTIFICATION_PERMISSION = "btn_request_notification_permission"
     const val TEXT_NOTIFICATION_PERMISSION_GRANTED = "text_notification_permission_granted"
     const val TEXT_PUSH_TOKEN = "text_push_token"
+    const val BTN_VIEW_PUSH_LOG = "btn_view_push_log"
+
+    // Push Log screen
+    const val BTN_CLOSE_PUSH_LOG = "btn_close_push_log"
+    const val BTN_CLEAR_PUSH_LOG = "btn_clear_push_log"
 }
 
 object LocationTestTags {

--- a/sample/src/main/res/xml/backup_rules.xml
+++ b/sample/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Legacy Auto Backup rules (API < 31). Exclude the Push Log store from cloud backup: it can
+     persist received push payloads (including custom key-value data), which should not leave the
+     device via backup. See data_extraction_rules.xml for the Android 12+ equivalent. -->
+<full-backup-content>
+    <exclude domain="sharedpref" path="com.klaviyo.sample.pushLog.xml" />
+</full-backup-content>

--- a/sample/src/main/res/xml/data_extraction_rules.xml
+++ b/sample/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Android 12+ (API 31+) backup & device-transfer rules. Exclude the Push Log store from both
+     cloud backup and device-to-device transfer: it can persist received push payloads (including
+     custom key-value data), which should not leave the device. -->
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="sharedpref" path="com.klaviyo.sample.pushLog.xml" />
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="sharedpref" path="com.klaviyo.sample.pushLog.xml" />
+    </device-transfer>
+</data-extraction-rules>


### PR DESCRIPTION
# Description
Android counterpart to the iOS "Push Log" POC ([klaviyo-swift-sdk #647](https://github.com/klaviyo/klaviyo-swift-sdk/pull/647)): adds a sample-app inbox that captures received Klaviyo pushes (title, body, custom key-value pairs) plus a docs guide, following the push-notification data-extraction guide.

## Due Diligence
- [x] I have tested this on an emulator and/or a physical device. <!-- Emulator (API 36): UI renders, empty-state shown. Live push delivery needs a real device + campaign (manual). -->
- [ ] I have added sufficient unit/integration tests of my changes. <!-- Sample-app POC only; no SDK code changed. -->
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all Android versions the SDK currently supports. <!-- Sample-app-only, uses standard APIs; minSdk 23. -->

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes. <!-- Sample app + docs only; no public API change. -->
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [x] Contains readme or migration guide changes. <!-- Adds PUSH_NOTIFICATION_DATA_GUIDE.md -->
- [ ] This is planned work for an upcoming release. <!-- POC / demo, not a release deliverable. -->

## Changelog / Code Overview
Mirrors the iOS example app's Push Log ("mobile inbox") POC.

**Sample app (`:sample`)**
- `SamplePushService` — subclasses `KlaviyoPushService`, overrides `onMessageReceived` to record each Klaviyo push into the store (calling `super` first so the SDK still displays it and tracks opens). Uses the SDK's `RemoteMessage` extensions (`title`, `body`, `isKlaviyoNotification`, `hasKlaviyoKeyValuePairs`, `keyValuePairs`).
- `PushLogEntry` / `PushLogStore` — data model + `StateFlow`-backed store (org.json persistence, debug-builds only, capped at 50 entries).
- `PushLogView` — Compose screen listing captured pushes with source chip, time, title, body, and custom data; empty state; Clear action.
- Wired a "Push Log (N)" button into the Push Notifications section; registered `SamplePushService` in the manifest (takes precedence over the SDK's default service per README § Advanced Setup).

**Docs**
- `PUSH_NOTIFICATION_DATA_GUIDE.md` — Android guide for extracting title/body/custom data/media.

> Note: unlike iOS (foreground/background/tapped delegates), Klaviyo formats every push as an FCM data message, so all pushes arrive via `onMessageReceived` regardless of app state. The sample therefore distinguishes only **Notification** (visible) vs **Silent** (data-only) sources.

Screens (emulator, API 36): main screen shows the new **Push Log (0)** button; tapping it opens the inbox empty state.

## Test Plan
1. Set a valid Klaviyo public key in `local.properties` and build/install `:sample` on a **physical device** (FCM push requires it).
2. Register the push token and grant notification permission in-app.
3. Send a standard push from a Klaviyo campaign/flow → open **Push Log** → confirm a **Notification** row with the correct title/body (and any custom key-value pairs).
4. Send a push with custom key-value pairs and/or a silent (data-only) push → confirm rows appear with the expected **Notification**/**Silent** source and custom data.
5. Tap **Clear** → confirm the log empties.

Automated verification done in this PR: `./gradlew :sample:assembleDebug` + `:sample:ktlintCheck` pass; merged manifest confirms `SamplePushService` precedence; app launches without crash and the Push Log screen renders.

## Related Issues/Tickets
- iOS POC: https://github.com/klaviyo/klaviyo-swift-sdk/pull/647
- Guide: https://docs.google.com/document/d/1VI2NPL36XQt_SZ7entI4rLXeYu5foIFjuc_2C7VU2RY/edit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an in-app Push Log to the sample app.
  * View received notifications and silent/data-only pushes with timestamps, titles, message content, and custom key/value data.
  * Added actions to open, clear, and close the Push Log; Push Log entries are capped at 50 and retained across debug sessions.
* **Documentation**
  * Added a guide for intercepting and parsing Klaviyo push data on Android (including visible vs silent pushes) while preserving open tracking.
* **Chores**
  * Updated backup/data-transfer rules to exclude the Push Log from cloud backup and device transfer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->