### PR TITLE
feat(forms): consolidate form CTA delivery into openDeepLink v3 (PUSH-638)

### DIFF
--- a/README.md
+++ b/README.md
@@ -799,8 +799,7 @@ object to the `registerForInAppForms()` method. For example, to set a session ti
 
 > Form lifecycle events are available in SDK version 4.4.0 and higher.
 
-You can register a handler to receive callbacks whenever a form is shown, dismissed, or a CTA button is tapped
-(distinguishing in-app deep-link CTAs from CTAs that open an external URL in the browser).
+You can register a handler to receive callbacks whenever a form is shown, dismissed, or a CTA button is tapped.
 This is useful for forwarding engagement data to a third-party analytics platform such as Amplitude, Segment, or Mixpanel.
 
 The handler is invoked on the **main thread**, so avoid performing long-running or blocking work inside it.
@@ -811,7 +810,6 @@ The handler is invoked on the **main thread**, so avoid performing long-running 
    ```kotlin
    import com.klaviyo.analytics.Klaviyo
    import com.klaviyo.forms.FormLifecycleEvent.FormCtaClicked
-   import com.klaviyo.forms.FormLifecycleEvent.FormCtaExternalUrlClicked
    import com.klaviyo.forms.FormLifecycleEvent.FormDismissed
    import com.klaviyo.forms.FormLifecycleEvent.FormShown
    import com.klaviyo.forms.registerFormLifecycleHandler
@@ -826,19 +824,13 @@ The handler is invoked on the **main thread**, so avoid performing long-running 
                // e.g. myAnalytics.track("Form Dismissed", mapOf("formId" to event.formId, "formName" to event.formName))
            }
            is FormCtaClicked -> {
+               // Fires for both in-app deep-link CTAs and CTAs that open an external URL;
+               // event.deepLinkUrl carries whichever URL the CTA navigates to.
                // e.g. myAnalytics.track("Form CTA Clicked", mapOf(
                //     "formId" to event.formId,
                //     "formName" to event.formName,
                //     "buttonLabel" to event.buttonLabel,
                //     "deepLinkUrl" to event.deepLinkUrl.toString()
-               // ))
-           }
-           is FormCtaExternalUrlClicked -> {
-               // e.g. myAnalytics.track("Form External URL Clicked", mapOf(
-               //     "formId" to event.formId,
-               //     "formName" to event.formName,
-               //     "buttonLabel" to event.buttonLabel,
-               //     "externalUrl" to event.externalUrl.toString()
                // ))
            }
        }
@@ -862,9 +854,9 @@ The handler is invoked on the **main thread**, so avoid performing long-running 
        } else if (event instanceof FormLifecycleEvent.FormDismissed dismissed) {
            // e.g. myAnalytics.track("Form Dismissed", ...)
        } else if (event instanceof FormLifecycleEvent.FormCtaClicked ctaClicked) {
+           // Fires for both deep-link and external-URL CTAs; ctaClicked.getDeepLinkUrl()
+           // carries whichever URL the CTA navigates to.
            // e.g. myAnalytics.track("Form CTA Clicked", ...)
-       } else if (event instanceof FormLifecycleEvent.FormCtaExternalUrlClicked externalUrlClicked) {
-           // e.g. myAnalytics.track("Form External URL Clicked", ...)
        }
    });
 

--- a/sample/src/main/java/com/klaviyo/sample/SampleApplication.kt
+++ b/sample/src/main/java/com/klaviyo/sample/SampleApplication.kt
@@ -6,7 +6,6 @@ import android.widget.Toast
 import com.klaviyo.analytics.Klaviyo
 import com.klaviyo.core.Registry
 import com.klaviyo.forms.FormLifecycleEvent.FormCtaClicked
-import com.klaviyo.forms.FormLifecycleEvent.FormCtaExternalUrlClicked
 import com.klaviyo.forms.FormLifecycleEvent.FormDismissed
 import com.klaviyo.forms.FormLifecycleEvent.FormShown
 import com.klaviyo.forms.registerForInAppForms
@@ -45,11 +44,6 @@ class SampleApplication : Application() {
                     is FormCtaClicked -> {
                         Registry.log.debug(
                             "Form Lifecycle: CTA ${event.buttonLabel} -> ${event.deepLinkUrl} from ${event.formName} (${event.formId})"
-                        )
-                    }
-                    is FormCtaExternalUrlClicked -> {
-                        Registry.log.debug(
-                            "Form Lifecycle: External URL CTA ${event.buttonLabel} -> ${event.externalUrl} from ${event.formName} (${event.formId})"
                         )
                     }
                 }

--- a/sdk/forms-core/src/main/java/com/klaviyo/forms/FormLifecycleEvent.kt
+++ b/sdk/forms-core/src/main/java/com/klaviyo/forms/FormLifecycleEvent.kt
@@ -46,36 +46,20 @@ sealed interface FormLifecycleEvent {
 
     /**
      * Triggered when a user taps a call-to-action (CTA) button in a form
-     * that has a deep link URL configured.
+     * that has a URL configured, whether it deep links within the host app
+     * or opens an external URL in the default browser.
      *
-     * Fired after the SDK has initiated deep link navigation. Not emitted
-     * if no deep link URL is configured for the CTA.
+     * Fired after the SDK has initiated navigation. Not emitted if no URL is
+     * configured for the CTA.
      *
      * @property buttonLabel The text label of the CTA button.
-     * @property deepLinkUrl The deep link URI configured for the CTA.
+     * @property deepLinkUrl The URI the CTA navigates to. This is an in-app deep
+     * link for deep-link CTAs, or the external URL for CTAs that open the browser.
      */
     data class FormCtaClicked(
         override val formId: String,
         override val formName: String,
         val buttonLabel: String,
         val deepLinkUrl: Uri
-    ) : FormLifecycleEvent
-
-    /**
-     * Triggered when a user taps a call-to-action (CTA) button in a form
-     * that opens an external web URL in the default browser.
-     *
-     * Fired after the SDK has dispatched the browser intent. Distinct from
-     * [FormCtaClicked] because the host app loses focus to the browser, which
-     * typically warrants different telemetry and UI handling.
-     *
-     * @property buttonLabel The text label of the CTA button.
-     * @property externalUrl The web URL opened in the default browser.
-     */
-    data class FormCtaExternalUrlClicked(
-        override val formId: String,
-        override val formName: String,
-        val buttonLabel: String,
-        val externalUrl: Uri
     ) : FormLifecycleEvent
 }

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/KlaviyoNativeBridge.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/KlaviyoNativeBridge.kt
@@ -21,7 +21,6 @@ import com.klaviyo.forms.bridge.NativeBridgeMessage.FormWillAppear
 import com.klaviyo.forms.bridge.NativeBridgeMessage.HandShook
 import com.klaviyo.forms.bridge.NativeBridgeMessage.JsReady
 import com.klaviyo.forms.bridge.NativeBridgeMessage.OpenDeepLink
-import com.klaviyo.forms.bridge.NativeBridgeMessage.OpenExternalUrl
 import com.klaviyo.forms.bridge.NativeBridgeMessage.TrackAggregateEvent
 import com.klaviyo.forms.bridge.NativeBridgeMessage.TrackProfileEvent
 import com.klaviyo.forms.presentation.PresentationManager
@@ -75,8 +74,7 @@ internal class KlaviyoNativeBridge : NativeBridge {
                 is FormWillAppear -> show(bridgeMessage)
                 is TrackAggregateEvent -> createAggregateEvent(bridgeMessage)
                 is TrackProfileEvent -> createProfileEvent(bridgeMessage)
-                is OpenDeepLink -> deepLink(bridgeMessage)
-                is OpenExternalUrl -> openExternalUrl(bridgeMessage)
+                is OpenDeepLink -> openCtaUrl(bridgeMessage)
                 is FormDisappeared -> close(bridgeMessage)
                 is Abort -> abort(bridgeMessage.reason)
             }
@@ -126,21 +124,49 @@ internal class KlaviyoNativeBridge : NativeBridge {
         Klaviyo.createEvent(message.event)
 
     /**
-     * Handle a [OpenDeepLink] message by broadcasting an intent to the host app
-     * similar to how we handle deep links from a notification
+     * Handle an [OpenDeepLink] message by opening its URL. Both in-app deep links and external
+     * web/system URLs arrive here; [OpenDeepLink.openExternally] — not the scheme — decides how to
+     * open, preserving the marketer's chosen CTA action.
      *
-     * There is a brief window between our overlay activity pausing and the next activity resuming.
-     * We alleviate this race condition by postponing till next activity resumes if current activity is null.
+     * When [OpenDeepLink.openExternally] is false, the URL is routed as an in-app deep link (like a
+     * notification deep link). There is a brief window between our overlay activity pausing and the
+     * next activity resuming; [DeepLinking.handleDeepLink] alleviates that race by postponing until
+     * the next activity resumes if the current activity is null.
+     *
+     * When true, the URL is opened in the default browser via a non-package-scoped intent, bypassing
+     * any registered deep link handler — mirroring
+     * [com.klaviyo.forms.webview.KlaviyoWebViewClient.shouldOverrideUrlLoading]. The `NEW_TASK` intent
+     * launches independently of the overlay activity, so no grace period is needed. The scheme is
+     * checked against [ALLOWED_OPEN_URL_SCHEMES] first — the same allowlist gate applied to push's
+     * `open_url`/`web_url` fields (see [com.klaviyo.pushFcm.KlaviyoRemoteMessage], PUSH-834) — to
+     * avoid routing dangerous or unintended URIs (e.g. `intent:`, `javascript:`, `file:`). The intent
+     * is built by [DeepLinking.makeExternalIntent], shared with the push `open_url` path.
+     *
+     * Fires [FormLifecycleEvent.FormCtaClicked] after dispatch, with the URL carried in
+     * [FormLifecycleEvent.FormCtaClicked.deepLinkUrl].
      */
-    private fun deepLink(message: OpenDeepLink) {
-        val deepLinkUri = message.route?.toUri()
+    private fun openCtaUrl(message: OpenDeepLink) {
+        val uri = message.route?.toUri()
 
-        if (deepLinkUri == null) {
+        if (uri == null) {
             Registry.log.warning("Form CTA with no Android route configured: ${message.formId}")
             return
         }
 
-        DeepLinking.handleDeepLink(deepLinkUri)
+        if (message.openExternally) {
+            if (uri.scheme?.lowercase() !in ALLOWED_OPEN_URL_SCHEMES) {
+                Registry.log.warning(
+                    "Form CTA external url '$uri' has a scheme not in the allowed list; ignoring."
+                )
+                return
+            }
+
+            DeepLinking.makeExternalIntent(uri).startActivityIfResolved(
+                Registry.config.applicationContext
+            )
+        } else {
+            DeepLinking.handleDeepLink(uri)
+        }
 
         if (message.formId.isEmpty() || message.formName.isEmpty()) {
             Registry.log.warning(
@@ -154,55 +180,7 @@ internal class KlaviyoNativeBridge : NativeBridge {
                 formId = message.formId,
                 formName = message.formName,
                 buttonLabel = message.buttonLabel,
-                deepLinkUrl = deepLinkUri
-            )
-        )
-    }
-
-    /**
-     * Handle an [OpenExternalUrl] message by opening the URL in the default browser.
-     *
-     * Unlike [deepLink], the intent is not package-scoped (no `setPackage`), so the OS routes it
-     * to the default browser, bypassing any registered deep link handler — mirroring
-     * [com.klaviyo.forms.webview.KlaviyoWebViewClient.shouldOverrideUrlLoading]. The `NEW_TASK`
-     * intent launches independently of the overlay activity, so no grace period is needed.
-     * Fires [FormLifecycleEvent.FormCtaExternalUrlClicked] after dispatch.
-     *
-     * The URL's scheme is checked against [ALLOWED_OPEN_URL_SCHEMES] before dispatch — the same
-     * allowlist gate applied to push's `open_url`/`web_url` fields (see
-     * [com.klaviyo.pushFcm.KlaviyoRemoteMessage], PUSH-834) — to avoid routing dangerous or
-     * unintended URIs (e.g. `intent:`, `javascript:`, `file:`) through the SDK. `smsto:` is
-     * included for both platforms since Android has a handler for it (iOS omits it only because
-     * iOS Messages has no `smsto:` handler). The intent itself is built by
-     * [DeepLinking.makeExternalIntent], shared with the push `open_url` path.
-     */
-    private fun openExternalUrl(message: OpenExternalUrl) {
-        val externalUri = message.url.toUri()
-
-        if (externalUri.scheme?.lowercase() !in ALLOWED_OPEN_URL_SCHEMES) {
-            Registry.log.warning(
-                "openExternalUrl url '$externalUri' has a scheme not in the allowed list; ignoring."
-            )
-            return
-        }
-
-        DeepLinking.makeExternalIntent(externalUri).startActivityIfResolved(
-            Registry.config.applicationContext
-        )
-
-        if (message.formId.isEmpty() || message.formName.isEmpty()) {
-            Registry.log.warning(
-                "OpenExternalUrl missing required fields, skipping lifecycle callback"
-            )
-            return
-        }
-
-        invokeFormLifecycleHandler(
-            FormLifecycleEvent.FormCtaExternalUrlClicked(
-                formId = message.formId,
-                formName = message.formName,
-                buttonLabel = message.buttonLabel,
-                externalUrl = externalUri
+                deepLinkUrl = uri
             )
         )
     }

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/NativeBridgeMessage.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/NativeBridgeMessage.kt
@@ -58,36 +58,23 @@ internal sealed class NativeBridgeMessage {
     ) : NativeBridgeMessage()
 
     /**
-     * Sent from the onsite-in-app-forms when a deep link is opened
+     * Sent from the onsite-in-app-forms when a form CTA navigates to a URL. Carries both in-app
+     * deep links and external web/system URLs; [openExternally] distinguishes them (onsite
+     * openDeepLink v3).
      *
-     * @param route The deep link route to be opened (usually a URL), or null if no Android route is configured
-     * @param formId The form ID of the form that triggered the deep link
-     * @param formName The name of the form that triggered the deep link
+     * @param route The URL to open (from the platform `android` field), or null if none is configured
+     * @param formId The form ID of the form that triggered the CTA
+     * @param formName The name of the form that triggered the CTA
      * @param buttonLabel The text label of the CTA button that was clicked
+     * @param openExternally When true, open the URL in the default browser (bypassing any registered
+     * deep link handler), gated by the scheme allowlist. When false, route it as an in-app deep link.
      */
     data class OpenDeepLink(
         val route: String?,
         val formId: FormId,
         val formName: String,
-        val buttonLabel: String
-    ) : NativeBridgeMessage()
-
-    /**
-     * Sent from the onsite-in-app-forms when a CTA opens an external URL in the default browser.
-     *
-     * Unlike [OpenDeepLink], this routes to the default browser (no host-app package scoping)
-     * rather than through any registered deep link handler.
-     *
-     * @param url The web URL to open in the default browser
-     * @param formId The form ID of the form that triggered the action
-     * @param formName The name of the form that triggered the action
-     * @param buttonLabel The text label of the CTA button that was clicked
-     */
-    data class OpenExternalUrl(
-        val url: String,
-        val formId: FormId,
-        val formName: String,
-        val buttonLabel: String
+        val buttonLabel: String,
+        val openExternally: Boolean
     ) : NativeBridgeMessage()
 
     /**
@@ -127,9 +114,9 @@ internal sealed class NativeBridgeMessage {
                 HandshakeSpec(keyName<FormWillAppear>(), 2),
                 HandshakeSpec(keyName<TrackAggregateEvent>(), 1),
                 HandshakeSpec(keyName<TrackProfileEvent>(), 1),
-                // Version 2 issues deep link after closing the form (v1 was before close, causing a timing issue)
-                HandshakeSpec(keyName<OpenDeepLink>(), 2),
-                HandshakeSpec(keyName<OpenExternalUrl>(), 1),
+                // v2 issues deep link after closing the form (v1 was before close, causing a timing issue).
+                // v3 carries both deep links and external URLs in one message, keyed by `openExternally`.
+                HandshakeSpec(keyName<OpenDeepLink>(), 3),
                 HandshakeSpec(keyName<FormDisappeared>(), 1),
                 HandshakeSpec(keyName<Abort>(), 1)
             )
@@ -170,16 +157,8 @@ internal sealed class NativeBridgeMessage {
                     route = jsonData.getDeepLink(),
                     formId = jsonData.optString("formId"),
                     formName = jsonData.optString("formName"),
-                    buttonLabel = jsonData.optString("buttonLabel")
-                )
-
-                keyName<OpenExternalUrl>() -> OpenExternalUrl(
-                    url = jsonData.optString("url").ifEmpty {
-                        throw IllegalStateException("openExternalUrl message missing url")
-                    },
-                    formId = jsonData.optString("formId"),
-                    formName = jsonData.optString("formName"),
-                    buttonLabel = jsonData.optString("buttonLabel")
+                    buttonLabel = jsonData.optString("buttonLabel"),
+                    openExternally = jsonData.optBoolean("openExternally", false)
                 )
 
                 keyName<FormDisappeared>() -> FormDisappeared(

--- a/sdk/forms/src/test/java/com/klaviyo/forms/InAppFormsJavaApiTest.java
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/InAppFormsJavaApiTest.java
@@ -105,17 +105,18 @@ public class InAppFormsJavaApiTest extends BaseTest {
     }
 
     @Test
-    public void testFormCtaExternalUrlClickedAccessibleFromJava() {
-        // Confirms the new lifecycle case and its getters (including the Uri-typed
-        // externalUrl) are reachable from Java in a FormLifecycleHandler lambda.
+    public void testFormCtaClickedAccessibleFromJava() {
+        // Confirms the CTA lifecycle case and its getters (including the Uri-typed
+        // deepLinkUrl, which also carries external browser URLs) are reachable from
+        // Java in a FormLifecycleHandler lambda.
         FormLifecycleHandler callback = (event) -> {
-            if (event instanceof FormLifecycleEvent.FormCtaExternalUrlClicked) {
-                FormLifecycleEvent.FormCtaExternalUrlClicked externalUrlClicked =
-                        (FormLifecycleEvent.FormCtaExternalUrlClicked) event;
-                String ignored = externalUrlClicked.getButtonLabel()
-                        + externalUrlClicked.getExternalUrl().toString()
-                        + externalUrlClicked.getFormId()
-                        + externalUrlClicked.getFormName();
+            if (event instanceof FormLifecycleEvent.FormCtaClicked) {
+                FormLifecycleEvent.FormCtaClicked ctaClicked =
+                        (FormLifecycleEvent.FormCtaClicked) event;
+                String ignored = ctaClicked.getButtonLabel()
+                        + ctaClicked.getDeepLinkUrl().toString()
+                        + ctaClicked.getFormId()
+                        + ctaClicked.getFormName();
             }
         };
         KlaviyoForms.registerFormLifecycleHandler(callback);

--- a/sdk/forms/src/test/java/com/klaviyo/forms/bridge/KlaviyoNativeBridgeTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/bridge/KlaviyoNativeBridgeTest.kt
@@ -303,7 +303,7 @@ internal class KlaviyoNativeBridgeTest : BaseTest() {
     @Test
     fun `openDeepLink broadcasts intent to start activity`() {
         /**
-         * @see com.klaviyo.forms.bridge.KlaviyoNativeBridge.deepLink
+         * @see com.klaviyo.forms.bridge.KlaviyoNativeBridge.openCtaUrl
          */
         mockkObject(DeepLinking)
         every { DeepLinking.handleDeepLink(any<Uri>()) } returns Unit
@@ -314,7 +314,7 @@ internal class KlaviyoNativeBridgeTest : BaseTest() {
     @Test
     fun `openDeepLink with empty android route skips lifecycle callback and does not navigate`() {
         /**
-         * @see com.klaviyo.forms.bridge.KlaviyoNativeBridge.deepLink
+         * @see com.klaviyo.forms.bridge.KlaviyoNativeBridge.openCtaUrl
          */
         val emptyAndroidMessage = """
             {
@@ -407,12 +407,14 @@ internal class KlaviyoNativeBridgeTest : BaseTest() {
 
     private val openExternalUrlMessage = """
         {
-          "type": "openExternalUrl",
+          "type": "openDeepLink",
           "data": {
-            "url": "https://example.com",
+            "ios": "https://example.com",
+            "android": "https://example.com",
             "formId": "64CjgW",
             "formName": "Test Form",
-            "buttonLabel": "Visit Site"
+            "buttonLabel": "Visit Site",
+            "openExternally": true
           }
         }
     """.trimIndent()
@@ -420,7 +422,7 @@ internal class KlaviyoNativeBridgeTest : BaseTest() {
     @Test
     fun `openExternalUrl launches browser intent without package and fires lifecycle callback`() {
         /**
-         * @see com.klaviyo.forms.bridge.KlaviyoNativeBridge.openExternalUrl
+         * @see com.klaviyo.forms.bridge.KlaviyoNativeBridge.openCtaUrl
          */
         every { mockContext.startActivity(any()) } just runs
         every { mockUri.scheme } returns "https"
@@ -442,18 +444,18 @@ internal class KlaviyoNativeBridgeTest : BaseTest() {
         assertEquals(listOf(Intent.CATEGORY_BROWSABLE), mockIntent.categories)
 
         assertEquals(1, events.size)
-        val ctaEvent = events[0] as FormLifecycleEvent.FormCtaExternalUrlClicked
+        val ctaEvent = events[0] as FormLifecycleEvent.FormCtaClicked
         assertEquals("64CjgW", ctaEvent.formId)
         assertEquals("Test Form", ctaEvent.formName)
         assertEquals("Visit Site", ctaEvent.buttonLabel)
-        assertEquals(mockUri, ctaEvent.externalUrl)
+        assertEquals(mockUri, ctaEvent.deepLinkUrl)
 
         Registry.unregister<FormLifecycleHandler>()
     }
 
     @Test
     fun `openExternalUrl with missing formId still navigates but skips lifecycle callback`() {
-        val message = """{"type":"openExternalUrl","data":{"url":"https://example.com","formName":"Test Form","buttonLabel":"Visit"}}"""
+        val message = """{"type":"openDeepLink","data":{"android":"https://example.com","formName":"Test Form","buttonLabel":"Visit","openExternally":true}}"""
 
         every { mockContext.startActivity(any()) } just runs
         every { mockUri.scheme } returns "https"
@@ -511,7 +513,7 @@ internal class KlaviyoNativeBridgeTest : BaseTest() {
             )
             assertEquals(
                 scheme,
-                (events[0] as FormLifecycleEvent.FormCtaExternalUrlClicked).externalUrl.scheme
+                (events[0] as FormLifecycleEvent.FormCtaClicked).deepLinkUrl.scheme
             )
 
             Registry.unregister<FormLifecycleHandler>()

--- a/sdk/forms/src/test/java/com/klaviyo/forms/bridge/NativeBridgeMessageTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/bridge/NativeBridgeMessageTest.kt
@@ -277,6 +277,8 @@ class NativeBridgeMessageTest : BaseTest() {
         assertEquals("abc123", result.formId)
         assertEquals("Test Form", result.formName)
         assertEquals("Click Me", result.buttonLabel)
+        // A deep link omits `openExternally`; it must default to false.
+        assertEquals(false, result.openExternally)
     }
 
     @Test
@@ -363,61 +365,69 @@ class NativeBridgeMessageTest : BaseTest() {
     }
 
     @Test
-    fun `test openExternalUrl decoding`() {
+    fun `external url decodes as openDeepLink with openExternally true`() {
+        // External web URLs now ride the openDeepLink message with openExternally: true,
+        // carrying the URL in the platform-split ios/android fields.
         val message = """
             {
-              "type": "openExternalUrl",
+              "type": "openDeepLink",
               "data": {
-                "url": "https://example.com",
+                "ios": "https://example.com",
+                "android": "https://example.com",
                 "formId": "abc123",
                 "formName": "Test Form",
-                "buttonLabel": "Visit Site"
+                "buttonLabel": "Visit Site",
+                "openExternally": true
               }
             }
         """.trimIndent()
 
-        val result = NativeBridgeMessage.decodeWebviewMessage(message) as NativeBridgeMessage.OpenExternalUrl
+        val result = NativeBridgeMessage.decodeWebviewMessage(message) as NativeBridgeMessage.OpenDeepLink
 
-        assertEquals("https://example.com", result.url)
+        assertEquals("https://example.com", result.route)
         assertEquals("abc123", result.formId)
         assertEquals("Test Form", result.formName)
         assertEquals("Visit Site", result.buttonLabel)
+        assertEquals(true, result.openExternally)
     }
 
     @Test
-    fun `openExternalUrl without metadata fields parses with empty defaults`() {
+    fun `external url without metadata fields parses with empty defaults`() {
         val message = """
             {
-              "type": "openExternalUrl",
+              "type": "openDeepLink",
               "data": {
-                "url": "https://example.com"
+                "android": "https://example.com",
+                "openExternally": true
               }
             }
         """.trimIndent()
 
-        val result = NativeBridgeMessage.decodeWebviewMessage(message) as NativeBridgeMessage.OpenExternalUrl
-        assertEquals("https://example.com", result.url)
+        val result = NativeBridgeMessage.decodeWebviewMessage(message) as NativeBridgeMessage.OpenDeepLink
+        assertEquals("https://example.com", result.route)
         assertEquals("", result.formId)
         assertEquals("", result.formName)
         assertEquals("", result.buttonLabel)
+        assertEquals(true, result.openExternally)
     }
 
     @Test
-    fun `openExternalUrl with missing url throws`() {
+    fun `external openDeepLink with missing route parses with null route`() {
         val message = """
             {
-              "type": "openExternalUrl",
+              "type": "openDeepLink",
               "data": {
                 "formId": "abc123",
                 "formName": "Test Form",
-                "buttonLabel": "Visit Site"
+                "buttonLabel": "Visit Site",
+                "openExternally": true
               }
             }
         """.trimIndent()
 
-        assertThrows(IllegalStateException::class.java) {
-            NativeBridgeMessage.decodeWebviewMessage(message)
-        }
+        val result = NativeBridgeMessage.decodeWebviewMessage(message) as NativeBridgeMessage.OpenDeepLink
+        assertNull(result.route)
+        assertEquals(true, result.openExternally)
     }
 
     @Test
@@ -485,11 +495,7 @@ class NativeBridgeMessageTest : BaseTest() {
                   },
                   {
                     "type": "openDeepLink",
-                    "version": 2
-                  },
-                  {
-                    "type": "openExternalUrl",
-                    "version": 1
+                    "version": 3
                   },
                   {
                     "type": "formDisappeared",


### PR DESCRIPTION
## Summary

Android side of the PUSH-638 form-CTA consolidation. Collapses external-URL and deep-link CTAs onto a **single `openDeepLink` bridge message** (distinguished by a new `openExternally` flag) and a **single `FormCtaClicked` lifecycle event**. Removes the separate `openExternalUrl` message and `FormCtaExternalUrlClicked` event.

Pairs with:
- fender onsite change — `klaviyo/fender#64597` (`openDeepLink` v3 + `openExternally`)
- iOS SDK change — `klaviyo/klaviyo-swift-sdk#654`

**Base:** `feat/push-trampoline` (where the `openExternalUrl` work landed via #499), so this diff is just the consolidation.

## What changed
- **FormLifecycleEvent**: remove `FormCtaExternalUrlClicked`; both deep-link and external-URL CTAs now surface as `FormCtaClicked`, with the URL in `deepLinkUrl`.
- **NativeBridgeMessage**: remove the `OpenExternalUrl` message; add `openExternally: Boolean` to `OpenDeepLink`; bump the advertised `openDeepLink` handshake version **2 → 3**.
- **KlaviyoNativeBridge**: a single `openCtaUrl` handler routes by `openExternally` — `true` opens the URL in the default browser (scheme allowlist + non-package-scoped intent, bypassing the deep link handler); `false` routes via `DeepLinking.handleDeepLink`. Both fire `FormCtaClicked`.
- Update README, sample app, and bridge/message unit tests.

## Why the flag (not scheme-sniffing)
onsite knows the marketer's intent (deep-link-to-screen vs open-URL action) and stamps `openExternally`. Routing on the flag keeps `tel:`/`sms:`/`mailto:`/`http(s)` external URLs opening via the system while preserving in-app deep links (including `https` universal links) through the registered handler — no `https` ambiguity.

## Test plan
- `./gradlew :sdk:forms:testDebugUnitTest` — bridge/message/lifecycle suites pass (`NativeBridgeMessageTest`, `KlaviyoNativeBridgeTest`, `FormLifecycleHandlerTest`), including new `openExternally` decode + default-false coverage and the external-URL routing/scheme-allowlist tests now exercised through `openDeepLink`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Unified CTA tracking so both in-app deep links and external URLs trigger the same CTA-clicked lifecycle event.
  - CTA destinations are now consistently available through the destination URL field.
  - External links continue opening in the device’s default browser, while in-app links follow normal app navigation.

- **Documentation**
  - Updated lifecycle event guidance and Kotlin/Java examples to reflect unified CTA handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->