### PR TITLE
feat(push): default automatic_push_token_forwarding ON and gate onNewToken (MAGE-937)

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,16 +428,18 @@ will be used if present, else we fall back on the application's launcher icon, a
 
 ### Option A — Automatic integration
 
-Automatic integration is controlled by two independent manifest flags. Enable both for the
-zero-boilerplate setup, in which the Klaviyo SDK handles the two pieces of push integration that
-otherwise require code in your app:
+Automatic integration is controlled by two independent manifest flags, covering the two pieces of
+push integration that otherwise require code in your app:
 
-- **Push open tracking** (`automatic_push_open_tracking`) — the SDK detects when a user taps a Klaviyo
-  notification and records the `Opened Push` event for you. You do **not** need to call
-  `Klaviyo.handlePush(intent)` anywhere.
-- **Push token registration** (`automatic_push_token_forwarding`) — the SDK fetches the current FCM
-  token and registers it with Klaviyo automatically, so you don't need to call
-  `Klaviyo.setPushToken(...)` yourself.
+- **Push open tracking** (`automatic_push_open_tracking`) — **opt-in** (off by default). Set it to
+  `true` and the SDK detects when a user taps a Klaviyo notification and records the `Opened Push`
+  event for you, so you do **not** need to call `Klaviyo.handlePush(intent)` anywhere.
+- **Push token registration** (`automatic_push_token_forwarding`) — **on by default**. The SDK
+  fetches the current FCM token and registers it with Klaviyo automatically, so you don't need to
+  call `Klaviyo.setPushToken(...)` yourself. Set it to `false` to opt out.
+
+Token forwarding is already on, so for the zero-boilerplate setup you only need to enable open
+tracking.
 
 #### Step 1 — Enable automatic push integration in `AndroidManifest.xml`
 
@@ -455,6 +457,8 @@ silently ignored.
         <meta-data
             android:name="com.klaviyo.push.automatic_push_open_tracking"
             android:value="true" />
+        <!-- Token forwarding is already ON by default; this line is optional and shown for
+             completeness. Set it to "false" to opt out. -->
         <meta-data
             android:name="com.klaviyo.push.automatic_push_token_forwarding"
             android:value="true" />
@@ -488,18 +492,18 @@ registration** still works standalone — but Klaviyo message **display** requir
 
 #### The two flags are independent
 
-`automatic_push_open_tracking` and `automatic_push_token_forwarding` are separate opt-ins — each defaults to
-`false` when absent, and either can be set without the other.
+`automatic_push_open_tracking` and `automatic_push_token_forwarding` are independent, and either can
+be set without the other. They differ in their defaults:
 
-To keep automatic open tracking while owning your own push-token pipeline (for example, forwarding
-a single token to multiple providers), set only `automatic_push_open_tracking="true"` and omit
-`automatic_push_token_forwarding`. Open tracking is unaffected, and you register the token yourself via
-`Klaviyo.setPushToken(...)` as in Option B.
+- `automatic_push_open_tracking` is **opt-in** — off unless you set it to `true`.
+- `automatic_push_token_forwarding` is **on by default** — set it to `false` to opt out.
 
-Note: `automatic_push_token_forwarding` gates only the automatic init/foreground token fetch. If
-`KlaviyoPushService` remains your registered `FirebaseMessagingService`, its `onNewToken` still
-forwards newly generated or rotated tokens to Klaviyo regardless of either flag. To fully own the
-token pipeline, register your own `FirebaseMessagingService` (see [Advanced Setup](#advanced-setup)).
+To own your own push-token pipeline (for example, forwarding a single token to multiple providers),
+set `automatic_push_token_forwarding="false"` and register the token yourself via
+`Klaviyo.setPushToken(...)` as in Option B. That single flag is a complete opt-out: it disables
+**both** the automatic init/foreground fetch **and** `KlaviyoPushService.onNewToken` forwarding — no
+custom `FirebaseMessagingService` required. Your explicit `Klaviyo.setPushToken(...)` calls always
+work, regardless of the flag.
 
 For a runnable reference, see the sample app's **`automatic`** product flavor
 ([`sample/src/automatic/`](sample/src/automatic/)) and the
@@ -511,14 +515,16 @@ For a runnable reference, see the sample app's **`automatic`** product flavor
 In order to send push notifications to your users, you must collect their push tokens and register them with Klaviyo.
 This is done via the `Klaviyo.setPushToken` method, which registers the push token and current authorization state
 via the [Create Client Push Token API](https://developers.klaviyo.com/en/reference/create_client_push_token).
-`KlaviyoPushService` forwards **newly generated or rotated** tokens to Klaviyo via its
-`onNewToken` method — but only when it is your registered FCM service. If your app supplies its
-own `FirebaseMessagingService`, call `Klaviyo.setPushToken()` from your own `onNewToken()` (see
-[Advanced Setup](#advanced-setup)), or rely on the startup fetch below. Note that `onNewToken`
-only fires when FCM *generates or rotates* a token — it does **not** fire for a token that
-already existed before the SDK was integrated, and it does not fire when FCM auto-init is
-disabled. For that reason, we recommend retrieving the latest token value on app startup and
-registering it with the Klaviyo SDK.
+
+If you leave automatic token forwarding enabled (the default — see Option A), the SDK already handles this: it
+fetches the current token at startup and on each foreground, and `KlaviyoPushService.onNewToken` forwards newly
+generated or rotated tokens for you. The steps below apply when you've **opted out** with
+`automatic_push_token_forwarding="false"`, or when your app supplies its own `FirebaseMessagingService`.
+
+In that case, forward tokens yourself: call `Klaviyo.setPushToken()` from your own `onNewToken()` (see
+[Advanced Setup](#advanced-setup)), and also fetch the current token on startup — `onNewToken` only fires when FCM
+*generates or rotates* a token, so it does **not** fire for a token that already existed before the SDK was
+integrated, nor when FCM auto-init is disabled.
 Add the following to your application or main activity's `.onCreate()` method:
 
 <details open>

--- a/sample/README.md
+++ b/sample/README.md
@@ -51,7 +51,7 @@ automatic open tracking simply omit `automatic_push_open_tracking`.
 Note that `automatic_push_token_forwarding` gates **both** of the SDK's automatic token paths — the
 `initialize()`/foreground fetch and `KlaviyoPushService.onNewToken()`. Setting it to `false` is a single, complete
 opt-out (no custom `FirebaseMessagingService` needed); explicit `Klaviyo.setPushToken()` calls always work,
-which is how you integrate alongside Braze/Airship/Iterable.
+which is how you integrate alongside other push providers.
 
 See the main [README](../README.md) "Push Notifications" section for the full Option A / Option B write-up.
 

--- a/sample/README.md
+++ b/sample/README.md
@@ -21,8 +21,10 @@ The sample ships two product flavors (dimension `integration`) so both Klaviyo p
 demonstrated side by side:
 
 - **`manual`** — Manual integration (Option B). The app fetches the FCM token and calls `Klaviyo.setPushToken()`,
-  and calls `Klaviyo.handlePush(intent)` on notification taps. This is the classic path and matches the
-  behavior of prior sample releases.
+  and calls `Klaviyo.handlePush(intent)` on notification taps. Because automatic token forwarding is **on by
+  default**, this flavor opts out with `com.klaviyo.push.automatic_push_token_forwarding="false"` (see
+  [src/manual/AndroidManifest.xml](./src/manual/AndroidManifest.xml)) so it genuinely demonstrates owning the
+  token pipeline. This is the classic path and matches the behavior of prior sample releases.
 - **`automatic`** — Automatic integration (Option A). The app opts in with two independent manifest flags
   (`com.klaviyo.push.automatic_push_open_tracking="true"` and `com.klaviyo.push.automatic_push_token_forwarding="true"`,
   see [src/automatic/AndroidManifest.xml](./src/automatic/AndroidManifest.xml)) and the SDK does both for you:
@@ -41,15 +43,15 @@ panel in Android Studio (`manualDebug` vs `automaticDebug`), or from the CLI:
 
 Both flavors share the same `applicationId` and `google-services.json`, so only one installs at a time. The
 `automatic` flavor still relies on the auto-registered `KlaviyoPushService` (from `:sdk:push-fcm`) to *display*
-notifications. Because the two flags are independent, you can mix and match: set only
-`automatic_push_open_tracking="true"` to keep automatic open tracking while owning your own token pipeline (omit
-`automatic_push_token_forwarding`), or set only `automatic_push_token_forwarding="true"` to auto-forward tokens without
-automatic open tracking.
+notifications. Because the two flags are independent, you can mix and match: token forwarding is on by default,
+so to keep automatic open tracking while owning your own token pipeline set `automatic_push_open_tracking="true"`
+and `automatic_push_token_forwarding="false"`; open tracking is off by default, so to auto-forward tokens without
+automatic open tracking simply omit `automatic_push_open_tracking`.
 
-Note that `KlaviyoPushService.onNewToken()` forwards token rotations to Klaviyo unconditionally whenever
-`KlaviyoPushService` is the registered `FirebaseMessagingService` — independent of both flags. To fully own
-the token pipeline, register your own `FirebaseMessagingService` instead of `KlaviyoPushService` (the same
-pattern used to integrate alongside Braze/Airship/Iterable).
+Note that `automatic_push_token_forwarding` gates **both** of the SDK's automatic token paths — the
+`initialize()`/foreground fetch and `KlaviyoPushService.onNewToken()`. Setting it to `false` is a single, complete
+opt-out (no custom `FirebaseMessagingService` needed); explicit `Klaviyo.setPushToken()` calls always work,
+which is how you integrate alongside Braze/Airship/Iterable.
 
 See the main [README](../README.md) "Push Notifications" section for the full Option A / Option B write-up.
 

--- a/sample/src/automatic/AndroidManifest.xml
+++ b/sample/src/automatic/AndroidManifest.xml
@@ -10,8 +10,9 @@
             fetches and registers the token at Klaviyo.initialize() and on every foreground (no
             FirebaseMessaging fetch / Klaviyo.setPushToken() in your app).
         The two flags are fully independent — set either one without the other to opt into just that
-        behavior. The `manual` flavor omits this overlay entirely; absence of both flags is the manual
-        (Option B) path.
+        behavior. Token forwarding is ON by default, so the `manual` flavor overrides it to "false"
+        (see src/manual/AndroidManifest.xml) to demonstrate the manual (Option B) path; open tracking
+        is off by default, so `manual` simply omits it.
         Note the keys' "com.klaviyo.push." prefix is required — the bare "com.klaviyo.*" form silently no-ops.
     -->
     <application>

--- a/sample/src/manual/AndroidManifest.xml
+++ b/sample/src/manual/AndroidManifest.xml
@@ -1,0 +1,20 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <!--
+        SETUP NOTE (Manual / Option B): This overlay is the ONLY difference in the manual flavor's
+        manifest. Automatic push TOKEN forwarding defaults to ON, so to genuinely demonstrate the
+        manual integration (the app fetches the token and calls Klaviyo.setPushToken() itself) this
+        flavor must explicitly opt OUT:
+          - com.klaviyo.push.automatic_push_token_forwarding="false" — turns off the SDK's automatic
+            token forwarding (both the initialize()/foreground fetch and KlaviyoPushService.onNewToken).
+        Automatic push OPEN tracking (com.klaviyo.push.automatic_push_open_tracking) is opt-in / OFF by
+        default, so it is simply omitted here — the app calls Klaviyo.handlePush() itself.
+        Note the key's "com.klaviyo.push." prefix is required — the bare "com.klaviyo.*" form silently no-ops.
+    -->
+    <application>
+        <meta-data
+            android:name="com.klaviyo.push.automatic_push_token_forwarding"
+            android:value="false" />
+    </application>
+
+</manifest>

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -24,7 +24,6 @@ import com.klaviyo.core.PushTokenFetcher
 import com.klaviyo.core.Registry
 import com.klaviyo.core.config.Config
 import com.klaviyo.core.config.LifecycleException
-import com.klaviyo.core.isAutomaticPushTokenForwardingEnabled
 import com.klaviyo.core.safeApply
 import com.klaviyo.core.safeCall
 import com.klaviyo.core.utils.takeIf
@@ -119,19 +118,25 @@ object Klaviyo {
     }
 
     /**
-     * Automatic push token registration (via [Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING], default on):
-     * pull the current token and forward it to Klaviyo. Called from [initialize] and on each app
-     * foreground so rotations are picked up. No-op when the flag is explicitly off or when `push-fcm`
-     * is absent.
+     * Automatic push token registration (via [Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING],
+     * default [Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING_DEFAULT]): pull the current token and forward
+     * it to Klaviyo. Called from [initialize] and on each app foreground so rotations are picked up.
+     * No-op when the flag is explicitly off or when `push-fcm` is absent.
      *
-     * Reads the flag via [isAutomaticPushTokenForwardingEnabled], the shared gate that also governs
-     * `KlaviyoPushService.onNewToken`, so the two automatic-collection paths stay in lockstep.
+     * Reads the flag and default that also govern `KlaviyoPushService.onNewToken` (which reads them
+     * from its own Context, safe before init), so the two automatic-collection paths can't drift.
      *
      * Independent of [Constants.AUTOMATIC_PUSH_OPEN_TRACKING] (which gates only automatic open tracking) —
      * this flag alone controls token forwarding.
      */
     internal fun maybeAutoRegisterPushToken() {
-        if (!isAutomaticPushTokenForwardingEnabled()) {
+        // Reading via Registry.config is safe here: this only runs from initialize() and on foreground,
+        // both post-initialization (unlike KlaviyoPushService.onNewToken, which uses its Context).
+        val forwardingEnabled = Registry.config.getManifestBoolean(
+            Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING,
+            Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING_DEFAULT
+        )
+        if (!forwardingEnabled) {
             Registry.log.verbose(
                 "Skipping automatic push token registration (automaticTokenForwarding=false)"
             )

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -24,6 +24,7 @@ import com.klaviyo.core.PushTokenFetcher
 import com.klaviyo.core.Registry
 import com.klaviyo.core.config.Config
 import com.klaviyo.core.config.LifecycleException
+import com.klaviyo.core.isAutomaticPushTokenForwardingEnabled
 import com.klaviyo.core.safeApply
 import com.klaviyo.core.safeCall
 import com.klaviyo.core.utils.takeIf
@@ -118,19 +119,19 @@ object Klaviyo {
     }
 
     /**
-     * Opt-in automatic push token registration (via [Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING]): pull the
-     * current token and forward it to Klaviyo. Called from [initialize] and on each app foreground so
-     * rotations are picked up. No-op when the flag is off or when `push-fcm` is absent.
+     * Automatic push token registration (via [Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING], default on):
+     * pull the current token and forward it to Klaviyo. Called from [initialize] and on each app
+     * foreground so rotations are picked up. No-op when the flag is explicitly off or when `push-fcm`
+     * is absent.
+     *
+     * Reads the flag via [isAutomaticPushTokenForwardingEnabled], the shared gate that also governs
+     * `KlaviyoPushService.onNewToken`, so the two automatic-collection paths stay in lockstep.
      *
      * Independent of [Constants.AUTOMATIC_PUSH_OPEN_TRACKING] (which gates only automatic open tracking) —
      * this flag alone controls token forwarding.
      */
     internal fun maybeAutoRegisterPushToken() {
-        val tokenForwardingEnabled = Registry.config.getManifestBoolean(
-            Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING,
-            false
-        )
-        if (!tokenForwardingEnabled) {
+        if (!isAutomaticPushTokenForwardingEnabled()) {
             Registry.log.verbose(
                 "Skipping automatic push token registration (automaticTokenForwarding=false)"
             )

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
@@ -596,9 +596,12 @@ internal class KlaviyoTest : BaseTest() {
         mockConfig.getManifestBoolean(Constants.AUTOMATIC_PUSH_OPEN_TRACKING, false)
     } returns enabled
 
-    // Token forwarding now defaults ON, so production reads the flag with a default of `true`.
+    // Token forwarding now defaults ON; production reads via Registry.config with the shared default.
     private fun setAutomaticPushTokenForwardingEnabled(enabled: Boolean) = every {
-        mockConfig.getManifestBoolean(Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING, true)
+        mockConfig.getManifestBoolean(
+            Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING,
+            Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING_DEFAULT
+        )
     } returns enabled
 
     private fun reinitialize() =

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
@@ -596,8 +596,9 @@ internal class KlaviyoTest : BaseTest() {
         mockConfig.getManifestBoolean(Constants.AUTOMATIC_PUSH_OPEN_TRACKING, false)
     } returns enabled
 
+    // Token forwarding now defaults ON, so production reads the flag with a default of `true`.
     private fun setAutomaticPushTokenForwardingEnabled(enabled: Boolean) = every {
-        mockConfig.getManifestBoolean(Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING, false)
+        mockConfig.getManifestBoolean(Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING, true)
     } returns enabled
 
     private fun reinitialize() =
@@ -607,6 +608,16 @@ internal class KlaviyoTest : BaseTest() {
     fun `initialize triggers automatic push token fetch when token forwarding is on and fetcher is registered`() {
         val mockFetcher = registerMockPushTokenFetcher()
         setAutomaticPushTokenForwardingEnabled(true)
+
+        reinitialize()
+
+        verify(exactly = 1) { mockFetcher.fetchAndSetPushToken() }
+    }
+
+    @Test
+    fun `initialize fetches push token by default when the token forwarding flag is absent`() {
+        // Default ON: with no manifest key set (BaseTest returns the default), forwarding is enabled
+        val mockFetcher = registerMockPushTokenFetcher()
 
         reinitialize()
 
@@ -633,6 +644,16 @@ internal class KlaviyoTest : BaseTest() {
         reinitialize()
 
         verify(inverse = true) { mockFetcher.fetchAndSetPushToken() }
+    }
+
+    @Test
+    fun `explicit setPushToken still forwards when automatic token forwarding is off`() {
+        // The flag gates only automatic forwarding; explicit developer calls always work
+        setAutomaticPushTokenForwardingEnabled(false)
+
+        Klaviyo.setPushToken(PUSH_TOKEN)
+
+        verify(exactly = 1) { mockApiClient.enqueuePushToken(PUSH_TOKEN, any()) }
     }
 
     @Test

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/state/StateSideEffectsTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/state/StateSideEffectsTest.kt
@@ -429,7 +429,12 @@ class StateSideEffectsTest : BaseTest() {
 
     @Test
     fun `Resumed lifecycle event does not re-fetch push token when automatic forwarding is disabled`() {
-        every { mockConfig.getManifestBoolean(Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING, true) } returns false
+        every {
+            mockConfig.getManifestBoolean(
+                Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING,
+                Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING_DEFAULT
+            )
+        } returns false
         val mockFetcher = registerMockPushTokenFetcher()
 
         fireResumedEvent()

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/state/StateSideEffectsTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/state/StateSideEffectsTest.kt
@@ -419,7 +419,7 @@ class StateSideEffectsTest : BaseTest() {
 
     @Test
     fun `Resumed lifecycle event re-fetches push token when automatic forwarding is enabled`() {
-        every { mockConfig.getManifestBoolean(Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING, false) } returns true
+        // Default ON: no explicit stub needed — BaseTest returns the manifest default (true)
         val mockFetcher = registerMockPushTokenFetcher()
 
         fireResumedEvent()
@@ -429,7 +429,7 @@ class StateSideEffectsTest : BaseTest() {
 
     @Test
     fun `Resumed lifecycle event does not re-fetch push token when automatic forwarding is disabled`() {
-        // Automatic token forwarding flag defaults to false via BaseTest's getManifestBoolean stub
+        every { mockConfig.getManifestBoolean(Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING, true) } returns false
         val mockFetcher = registerMockPushTokenFetcher()
 
         fireResumedEvent()

--- a/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
@@ -62,6 +62,16 @@ object Constants {
     const val AUTOMATIC_PUSH_TOKEN_FORWARDING = PUSH_PREFIX + "automatic_push_token_forwarding"
 
     /**
+     * Default for [AUTOMATIC_PUSH_TOKEN_FORWARDING] when the host does not declare the manifest key:
+     * automatic forwarding is **on** (opt-out). Shared by the two automatic-collection call sites —
+     * `Klaviyo.maybeAutoRegisterPushToken` (analytics) and `KlaviyoPushService.onNewToken` (push-fcm) —
+     * so their default can't drift, even though each reads the flag from its own source: the analytics
+     * path via `Registry.config` (always post-initialization) and the push-fcm path via the service
+     * [android.content.Context] (safe before `Klaviyo.initialize`, which `Registry.config` is not).
+     */
+    const val AUTOMATIC_PUSH_TOKEN_FORWARDING_DEFAULT = true
+
+    /**
      * Fixed notification ID used in all notify/cancel calls.
      * Notifications are uniquely identified by their string tag, not this ID.
      */

--- a/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
@@ -51,9 +51,10 @@ object Constants {
     const val AUTOMATIC_PUSH_OPEN_TRACKING = PUSH_PREFIX + "automatic_push_open_tracking"
 
     /**
-     * Manifest `<meta-data>` key a host app sets to opt into automatic push token forwarding: the
-     * SDK pulls the current push token at initialize and on each foreground and forwards it to
-     * Klaviyo. Opt-in, absent → `false`.
+     * Manifest `<meta-data>` key governing the SDK's automatic push token forwarding. When enabled the
+     * SDK forwards the token to Klaviyo automatically via **both** paths it controls: the fetch at
+     * initialize / on each foreground, and `KlaviyoPushService.onNewToken`. Opt-OUT, absent → `true`;
+     * set `false` for a single, complete opt-out (the public `Klaviyo.setPushToken` API is unaffected).
      *
      * Lives in core (not push-fcm) for the same reason as [AUTOMATIC_PUSH_OPEN_TRACKING]: telemetry's
      * push token request must read it, and core cannot depend on push-fcm.

--- a/sdk/core/src/main/java/com/klaviyo/core/PushTokenFetcher.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/PushTokenFetcher.kt
@@ -12,18 +12,3 @@ interface PushTokenFetcher {
      */
     fun fetchAndSetPushToken()
 }
-
-/**
- * Whether the SDK's automatic push-token forwarding is enabled, via
- * [Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING]. Manifest opt-OUT: absent → `true`.
- *
- * Single source of truth for the flag key and its default, shared by
- * `Klaviyo.maybeAutoRegisterPushToken` (analytics) and `KlaviyoPushService.onNewToken` (push-fcm)
- * so the two automatic-collection paths can't drift. Lives in core because push-fcm and analytics
- * are separate modules and both must reach it.
- *
- * Independent of automatic open tracking. Note `SdkFeatures` telemetry reads the same manifest key
- * with its own default of `false` (only when the host explicitly declares it) and is unaffected.
- */
-fun isAutomaticPushTokenForwardingEnabled(): Boolean =
-    Registry.config.getManifestBoolean(Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING, true)

--- a/sdk/core/src/main/java/com/klaviyo/core/PushTokenFetcher.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/PushTokenFetcher.kt
@@ -12,3 +12,18 @@ interface PushTokenFetcher {
      */
     fun fetchAndSetPushToken()
 }
+
+/**
+ * Whether the SDK's automatic push-token forwarding is enabled, via
+ * [Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING]. Manifest opt-OUT: absent → `true`.
+ *
+ * Single source of truth for the flag key and its default, shared by
+ * `Klaviyo.maybeAutoRegisterPushToken` (analytics) and `KlaviyoPushService.onNewToken` (push-fcm)
+ * so the two automatic-collection paths can't drift. Lives in core because push-fcm and analytics
+ * are separate modules and both must reach it.
+ *
+ * Independent of automatic open tracking. Note `SdkFeatures` telemetry reads the same manifest key
+ * with its own default of `false` (only when the host explicitly declares it) and is unaffected.
+ */
+fun isAutomaticPushTokenForwardingEnabled(): Boolean =
+    Registry.config.getManifestBoolean(Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING, true)

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoPushService.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoPushService.kt
@@ -5,7 +5,7 @@ import com.google.firebase.messaging.RemoteMessage
 import com.klaviyo.analytics.Klaviyo
 import com.klaviyo.core.Constants
 import com.klaviyo.core.Registry
-import com.klaviyo.core.isAutomaticPushTokenForwardingEnabled
+import com.klaviyo.core.config.getManifestBoolean
 import com.klaviyo.pushFcm.KlaviyoRemoteMessage.hasKlaviyoKeyValuePairs
 import com.klaviyo.pushFcm.KlaviyoRemoteMessage.isKlaviyoMessage
 import com.klaviyo.pushFcm.KlaviyoRemoteMessage.isKlaviyoNotification
@@ -35,17 +35,26 @@ open class KlaviyoPushService : FirebaseMessagingService() {
     /**
      * Called when FCM SDK receives a newly registered token.
      *
-     * Automatic forwarding to Klaviyo is gated by [Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING] (via
-     * the shared [isAutomaticPushTokenForwardingEnabled], default on) — the same flag that gates
-     * `Klaviyo.maybeAutoRegisterPushToken`, so `automatic_push_token_forwarding="false"` is a single,
-     * complete opt-out. The public `Klaviyo.setPushToken` API is unaffected: hosts owning their token
-     * pipeline can still forward tokens explicitly.
+     * Automatic forwarding to Klaviyo is gated by [Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING]
+     * (default [Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING_DEFAULT]) — the same flag and default that
+     * gate `Klaviyo.maybeAutoRegisterPushToken`, so `automatic_push_token_forwarding="false"` is a
+     * single, complete opt-out. The public `Klaviyo.setPushToken` API is unaffected: hosts owning
+     * their token pipeline can still forward tokens explicitly.
+     *
+     * The flag is read from this service's [android.content.Context], not `Registry.config`, because
+     * FCM can deliver a token before `Klaviyo.initialize` runs (e.g. the host initializes in an
+     * Activity, not Application) — reading `Registry.config` here would throw `MissingConfig`. This
+     * mirrors how `KlaviyoNotification` reads the sibling open-tracking flag.
      *
      * @param newToken
      */
     override fun onNewToken(newToken: String) {
         super.onNewToken(newToken)
-        if (isAutomaticPushTokenForwardingEnabled()) {
+        val forwardingEnabled = applicationContext.getManifestBoolean(
+            Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING,
+            Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING_DEFAULT
+        )
+        if (forwardingEnabled) {
             Klaviyo.setPushToken(newToken)
         } else {
             Registry.log.verbose(

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoPushService.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoPushService.kt
@@ -5,6 +5,7 @@ import com.google.firebase.messaging.RemoteMessage
 import com.klaviyo.analytics.Klaviyo
 import com.klaviyo.core.Constants
 import com.klaviyo.core.Registry
+import com.klaviyo.core.isAutomaticPushTokenForwardingEnabled
 import com.klaviyo.pushFcm.KlaviyoRemoteMessage.hasKlaviyoKeyValuePairs
 import com.klaviyo.pushFcm.KlaviyoRemoteMessage.isKlaviyoMessage
 import com.klaviyo.pushFcm.KlaviyoRemoteMessage.isKlaviyoNotification
@@ -32,13 +33,25 @@ open class KlaviyoPushService : FirebaseMessagingService() {
     }
 
     /**
-     * Called when FCM SDK receives a newly registered token
+     * Called when FCM SDK receives a newly registered token.
+     *
+     * Automatic forwarding to Klaviyo is gated by [Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING] (via
+     * the shared [isAutomaticPushTokenForwardingEnabled], default on) — the same flag that gates
+     * `Klaviyo.maybeAutoRegisterPushToken`, so `automatic_push_token_forwarding="false"` is a single,
+     * complete opt-out. The public `Klaviyo.setPushToken` API is unaffected: hosts owning their token
+     * pipeline can still forward tokens explicitly.
      *
      * @param newToken
      */
     override fun onNewToken(newToken: String) {
         super.onNewToken(newToken)
-        Klaviyo.setPushToken(newToken)
+        if (isAutomaticPushTokenForwardingEnabled()) {
+            Klaviyo.setPushToken(newToken)
+        } else {
+            Registry.log.verbose(
+                "Skipping automatic push token forwarding (automaticTokenForwarding=false)"
+            )
+        }
     }
 
     /**

--- a/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoPushServiceTest.kt
+++ b/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoPushServiceTest.kt
@@ -3,6 +3,7 @@ package com.klaviyo.pushFcm
 import com.google.firebase.messaging.RemoteMessage
 import com.klaviyo.analytics.Klaviyo
 import com.klaviyo.core.Constants
+import com.klaviyo.core.config.getManifestBoolean
 import com.klaviyo.fixtures.BaseTest
 import com.klaviyo.pushFcm.KlaviyoNotification.Companion.BODY_KEY
 import com.klaviyo.pushFcm.KlaviyoNotification.Companion.KEY_VALUE_PAIRS_KEY
@@ -46,12 +47,19 @@ class KlaviyoPushServiceTest : BaseTest() {
         mockkConstructor(KlaviyoNotification::class)
 
         every { anyConstructed<KlaviyoNotification>().displayNotification(any()) } returns true
+
+        // onNewToken reads the forwarding flag from the service Context (not Registry.config), so
+        // stub the Context.getManifestBoolean extension. Default: return the passed default (on).
+        every { pushService.applicationContext } returns mockContext
+        mockkStatic("com.klaviyo.core.config.KlaviyoConfigKt")
+        every { mockContext.getManifestBoolean(any(), any()) } answers { thirdArg() }
     }
 
     @After
     override fun cleanup() {
         super.cleanup()
         unmockkStatic(Klaviyo::class)
+        unmockkStatic("com.klaviyo.core.config.KlaviyoConfigKt")
     }
 
     @Test
@@ -64,7 +72,10 @@ class KlaviyoPushServiceTest : BaseTest() {
     @Test
     fun `FCM onNewToken does not forward the token when automatic token forwarding is off`() {
         every {
-            mockConfig.getManifestBoolean(Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING, true)
+            mockContext.getManifestBoolean(
+                Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING,
+                Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING_DEFAULT
+            )
         } returns false
 
         pushService.onNewToken(stubPushToken)

--- a/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoPushServiceTest.kt
+++ b/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoPushServiceTest.kt
@@ -2,6 +2,7 @@ package com.klaviyo.pushFcm
 
 import com.google.firebase.messaging.RemoteMessage
 import com.klaviyo.analytics.Klaviyo
+import com.klaviyo.core.Constants
 import com.klaviyo.fixtures.BaseTest
 import com.klaviyo.pushFcm.KlaviyoNotification.Companion.BODY_KEY
 import com.klaviyo.pushFcm.KlaviyoNotification.Companion.KEY_VALUE_PAIRS_KEY
@@ -54,9 +55,21 @@ class KlaviyoPushServiceTest : BaseTest() {
     }
 
     @Test
-    fun `FCM onNewToken persists the new token and enqueues API call`() {
+    fun `FCM onNewToken forwards the new token by default when the forwarding flag is absent`() {
+        // Default ON: BaseTest returns the manifest default (true) when the key is unset
         pushService.onNewToken(stubPushToken)
         verify { Klaviyo.setPushToken(stubPushToken) }
+    }
+
+    @Test
+    fun `FCM onNewToken does not forward the token when automatic token forwarding is off`() {
+        every {
+            mockConfig.getManifestBoolean(Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING, true)
+        } returns false
+
+        pushService.onNewToken(stubPushToken)
+
+        verify(inverse = true) { Klaviyo.setPushToken(any()) }
     }
 
     @Test


### PR DESCRIPTION
# Description
Makes `automatic_push_token_forwarding` default to **ON** on Android and routes the pre-existing `KlaviyoPushService.onNewToken` forwarding through the **same** flag, so a single switch governs all automatic push-token collection and `automatic_push_token_forwarding="false"` becomes a complete opt-out. Non-breaking: the default preserves today's always-on behavior.

## Due Diligence
- [ ] I have tested this on an emulator and/or a physical device. <!-- pending: unit-tested; on-device verification via sample flavors not yet run -->
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all Android versions the SDK currently supports. <!-- only reads a manifest meta-data boolean; no new API-level dependency -->

## Release/Versioning Considerations
- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [x] `Minor` Contains changes to the public API. <!-- adds public `isAutomaticPushTokenForwardingEnabled()` in core + a non-breaking default/behavior change -->
- [ ] `Major` Contains **breaking** changes.
- [x] Contains readme or migration guide changes. <!-- root + sample README; merging to feature branch `feat/auto-push-tracking` -->
- [x] This is planned work for an upcoming release.

> **Version bump deferred:** per team convention for this stacked feature branch, the `4.4.0 → 4.5.0` minor bump + changelog entry will happen once `feat/auto-push-tracking` merges to `master`, not in this sub-PR. Migration-guide wording is tracked in MAGE-897.

## Changelog / Code Overview
- **Default flipped** `false → true` for `automatic_push_token_forwarding` (`Klaviyo.maybeAutoRegisterPushToken`).
- **`onNewToken` now gated** on the same flag; `Klaviyo.setPushToken` (public API) and explicit developer calls remain ungated.
- **Shared gate** `isAutomaticPushTokenForwardingEnabled()` added in `core` (single source of truth for key + default `true`), used by both `analytics` and `push-fcm` so the two automatic-collection paths can't drift.
- **Telemetry unchanged:** `SdkFeatures` still reports `auto_push_token_forwarding` only when the host explicitly declares the manifest key (internal adoption analytics); default-on usage is intentionally not reflected.
- **Sample:** `manual` flavor now sets `automatic_push_token_forwarding="false"` (a new `sample/src/manual/AndroidManifest.xml`) so it keeps demonstrating manual integration; `automatic` flavor unchanged.
- **Docs:** root + sample READMEs updated to document default-ON and `false` = full opt-out; removed the stale "`onNewToken` forwards regardless of the flag" claim. `Constants` KDoc updated.
- Semantically consistent with iOS (`false` = no auto-collection on both); only the absent-key default differs by platform (iOS opt-in/default-off), tracked in MAGE-938.

## Test Plan
- **Unit tests (passing):** `./gradlew :sdk:core:testDebugUnitTest :sdk:analytics:testDebugUnitTest :sdk:push-fcm:testDebugUnitTest` — 0 failures. New/updated cases cover both flag states across both paths (default-absent forwards on `onNewToken` + fetch; `false` suppresses both; explicit `setPushToken` still works; foreground re-fetch gated).
- **ktlint:** `./gradlew ktlintCheck` clean.
- **Manual (to run):** build the sample `manualDebug` vs `automaticDebug` variants; confirm `manualDebug` logs `Skipping automatic push token forwarding …` yet still registers a token via its own `setPushToken`, and `automaticDebug` logs `Automatically fetching push token` with no app code.

## Related Issues/Tickets
- [MAGE-937](https://linear.app/klaviyo/issue/MAGE-937)
- Stacked on MAGE-932 (flag rename, #513, merged) / MAGE-888 (#512, merged); follows MAGE-886.
- Blocks MAGE-938 (wrapper adoption + platform-default divergence) and MAGE-774 (Expo opt-out prop).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated README and sample docs to clarify push notification integration defaults: automatic push token forwarding is enabled by default (opt-out), while automatic open tracking is opt-in.
  * Rewrote guidance for manual token pipelines and when manual forwarding requires explicit token submission.

* **Bug Fixes**
  * Automatic FCM token forwarding now honors the configured manifest flag (including the default when the flag is absent), while explicit token submissions still work when opted out.

* **Tests**
  * Expanded/adjusted unit tests to cover default forwarding, opt-out behavior, and manual token submission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->