### PR TITLE
feat: API client network-behavior RCA items (MAGE-694, MAGE-496, MAGE-500)

### DIFF
--- a/sample/src/debug/AndroidManifest.xml
+++ b/sample/src/debug/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Debug-only manifest overlay. This source set is compiled into debug builds
+  ONLY, so release builds never see the networkSecurityConfig below. It opts
+  the sample into trusting user-added CA certs (see res/xml/network_security_config)
+  so an intercepting proxy (e.g. Proxyman) can MITM HTTPS during network testing.
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application android:networkSecurityConfig="@xml/network_security_config" />
+</manifest>

--- a/sample/src/debug/res/xml/network_security_config.xml
+++ b/sample/src/debug/res/xml/network_security_config.xml
@@ -4,9 +4,15 @@
   into release artifacts). Trust the system CA store plus user-added CAs so an
   intercepting proxy (e.g. Proxyman) can decrypt the sample's HTTPS traffic for
   network testing.
+
+  cleartextTrafficPermitted="true": attaching ANY network-security-config makes
+  Android ignore android:usesCleartextTraffic from the manifest, and cleartext
+  defaults to disallowed on targetSdk 28+. Re-permitting it here (debug only)
+  preserves plain-HTTP endpoints in debug builds (e.g. a local backend/proxy over
+  http). Release trust/cleartext behavior is unchanged.
 -->
 <network-security-config>
-    <base-config>
+    <base-config cleartextTrafficPermitted="true">
         <trust-anchors>
             <certificates src="system" />
             <certificates src="user" />

--- a/sample/src/debug/res/xml/network_security_config.xml
+++ b/sample/src/debug/res/xml/network_security_config.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Debug-only source set: present in debug builds exclusively (never packaged
+  into release artifacts). Trust the system CA store plus user-added CAs so an
+  intercepting proxy (e.g. Proxyman) can decrypt the sample's HTTPS traffic for
+  network testing.
+-->
+<network-security-config>
+    <base-config>
+        <trust-anchors>
+            <certificates src="system" />
+            <certificates src="user" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>

--- a/sample/src/debug/res/xml/network_security_config.xml
+++ b/sample/src/debug/res/xml/network_security_config.xml
@@ -4,12 +4,6 @@
   into release artifacts). Trust the system CA store plus user-added CAs so an
   intercepting proxy (e.g. Proxyman) can decrypt the sample's HTTPS traffic for
   network testing.
-
-  cleartextTrafficPermitted="true": attaching ANY network-security-config makes
-  Android ignore android:usesCleartextTraffic from the manifest, and cleartext
-  defaults to disallowed on targetSdk 28+. Re-permitting it here (debug only)
-  preserves plain-HTTP endpoints in debug builds (e.g. a local backend/proxy over
-  http). Release trust/cleartext behavior is unchanged.
 -->
 <network-security-config>
     <base-config cleartextTrafficPermitted="true">

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/KlaviyoApiClient.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/KlaviyoApiClient.kt
@@ -220,12 +220,18 @@ internal object KlaviyoApiClient : ApiClient {
                 while (apiQueue.size >= MAX_QUEUE_SIZE) {
                     // Evict the oldest request by enqueue timestamp, not the front of the deque —
                     // head-of-line requests are inserted at the front but are the newest.
+                    // The minByOrNull + remove pair is not atomic on the ConcurrentLinkedDeque, so a
+                    // concurrent enqueue could target the same victim. We gate the side effects on
+                    // remove()'s boolean: if another thread already evicted this request, remove()
+                    // returns false and the while-loop simply re-scans — a best-effort, self-healing
+                    // soft bound rather than a hard guarantee.
                     val evicted = apiQueue.minByOrNull { it.queuedTime } ?: break
-                    apiQueue.remove(evicted)
-                    Registry.dataStore.clear(evicted.uuid)
-                    Registry.log.warning(
-                        "API queue at capacity ($MAX_QUEUE_SIZE), evicting oldest request: ${evicted.type}"
-                    )
+                    if (apiQueue.remove(evicted)) {
+                        Registry.dataStore.clear(evicted.uuid)
+                        Registry.log.warning(
+                            "API queue at capacity ($MAX_QUEUE_SIZE), evicting oldest request: ${evicted.type}"
+                        )
+                    }
                 }
                 Registry.dataStore.store(request.uuid, request.toString())
                 if (headOfLine) {

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/KlaviyoApiClient.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/KlaviyoApiClient.kt
@@ -42,8 +42,10 @@ internal object KlaviyoApiClient : ApiClient {
      * Maximum number of requests that can sit in the API queue at one time.
      *
      * Matches the iOS SDK cap (200) for behavioural parity across platforms.
-     * When the queue reaches this limit, the oldest request (front of deque) is evicted
-     * to make room for the incoming one. This prevents the queue from growing unbounded during
+     * When the queue reaches this limit, the oldest request (smallest [KlaviyoApiRequest.queuedTime])
+     * is evicted to make room for the incoming one. Evicting by enqueue timestamp — rather than
+     * the front of the deque — protects freshly-enqueued head-of-line requests, which are inserted
+     * at the front but are the newest. This prevents the queue from growing unbounded during
      * request storms — for example, a push-token registration loop that floods the queue and
      * blocks legitimate new requests from ever reaching the network.
      */
@@ -216,7 +218,10 @@ internal object KlaviyoApiClient : ApiClient {
         }.forEach { request ->
             if (!apiQueue.contains(request)) {
                 while (apiQueue.size >= MAX_QUEUE_SIZE) {
-                    val evicted = apiQueue.pollFirst() ?: break
+                    // Evict the oldest request by enqueue timestamp, not the front of the deque —
+                    // head-of-line requests are inserted at the front but are the newest.
+                    val evicted = apiQueue.minByOrNull { it.queuedTime } ?: break
+                    apiQueue.remove(evicted)
                     Registry.dataStore.clear(evicted.uuid)
                     Registry.log.warning(
                         "API queue at capacity ($MAX_QUEUE_SIZE), evicting oldest request: ${evicted.type}"

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/KlaviyoApiClient.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/KlaviyoApiClient.kt
@@ -41,13 +41,9 @@ internal object KlaviyoApiClient : ApiClient {
     /**
      * Maximum number of requests that can sit in the API queue at one time.
      *
-     * Matches the iOS SDK cap (200) for behavioural parity across platforms.
-     * When the queue reaches this limit, the oldest request (smallest [KlaviyoApiRequest.queuedTime])
-     * is evicted to make room for the incoming one. Evicting by enqueue timestamp — rather than
-     * the front of the deque — protects freshly-enqueued head-of-line requests, which are inserted
-     * at the front but are the newest. This prevents the queue from growing unbounded during
-     * request storms — for example, a push-token registration loop that floods the queue and
-     * blocks legitimate new requests from ever reaching the network.
+     * When the queue reaches this limit, the oldest request is evicted to make room.
+     * We evict by enqueued time, not simply queue position, to honor actual age.
+     * This prevents the queue from growing unbounded during request storms.
      */
     internal const val MAX_QUEUE_SIZE: Int = 200
 

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/KlaviyoApiClient.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/KlaviyoApiClient.kt
@@ -38,6 +38,17 @@ import org.json.JSONObject
 internal object KlaviyoApiClient : ApiClient {
     internal const val QUEUE_KEY = "klaviyo_api_request_queue"
 
+    /**
+     * Maximum number of requests that can sit in the API queue at one time.
+     *
+     * Matches the iOS SDK cap (200) for behavioural parity across platforms.
+     * When the queue reaches this limit, the oldest request (front of deque) is evicted
+     * to make room for the incoming one. This prevents the queue from growing unbounded during
+     * request storms — for example, a push-token registration loop that floods the queue and
+     * blocks legitimate new requests from ever reaching the network.
+     */
+    internal const val MAX_QUEUE_SIZE: Int = 200
+
     private var handlerThread = Registry.threadHelper.getHandlerThread(
         KlaviyoApiClient::class.simpleName
     )
@@ -204,6 +215,13 @@ internal object KlaviyoApiClient : ApiClient {
             }
         }.forEach { request ->
             if (!apiQueue.contains(request)) {
+                while (apiQueue.size >= MAX_QUEUE_SIZE) {
+                    val evicted = apiQueue.pollFirst() ?: break
+                    Registry.dataStore.clear(evicted.uuid)
+                    Registry.log.warning(
+                        "API queue at capacity ($MAX_QUEUE_SIZE), evicting oldest request: ${evicted.type}"
+                    )
+                }
                 Registry.dataStore.store(request.uuid, request.toString())
                 if (headOfLine) {
                     apiQueue.offerFirst(request)
@@ -489,8 +507,6 @@ internal object KlaviyoApiClient : ApiClient {
 
         private var flushInterval: Long = defaultFlushInterval
 
-        private val flushDepth: Int = Registry.config.networkFlushDepth
-
         /**
          * Send queued requests serially
          * The queue will flush whenever the triggers specified in config are met
@@ -499,7 +515,7 @@ internal object KlaviyoApiClient : ApiClient {
         override fun run() {
             val queueTimePassed = Registry.clock.currentTimeMillis() - enqueuedTime
 
-            if (getQueueSize() < flushDepth && queueTimePassed < flushInterval && !force) {
+            if (queueTimePassed < flushInterval && !force) {
                 return requeue()
             }
 

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequest.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequest.kt
@@ -489,7 +489,12 @@ internal open class KlaviyoApiRequest(
         )
 
         try {
-            val retryAfter = this.responseHeaders[HEADER_RETRY_AFTER]?.getOrNull(0)
+            // Look up Retry-After case-insensitively: HTTP header names are case-insensitive and an
+            // HTTP/2 stack may deliver it lowercased, so a case-sensitive map lookup could miss it.
+            // headerFields can contain a null key (the status line), so compare from the constant.
+            val retryAfter = this.responseHeaders.entries
+                .firstOrNull { HEADER_RETRY_AFTER.equals(it.key, ignoreCase = true) }
+                ?.value?.getOrNull(0)
 
             if (retryAfter?.isNotEmpty() == true) {
                 val retryAfterInterval = (retryAfter.toInt() + jitterSeconds).times(1_000L)

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequest.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequest.kt
@@ -468,32 +468,38 @@ internal open class KlaviyoApiRequest(
     /**
      * Compute a retry interval based on state of the request
      *
-     * If present, obey the Retry-After response header, plus some jitter.
-     * Absent the header, use an exponential backoff algorithm, with a
-     * floor set by current network connection, and ceiling set by the config.
+     * Always compute an exponential backoff interval, with a floor set by the
+     * current network connection and a ceiling set by the config. If the server
+     * sent a usable Retry-After response header, wait the GREATER of that header
+     * value and the exponential backoff (each plus the same jitter). Taking the
+     * greater of the two ensures a request deep in a rate-limit storm keeps
+     * backing off rather than retrying too soon just because the server's
+     * rate-limit window reset to a short Retry-After.
      */
     fun computeRetryInterval(): Long {
         val jitterSeconds = Registry.config.networkJitterRange.random()
-
-        try {
-            val retryAfter = this.responseHeaders[HEADER_RETRY_AFTER]?.getOrNull(0)
-
-            if (retryAfter?.isNotEmpty() == true) {
-                return (retryAfter.toInt() + jitterSeconds).times(1_000L)
-            }
-        } catch (e: NumberFormatException) {
-            Registry.log.warning("Invalid Retry-After header value", e)
-        }
 
         val networkType = Registry.networkMonitor.getNetworkType().position
         val minRetryInterval = Registry.config.networkFlushIntervals[networkType]
         val exponentialBackoff = (2.0.pow(attempts).toLong() + jitterSeconds).times(1_000L)
         val maxRetryInterval = Registry.config.networkMaxRetryInterval
-
-        return min(
+        val backoffInterval = min(
             max(minRetryInterval, exponentialBackoff),
             maxRetryInterval
         )
+
+        try {
+            val retryAfter = this.responseHeaders[HEADER_RETRY_AFTER]?.getOrNull(0)
+
+            if (retryAfter?.isNotEmpty() == true) {
+                val retryAfterInterval = (retryAfter.toInt() + jitterSeconds).times(1_000L)
+                return max(retryAfterInterval, backoffInterval)
+            }
+        } catch (e: NumberFormatException) {
+            Registry.log.warning("Invalid Retry-After header value", e)
+        }
+
+        return backoffInterval
     }
 
     /**

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequest.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequest.kt
@@ -69,6 +69,7 @@ internal open class KlaviyoApiRequest(
         const val HTTP_MULT_CHOICE = HttpURLConnection.HTTP_MULT_CHOICE
         const val HTTP_RETRY = 429 // oddly not a const in HttpURLConnection
         const val HTTP_BAD_REQUEST = HttpURLConnection.HTTP_BAD_REQUEST
+        val HTTP_5XX_RETRYABLE_RANGE = 500..599
 
         // JSON keys for persistence
         const val TYPE_JSON_KEY = "request_type"
@@ -432,8 +433,16 @@ internal open class KlaviyoApiRequest(
 
         status = when (responseCode) {
             in successCodes -> Status.Complete
-            // 429 rate limit, 500, 502, 503 and 504 are all treated as retryable
-            HTTP_RETRY, 500, in 502..504 -> {
+            // 429 rate limit plus the entire 5xx range (500–599) are treated as retryable.
+            // Widening from the legacy {500,502,503,504} allowlist to the full range covers
+            // transient CDN/edge failures such as Cloudflare's 520–527 codes, which were the
+            // codes observed during the cannot-access-klaviyo-com incident. We deliberately
+            // retry even 501 (Not Implemented) and 505 (HTTP Version Not Supported): for the
+            // SDK's fixed request shapes a genuine origin 501/505 is effectively unreachable,
+            // so any 5xx we actually observe is almost certainly edge/proxy noise during an
+            // incident — exactly what we want to retry. 4xx codes (including 403 load-shed)
+            // remain non-retryable so the backend can shed load.
+            HTTP_RETRY, in HTTP_5XX_RETRYABLE_RANGE -> {
                 if (attempts < maxAttempts) {
                     Status.PendingRetry
                 } else {

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/KlaviyoApiClientTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/KlaviyoApiClientTest.kt
@@ -735,7 +735,8 @@ internal class KlaviyoApiClientTest : BaseTest() {
 
         fun expectedBackoffInterval(startAttempts: Int) =
             expectedBackoffIntervals.getOrElse(startAttempts) {
-                300_000L // Max backoff time should be used from here on, because 512s > 300s
+                // Max backoff (cap) should be used from here on, because 512s > the configured cap
+                Registry.config.networkMaxRetryInterval
             }
 
         // First unsent request, which we will retry till max attempts
@@ -792,7 +793,7 @@ internal class KlaviyoApiClientTest : BaseTest() {
 
         // First request should have been retried exactly 50 times
         assertEquals(50, request1.attempts)
-        assertEquals(300_000L, scheduledIntervals.maxOrNull() ?: 0L)
+        assertEquals(Registry.config.networkMaxRetryInterval, scheduledIntervals.maxOrNull() ?: 0L)
 
         // Upon final failure, request 1 should have been dropped from the queue
         assertEquals(1, KlaviyoApiClient.getQueueSize())

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/KlaviyoApiClientTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/KlaviyoApiClientTest.kt
@@ -69,7 +69,6 @@ internal class KlaviyoApiClientTest : BaseTest() {
     private val flushIntervalWifi = 10_000L
     private val flushIntervalCell = 20_000L
     private val flushIntervalOffline = 30_000L
-    private val queueDepth = 10
     private var postedJob: KlaviyoApiClient.NetworkRunnable? = null
     private val mockQueueScheduler = mockk<QueueScheduler>(relaxed = true)
 
@@ -97,7 +96,6 @@ internal class KlaviyoApiClientTest : BaseTest() {
             flushIntervalCell,
             flushIntervalOffline
         )
-        every { mockConfig.networkFlushDepth } returns queueDepth
         every { mockNetworkMonitor.isNetworkConnected() } returns false
         every { mockNetworkMonitor.getNetworkType() } returns NetworkMonitor.NetworkType.Wifi
         every { mockLifecycleMonitor.onActivityEvent(capture(slotOnActivityEvent)) } returns Unit
@@ -446,18 +444,6 @@ internal class KlaviyoApiClientTest : BaseTest() {
     }
 
     @Test
-    fun `Flushes queue when configured size is reached`() {
-        repeat(queueDepth) {
-            KlaviyoApiClient.enqueueRequest(mockRequest("uuid-$it"))
-            assertEquals(it + 1, KlaviyoApiClient.getQueueSize())
-        }
-
-        postedJob!!.run()
-
-        assertEquals(0, KlaviyoApiClient.getQueueSize())
-    }
-
-    @Test
     fun `Flushes queue when configured time has elapsed`() {
         val requestMock = mockRequest()
 
@@ -471,20 +457,19 @@ internal class KlaviyoApiClientTest : BaseTest() {
     }
 
     @Test
-    fun `Does not flush queue if no criteria is met`() {
-        repeat(queueDepth - 1) {
-            KlaviyoApiClient.enqueueRequest(mockRequest("uuid-$it"))
-            assertEquals(it + 1, KlaviyoApiClient.getQueueSize())
-        }
+    fun `Does not flush queue if flush interval has not elapsed`() {
+        KlaviyoApiClient.enqueueRequest(mockRequest("uuid-0"))
+        assertEquals(1, KlaviyoApiClient.getQueueSize())
 
+        // Time has not advanced, so flush interval has not elapsed
         postedJob!!.run()
 
-        assertEquals(queueDepth - 1, KlaviyoApiClient.getQueueSize())
+        assertEquals(1, KlaviyoApiClient.getQueueSize())
     }
 
     @Test
-    fun `Flushes queue if forced when no criteria is met`() {
-        repeat(queueDepth - 1) {
+    fun `Flushes queue if forced when flush interval has not elapsed`() {
+        repeat(5) {
             KlaviyoApiClient.enqueueRequest(mockRequest("uuid-$it"))
             assertEquals(it + 1, KlaviyoApiClient.getQueueSize())
         }
@@ -492,6 +477,35 @@ internal class KlaviyoApiClientTest : BaseTest() {
         KlaviyoApiClient.flushQueue()
 
         assertEquals(0, KlaviyoApiClient.getQueueSize())
+    }
+
+    @Test
+    fun `Queue cap evicts oldest request on overflow and emits warning log`() {
+        // Fill the queue to capacity
+        repeat(KlaviyoApiClient.MAX_QUEUE_SIZE) {
+            KlaviyoApiClient.enqueueRequest(mockRequest("uuid-$it"))
+        }
+        assertEquals(KlaviyoApiClient.MAX_QUEUE_SIZE, KlaviyoApiClient.getQueueSize())
+
+        // The oldest request (uuid-0) is at the front of the deque
+        val oldestUuid = "uuid-0"
+        assertNotNull(spyDataStore.fetch(oldestUuid))
+
+        // Enqueue one more request — should evict uuid-0
+        val newestRequest = mockRequest("uuid-newest")
+        KlaviyoApiClient.enqueueRequest(newestRequest)
+
+        // Queue size stays at the cap
+        assertEquals(KlaviyoApiClient.MAX_QUEUE_SIZE, KlaviyoApiClient.getQueueSize())
+
+        // Oldest was evicted from the datastore
+        assertNull(spyDataStore.fetch(oldestUuid))
+
+        // Newest request is present in the datastore
+        assertNotNull(spyDataStore.fetch("uuid-newest"))
+
+        // A warning log was emitted for the eviction
+        verify(atLeast = 1) { spyLog.warning(any(), null) }
     }
 
     @Test

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/KlaviyoApiClientTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/KlaviyoApiClientTest.kt
@@ -480,29 +480,69 @@ internal class KlaviyoApiClientTest : BaseTest() {
     }
 
     @Test
-    fun `Queue cap evicts oldest request on overflow and emits warning log`() {
-        // Fill the queue to capacity
+    fun `Queue cap evicts request with oldest queuedTime on overflow and emits warning log`() {
+        // Fill the queue to capacity, advancing the clock so each request captures a
+        // progressively later queuedTime — uuid-0 therefore holds the oldest queuedTime.
         repeat(KlaviyoApiClient.MAX_QUEUE_SIZE) {
-            KlaviyoApiClient.enqueueRequest(mockRequest("uuid-$it"))
+            val request = mockRequest("uuid-$it") // queuedTime is captured from staticClock here
+            KlaviyoApiClient.enqueueRequest(request)
+            staticClock.time += 1
         }
         assertEquals(KlaviyoApiClient.MAX_QUEUE_SIZE, KlaviyoApiClient.getQueueSize())
 
-        // The oldest request (uuid-0) is at the front of the deque
+        // uuid-0 has the oldest queuedTime
         val oldestUuid = "uuid-0"
         assertNotNull(spyDataStore.fetch(oldestUuid))
 
-        // Enqueue one more request — should evict uuid-0
+        // Enqueue one more request — should evict the request with the oldest queuedTime
         val newestRequest = mockRequest("uuid-newest")
         KlaviyoApiClient.enqueueRequest(newestRequest)
 
         // Queue size stays at the cap
         assertEquals(KlaviyoApiClient.MAX_QUEUE_SIZE, KlaviyoApiClient.getQueueSize())
 
-        // Oldest was evicted from the datastore
+        // The oldest request by queuedTime was evicted from the datastore
         assertNull(spyDataStore.fetch(oldestUuid))
 
         // Newest request is present in the datastore
         assertNotNull(spyDataStore.fetch("uuid-newest"))
+
+        // A warning log was emitted for the eviction
+        verify(atLeast = 1) { spyLog.warning(any(), null) }
+    }
+
+    @Test
+    fun `Queue cap protects freshly-enqueued head-of-line request and evicts oldest by queuedTime`() {
+        // Fill the queue with regular requests just under capacity, advancing the clock so
+        // uuid-0 holds the oldest queuedTime and sits at the front (head) of the deque.
+        repeat(KlaviyoApiClient.MAX_QUEUE_SIZE - 1) {
+            val request = mockRequest("uuid-$it") // queuedTime is captured from staticClock here
+            KlaviyoApiClient.enqueueRequest(request)
+            staticClock.time += 1
+        }
+        assertEquals(KlaviyoApiClient.MAX_QUEUE_SIZE - 1, KlaviyoApiClient.getQueueSize())
+
+        // A head-of-line request is enqueued last, so it has the NEWEST queuedTime, and it is
+        // inserted at the FRONT of the deque via offerFirst. This is the exact shape that used to
+        // break: blindly evicting the front would remove this freshly-enqueued priority request.
+        val headOfLineRequest = mockRequest("hol-newest")
+        KlaviyoApiClient.enqueueRequest(headOfLineRequest, headOfLine = true)
+        staticClock.time += 1
+        assertEquals(KlaviyoApiClient.MAX_QUEUE_SIZE, KlaviyoApiClient.getQueueSize())
+
+        // Enqueuing one more request overflows the cap and triggers eviction.
+        val incomingRequest = mockRequest("uuid-incoming")
+        KlaviyoApiClient.enqueueRequest(incomingRequest)
+
+        // The oldest request by queuedTime (uuid-0) is evicted — NOT the front of the deque.
+        assertNull(spyDataStore.fetch("uuid-0"))
+
+        // The freshly-enqueued head-of-line request is protected because it is the newest.
+        assertNotNull(spyDataStore.fetch("hol-newest"))
+
+        // The incoming request was accepted and the queue stays bounded at the cap.
+        assertNotNull(spyDataStore.fetch("uuid-incoming"))
+        assertEquals(KlaviyoApiClient.MAX_QUEUE_SIZE, KlaviyoApiClient.getQueueSize())
 
         // A warning log was emitted for the eviction
         verify(atLeast = 1) { spyLog.warning(any(), null) }

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/KlaviyoApiClientTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/KlaviyoApiClientTest.kt
@@ -720,6 +720,23 @@ internal class KlaviyoApiClientTest : BaseTest() {
     fun `Rate limited requests are retried with backoff until max attempts in absence of Retry-After header`() {
         val defaultInterval =
             Registry.config.networkFlushIntervals[NetworkMonitor.NetworkType.Wifi.position]
+        val expectedBackoffIntervals = listOf(
+            defaultInterval, // First attempt starts after default interval
+            defaultInterval, // First RETRY starts after default interval bc 2s < 10s
+            defaultInterval, // Second RETRY starts after default interval bc 4s < 10s
+            defaultInterval, // Third RETRY starts after default interval bc 8s < 10s
+            16_000L, // Exp. backoff time should be used bc 16s > 10s
+            32_000L, // Exp. backoff time should be used bc 32s > 10s
+            64_000L, // Exp. backoff time should be used bc 64s > 10s
+            128_000L, // Exp. backoff time should be used bc 128s > 10s
+            256_000L // Exp. backoff time should be used bc 256s > 10s
+        )
+        val scheduledIntervals = mutableListOf<Long>()
+
+        fun expectedBackoffInterval(startAttempts: Int) =
+            expectedBackoffIntervals.getOrElse(startAttempts) {
+                300_000L // Max backoff time should be used from here on, because 512s > 300s
+            }
 
         // First unsent request, which we will retry till max attempts
         val request1 = mockRequest("uuid-retry", KlaviyoApiRequest.Status.Unsent).also {
@@ -732,6 +749,14 @@ internal class KlaviyoApiClientTest : BaseTest() {
                 50 -> KlaviyoApiRequest.Status.Failed.name
                 else -> KlaviyoApiRequest.Status.PendingRetry.name
             }
+        }
+        every { request1.computeRetryInterval() } answers {
+            expectedBackoffInterval(request1.attempts - 1)
+        }
+        every { mockHandler.postDelayed(any(), any()) } answers {
+            postedJob = firstArg<KlaviyoApiClient.NetworkRunnable>()
+            scheduledIntervals += secondArg<Long>()
+            true
         }
 
         // Second unset request in queue to ensure which shouldn't sent until first has failed
@@ -750,22 +775,16 @@ internal class KlaviyoApiClientTest : BaseTest() {
             val startAttempts = request1.attempts
 
             // Advance the time with our expected backoff interval
-            staticClock.time += listOf(
-                defaultInterval, // First attempt starts after default interval
-                defaultInterval, // First RETRY starts after default interval bc 2s < 10s
-                defaultInterval, // Second RETRY starts after default interval bc 4s < 10s
-                defaultInterval, // Third RETRY starts after default interval bc 8s < 10s
-                16_000L, // Exp. backoff time should be used bc 16s > 10s
-                32_000L, // Exp. backoff time should be used bc 32s > 10s
-                64_000L, // Exp. backoff time should be used bc 64s > 10s
-                128_000L // Exp. backoff time should be used bc 128s > 10s
-            ).getOrElse(startAttempts) { 180_000L } // Max backoff time should be used from here on, because 256s > 180s
+            staticClock.time += expectedBackoffInterval(startAttempts)
 
             // Run after advancing the clock (this mimics how handler.postDelay would run jobs)
             postedJob!!.run()
 
             // It should have attempted one send if the correct time elapsed
             assertEquals(startAttempts + 1, request1.attempts)
+            if (request1.state != KlaviyoApiRequest.Status.Failed.name) {
+                assertEquals(expectedBackoffInterval(startAttempts), scheduledIntervals.last())
+            }
 
             // Fail test if we exceed max attempts
             assert(request1.attempts <= 50)
@@ -773,6 +792,7 @@ internal class KlaviyoApiClientTest : BaseTest() {
 
         // First request should have been retried exactly 50 times
         assertEquals(50, request1.attempts)
+        assertEquals(300_000L, scheduledIntervals.maxOrNull() ?: 0L)
 
         // Upon final failure, request 1 should have been dropped from the queue
         assertEquals(1, KlaviyoApiClient.getQueueSize())

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequestTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequestTest.kt
@@ -75,6 +75,20 @@ internal class KlaviyoApiRequestTest : BaseApiRequestTest<KlaviyoApiRequest>() {
         return connectionSpy
     }
 
+    /**
+     * Sends a single request against a connection stubbed to return [responseCode] and asserts the
+     * resulting [KlaviyoApiRequest.Status] and that exactly one attempt was made. Shared by the
+     * single-send status-code tests to keep their boilerplate DRY.
+     */
+    private fun assertStatusForResponseCode(responseCode: Int, expected: KlaviyoApiRequest.Status) {
+        val connectionMock = withConnectionMock(URL(expectedFullUrl))
+        every { connectionMock.responseCode } returns responseCode
+
+        val request = makeTestRequest()
+        assertEquals(expected, request.send())
+        assertEquals(1, request.attempts)
+    }
+
     @Before
     override fun setup() {
         super.setup()
@@ -722,42 +736,68 @@ internal class KlaviyoApiRequestTest : BaseApiRequestTest<KlaviyoApiRequest>() {
 
     @Test
     fun `500 response code returns PendingRetry when under max attempts`() {
-        val connectionMock = withConnectionMock(URL(expectedFullUrl))
-        every { connectionMock.responseCode } returns 500
-
-        val request = makeTestRequest()
-        assertEquals(KlaviyoApiRequest.Status.PendingRetry, request.send())
-        assertEquals(1, request.attempts)
+        assertStatusForResponseCode(500, KlaviyoApiRequest.Status.PendingRetry)
     }
 
     @Test
     fun `502 response code returns PendingRetry when under max attempts`() {
-        val connectionMock = withConnectionMock(URL(expectedFullUrl))
-        every { connectionMock.responseCode } returns 502
-
-        val request = makeTestRequest()
-        assertEquals(KlaviyoApiRequest.Status.PendingRetry, request.send())
-        assertEquals(1, request.attempts)
+        assertStatusForResponseCode(502, KlaviyoApiRequest.Status.PendingRetry)
     }
 
     @Test
     fun `503 response code returns PendingRetry when under max attempts`() {
-        val connectionMock = withConnectionMock(URL(expectedFullUrl))
-        every { connectionMock.responseCode } returns 503
-
-        val request = makeTestRequest()
-        assertEquals(KlaviyoApiRequest.Status.PendingRetry, request.send())
-        assertEquals(1, request.attempts)
+        assertStatusForResponseCode(503, KlaviyoApiRequest.Status.PendingRetry)
     }
 
     @Test
     fun `504 response code returns PendingRetry when under max attempts`() {
-        val connectionMock = withConnectionMock(URL(expectedFullUrl))
-        every { connectionMock.responseCode } returns 504
+        assertStatusForResponseCode(504, KlaviyoApiRequest.Status.PendingRetry)
+    }
 
-        val request = makeTestRequest()
-        assertEquals(KlaviyoApiRequest.Status.PendingRetry, request.send())
-        assertEquals(1, request.attempts)
+    @Test
+    fun `522 Cloudflare response code returns PendingRetry when under max attempts`() {
+        // 522 (connection timed out) is a Cloudflare edge code outside the legacy allowlist
+        // and was one of the codes observed during the cannot-access-klaviyo-com incident.
+        assertStatusForResponseCode(522, KlaviyoApiRequest.Status.PendingRetry)
+    }
+
+    @Test
+    fun `525 Cloudflare response code returns PendingRetry when under max attempts`() {
+        assertStatusForResponseCode(525, KlaviyoApiRequest.Status.PendingRetry)
+    }
+
+    @Test
+    fun `599 upper-bound 5xx response code returns PendingRetry when under max attempts`() {
+        assertStatusForResponseCode(599, KlaviyoApiRequest.Status.PendingRetry)
+    }
+
+    @Test
+    fun `501 response code returns PendingRetry when under max attempts`() {
+        // 501 (Not Implemented) is inside the full 5xx retryable range and we deliberately
+        // retry it: for the SDK's fixed request shapes a genuine origin 501 is effectively
+        // unreachable, so an observed 501 is almost certainly edge/proxy noise worth retrying.
+        assertStatusForResponseCode(501, KlaviyoApiRequest.Status.PendingRetry)
+    }
+
+    @Test
+    fun `505 response code returns PendingRetry when under max attempts`() {
+        // 505 (HTTP Version Not Supported) is inside the full 5xx retryable range and we
+        // deliberately retry it: for the SDK's fixed request shapes a genuine origin 505 is
+        // effectively unreachable, so an observed 505 is almost certainly edge/proxy noise
+        // worth retrying.
+        assertStatusForResponseCode(505, KlaviyoApiRequest.Status.PendingRetry)
+    }
+
+    @Test
+    fun `499 response code returns Failed immediately`() {
+        // Lower-bound sanity: 499 sits just below the 5xx range and must stay non-retryable.
+        assertStatusForResponseCode(499, KlaviyoApiRequest.Status.Failed)
+    }
+
+    @Test
+    fun `600 response code returns Failed immediately`() {
+        // Upper-bound sanity: 600 sits just above the 5xx range and must stay non-retryable.
+        assertStatusForResponseCode(600, KlaviyoApiRequest.Status.Failed)
     }
 
     @Test
@@ -778,41 +818,21 @@ internal class KlaviyoApiRequestTest : BaseApiRequestTest<KlaviyoApiRequest>() {
 
     @Test
     fun `400 response code returns Failed immediately`() {
-        val connectionMock = withConnectionMock(URL(expectedFullUrl))
-        every { connectionMock.responseCode } returns 400
-
-        val request = makeTestRequest()
-        assertEquals(KlaviyoApiRequest.Status.Failed, request.send())
-        assertEquals(1, request.attempts)
+        assertStatusForResponseCode(400, KlaviyoApiRequest.Status.Failed)
     }
 
     @Test
     fun `401 response code returns Failed immediately`() {
-        val connectionMock = withConnectionMock(URL(expectedFullUrl))
-        every { connectionMock.responseCode } returns 401
-
-        val request = makeTestRequest()
-        assertEquals(KlaviyoApiRequest.Status.Failed, request.send())
-        assertEquals(1, request.attempts)
+        assertStatusForResponseCode(401, KlaviyoApiRequest.Status.Failed)
     }
 
     @Test
     fun `403 response code returns Failed immediately`() {
-        val connectionMock = withConnectionMock(URL(expectedFullUrl))
-        every { connectionMock.responseCode } returns 403
-
-        val request = makeTestRequest()
-        assertEquals(KlaviyoApiRequest.Status.Failed, request.send())
-        assertEquals(1, request.attempts)
+        assertStatusForResponseCode(403, KlaviyoApiRequest.Status.Failed)
     }
 
     @Test
     fun `404 response code returns Failed immediately`() {
-        val connectionMock = withConnectionMock(URL(expectedFullUrl))
-        every { connectionMock.responseCode } returns 404
-
-        val request = makeTestRequest()
-        assertEquals(KlaviyoApiRequest.Status.Failed, request.send())
-        assertEquals(1, request.attempts)
+        assertStatusForResponseCode(404, KlaviyoApiRequest.Status.Failed)
     }
 }

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequestTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequestTest.kt
@@ -214,8 +214,10 @@ internal class KlaviyoApiRequestTest : BaseApiRequestTest<KlaviyoApiRequest>() {
     }
 
     @Test
-    fun `Parses Retry-After header if present and adds jitter`() {
+    fun `Uses Retry-After header plus jitter when greater than exponential backoff`() {
+        // Retry-After is 25s; Wifi backoff floor is 10s, so Retry-After wins. Jitter forced to 1s.
         val expectedHeaders = mapOf("Retry-After" to listOf("25"))
+        every { mockNetworkMonitor.getNetworkType() } returns NetworkMonitor.NetworkType.Wifi
         every { mockConfig.networkJitterRange } returns 1..1
         withConnectionMock(URL(expectedFullUrl)).also {
             every { it.headerFields } returns expectedHeaders
@@ -224,6 +226,21 @@ internal class KlaviyoApiRequestTest : BaseApiRequestTest<KlaviyoApiRequest>() {
         val request = makeTestRequest()
         request.send()
         assertEquals(26_000L, request.computeRetryInterval())
+    }
+
+    @Test
+    fun `Uses exponential backoff interval when greater than Retry-After header`() {
+        // Retry-After is 2s but the Wifi backoff floor is 10s, so backoff wins. Jitter forced to 1s.
+        val expectedHeaders = mapOf("Retry-After" to listOf("2"))
+        every { mockNetworkMonitor.getNetworkType() } returns NetworkMonitor.NetworkType.Wifi
+        every { mockConfig.networkJitterRange } returns 1..1
+        withConnectionMock(URL(expectedFullUrl)).also {
+            every { it.headerFields } returns expectedHeaders
+        }
+
+        val request = makeTestRequest()
+        request.send()
+        assertEquals(10_000L, request.computeRetryInterval())
     }
 
     @Test

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequestTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequestTest.kt
@@ -256,7 +256,7 @@ internal class KlaviyoApiRequestTest : BaseApiRequestTest<KlaviyoApiRequest>() {
         repeat(9) {
             request.send()
         }
-        assertEquals(300_000L, request.computeRetryInterval())
+        assertEquals(mockConfig.networkMaxRetryInterval, request.computeRetryInterval())
     }
 
     @Test

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequestTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequestTest.kt
@@ -244,6 +244,21 @@ internal class KlaviyoApiRequestTest : BaseApiRequestTest<KlaviyoApiRequest>() {
     }
 
     @Test
+    fun `Reads Retry-After header case-insensitively`() {
+        // An HTTP/2 stack may deliver the header lowercased; the lookup must still find it.
+        val expectedHeaders = mapOf("retry-after" to listOf("25"))
+        every { mockNetworkMonitor.getNetworkType() } returns NetworkMonitor.NetworkType.Wifi
+        every { mockConfig.networkJitterRange } returns 1..1
+        withConnectionMock(URL(expectedFullUrl)).also {
+            every { it.headerFields } returns expectedHeaders
+        }
+
+        val request = makeTestRequest()
+        request.send()
+        assertEquals(26_000L, request.computeRetryInterval())
+    }
+
+    @Test
     fun `Falls back on network interval without jitter when Retry-After header is missing or invalid`() {
         // Wifi interval is 10s, force jitter to be 1s
         every { mockNetworkMonitor.getNetworkType() } returns NetworkMonitor.NetworkType.Wifi

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequestTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequestTest.kt
@@ -230,17 +230,33 @@ internal class KlaviyoApiRequestTest : BaseApiRequestTest<KlaviyoApiRequest>() {
 
     @Test
     fun `Uses exponential backoff interval when greater than Retry-After header`() {
-        // Retry-After is 2s but the Wifi backoff floor is 10s, so backoff wins. Jitter forced to 1s.
+        // Retry-After is 2s and the Wifi backoff floor is 10s; after 4 attempts,
+        // 16s exponential backoff wins.
         val expectedHeaders = mapOf("Retry-After" to listOf("2"))
         every { mockNetworkMonitor.getNetworkType() } returns NetworkMonitor.NetworkType.Wifi
-        every { mockConfig.networkJitterRange } returns 1..1
+        every { mockConfig.networkJitterRange } returns 0..0
         withConnectionMock(URL(expectedFullUrl)).also {
             every { it.headerFields } returns expectedHeaders
         }
 
         val request = makeTestRequest()
-        request.send()
-        assertEquals(10_000L, request.computeRetryInterval())
+        repeat(4) {
+            request.send()
+        }
+        assertEquals(16_000L, request.computeRetryInterval())
+    }
+
+    @Test
+    fun `Caps exponential backoff interval at configured maximum`() {
+        every { mockNetworkMonitor.getNetworkType() } returns NetworkMonitor.NetworkType.Wifi
+        every { mockConfig.networkJitterRange } returns 0..0
+        withConnectionMock(URL(expectedFullUrl))
+
+        val request = makeTestRequest()
+        repeat(9) {
+            request.send()
+        }
+        assertEquals(300_000L, request.computeRetryInterval())
     }
 
     @Test

--- a/sdk/core/src/main/java/com/klaviyo/core/config/Config.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/config/Config.kt
@@ -43,9 +43,10 @@ interface Config {
         fun networkMaxRetryInterval(networkMaxRetryInterval: Long): Builder
 
         @Deprecated(
-            message = "Depth-triggered flushing has been removed. The queue now flushes only on " +
-                "the timer interval (see networkFlushInterval) and is internally bounded by a " +
-                "size cap. This setter has no effect and will be removed in a future major release.",
+            message = "Depth-triggered flushing has been removed. The queue now flushes on the " +
+                "timer interval (see networkFlushInterval) or when explicitly forced, and is " +
+                "internally bounded by a size cap. This setter has no effect and will be " +
+                "removed in a future major release.",
             level = DeprecationLevel.WARNING
         )
         fun networkFlushDepth(networkFlushDepth: Int): Builder

--- a/sdk/core/src/main/java/com/klaviyo/core/config/Config.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/config/Config.kt
@@ -41,6 +41,15 @@ interface Config {
         fun networkFlushInterval(networkFlushInterval: Long, type: NetworkMonitor.NetworkType): Builder
         fun networkMaxAttempts(networkMaxAttempts: Int): Builder
         fun networkMaxRetryInterval(networkMaxRetryInterval: Long): Builder
+
+        @Deprecated(
+            message = "Depth-triggered flushing has been removed. The queue now flushes only on " +
+                "the timer interval (see networkFlushInterval) and is internally bounded by a " +
+                "size cap. This setter has no effect and will be removed in a future major release.",
+            level = DeprecationLevel.WARNING
+        )
+        fun networkFlushDepth(networkFlushDepth: Int): Builder
+
         fun build(): Config
     }
 }

--- a/sdk/core/src/main/java/com/klaviyo/core/config/Config.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/config/Config.kt
@@ -21,7 +21,6 @@ interface Config {
     val networkTimeout: Int
     val uxNetworkTimeout: Int
     val networkFlushIntervals: LongArray
-    val networkFlushDepth: Int
     val networkMaxAttempts: Int
     val networkMaxRetryInterval: Long
     val networkJitterRange: IntRange
@@ -40,7 +39,6 @@ interface Config {
         fun networkTimeout(networkTimeout: Int): Builder
         fun uxNetworkTimeout(uxNetworkTimeout: Int): Builder
         fun networkFlushInterval(networkFlushInterval: Long, type: NetworkMonitor.NetworkType): Builder
-        fun networkFlushDepth(networkFlushDepth: Int): Builder
         fun networkMaxAttempts(networkMaxAttempts: Int): Builder
         fun networkMaxRetryInterval(networkMaxRetryInterval: Long): Builder
         fun build(): Config

--- a/sdk/core/src/main/java/com/klaviyo/core/config/KlaviyoConfig.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/config/KlaviyoConfig.kt
@@ -256,6 +256,17 @@ object KlaviyoConfig : Config {
             }
         }
 
+        @Deprecated(
+            message = "Depth-triggered flushing has been removed. The queue now flushes only on " +
+                "the timer interval (see networkFlushInterval) and is internally bounded by a " +
+                "size cap. This setter has no effect and will be removed in a future major release.",
+            level = DeprecationLevel.WARNING
+        )
+        override fun networkFlushDepth(networkFlushDepth: Int) = apply {
+            // No-op: depth-triggered flushing was removed; retained for one release as a
+            // deprecated setter so existing caller code keeps compiling.
+        }
+
         override fun build(): Config {
             val context = applicationContext ?: throw MissingContext()
             val packageInfo = context.packageManager.getPackageInfoCompat(

--- a/sdk/core/src/main/java/com/klaviyo/core/config/KlaviyoConfig.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/config/KlaviyoConfig.kt
@@ -75,14 +75,6 @@ object KlaviyoConfig : Config {
     private const val NETWORK_FLUSH_INTERVAL_OFFLINE_DEFAULT = 60_000L
 
     /**
-     * How many API requests can be enqueued before flush
-     *
-     * Reasoning: The goal of depth control is to limit duration that radios are active
-     * if a typical request takes 1-3 seconds, this should ideally limit us to 30-90 seconds
-     */
-    private const val NETWORK_FLUSH_DEPTH_DEFAULT: Int = 25
-
-    /**
      * How many retries to allow an API request before permanent failure
      *
      * Reasoning: Most likely the rate limit should be cleared within 2-3 retries with exp backoff.
@@ -131,8 +123,6 @@ object KlaviyoConfig : Config {
         NETWORK_FLUSH_INTERVAL_OFFLINE_DEFAULT
     )
         private set
-    override var networkFlushDepth = NETWORK_FLUSH_DEPTH_DEFAULT
-        private set
     override var networkMaxAttempts = NETWORK_MAX_ATTEMPTS_DEFAULT
         private set
     override var networkMaxRetryInterval = NETWORK_MAX_RETRY_INTERVAL_DEFAULT
@@ -167,7 +157,6 @@ object KlaviyoConfig : Config {
             NETWORK_FLUSH_INTERVAL_CELL_DEFAULT,
             NETWORK_FLUSH_INTERVAL_OFFLINE_DEFAULT
         )
-        private var networkFlushDepth = NETWORK_FLUSH_DEPTH_DEFAULT
         private var networkMaxAttempts = NETWORK_MAX_ATTEMPTS_DEFAULT
         private var networkMaxRetryInterval = NETWORK_MAX_RETRY_INTERVAL_DEFAULT
 
@@ -247,16 +236,6 @@ object KlaviyoConfig : Config {
             }
         }
 
-        override fun networkFlushDepth(networkFlushDepth: Int) = apply {
-            if (networkFlushDepth > 0) {
-                this.networkFlushDepth = networkFlushDepth
-            } else {
-                Registry.log.error(
-                    "${KlaviyoConfig::networkFlushDepth.name} must be greater than 0"
-                )
-            }
-        }
-
         override fun networkMaxAttempts(networkMaxAttempts: Int) = apply {
             if (networkMaxAttempts >= 0) {
                 this.networkMaxAttempts = networkMaxAttempts
@@ -305,7 +284,6 @@ object KlaviyoConfig : Config {
             KlaviyoConfig.networkTimeout = networkTimeout
             KlaviyoConfig.uxNetworkTimeout = uxNetworkTimeout
             KlaviyoConfig.networkFlushIntervals = networkFlushIntervals
-            KlaviyoConfig.networkFlushDepth = networkFlushDepth
             KlaviyoConfig.networkMaxAttempts = networkMaxAttempts
             KlaviyoConfig.networkMaxRetryInterval = networkMaxRetryInterval
 

--- a/sdk/core/src/main/java/com/klaviyo/core/config/KlaviyoConfig.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/config/KlaviyoConfig.kt
@@ -265,8 +265,18 @@ object KlaviyoConfig : Config {
             level = DeprecationLevel.WARNING
         )
         override fun networkFlushDepth(networkFlushDepth: Int) = apply {
-            // No-op: depth-triggered flushing was removed; retained for one release as a
-            // deprecated setter so existing caller code keeps compiling.
+            // Depth-triggered flushing was removed; retained for one release as a deprecated
+            // setter so existing caller code keeps compiling. Warn at runtime in addition to the
+            // compile-time deprecation: callers who haven't migrated get a hint that their config
+            // is being ignored, and out-of-range values (which the old setter rejected explicitly)
+            // are no longer swallowed silently. The value is echoed back to make that concrete.
+            Registry.log.warning(
+                "networkFlushDepth($networkFlushDepth) is deprecated and has no effect: " +
+                    "depth-triggered flushing was removed. The queue flushes on the timer " +
+                    "interval (see networkFlushInterval) or when explicitly forced, and is " +
+                    "internally bounded by a size cap. Remove this call — the setter will be " +
+                    "deleted in a future major release."
+            )
         }
 
         override fun build(): Config {

--- a/sdk/core/src/main/java/com/klaviyo/core/config/KlaviyoConfig.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/config/KlaviyoConfig.kt
@@ -257,9 +257,10 @@ object KlaviyoConfig : Config {
         }
 
         @Deprecated(
-            message = "Depth-triggered flushing has been removed. The queue now flushes only on " +
-                "the timer interval (see networkFlushInterval) and is internally bounded by a " +
-                "size cap. This setter has no effect and will be removed in a future major release.",
+            message = "Depth-triggered flushing has been removed. The queue now flushes on the " +
+                "timer interval (see networkFlushInterval) or when explicitly forced, and is " +
+                "internally bounded by a size cap. This setter has no effect and will be " +
+                "removed in a future major release.",
             level = DeprecationLevel.WARNING
         )
         override fun networkFlushDepth(networkFlushDepth: Int) = apply {

--- a/sdk/core/src/main/java/com/klaviyo/core/config/KlaviyoConfig.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/config/KlaviyoConfig.kt
@@ -82,11 +82,12 @@ object KlaviyoConfig : Config {
     private const val NETWORK_MAX_ATTEMPTS_DEFAULT: Int = 50
 
     /**
-     * Maximum interval between retries for the exponential backoff, in milliseconds (3 minutes)
+     * Maximum interval between retries for the exponential backoff, in milliseconds (5 minutes)
      *
-     * Reasoning: We don't want to wait so long that the user has left the app.
+     * Reasoning: We don't want to wait so long that the user has left the app, but 180s was more
+     * aggressive than comparable SDKs (Segment caps at 300s), so we align with 300s (MAGE-500).
      */
-    private const val NETWORK_MAX_RETRY_INTERVAL_DEFAULT: Long = 180_000
+    private const val NETWORK_MAX_RETRY_INTERVAL_DEFAULT: Long = 300_000
 
     override val isDebugBuild = BuildConfig.DEBUG
 

--- a/sdk/core/src/test/java/com/klaviyo/core/config/KlaviyoConfigTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/config/KlaviyoConfigTest.kt
@@ -170,6 +170,20 @@ internal class KlaviyoConfigTest : BaseTest() {
     }
 
     @Test
+    fun `KlaviyoConfig Builder warns that deprecated networkFlushDepth has no effect`() {
+        @Suppress("DEPRECATION")
+        KlaviyoConfig.Builder()
+            .apiKey(API_KEY)
+            .applicationContext(mockContext)
+            .networkFlushDepth(25)
+            .networkFlushDepth(-5) // out-of-range is warned too, not silently swallowed
+            .build()
+
+        // The setter is a no-op, but every call must hint to the caller that it has no effect
+        verify(exactly = 2) { spyLog.warning(any(), null) }
+    }
+
+    @Test
     fun `KlaviyoConfig Builder missing API key throws expected exception`() {
         assertThrows(MissingAPIKey::class.java) {
             KlaviyoConfig.Builder()

--- a/sdk/core/src/test/java/com/klaviyo/core/config/KlaviyoConfigTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/config/KlaviyoConfigTest.kt
@@ -126,7 +126,7 @@ internal class KlaviyoConfigTest : BaseTest() {
             KlaviyoConfig.networkFlushIntervals[NetworkMonitor.NetworkType.Offline.position]
         )
         assertEquals(50, KlaviyoConfig.networkMaxAttempts)
-        assertEquals(180_000L, KlaviyoConfig.networkMaxRetryInterval)
+        assertEquals(300_000L, KlaviyoConfig.networkMaxRetryInterval)
         assertEquals("android", KlaviyoConfig.sdkName)
         assertEquals("9.9.9", KlaviyoConfig.sdkVersion)
     }
@@ -162,7 +162,7 @@ internal class KlaviyoConfigTest : BaseTest() {
             KlaviyoConfig.networkFlushIntervals[NetworkMonitor.NetworkType.Offline.position]
         )
         assertEquals(50, KlaviyoConfig.networkMaxAttempts)
-        assertEquals(180_000, KlaviyoConfig.networkMaxRetryInterval)
+        assertEquals(300_000, KlaviyoConfig.networkMaxRetryInterval)
         assertEquals("android", KlaviyoConfig.sdkName)
         assertEquals("9.9.9", KlaviyoConfig.sdkVersion)
         // Each bad call should have generated an error log

--- a/sdk/core/src/test/java/com/klaviyo/core/config/KlaviyoConfigTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/config/KlaviyoConfigTest.kt
@@ -70,7 +70,6 @@ internal class KlaviyoConfigTest : BaseTest() {
             .networkFlushInterval(1, NetworkMonitor.NetworkType.Wifi)
             .networkFlushInterval(3, NetworkMonitor.NetworkType.Cell)
             .networkFlushInterval(6, NetworkMonitor.NetworkType.Offline)
-            .networkFlushDepth(4)
             .networkMaxAttempts(5)
             .networkMaxRetryInterval(7)
             .baseCdnUrl("spider-water.com")
@@ -95,7 +94,6 @@ internal class KlaviyoConfigTest : BaseTest() {
             6,
             KlaviyoConfig.networkFlushIntervals[NetworkMonitor.NetworkType.Offline.position]
         )
-        assertEquals(4, KlaviyoConfig.networkFlushDepth)
         assertEquals(5, KlaviyoConfig.networkMaxAttempts)
         assertEquals(7, KlaviyoConfig.networkMaxRetryInterval)
         assertEquals("android", KlaviyoConfig.sdkName)
@@ -127,7 +125,6 @@ internal class KlaviyoConfigTest : BaseTest() {
             60_000L,
             KlaviyoConfig.networkFlushIntervals[NetworkMonitor.NetworkType.Offline.position]
         )
-        assertEquals(25, KlaviyoConfig.networkFlushDepth)
         assertEquals(50, KlaviyoConfig.networkMaxAttempts)
         assertEquals(180_000L, KlaviyoConfig.networkMaxRetryInterval)
         assertEquals("android", KlaviyoConfig.sdkName)
@@ -145,7 +142,6 @@ internal class KlaviyoConfigTest : BaseTest() {
             .networkFlushInterval(-5000, NetworkMonitor.NetworkType.Wifi)
             .networkFlushInterval(-5000, NetworkMonitor.NetworkType.Cell)
             .networkFlushInterval(-5000, NetworkMonitor.NetworkType.Offline)
-            .networkFlushDepth(-10)
             .networkMaxAttempts(-10)
             .networkMaxRetryInterval(-1)
             .build()
@@ -165,13 +161,12 @@ internal class KlaviyoConfigTest : BaseTest() {
             60_000,
             KlaviyoConfig.networkFlushIntervals[NetworkMonitor.NetworkType.Offline.position]
         )
-        assertEquals(25, KlaviyoConfig.networkFlushDepth)
         assertEquals(50, KlaviyoConfig.networkMaxAttempts)
         assertEquals(180_000, KlaviyoConfig.networkMaxRetryInterval)
         assertEquals("android", KlaviyoConfig.sdkName)
         assertEquals("9.9.9", KlaviyoConfig.sdkVersion)
         // Each bad call should have generated an error log
-        verify(exactly = 9) { spyLog.error(any(), null) }
+        verify(exactly = 8) { spyLog.error(any(), null) }
     }
 
     @Test

--- a/sdk/fixtures/src/main/java/com/klaviyo/fixtures/BaseTest.kt
+++ b/sdk/fixtures/src/main/java/com/klaviyo/fixtures/BaseTest.kt
@@ -86,7 +86,7 @@ abstract class BaseTest {
         every { networkMaxAttempts } returns 50
         every { networkTimeout } returns 1000
         every { uxNetworkTimeout } returns 100
-        every { networkMaxRetryInterval } returns 180_000L
+        every { networkMaxRetryInterval } returns 300_000L
         every { networkFlushIntervals } returns longArrayOf(10_000, 30_000, 60_000)
         every { networkJitterRange } returns 0..0
         every { baseUrl } returns "https://test.fake-klaviyo.com"


### PR DESCRIPTION
# Description

Note: All this code was previously reviewed in individual PRs.

Consolidated API-client network-behavior fixes from the post-incident RCA: widen 5xx retry coverage, cap the request queue at 200 with oldest-first eviction, and wait `max(Retry-After, backoff)`. Merged down from the stacked chain into one feature branch targeting `rel/4.5.0`.

## Due Diligence
- [x] I have tested this on an emulator and/or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [x] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all Android versions the SDK currently supports.

## Release/Versioning Considerations
- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [x] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

Public surface changes only via a `@Deprecated` no-op on `Config.Builder.networkFlushDepth(Int)` (source/binary compatible); all other changes are backwards-compatible behavior. Targeting `rel/4.5.0`.

## Changelog / Code Overview

- **Retry the entire 5xx range (MAGE-694).** Retry `429` + all `500–599` with no exclusions, so CDN/edge failures (e.g. Cloudflare `520–527`) like those seen during the cannot-access-klaviyo.com incident are retried instead of dropped. `501`/`505` are deliberately included — for the SDK's fixed request shapes a genuine origin 501/505 is unreachable, so any 5xx we see is edge noise worth retrying (data-retention > a wasted retry).
- **Align queue-depth behavior with iOS (MAGE-496).** Cap the request queue at **200** (`MAX_QUEUE_SIZE`); at capacity, evict the **oldest request by enqueue timestamp** (`queuedTime`) rather than the front of the deque, so freshly-inserted head-of-line/priority events are protected. Eviction drains fully to the cap even if the queue was already oversized (init-merge / in-flight reinsertion). **Retire the depth-triggered flush** — flushing is now interval + forced only, matching iOS. `Config.Builder.networkFlushDepth(Int)` is kept as a `@Deprecated` no-op (no source/binary break, no forced major bump).
- **Greater-of Retry-After vs exponential backoff (MAGE-500).** Wait `max(Retry-After, cappedExponentialBackoff)` instead of Retry-After alone, and raise the backoff cap **180s → 300s**. Damps sustained fleet-wide retry volume during rate-limit storms (esp. `Retry-After: 0` bursts) while never retrying sooner than the server asked.

## Test Plan

`:sdk:core` + `:sdk:analytics` unit suites green; eviction covered by mocked-clock tests (FIFO order, head-of-line protection, true 200-cap). ktlint clean. CI green on the merged branch.

**On-device UAT** — automated, Proxyman MITM fault-injection + mobile-mcp on the emulator (in-repo sample app, SDK 4.4.1 / Android 36). Full test plan + per-case evidence are posted in the **MAGE-957** issue comments.

| Case | Validates | Result |
|------|-----------|--------|
| TC-001 | Cloudflare 522 retried → delivered on recovery | ✅ Pass |
| TC-002 | 403 load-shed stays terminal (no retry) | ✅ Pass |
| TC-003 | 5xx bounds — 500/599 retried, 499/600 terminal | ✅ Pass |
| TC-004 | Transient network/IO failure retried | ✅ Pass |
| TC-005 | Retry-After honored as a floor | ✅ Pass |
| TC-006 | Exponential backoff on deep retries | ✅ Pass |
| TC-007 | 300s retry-interval ceiling | ⏭️ Skipped — unit-covered |
| TC-008 | Queue caps at 200, evicts oldest | ✅ Pass |
| TC-009 | Depth-flush trigger removed (no-op) | ✅ Pass |

No regressions observed; safe to land pending standard review/CI.

## Related Issues/Tickets

- **Test + release tracking:** MAGE-957 — full on-device UAT summary + per-case evidence are posted in the issue comments.
- **RCA items implemented here:** MAGE-694 (widen 5xx retry range), MAGE-496 (queue cap + evict-oldest), MAGE-500 (max(Retry-After, backoff) + 300s cap).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enforced a maximum queued analytics request limit; when exceeded, oldest requests are evicted (with a warning), while newer priority requests are protected.
  * Queue flushing now relies on the timer interval or explicit forcing (no depth-based gating).
  * Expanded retry logic to treat HTTP 429 and all HTTP 5xx (500–599) responses as retryable.
  * Retry delays now use the longer of exponential backoff and `Retry-After` (case-insensitive), with a higher max retry cap (5 minutes).
  * Debug sample builds now trust user-added CA certificates to enable HTTPS interception during testing.
* **Deprecations**
  * Depth-based flushing configuration (`networkFlushDepth`) is deprecated and removed from runtime behavior; it no longer affects behavior and is scheduled for future removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->