### PR TITLE
chore: bump version to 4.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,10 +105,10 @@ The sample app serves as both a reference implementation and a testing tool for 
       ```kotlin
       // build.gradle.kts
       dependencies {
-          implementation("com.github.klaviyo.klaviyo-android-sdk:analytics:4.4.1")
-          implementation("com.github.klaviyo.klaviyo-android-sdk:push-fcm:4.4.1")
-          implementation("com.github.klaviyo.klaviyo-android-sdk:forms:4.4.1")
-          implementation("com.github.klaviyo.klaviyo-android-sdk:location:4.4.1")
+          implementation("com.github.klaviyo.klaviyo-android-sdk:analytics:4.5.0")
+          implementation("com.github.klaviyo.klaviyo-android-sdk:push-fcm:4.5.0")
+          implementation("com.github.klaviyo.klaviyo-android-sdk:forms:4.5.0")
+          implementation("com.github.klaviyo.klaviyo-android-sdk:location:4.5.0")
       }
       ```
    </details>
@@ -119,10 +119,10 @@ The sample app serves as both a reference implementation and a testing tool for 
       ```groovy
        // build.gradle
        dependencies {
-           implementation "com.github.klaviyo.klaviyo-android-sdk:analytics:4.4.1"
-           implementation "com.github.klaviyo.klaviyo-android-sdk:push-fcm:4.4.1"
-           implementation "com.github.klaviyo.klaviyo-android-sdk:forms:4.4.1"
-           implementation "com.github.klaviyo.klaviyo-android-sdk:location:4.4.1"
+           implementation "com.github.klaviyo.klaviyo-android-sdk:analytics:4.5.0"
+           implementation "com.github.klaviyo.klaviyo-android-sdk:push-fcm:4.5.0"
+           implementation "com.github.klaviyo.klaviyo-android-sdk:forms:4.5.0"
+           implementation "com.github.klaviyo.klaviyo-android-sdk:location:4.5.0"
        }
       ```
    </details>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,2 +1,2 @@
 <!-- Redirect to latest version -->
-<meta HTTP-EQUIV="REFRESH" content="0; url=./4.4.1/index.html">
+<meta HTTP-EQUIV="REFRESH" content="0; url=./4.5.0/index.html">

--- a/sdk/core/src/main/res/values/strings.xml
+++ b/sdk/core/src/main/res/values/strings.xml
@@ -2,7 +2,7 @@
 <resources>
     <!-- Please do not modify / override these values, they are critical for internal versioning  -->
     <string name="klaviyo_sdk_name_override">android</string>
-    <string name="klaviyo_sdk_version_override">4.4.1</string>
+    <string name="klaviyo_sdk_version_override">4.5.0</string>
     <string name="klaviyo_sdk_plugin_name_override"/>
     <string name="klaviyo_sdk_plugin_version_override"/>
 </resources>

--- a/versions.properties
+++ b/versions.properties
@@ -13,7 +13,7 @@
 #  NOTE: Semantic version of the SDK lives in strings.xml
 #  Use this shell script to update the version numbers automatically:
 #  ./bumpVersion.sh
-version.klaviyo.versionCode=43
+version.klaviyo.versionCode=44
 
 # Project gradle plugins
 plugin.android=8.11.0


### PR DESCRIPTION
## Summary
- Runs `bump-version.sh` output: bumps SDK version from `4.4.1` → `4.5.0` and version code from `43` → `44`
- Updates `README.md`, `docs/index.html`, `sdk/core/src/main/res/values/strings.xml`, and `versions.properties`

## Test plan
- [ ] Verify version string `4.5.0` appears correctly in a debug build (`Klaviyo.sdkVersion`)
- [ ] Confirm CI passes (no functional code changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the SDK version from 4.4.1 to 4.5.0.
  * Incremented the Android build version code.
  * Updated installation instructions for all SDK modules.
  * Documentation homepage now redirects to the latest 4.5.0 documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->