### PR TITLE
refactor(push): rename automatic push integration manifest keys (MAGE-932)

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,10 +432,10 @@ Automatic integration is controlled by two independent manifest flags. Enable bo
 zero-boilerplate setup, in which the Klaviyo SDK handles the two pieces of push integration that
 otherwise require code in your app:
 
-- **Push open tracking** (`automatic_push_tracking`) — the SDK detects when a user taps a Klaviyo
+- **Push open tracking** (`automatic_push_open_tracking`) — the SDK detects when a user taps a Klaviyo
   notification and records the `Opened Push` event for you. You do **not** need to call
   `Klaviyo.handlePush(intent)` anywhere.
-- **Push token registration** (`automatic_token_forwarding`) — the SDK fetches the current FCM
+- **Push token registration** (`automatic_push_token_forwarding`) — the SDK fetches the current FCM
   token and registers it with Klaviyo automatically, so you don't need to call
   `Klaviyo.setPushToken(...)` yourself.
 
@@ -443,7 +443,7 @@ otherwise require code in your app:
 
 Add the following meta-data to the `<application>` element. Note the `com.klaviyo.push.`
 namespace — it matches the existing Klaviyo notification meta-data keys. **The exact keys are
-required**; a bare `com.klaviyo.automatic_push_tracking` (without the `push.` segment) is
+required**; a bare `com.klaviyo.automatic_push_open_tracking` (without the `push.` segment) is
 silently ignored.
 
 ```xml
@@ -453,10 +453,10 @@ silently ignored.
     <application>
         <!-- ... -->
         <meta-data
-            android:name="com.klaviyo.push.automatic_push_tracking"
+            android:name="com.klaviyo.push.automatic_push_open_tracking"
             android:value="true" />
         <meta-data
-            android:name="com.klaviyo.push.automatic_token_forwarding"
+            android:name="com.klaviyo.push.automatic_push_token_forwarding"
             android:value="true" />
     </application>
 </manifest>
@@ -488,15 +488,15 @@ registration** still works standalone — but Klaviyo message **display** requir
 
 #### The two flags are independent
 
-`automatic_push_tracking` and `automatic_token_forwarding` are separate opt-ins — each defaults to
+`automatic_push_open_tracking` and `automatic_push_token_forwarding` are separate opt-ins — each defaults to
 `false` when absent, and either can be set without the other.
 
 To keep automatic open tracking while owning your own push-token pipeline (for example, forwarding
-a single token to multiple providers), set only `automatic_push_tracking="true"` and omit
-`automatic_token_forwarding`. Open tracking is unaffected, and you register the token yourself via
+a single token to multiple providers), set only `automatic_push_open_tracking="true"` and omit
+`automatic_push_token_forwarding`. Open tracking is unaffected, and you register the token yourself via
 `Klaviyo.setPushToken(...)` as in Option B.
 
-Note: `automatic_token_forwarding` gates only the automatic init/foreground token fetch. If
+Note: `automatic_push_token_forwarding` gates only the automatic init/foreground token fetch. If
 `KlaviyoPushService` remains your registered `FirebaseMessagingService`, its `onNewToken` still
 forwards newly generated or rotated tokens to Klaviyo regardless of either flag. To fully own the
 token pipeline, register your own `FirebaseMessagingService` (see [Advanced Setup](#advanced-setup)).

--- a/sample/README.md
+++ b/sample/README.md
@@ -24,10 +24,10 @@ demonstrated side by side:
   and calls `Klaviyo.handlePush(intent)` on notification taps. This is the classic path and matches the
   behavior of prior sample releases.
 - **`automatic`** — Automatic integration (Option A). The app opts in with two independent manifest flags
-  (`com.klaviyo.push.automatic_push_tracking="true"` and `com.klaviyo.push.automatic_token_forwarding="true"`,
+  (`com.klaviyo.push.automatic_push_open_tracking="true"` and `com.klaviyo.push.automatic_push_token_forwarding="true"`,
   see [src/automatic/AndroidManifest.xml](./src/automatic/AndroidManifest.xml)) and the SDK does both for you:
-  `automatic_token_forwarding` auto-registers the push token at `initialize()` / every foreground, and
-  `automatic_push_tracking` makes the SDK detect notification taps and report opens for you — so the
+  `automatic_push_token_forwarding` auto-registers the push token at `initialize()` / every foreground, and
+  `automatic_push_open_tracking` makes the SDK detect notification taps and report opens for you — so the
   sample's `SampleActivity` contains **zero** push boilerplate. Compare the two `SampleActivity.kt` copies
   to see exactly what code disappears when you opt in.
 
@@ -42,8 +42,8 @@ panel in Android Studio (`manualDebug` vs `automaticDebug`), or from the CLI:
 Both flavors share the same `applicationId` and `google-services.json`, so only one installs at a time. The
 `automatic` flavor still relies on the auto-registered `KlaviyoPushService` (from `:sdk:push-fcm`) to *display*
 notifications. Because the two flags are independent, you can mix and match: set only
-`automatic_push_tracking="true"` to keep automatic open tracking while owning your own token pipeline (omit
-`automatic_token_forwarding`), or set only `automatic_token_forwarding="true"` to auto-forward tokens without
+`automatic_push_open_tracking="true"` to keep automatic open tracking while owning your own token pipeline (omit
+`automatic_push_token_forwarding`), or set only `automatic_push_token_forwarding="true"` to auto-forward tokens without
 automatic open tracking.
 
 Note that `KlaviyoPushService.onNewToken()` forwards token rotations to Klaviyo unconditionally whenever

--- a/sample/src/automatic/AndroidManifest.xml
+++ b/sample/src/automatic/AndroidManifest.xml
@@ -3,10 +3,10 @@
     <!--
         SETUP NOTE (Automatic / Option A): This overlay is the ONLY difference in the automatic flavor's
         manifest. It opts into both automatic behaviors via two independent flags:
-          - com.klaviyo.push.automatic_push_tracking="true" — automatic push OPEN tracking: the SDK
+          - com.klaviyo.push.automatic_push_open_tracking="true" — automatic push OPEN tracking: the SDK
             automatically detects notification taps and reports the open via Klaviyo.handlePush() for
             you (no handlePush() call in your Activity), and
-          - com.klaviyo.push.automatic_token_forwarding="true" — automatic push TOKEN registration: the SDK
+          - com.klaviyo.push.automatic_push_token_forwarding="true" — automatic push TOKEN registration: the SDK
             fetches and registers the token at Klaviyo.initialize() and on every foreground (no
             FirebaseMessaging fetch / Klaviyo.setPushToken() in your app).
         The two flags are fully independent — set either one without the other to opt into just that
@@ -16,10 +16,10 @@
     -->
     <application>
         <meta-data
-            android:name="com.klaviyo.push.automatic_push_tracking"
+            android:name="com.klaviyo.push.automatic_push_open_tracking"
             android:value="true" />
         <meta-data
-            android:name="com.klaviyo.push.automatic_token_forwarding"
+            android:name="com.klaviyo.push.automatic_push_token_forwarding"
             android:value="true" />
     </application>
 

--- a/sample/src/automatic/java/com/klaviyo/sample/SampleActivity.kt
+++ b/sample/src/automatic/java/com/klaviyo/sample/SampleActivity.kt
@@ -16,12 +16,12 @@ import com.klaviyo.analytics.model.EventMetric
 
 /**
  * SETUP NOTE: This is the `automatic` flavor's Activity, demonstrating automatic push integration (Option A).
- * By setting com.klaviyo.push.automatic_token_forwarding="true" and com.klaviyo.push.automatic_push_tracking="true"
+ * By setting com.klaviyo.push.automatic_push_token_forwarding="true" and com.klaviyo.push.automatic_push_open_tracking="true"
  * in the manifest (see src/automatic/AndroidManifest.xml), the SDK takes over both push responsibilities, so
  * there is *zero* push boilerplate here:
- *  - Push token (automatic_token_forwarding): auto-registered at Klaviyo.initialize() and on every foreground
+ *  - Push token (automatic_push_token_forwarding): auto-registered at Klaviyo.initialize() and on every foreground
  *    (no FirebaseMessaging fetch, no Klaviyo.setPushToken() call). Contrast with the `manual` flavor's onCreate.
- *  - Push opens (automatic_push_tracking): the SDK automatically detects when a user taps a push notification
+ *  - Push opens (automatic_push_open_tracking): the SDK automatically detects when a user taps a push notification
  *    and reports the open event via Klaviyo.handlePush() for you, so there is no handlePush() call in
  *    onNewIntent. Contrast with the `manual` flavor's onNewIntent.
  * Displaying notifications still relies on the auto-registered KlaviyoPushService from :sdk:push-fcm.
@@ -67,7 +67,7 @@ class SampleActivity : ComponentActivity() {
         }
 
         // SETUP NOTE (Automatic / Option A): No Klaviyo.handlePush(intent) here.
-        // Because com.klaviyo.push.automatic_push_tracking is enabled, the SDK automatically detects
+        // Because com.klaviyo.push.automatic_push_open_tracking is enabled, the SDK automatically detects
         // notification taps, reports the open, and invokes your deep link handler for you.
     }
 

--- a/sample/src/manual/java/com/klaviyo/sample/SampleActivity.kt
+++ b/sample/src/manual/java/com/klaviyo/sample/SampleActivity.kt
@@ -35,7 +35,7 @@ class SampleActivity : ComponentActivity() {
 
         // SETUP NOTE (Manual / Option B): Fetch the current push token and register it with Klaviyo.
         // The `automatic` flavor omits this entirely — the SDK auto-registers the token at initialize()
-        // and on every foreground once com.klaviyo.push.automatic_token_forwarding is enabled.
+        // and on every foreground once com.klaviyo.push.automatic_push_token_forwarding is enabled.
         FirebaseMessaging.getInstance().token.addOnSuccessListener { token ->
             // Dispatch to main for the UI update
             lifecycleScope.launch(Dispatchers.Main) {

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -118,16 +118,16 @@ object Klaviyo {
     }
 
     /**
-     * Opt-in automatic push token registration (via [Constants.AUTOMATIC_TOKEN_FORWARDING]): pull the
+     * Opt-in automatic push token registration (via [Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING]): pull the
      * current token and forward it to Klaviyo. Called from [initialize] and on each app foreground so
      * rotations are picked up. No-op when the flag is off or when `push-fcm` is absent.
      *
-     * Independent of [Constants.AUTOMATIC_PUSH_TRACKING] (which gates only automatic open tracking) —
+     * Independent of [Constants.AUTOMATIC_PUSH_OPEN_TRACKING] (which gates only automatic open tracking) —
      * this flag alone controls token forwarding.
      */
     internal fun maybeAutoRegisterPushToken() {
         val tokenForwardingEnabled = Registry.config.getManifestBoolean(
-            Constants.AUTOMATIC_TOKEN_FORWARDING,
+            Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING,
             false
         )
         if (!tokenForwardingEnabled) {

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
@@ -593,11 +593,11 @@ internal class KlaviyoTest : BaseTest() {
     }
 
     private fun setAutomaticPushTracking(enabled: Boolean) = every {
-        mockConfig.getManifestBoolean(Constants.AUTOMATIC_PUSH_TRACKING, false)
+        mockConfig.getManifestBoolean(Constants.AUTOMATIC_PUSH_OPEN_TRACKING, false)
     } returns enabled
 
     private fun setTokenForwardingEnabled(enabled: Boolean) = every {
-        mockConfig.getManifestBoolean(Constants.AUTOMATIC_TOKEN_FORWARDING, false)
+        mockConfig.getManifestBoolean(Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING, false)
     } returns enabled
 
     private fun reinitialize() =

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
@@ -592,11 +592,11 @@ internal class KlaviyoTest : BaseTest() {
         assertEquals(Klaviyo.getPushToken(), PUSH_TOKEN)
     }
 
-    private fun setAutomaticPushTracking(enabled: Boolean) = every {
+    private fun setAutomaticPushOpenTracking(enabled: Boolean) = every {
         mockConfig.getManifestBoolean(Constants.AUTOMATIC_PUSH_OPEN_TRACKING, false)
     } returns enabled
 
-    private fun setTokenForwardingEnabled(enabled: Boolean) = every {
+    private fun setAutomaticPushTokenForwardingEnabled(enabled: Boolean) = every {
         mockConfig.getManifestBoolean(Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING, false)
     } returns enabled
 
@@ -606,7 +606,7 @@ internal class KlaviyoTest : BaseTest() {
     @Test
     fun `initialize triggers automatic push token fetch when token forwarding is on and fetcher is registered`() {
         val mockFetcher = registerMockPushTokenFetcher()
-        setTokenForwardingEnabled(true)
+        setAutomaticPushTokenForwardingEnabled(true)
 
         reinitialize()
 
@@ -617,8 +617,8 @@ internal class KlaviyoTest : BaseTest() {
     fun `initialize fetches push token when token forwarding is on even if automatic push tracking is off`() {
         // Independence: token forwarding no longer depends on the open-tracking flag
         val mockFetcher = registerMockPushTokenFetcher()
-        setAutomaticPushTracking(false)
-        setTokenForwardingEnabled(true)
+        setAutomaticPushOpenTracking(false)
+        setAutomaticPushTokenForwardingEnabled(true)
 
         reinitialize()
 
@@ -628,7 +628,7 @@ internal class KlaviyoTest : BaseTest() {
     @Test
     fun `initialize does not fetch push token when token forwarding is off`() {
         val mockFetcher = registerMockPushTokenFetcher()
-        setTokenForwardingEnabled(false)
+        setAutomaticPushTokenForwardingEnabled(false)
 
         reinitialize()
 
@@ -639,8 +639,8 @@ internal class KlaviyoTest : BaseTest() {
     fun `initialize does not fetch push token when only automatic push tracking is on`() {
         // Independence: automatic push tracking alone must not trigger token forwarding
         val mockFetcher = registerMockPushTokenFetcher()
-        setAutomaticPushTracking(true)
-        setTokenForwardingEnabled(false)
+        setAutomaticPushOpenTracking(true)
+        setAutomaticPushTokenForwardingEnabled(false)
 
         reinitialize()
 
@@ -650,7 +650,7 @@ internal class KlaviyoTest : BaseTest() {
     @Test
     fun `initialize does not crash and logs a warning when the push token fetch throws`() {
         val mockFetcher = registerMockPushTokenFetcher()
-        setTokenForwardingEnabled(true)
+        setAutomaticPushTokenForwardingEnabled(true)
         every { mockFetcher.fetchAndSetPushToken() } throws RuntimeException("fetch blew up")
 
         // runCatching around the fetch must contain the failure so initialize still completes
@@ -663,7 +663,7 @@ internal class KlaviyoTest : BaseTest() {
     @Test
     fun `initialize does not crash when flag is on but no push token fetcher is registered`() {
         Registry.unregister<PushTokenFetcher>()
-        setTokenForwardingEnabled(true)
+        setAutomaticPushTokenForwardingEnabled(true)
 
         // push-fcm absent: lookup is null and automatic registration is a graceful no-op
         reinitialize()

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/EventApiRequestTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/EventApiRequestTest.kt
@@ -238,10 +238,10 @@ internal class EventApiRequestTest : BaseApiRequestTest<EventApiRequest>() {
 
     @Test
     fun `Does not include the SDK features header even when the flags that would trigger it on PushTokenApiRequest are set`() {
-        every { mockConfig.hasManifestKey(Constants.AUTOMATIC_PUSH_TRACKING) } returns true
-        every { mockConfig.hasManifestKey(Constants.AUTOMATIC_TOKEN_FORWARDING) } returns true
-        every { mockConfig.getManifestBoolean(Constants.AUTOMATIC_PUSH_TRACKING, false) } returns true
-        every { mockConfig.getManifestBoolean(Constants.AUTOMATIC_TOKEN_FORWARDING, false) } returns true
+        every { mockConfig.hasManifestKey(Constants.AUTOMATIC_PUSH_OPEN_TRACKING) } returns true
+        every { mockConfig.hasManifestKey(Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING) } returns true
+        every { mockConfig.getManifestBoolean(Constants.AUTOMATIC_PUSH_OPEN_TRACKING, false) } returns true
+        every { mockConfig.getManifestBoolean(Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING, false) } returns true
         val request = EventApiRequest(stubEvent, stubProfile)
         assertNull(request.headers["X-Klaviyo-Sdk-Features"])
     }

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/PushTokenApiRequestTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/PushTokenApiRequestTest.kt
@@ -105,26 +105,26 @@ internal class PushTokenApiRequestTest : BaseApiRequestTest<PushTokenApiRequest>
 
     @Test
     fun `SDK features header includes only auto_push_tracking when only that key is present`() {
-        every { mockConfig.hasManifestKey(Constants.AUTOMATIC_PUSH_TRACKING) } returns true
-        every { mockConfig.getManifestBoolean(Constants.AUTOMATIC_PUSH_TRACKING, false) } returns true
+        every { mockConfig.hasManifestKey(Constants.AUTOMATIC_PUSH_OPEN_TRACKING) } returns true
+        every { mockConfig.getManifestBoolean(Constants.AUTOMATIC_PUSH_OPEN_TRACKING, false) } returns true
         val request = PushTokenApiRequest(PUSH_TOKEN, stubProfile)
         assertEquals("auto_push_tracking=1;", request.headers["X-Klaviyo-Sdk-Features"])
     }
 
     @Test
     fun `SDK features header includes only auto_push_token_forwarding when only that key is present`() {
-        every { mockConfig.hasManifestKey(Constants.AUTOMATIC_TOKEN_FORWARDING) } returns true
-        every { mockConfig.getManifestBoolean(Constants.AUTOMATIC_TOKEN_FORWARDING, false) } returns true
+        every { mockConfig.hasManifestKey(Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING) } returns true
+        every { mockConfig.getManifestBoolean(Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING, false) } returns true
         val request = PushTokenApiRequest(PUSH_TOKEN, stubProfile)
         assertEquals("auto_push_token_forwarding=1;", request.headers["X-Klaviyo-Sdk-Features"])
     }
 
     @Test
     fun `SDK features header includes both attributes when both keys present and forwarding on`() {
-        every { mockConfig.hasManifestKey(Constants.AUTOMATIC_PUSH_TRACKING) } returns true
-        every { mockConfig.hasManifestKey(Constants.AUTOMATIC_TOKEN_FORWARDING) } returns true
-        every { mockConfig.getManifestBoolean(Constants.AUTOMATIC_PUSH_TRACKING, false) } returns true
-        every { mockConfig.getManifestBoolean(Constants.AUTOMATIC_TOKEN_FORWARDING, false) } returns true
+        every { mockConfig.hasManifestKey(Constants.AUTOMATIC_PUSH_OPEN_TRACKING) } returns true
+        every { mockConfig.hasManifestKey(Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING) } returns true
+        every { mockConfig.getManifestBoolean(Constants.AUTOMATIC_PUSH_OPEN_TRACKING, false) } returns true
+        every { mockConfig.getManifestBoolean(Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING, false) } returns true
         val request = PushTokenApiRequest(PUSH_TOKEN, stubProfile)
         assertEquals(
             "auto_push_tracking=1; auto_push_token_forwarding=1;",
@@ -134,10 +134,10 @@ internal class PushTokenApiRequestTest : BaseApiRequestTest<PushTokenApiRequest>
 
     @Test
     fun `SDK features header includes both attributes when both keys present and forwarding off`() {
-        every { mockConfig.hasManifestKey(Constants.AUTOMATIC_PUSH_TRACKING) } returns true
-        every { mockConfig.hasManifestKey(Constants.AUTOMATIC_TOKEN_FORWARDING) } returns true
-        every { mockConfig.getManifestBoolean(Constants.AUTOMATIC_PUSH_TRACKING, false) } returns true
-        every { mockConfig.getManifestBoolean(Constants.AUTOMATIC_TOKEN_FORWARDING, false) } returns false
+        every { mockConfig.hasManifestKey(Constants.AUTOMATIC_PUSH_OPEN_TRACKING) } returns true
+        every { mockConfig.hasManifestKey(Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING) } returns true
+        every { mockConfig.getManifestBoolean(Constants.AUTOMATIC_PUSH_OPEN_TRACKING, false) } returns true
+        every { mockConfig.getManifestBoolean(Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING, false) } returns false
         val request = PushTokenApiRequest(PUSH_TOKEN, stubProfile)
         assertEquals(
             "auto_push_tracking=1; auto_push_token_forwarding=0;",

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/state/StateSideEffectsTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/state/StateSideEffectsTest.kt
@@ -419,7 +419,7 @@ class StateSideEffectsTest : BaseTest() {
 
     @Test
     fun `Resumed lifecycle event re-fetches push token when automatic forwarding is enabled`() {
-        every { mockConfig.getManifestBoolean(Constants.AUTOMATIC_TOKEN_FORWARDING, false) } returns true
+        every { mockConfig.getManifestBoolean(Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING, false) } returns true
         val mockFetcher = registerMockPushTokenFetcher()
 
         fireResumedEvent()

--- a/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
@@ -48,17 +48,17 @@ object Constants {
      * Lives in core (not push-fcm) because telemetry's push token request must read it, and core
      * cannot depend on push-fcm.
      */
-    const val AUTOMATIC_PUSH_TRACKING = PUSH_PREFIX + "automatic_push_tracking"
+    const val AUTOMATIC_PUSH_OPEN_TRACKING = PUSH_PREFIX + "automatic_push_open_tracking"
 
     /**
      * Manifest `<meta-data>` key a host app sets to opt into automatic push token forwarding: the
      * SDK pulls the current push token at initialize and on each foreground and forwards it to
      * Klaviyo. Opt-in, absent → `false`.
      *
-     * Lives in core (not push-fcm) for the same reason as [AUTOMATIC_PUSH_TRACKING]: telemetry's
+     * Lives in core (not push-fcm) for the same reason as [AUTOMATIC_PUSH_OPEN_TRACKING]: telemetry's
      * push token request must read it, and core cannot depend on push-fcm.
      */
-    const val AUTOMATIC_TOKEN_FORWARDING = PUSH_PREFIX + "automatic_token_forwarding"
+    const val AUTOMATIC_PUSH_TOKEN_FORWARDING = PUSH_PREFIX + "automatic_push_token_forwarding"
 
     /**
      * Fixed notification ID used in all notify/cancel calls.

--- a/sdk/core/src/main/java/com/klaviyo/core/SdkFeatures.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/SdkFeatures.kt
@@ -22,15 +22,15 @@ enum class SdkFeatureKey(
 ) {
     AUTO_PUSH_TRACKING(
         wireName = "auto_push_tracking",
-        manifestKey = Constants.AUTOMATIC_PUSH_TRACKING,
+        manifestKey = Constants.AUTOMATIC_PUSH_OPEN_TRACKING,
         scope = SdkFeatureScope.PUSH_TOKEN_REGISTRATION
     ),
 
-    // `automatic_token_forwarding` opt-in flag, reported directly. Independent of the open-tracking
+    // `automatic_push_token_forwarding` opt-in flag, reported directly. Independent of the open-tracking
     // flag, so the backend sees how the host set each flag.
     AUTO_PUSH_TOKEN_FORWARDING(
         wireName = "auto_push_token_forwarding",
-        manifestKey = Constants.AUTOMATIC_TOKEN_FORWARDING,
+        manifestKey = Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING,
         scope = SdkFeatureScope.PUSH_TOKEN_REGISTRATION
     )
 }

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoNotification.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoNotification.kt
@@ -173,7 +173,7 @@ class KlaviyoNotification(private val message: RemoteMessage) {
         // Read the flag from the build-time context, not Registry.config, since FCM can build a
         // notification before Klaviyo.initialize runs (e.g. init in an Activity, not Application).
         val autoTracking = context.getManifestBoolean(
-            KlaviyoPushService.METADATA_AUTOMATIC_PUSH_TRACKING,
+            KlaviyoPushService.METADATA_AUTOMATIC_PUSH_OPEN_TRACKING,
             false
         )
         // One id per notification, stamped on the body and every action-button intent, so

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoPushService.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoPushService.kt
@@ -28,7 +28,7 @@ open class KlaviyoPushService : FirebaseMessagingService() {
          * `true`, Klaviyo notification taps route through [KlaviyoTrampolineActivity], which tracks the
          * open itself so the host app no longer needs to call `Klaviyo.handlePush(intent)` in its Activities.
          */
-        const val METADATA_AUTOMATIC_PUSH_TRACKING = Constants.AUTOMATIC_PUSH_TRACKING
+        const val METADATA_AUTOMATIC_PUSH_OPEN_TRACKING = Constants.AUTOMATIC_PUSH_OPEN_TRACKING
     }
 
     /**

--- a/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoNotificationTest.kt
+++ b/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoNotificationTest.kt
@@ -844,7 +844,7 @@ class KlaviyoNotificationTest : BaseTest() {
         // build-time context (not Registry.config), so it works pre-init.
         every {
             mockContext.getManifestBoolean(
-                KlaviyoPushService.METADATA_AUTOMATIC_PUSH_TRACKING,
+                KlaviyoPushService.METADATA_AUTOMATIC_PUSH_OPEN_TRACKING,
                 false
             )
         } returns true

--- a/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoNotificationTest.kt
+++ b/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoNotificationTest.kt
@@ -117,7 +117,7 @@ class KlaviyoNotificationTest : BaseTest() {
         } returns mockk(relaxed = true)
         // buildNotification reads the auto-tracking flag from the build-time context via the
         // Context.getManifestBoolean extension. Default to off (return the passed default);
-        // flag-on tests override via enableAutomaticTracking().
+        // flag-on tests override via enableAutomaticPushOpenTracking().
         mockkStatic("com.klaviyo.core.config.KlaviyoConfigKt")
         // Extension fn: receiver is the first arg, so the default value is the third arg.
         every { mockContext.getManifestBoolean(any(), any()) } answers { thirdArg() }
@@ -839,7 +839,7 @@ class KlaviyoNotificationTest : BaseTest() {
     }
 
     /** Opt into automatic push tracking for the duration of a test. */
-    private fun enableAutomaticTracking() {
+    private fun enableAutomaticPushOpenTracking() {
         // Overrides the flag-off default stubbed in setup(); buildNotification reads this off the
         // build-time context (not Registry.config), so it works pre-init.
         every {
@@ -852,7 +852,7 @@ class KlaviyoNotificationTest : BaseTest() {
 
     @Test
     fun `automatic tracking on - body deep link tap routes through trampoline`() {
-        enableAutomaticTracking()
+        enableAutomaticPushOpenTracking()
         val mockDeepLinkUri = mockk<Uri>(relaxed = true)
         val mockTrampolineIntent = mockk<Intent>(relaxed = true)
         val intentSlot = slot<Intent>()
@@ -878,7 +878,7 @@ class KlaviyoNotificationTest : BaseTest() {
 
     @Test
     fun `automatic tracking on - plain body tap routes through trampoline launch`() {
-        enableAutomaticTracking()
+        enableAutomaticPushOpenTracking()
         val mockTrampolineIntent = mockk<Intent>(relaxed = true)
         val intentSlot = slot<Intent>()
 
@@ -900,7 +900,7 @@ class KlaviyoNotificationTest : BaseTest() {
 
     @Test
     fun `automatic tracking on - deep_link action button routes through trampoline with extras`() {
-        enableAutomaticTracking()
+        enableAutomaticPushOpenTracking()
         val parsedUri = mockk<Uri>(relaxed = true)
         every { Uri.parse("klaviyotest://order/123") } returns parsedUri
         val mockButtonIntent = mockk<Intent>(relaxed = true)
@@ -934,7 +934,7 @@ class KlaviyoNotificationTest : BaseTest() {
 
     @Test
     fun `automatic tracking on - open_app action button routes through trampoline with extras`() {
-        enableAutomaticTracking()
+        enableAutomaticPushOpenTracking()
         val mockButtonIntent = mockk<Intent>(relaxed = true)
         every { KlaviyoTrampolineActivity.forDestination(mockContext, null) } returns mockButtonIntent
 
@@ -959,7 +959,7 @@ class KlaviyoNotificationTest : BaseTest() {
 
     @Test
     fun `open_url tap targets trampoline even with automatic tracking on`() {
-        enableAutomaticTracking()
+        enableAutomaticPushOpenTracking()
         with(KlaviyoRemoteMessage) {
             every { mockRemoteMessage.webUrl } returns "https://example.com"
             every { mockRemoteMessage.deepLink } returns null
@@ -997,7 +997,7 @@ class KlaviyoNotificationTest : BaseTest() {
     fun `body and action button share one dedup uid per notification`() {
         // The dedup key must be per-notification, not per-intent: body and every action button
         // carry the same uid so distinct targets on one notification collapse to a single open.
-        enableAutomaticTracking()
+        enableAutomaticPushOpenTracking()
         val bodyUri = mockk<Uri>(relaxed = true)
         val buttonUri = mockk<Uri>(relaxed = true)
         every { Uri.parse("klaviyotest://order/123") } returns buttonUri


### PR DESCRIPTION
## Summary

Renames the two opt-in push-integration manifest `<meta-data>` keys for clarity ([MAGE-932](https://linear.app/klaviyo/issue/MAGE-932)):

- `com.klaviyo.push.automatic_push_tracking` → `com.klaviyo.push.automatic_push_open_tracking`
- `com.klaviyo.push.automatic_token_forwarding` → `com.klaviyo.push.automatic_push_token_forwarding`

Prompted by Slack feedback that `automatic_push_open_tracking` more clearly conveys what the flag does.

## What changed

- **Manifest key string values** in `Constants.kt`.
- **Kotlin constants/aliases renamed to match** (`AUTOMATIC_PUSH_OPEN_TRACKING`, `AUTOMATIC_PUSH_TOKEN_FORWARDING`, `KlaviyoPushService.METADATA_AUTOMATIC_PUSH_OPEN_TRACKING`), propagated through `SdkFeatures.kt`, `Klaviyo.kt`, `KlaviyoNotification.kt`, and affected tests.
- **Sample app + README docs** updated (root `README.md`, `sample/README.md`, automatic-flavor `AndroidManifest.xml`, both `SampleActivity.kt` copies).

## Intentionally left unchanged

- **`X-Klaviyo-Sdk-Features` wire names** (`auto_push_tracking`, `auto_push_token_forwarding`) — out of scope per the ticket.

## Verification

- `./gradlew ktlintFormat` — clean
- `./gradlew :sdk:core:testDebugUnitTest :sdk:analytics:testDebugUnitTest :sdk:push-fcm:testDebugUnitTest` — BUILD SUCCESSFUL
- `./gradlew :sample:assembleAutomaticDebug` — BUILD SUCCESSFUL

## Note for reviewer

`README.md` (~line 494) documents a `disable_automatic_token_forwarding` opt-*out* flag that does not exist in code (the real flag is the opt-*in* one). Pre-existing inconsistency, unrelated to this rename — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected automatic push open tracking configuration and metadata names.
  - Corrected automatic push token forwarding configuration.
  - Ensured push open tracking and token forwarding can be enabled independently.
  - Updated SDK feature reporting and notification behavior to recognize the corrected settings.

- **Documentation**
  - Updated integration guides, manifest examples, and setup instructions with the correct configuration keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->