### PR TITLE
Remove push as codeowner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,2 @@
 # Default owner
 *   @klaviyo/mobile-app-growth
-
-# Push notifications specific ownership
-/sdk/push/        @klaviyo/mobile-app-growth @klaviyo/mobile-push-team


### PR DESCRIPTION
Highly [requested](https://klaviyo.slack.com/archives/C05JHV117A6/p1784058282272079?thread_ts=1784058159.266729&cid=C05JHV117A6), long awaited final severance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository ownership configuration by removing the dedicated ownership assignment for the push notifications area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->