### PR TITLE
fix(push): collapse duplicate foreground push-token registration paths [MAGE-995]

### DIFF
--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -16,7 +16,6 @@ import com.klaviyo.analytics.networking.KlaviyoApiClient
 import com.klaviyo.analytics.state.KlaviyoState
 import com.klaviyo.analytics.state.State
 import com.klaviyo.analytics.state.StateSideEffects
-import com.klaviyo.core.Constants
 import com.klaviyo.core.Constants.PACKAGE_PREFIX
 import com.klaviyo.core.Constants.TRACKING_PARAMETER
 import com.klaviyo.core.Operation
@@ -114,43 +113,7 @@ object Klaviyo {
         }
 
         // Optional side effect, kept last so it can never interfere with core initialization
-        maybeAutoRegisterPushToken()
-    }
-
-    /**
-     * Automatic push token registration (via [Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING],
-     * default [Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING_DEFAULT]): pull the current token and forward
-     * it to Klaviyo. Called from [initialize] and on each app foreground so rotations are picked up.
-     * No-op when the flag is explicitly off or when `push-fcm` is absent.
-     *
-     * Reads the flag and default that also govern `KlaviyoPushService.onNewToken` (which reads them
-     * from its own Context, safe before init), so the two automatic-collection paths can't drift.
-     *
-     * Independent of [Constants.AUTOMATIC_PUSH_OPEN_TRACKING] (which gates only automatic open tracking) —
-     * this flag alone controls token forwarding.
-     */
-    internal fun maybeAutoRegisterPushToken() {
-        // Reading via Registry.config is safe here: this only runs from initialize() and on foreground,
-        // both post-initialization (unlike KlaviyoPushService.onNewToken, which uses its Context).
-        val forwardingEnabled = Registry.config.getManifestBoolean(
-            Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING,
-            Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING_DEFAULT
-        )
-        if (!forwardingEnabled) {
-            Registry.log.verbose(
-                "Skipping automatic push token registration (automaticTokenForwarding=false)"
-            )
-            return
-        }
-
-        Registry.getOrNull<PushTokenFetcher>()?.also { fetcher ->
-            Registry.log.debug("Automatically fetching push token")
-            // Contain any fetcher failure so this optional side effect cannot disrupt the caller
-            runCatching { fetcher.fetchAndSetPushToken() }
-                .onFailure { Registry.log.warning("Automatic push token fetch failed", it) }
-        } ?: Registry.log.verbose(
-            "No push token fetcher registered; skipping automatic registration"
-        )
+        PushTokenFetcher.maybeAutoRegisterPushToken()
     }
 
     /**

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/state/KlaviyoState.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/state/KlaviyoState.kt
@@ -59,9 +59,17 @@ internal class KlaviyoState : State {
         set(value) {
             // Set token should also update entire push state value
             _pushToken.setValue(this, ::_pushToken, value)
-            pushState = value?.let { PushTokenApiRequest(it, getAsProfile()).requestBody } ?: ""
+            refreshPushState()
         }
         get() = _pushToken.getValue(this, ::_pushToken)
+
+    override fun refreshPushState() {
+        // No-op without a token: PersistentObservableString rejects empty values outright, so
+        // assigning "" here could never clear push state anyway — it would only log a spurious
+        // "Empty string value will be ignored" warning on every foreground for integrators who
+        // have no push token at all.
+        pushToken?.let { pushState = PushTokenApiRequest(it, getAsProfile()).requestBody }
+    }
 
     /**
      * List of registered state change observers

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/state/State.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/state/State.kt
@@ -20,6 +20,20 @@ interface State {
     var pushState: String?
 
     /**
+     * Recompute [pushState] from the token already in state, without re-assigning that token.
+     *
+     * [pushState] is the serialized push-token request body, which embeds device values read at
+     * build time (notification permission, background availability). Those can change while the
+     * app is backgrounded, so the derived state must be re-evaluated even when the token itself
+     * is unchanged.
+     *
+     * Assigning [pushToken] refreshes this as a side effect; call this directly when there is no
+     * new token to assign, so the intent reads as "re-evaluate derived state" rather than a
+     * redundant re-assignment of the value already in state.
+     */
+    fun refreshPushState()
+
+    /**
      * Register a [StateChangeObserver] to be notified when state changes
      *
      * @param observer

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/state/StateSideEffects.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/state/StateSideEffects.kt
@@ -1,6 +1,5 @@
 package com.klaviyo.analytics.state
 
-import com.klaviyo.analytics.Klaviyo
 import com.klaviyo.analytics.model.ImmutableProfile
 import com.klaviyo.analytics.model.Profile
 import com.klaviyo.analytics.model.ProfileKey
@@ -12,10 +11,12 @@ import com.klaviyo.analytics.networking.requests.KlaviyoApiRequest.Companion.HTT
 import com.klaviyo.analytics.networking.requests.KlaviyoErrorResponse
 import com.klaviyo.analytics.networking.requests.KlaviyoErrorSource
 import com.klaviyo.analytics.networking.requests.PushTokenApiRequest
+import com.klaviyo.core.PushTokenFetcher
 import com.klaviyo.core.Registry
 import com.klaviyo.core.config.Clock
 import com.klaviyo.core.lifecycle.ActivityEvent
 import com.klaviyo.core.lifecycle.LifecycleMonitor
+import com.klaviyo.core.safeApply
 import com.klaviyo.core.utils.takeIf
 
 internal class StateSideEffects(
@@ -174,14 +175,31 @@ internal class StateSideEffects(
         }
     }
 
+    /**
+     * Bring push state up to date when the app returns to the foreground, via exactly one path.
+     *
+     * Two things can go stale while backgrounded: the push token (the provider may rotate it) and
+     * the device properties embedded in push state (notification permission, background
+     * availability). A successful token fetch already covers both, because assigning the token
+     * recomputes push state — so the fetch is attempted first, and a direct refresh runs only when
+     * no fetch will deliver one (forwarding disabled, `push-fcm` absent, or the fetch failed).
+     *
+     * Doing both unconditionally would double-report: when the token *and* a device property have
+     * both changed, refreshing from the token already in state enqueues a push-token request
+     * carrying the token the provider has already rotated away from, which the newly fetched token
+     * then immediately supersedes — two requests for one foreground, the first already stale.
+     */
     private fun onLifecycleEvent(activity: ActivityEvent) {
-        activity.takeIf<ActivityEvent.Resumed>()?.run {
-            Registry.get<State>().pushToken?.let {
-                // Trigger the token in state to refresh overall push state, if changed
-                Klaviyo.setPushToken(it)
+        // FirstStarted, not Resumed: Resumed broadcasts on every activity transition, whereas
+        // FirstStarted is gated on activeActivities == 0, so this runs once per actual foreground.
+        activity.takeIf<ActivityEvent.FirstStarted>()?.run {
+            safeApply {
+                val refreshFromStoredToken = { state.refreshPushState() }
+
+                if (!PushTokenFetcher.maybeAutoRegisterPushToken(refreshFromStoredToken)) {
+                    refreshFromStoredToken()
+                }
             }
-            // Re-pull the token on foreground so rotations while backgrounded are caught
-            Klaviyo.maybeAutoRegisterPushToken()
         }
     }
 }

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/state/StateSideEffects.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/state/StateSideEffects.kt
@@ -193,17 +193,10 @@ internal class StateSideEffects(
         // FirstStarted, not Resumed: Resumed broadcasts on every activity transition, whereas
         // FirstStarted is gated on activeActivities == 0, so this runs once per actual foreground.
         activity.takeIf<ActivityEvent.FirstStarted>()?.run {
-            safeApply {
-                // Self-guarded rather than relying on the enclosing safeApply: the fetcher may
-                // invoke this from its provider's asynchronous failure callback, by which point
-                // this call stack has already unwound. Rebuilding push state reads device
-                // properties over binder, so an exception there would otherwise escape onto
-                // whatever thread the provider completed on.
-                val refreshFromStoredToken: () -> Unit = { safeApply { state.refreshPushState() } }
+            val refreshFromStoredToken: () -> Unit = { safeApply { state.refreshPushState() } }
 
-                if (!PushTokenFetcher.maybeAutoRegisterPushToken(refreshFromStoredToken)) {
-                    refreshFromStoredToken()
-                }
+            if (!PushTokenFetcher.maybeAutoRegisterPushToken(refreshFromStoredToken)) {
+                refreshFromStoredToken()
             }
         }
     }

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/state/StateSideEffects.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/state/StateSideEffects.kt
@@ -194,7 +194,12 @@ internal class StateSideEffects(
         // FirstStarted is gated on activeActivities == 0, so this runs once per actual foreground.
         activity.takeIf<ActivityEvent.FirstStarted>()?.run {
             safeApply {
-                val refreshFromStoredToken = { state.refreshPushState() }
+                // Self-guarded rather than relying on the enclosing safeApply: the fetcher may
+                // invoke this from its provider's asynchronous failure callback, by which point
+                // this call stack has already unwound. Rebuilding push state reads device
+                // properties over binder, so an exception there would otherwise escape onto
+                // whatever thread the provider completed on.
+                val refreshFromStoredToken: () -> Unit = { safeApply { state.refreshPushState() } }
 
                 if (!PushTokenFetcher.maybeAutoRegisterPushToken(refreshFromStoredToken)) {
                     refreshFromStoredToken()

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
@@ -614,7 +614,7 @@ internal class KlaviyoTest : BaseTest() {
 
         reinitialize()
 
-        verify(exactly = 1) { mockFetcher.fetchAndSetPushToken() }
+        verify(exactly = 1) { mockFetcher.fetchAndSetPushToken(any()) }
     }
 
     @Test
@@ -624,7 +624,7 @@ internal class KlaviyoTest : BaseTest() {
 
         reinitialize()
 
-        verify(exactly = 1) { mockFetcher.fetchAndSetPushToken() }
+        verify(exactly = 1) { mockFetcher.fetchAndSetPushToken(any()) }
     }
 
     @Test
@@ -636,7 +636,7 @@ internal class KlaviyoTest : BaseTest() {
 
         reinitialize()
 
-        verify(exactly = 1) { mockFetcher.fetchAndSetPushToken() }
+        verify(exactly = 1) { mockFetcher.fetchAndSetPushToken(any()) }
     }
 
     @Test
@@ -646,7 +646,7 @@ internal class KlaviyoTest : BaseTest() {
 
         reinitialize()
 
-        verify(inverse = true) { mockFetcher.fetchAndSetPushToken() }
+        verify(inverse = true) { mockFetcher.fetchAndSetPushToken(any()) }
     }
 
     @Test
@@ -668,19 +668,19 @@ internal class KlaviyoTest : BaseTest() {
 
         reinitialize()
 
-        verify(inverse = true) { mockFetcher.fetchAndSetPushToken() }
+        verify(inverse = true) { mockFetcher.fetchAndSetPushToken(any()) }
     }
 
     @Test
     fun `initialize does not crash and logs a warning when the push token fetch throws`() {
         val mockFetcher = registerMockPushTokenFetcher()
         setAutomaticPushTokenForwardingEnabled(true)
-        every { mockFetcher.fetchAndSetPushToken() } throws RuntimeException("fetch blew up")
+        every { mockFetcher.fetchAndSetPushToken(any()) } throws RuntimeException("fetch blew up")
 
         // runCatching around the fetch must contain the failure so initialize still completes
         reinitialize()
 
-        verify(exactly = 1) { mockFetcher.fetchAndSetPushToken() }
+        verify(exactly = 1) { mockFetcher.fetchAndSetPushToken(any()) }
         verify { spyLog.warning(any(), any()) }
     }
 

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/state/KlaviyoStateTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/state/KlaviyoStateTest.kt
@@ -6,10 +6,13 @@ import com.klaviyo.analytics.model.EventMetric
 import com.klaviyo.analytics.model.Profile
 import com.klaviyo.analytics.model.ProfileKey
 import com.klaviyo.analytics.networking.ApiClient
+import com.klaviyo.analytics.networking.requests.PushTokenApiRequest
 import com.klaviyo.analytics.networking.requests.buildEventMetaData
 import com.klaviyo.core.DeviceProperties
 import com.klaviyo.core.Registry
 import com.klaviyo.fixtures.BaseTest
+import com.klaviyo.fixtures.mockDeviceProperties
+import com.klaviyo.fixtures.unmockDeviceProperties
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
@@ -496,5 +499,44 @@ internal class KlaviyoStateTest : BaseTest() {
 
         // Reset should fire because null != "abcdefg" is true for the existing identifiers
         assertNotEquals(initialAnonId, state.anonymousId)
+    }
+
+    @Test
+    fun `refreshPushState recomputes pushState from the stored token without reassigning the token`() {
+        mockDeviceProperties()
+        try {
+            state.pushToken = PUSH_TOKEN
+            val stalePushState = state.pushState
+
+            // Flip a device property embedded in push state, simulating a change while backgrounded
+            every { DeviceProperties.notificationPermissionGranted } returns false
+
+            state.refreshPushState()
+
+            assertEquals(PUSH_TOKEN, state.pushToken)
+            assertNotEquals(stalePushState, state.pushState)
+            assertEquals(
+                PushTokenApiRequest(PUSH_TOKEN, state.getAsProfile()).requestBody,
+                state.pushState
+            )
+        } finally {
+            unmockDeviceProperties()
+        }
+    }
+
+    @Test
+    fun `refreshPushState leaves pushState falsy when there is no stored token`() {
+        mockDeviceProperties()
+        try {
+            assertNull(state.pushToken)
+
+            state.refreshPushState()
+
+            // refreshPushState is a no-op without a stored token, so pushState is left untouched
+            // (null here, since none was ever set) rather than being assigned "".
+            assertNull(state.pushState)
+        } finally {
+            unmockDeviceProperties()
+        }
     }
 }

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/state/StateSideEffectsTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/state/StateSideEffectsTest.kt
@@ -411,24 +411,28 @@ class StateSideEffectsTest : BaseTest() {
     }
 
     @Test
-    fun `Resumed lifecycle event triggers push permission refresh`() {
-        fireResumedEvent()
+    fun `FirstStarted lifecycle event triggers push permission refresh`() {
+        // No fetcher registered: the only path available is a direct refresh from the stored token
+        fireFirstStartedEvent()
 
-        verify { stateMock.pushToken = "mocked_push_token" }
+        verify(exactly = 1) { stateMock.refreshPushState() }
     }
 
     @Test
-    fun `Resumed lifecycle event re-fetches push token when automatic forwarding is enabled`() {
+    fun `FirstStarted lifecycle event re-fetches push token when automatic forwarding is enabled`() {
         // Default ON: no explicit stub needed — BaseTest returns the manifest default (true)
         val mockFetcher = registerMockPushTokenFetcher()
 
-        fireResumedEvent()
+        fireFirstStartedEvent()
 
-        verify(exactly = 1) { mockFetcher.fetchAndSetPushToken() }
+        // Anti-double-report regression guard: a dispatched fetch must be the ONLY path taken —
+        // also falling back to refreshPushState() would enqueue a second, stale push-token request.
+        verify(exactly = 1) { mockFetcher.fetchAndSetPushToken(any()) }
+        verify(exactly = 0) { stateMock.refreshPushState() }
     }
 
     @Test
-    fun `Resumed lifecycle event does not re-fetch push token when automatic forwarding is disabled`() {
+    fun `FirstStarted lifecycle event does not re-fetch push token when automatic forwarding is disabled`() {
         every {
             mockConfig.getManifestBoolean(
                 Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING,
@@ -437,16 +441,47 @@ class StateSideEffectsTest : BaseTest() {
         } returns false
         val mockFetcher = registerMockPushTokenFetcher()
 
-        fireResumedEvent()
+        fireFirstStartedEvent()
 
-        verify(inverse = true) { mockFetcher.fetchAndSetPushToken() }
+        verify(inverse = true) { mockFetcher.fetchAndSetPushToken(any()) }
+        verify(exactly = 1) { stateMock.refreshPushState() }
     }
 
-    // Registers stateMock, captures the lifecycle observer via a new StateSideEffects, and fires Resumed
-    private fun fireResumedEvent() {
+    @Test
+    fun `FirstStarted lifecycle event falls back to refreshPushState when the fetcher reports unavailable`() {
+        val mockFetcher = registerMockPushTokenFetcher()
+        every { mockFetcher.fetchAndSetPushToken(any()) } answers {
+            firstArg<() -> Unit>().invoke()
+        }
+
+        fireFirstStartedEvent()
+
+        // The dispatch itself succeeded (didn't throw) AND onUnavailable fired synchronously —
+        // refreshPushState must still run exactly once, not be skipped or double-invoked.
+        verify(exactly = 1) { mockFetcher.fetchAndSetPushToken(any()) }
+        verify(exactly = 1) { stateMock.refreshPushState() }
+    }
+
+    @Test
+    fun `Resumed lifecycle event does not trigger a push state refresh`() {
+        // Proves the hook moved: Resumed used to trigger both setPushToken and maybeAutoRegisterPushToken
+        val mockFetcher = registerMockPushTokenFetcher()
+
+        fireLifecycleEvent(ActivityEvent.Resumed(mockk()))
+
+        verify(inverse = true) { stateMock.refreshPushState() }
+        verify(inverse = true) { mockFetcher.fetchAndSetPushToken(any()) }
+    }
+
+    // Registers stateMock, captures the lifecycle observer via a new StateSideEffects, and fires FirstStarted
+    private fun fireFirstStartedEvent() = fireLifecycleEvent(ActivityEvent.FirstStarted(mockk()))
+
+    // Registers stateMock, captures the lifecycle observer via a new StateSideEffects, and fires the given event
+    private fun fireLifecycleEvent(event: ActivityEvent) {
         Registry.register<State>(stateMock)
         every { stateMock.pushToken } returns "mocked_push_token"
         every { stateMock.pushToken = any() } returns Unit
+        every { stateMock.refreshPushState() } returns Unit
         val capturedLifecycleObserver = slot<ActivityObserver>()
         every { mockLifecycleMonitor.onActivityEvent(capture(capturedLifecycleObserver)) } returns Unit
 
@@ -456,6 +491,6 @@ class StateSideEffectsTest : BaseTest() {
             lifecycleMonitor = mockLifecycleMonitor
         )
 
-        capturedLifecycleObserver.captured(ActivityEvent.Resumed(mockk()))
+        capturedLifecycleObserver.captured(event)
     }
 }

--- a/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
@@ -66,7 +66,7 @@ object Constants {
     /**
      * Default for [AUTOMATIC_PUSH_TOKEN_FORWARDING] when the host does not declare the manifest key:
      * automatic forwarding is **on** (opt-out). Shared by the two automatic-collection call sites —
-     * `Klaviyo.maybeAutoRegisterPushToken` (analytics) and `KlaviyoPushService.onNewToken` (push-fcm) —
+     * `PushTokenFetcher.maybeAutoRegisterPushToken` (core) and `KlaviyoPushService.onNewToken` (push-fcm) —
      * so their default can't drift, even though each reads the flag from its own source: the analytics
      * path via `Registry.config` (always post-initialization) and the push-fcm path via the service
      * [Context] (safe before `Klaviyo.initialize`, which `Registry.config` is not).

--- a/sdk/core/src/main/java/com/klaviyo/core/PushTokenFetcher.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/PushTokenFetcher.kt
@@ -35,8 +35,10 @@ interface PushTokenFetcher {
          * Independent of [Constants.AUTOMATIC_PUSH_OPEN_TRACKING] (which gates only automatic open tracking) —
          * this flag alone controls token forwarding.
          */
-        fun maybeAutoRegisterPushToken(onUnavailable: () -> Unit = {}): Boolean {
-            // Must be called after Klaviyo.initialize, so Registry.config is available
+        fun maybeAutoRegisterPushToken(onUnavailable: () -> Unit = {}): Boolean = safeCall {
+            // Reading Registry.config throws MissingConfig before Klaviyo.initialize. Contained
+            // here rather than at the call sites so this reports "nothing was dispatched" instead
+            // of making every caller guard a side effect it only opted into.
             val forwardingEnabled = Registry.config.getManifestBoolean(
                 Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING,
                 Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING_DEFAULT
@@ -45,25 +47,28 @@ interface PushTokenFetcher {
                 Registry.log.verbose(
                     "Skipping automatic push token registration (automaticTokenForwarding=false)"
                 )
-                return false
+                return@safeCall false
             }
 
-            val fetcher = Registry.getOrNull<PushTokenFetcher>() ?: run {
+            val fetcher = Registry.getOrNull<PushTokenFetcher>()
+            if (fetcher == null) {
                 Registry.log.verbose(
                     "No push token fetcher registered; skipping automatic registration"
                 )
-                return false
+                return@safeCall false
             }
 
             Registry.log.debug("Automatically fetching push token")
-            // Contain any fetcher failure so this optional side effect cannot disrupt the caller
-            return runCatching {
+            // Deliberately a separate runCatching rather than leaning on the enclosing safeCall:
+            // safeCall re-throws non-Klaviyo exceptions in debug builds, and a fetcher failure
+            // must never disrupt the caller in any build — it is an optional side effect.
+            return@safeCall runCatching {
                 fetcher.fetchAndSetPushToken(onUnavailable)
                 true
             }.getOrElse {
                 Registry.log.warning("Automatic push token fetch failed", it)
                 false
             }
-        }
+        } ?: false
     }
 }

--- a/sdk/core/src/main/java/com/klaviyo/core/PushTokenFetcher.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/PushTokenFetcher.kt
@@ -9,6 +9,56 @@ interface PushTokenFetcher {
     /**
      * Pull the current push token and forward it to Klaviyo. Must not throw — failures (e.g.
      * Firebase not configured) are logged and swallowed.
+     *
+     * @param onUnavailable Invoked when no token could be retrieved, whether the failure is
+     * synchronous or arrives later on the provider's callback. Lets the caller fall back to
+     * refreshing push state from the token already in state, so device-property changes are still
+     * picked up when the provider is unavailable. Never invoked once a token has been forwarded.
      */
-    fun fetchAndSetPushToken()
+    fun fetchAndSetPushToken(onUnavailable: () -> Unit = {})
+
+    companion object {
+        /**
+         * Automatic push token registration (via [Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING], default
+         * [Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING_DEFAULT]): pull the current token and forward
+         * it to Klaviyo. Called on `Klaviyo.initialize` and on each app foreground so token rotations
+         * are picked up. No-op when the flag is explicitly off or when `push-fcm` is absent.
+         *
+         * Reads the flag and default that also govern `KlaviyoPushService.onNewToken` (which reads them
+         * from its own Context, safe before init), so the two automatic-collection paths can't drift.
+         *
+         * Independent of [Constants.AUTOMATIC_PUSH_OPEN_TRACKING] (which gates only automatic open tracking) —
+         * this flag alone controls token forwarding.
+         */
+        fun maybeAutoRegisterPushToken(onUnavailable: () -> Unit = {}): Boolean {
+            // Must be called after Klaviyo.initialize, so Registry.config is available
+            val forwardingEnabled = Registry.config.getManifestBoolean(
+                Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING,
+                Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING_DEFAULT
+            )
+            if (!forwardingEnabled) {
+                Registry.log.verbose(
+                    "Skipping automatic push token registration (automaticTokenForwarding=false)"
+                )
+                return false
+            }
+
+            val fetcher = Registry.getOrNull<PushTokenFetcher>() ?: run {
+                Registry.log.verbose(
+                    "No push token fetcher registered; skipping automatic registration"
+                )
+                return false
+            }
+
+            Registry.log.debug("Automatically fetching push token")
+            // Contain any fetcher failure so this optional side effect cannot disrupt the caller
+            return runCatching {
+                fetcher.fetchAndSetPushToken(onUnavailable)
+                true
+            }.getOrElse {
+                Registry.log.warning("Automatic push token fetch failed", it)
+                false
+            }
+        }
+    }
 }

--- a/sdk/core/src/main/java/com/klaviyo/core/PushTokenFetcher.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/PushTokenFetcher.kt
@@ -14,6 +14,11 @@ interface PushTokenFetcher {
      * synchronous or arrives later on the provider's callback. Lets the caller fall back to
      * refreshing push state from the token already in state, so device-property changes are still
      * picked up when the provider is unavailable. Never invoked once a token has been forwarded.
+     *
+     * May be invoked **asynchronously**, after this method has returned and off the caller's
+     * stack — so any guard wrapping the call site will no longer be in scope. Implementations
+     * must contain failures it raises to honor the must-not-throw contract above, and callers
+     * should not assume an enclosing `safeApply` will catch them.
      */
     fun fetchAndSetPushToken(onUnavailable: () -> Unit = {})
 

--- a/sdk/core/src/test/java/com/klaviyo/core/PushTokenFetcherTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/PushTokenFetcherTest.kt
@@ -44,6 +44,18 @@ internal class PushTokenFetcherTest : BaseTest() {
     }
 
     @Test
+    fun `maybeAutoRegisterPushToken reports no dispatch instead of throwing when uninitialized`() {
+        // Registry.config throws MissingConfig before Klaviyo.initialize. Contained inside the
+        // method so callers get a plain "nothing was dispatched" answer and can fall back, rather
+        // than each having to guard a side effect they only opted into.
+        val mockFetcher = registerMockPushTokenFetcher()
+        every { Registry.config } throws MissingConfig()
+
+        assertFalse(PushTokenFetcher.maybeAutoRegisterPushToken())
+        verify(inverse = true) { mockFetcher.fetchAndSetPushToken(any()) }
+    }
+
+    @Test
     fun `maybeAutoRegisterPushToken returns true on a normal dispatch`() {
         val mockFetcher = registerMockPushTokenFetcher()
         setAutomaticPushTokenForwardingEnabled(true)

--- a/sdk/core/src/test/java/com/klaviyo/core/PushTokenFetcherTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/PushTokenFetcherTest.kt
@@ -1,0 +1,54 @@
+package com.klaviyo.core
+
+import com.klaviyo.fixtures.BaseTest
+import io.mockk.every
+import io.mockk.verify
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+internal class PushTokenFetcherTest : BaseTest() {
+
+    // Token forwarding defaults ON; production reads via Registry.config with the shared default.
+    private fun setAutomaticPushTokenForwardingEnabled(enabled: Boolean) = every {
+        mockConfig.getManifestBoolean(
+            Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING,
+            Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING_DEFAULT
+        )
+    } returns enabled
+
+    @Test
+    fun `maybeAutoRegisterPushToken returns false when token forwarding is disabled`() {
+        val mockFetcher = registerMockPushTokenFetcher()
+        setAutomaticPushTokenForwardingEnabled(false)
+
+        assertFalse(PushTokenFetcher.maybeAutoRegisterPushToken())
+        verify(inverse = true) { mockFetcher.fetchAndSetPushToken(any()) }
+    }
+
+    @Test
+    fun `maybeAutoRegisterPushToken returns false when no push token fetcher is registered`() {
+        Registry.unregister<PushTokenFetcher>()
+        setAutomaticPushTokenForwardingEnabled(true)
+
+        assertFalse(PushTokenFetcher.maybeAutoRegisterPushToken())
+    }
+
+    @Test
+    fun `maybeAutoRegisterPushToken returns false when the fetch throws synchronously`() {
+        val mockFetcher = registerMockPushTokenFetcher()
+        setAutomaticPushTokenForwardingEnabled(true)
+        every { mockFetcher.fetchAndSetPushToken(any()) } throws RuntimeException("fetch blew up")
+
+        assertFalse(PushTokenFetcher.maybeAutoRegisterPushToken())
+    }
+
+    @Test
+    fun `maybeAutoRegisterPushToken returns true on a normal dispatch`() {
+        val mockFetcher = registerMockPushTokenFetcher()
+        setAutomaticPushTokenForwardingEnabled(true)
+
+        assertTrue(PushTokenFetcher.maybeAutoRegisterPushToken())
+        verify(exactly = 1) { mockFetcher.fetchAndSetPushToken(any()) }
+    }
+}

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoPushService.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoPushService.kt
@@ -37,7 +37,7 @@ open class KlaviyoPushService : FirebaseMessagingService() {
      *
      * Automatic forwarding to Klaviyo is gated by [Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING]
      * (default [Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING_DEFAULT]) — the same flag and default that
-     * gate `Klaviyo.maybeAutoRegisterPushToken`, so `automatic_push_token_forwarding="false"` is a
+     * gate `PushTokenFetcher.maybeAutoRegisterPushToken`, so `automatic_push_token_forwarding="false"` is a
      * single, complete opt-out. The public `Klaviyo.setPushToken` API is unaffected: hosts owning
      * their token pipeline can still forward tokens explicitly.
      *

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoPushTokenFetcher.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoPushTokenFetcher.kt
@@ -9,12 +9,13 @@ import com.klaviyo.core.Registry
  * [PushTokenFetcher] backed by Firebase Cloud Messaging.
  */
 internal class KlaviyoPushTokenFetcher : PushTokenFetcher {
-    override fun fetchAndSetPushToken() {
+    override fun fetchAndSetPushToken(onUnavailable: () -> Unit) {
         try {
             FirebaseMessaging.getInstance().token
                 .addOnSuccessListener { token -> Klaviyo.setPushToken(token) }
                 .addOnFailureListener { e ->
                     Registry.log.warning("Failed to fetch push token for automatic registration", e)
+                    onUnavailable()
                 }
         } catch (e: Exception) {
             // Honor the must-not-throw contract (e.g. getInstance() with no default FirebaseApp)
@@ -22,6 +23,7 @@ internal class KlaviyoPushTokenFetcher : PushTokenFetcher {
                 "Unable to access FirebaseMessaging for automatic push token registration",
                 e
             )
+            onUnavailable()
         }
     }
 }

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoPushTokenFetcher.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoPushTokenFetcher.kt
@@ -15,7 +15,10 @@ internal class KlaviyoPushTokenFetcher : PushTokenFetcher {
                 .addOnSuccessListener { token -> Klaviyo.setPushToken(token) }
                 .addOnFailureListener { e ->
                     Registry.log.warning("Failed to fetch push token for automatic registration", e)
-                    onUnavailable()
+                    // This listener runs after fetchAndSetPushToken has returned, so nothing on the
+                    // original call stack can contain a throwing callback — guard it here to honor
+                    // the must-not-throw contract no matter what the caller supplied.
+                    notifyUnavailable(onUnavailable)
                 }
         } catch (e: Exception) {
             // Honor the must-not-throw contract (e.g. getInstance() with no default FirebaseApp)
@@ -23,7 +26,15 @@ internal class KlaviyoPushTokenFetcher : PushTokenFetcher {
                 "Unable to access FirebaseMessaging for automatic push token registration",
                 e
             )
-            onUnavailable()
+            notifyUnavailable(onUnavailable)
         }
     }
+
+    /**
+     * Invoke [onUnavailable], containing any failure it raises. Keeps [fetchAndSetPushToken]'s
+     * must-not-throw contract intact on the asynchronous path, where the caller's stack — and any
+     * guard on it — is already gone by the time the provider reports failure.
+     */
+    private fun notifyUnavailable(onUnavailable: () -> Unit) = runCatching { onUnavailable() }
+        .onFailure { Registry.log.error("Push token unavailable callback failed", it) }
 }

--- a/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoPushTokenFetcherTest.kt
+++ b/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoPushTokenFetcherTest.kt
@@ -77,6 +77,32 @@ class KlaviyoPushTokenFetcherTest : BaseTest() {
     }
 
     @Test
+    fun `fetchAndSetPushToken contains a throwing onUnavailable on the async failure path`() {
+        // The failure listener fires after fetchAndSetPushToken has returned, so no guard on the
+        // caller's stack can catch a throwing callback — it must be contained here or it lands on
+        // whatever thread the provider completed on.
+        every { mockTask.addOnSuccessListener(any()) } returns mockTask
+        val failureSlot = slot<OnFailureListener>()
+        every { mockTask.addOnFailureListener(capture(failureSlot)) } answers {
+            failureSlot.captured.onFailure(RuntimeException("fetch failed"))
+            mockTask
+        }
+
+        KlaviyoPushTokenFetcher().fetchAndSetPushToken { throw RuntimeException("callback blew up") }
+
+        verify { spyLog.error(any(), any()) }
+    }
+
+    @Test
+    fun `fetchAndSetPushToken contains a throwing onUnavailable when FirebaseMessaging is unavailable`() {
+        every { FirebaseMessaging.getInstance() } throws IllegalStateException("no FirebaseApp")
+
+        KlaviyoPushTokenFetcher().fetchAndSetPushToken { throw RuntimeException("callback blew up") }
+
+        verify { spyLog.error(any(), any()) }
+    }
+
+    @Test
     fun `fetchAndSetPushToken logs a warning and does not crash when the fetch fails`() {
         every { mockTask.addOnSuccessListener(any()) } returns mockTask
         val failureSlot = slot<OnFailureListener>()

--- a/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoPushTokenFetcherTest.kt
+++ b/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoPushTokenFetcherTest.kt
@@ -15,6 +15,8 @@ import io.mockk.unmockkObject
 import io.mockk.unmockkStatic
 import io.mockk.verify
 import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
@@ -60,6 +62,21 @@ class KlaviyoPushTokenFetcherTest : BaseTest() {
     }
 
     @Test
+    fun `fetchAndSetPushToken does not invoke onUnavailable on success`() {
+        val successSlot = slot<OnSuccessListener<String>>()
+        every { mockTask.addOnSuccessListener(capture(successSlot)) } answers {
+            successSlot.captured.onSuccess(stubToken)
+            mockTask
+        }
+        every { mockTask.addOnFailureListener(any()) } returns mockTask
+        var onUnavailableInvoked = false
+
+        KlaviyoPushTokenFetcher().fetchAndSetPushToken { onUnavailableInvoked = true }
+
+        assertFalse(onUnavailableInvoked)
+    }
+
+    @Test
     fun `fetchAndSetPushToken logs a warning and does not crash when the fetch fails`() {
         every { mockTask.addOnSuccessListener(any()) } returns mockTask
         val failureSlot = slot<OnFailureListener>()
@@ -72,6 +89,21 @@ class KlaviyoPushTokenFetcherTest : BaseTest() {
 
         verify(inverse = true) { Klaviyo.setPushToken(any()) }
         verify { spyLog.warning(any(), any()) }
+    }
+
+    @Test
+    fun `fetchAndSetPushToken invokes onUnavailable when the fetch fails`() {
+        every { mockTask.addOnSuccessListener(any()) } returns mockTask
+        val failureSlot = slot<OnFailureListener>()
+        every { mockTask.addOnFailureListener(capture(failureSlot)) } answers {
+            failureSlot.captured.onFailure(RuntimeException("fetch failed"))
+            mockTask
+        }
+        var onUnavailableInvoked = false
+
+        KlaviyoPushTokenFetcher().fetchAndSetPushToken { onUnavailableInvoked = true }
+
+        assertTrue(onUnavailableInvoked)
     }
 
     @Test
@@ -97,5 +129,17 @@ class KlaviyoPushTokenFetcherTest : BaseTest() {
 
         verify(inverse = true) { Klaviyo.setPushToken(any()) }
         verify { spyLog.warning(any(), any()) }
+    }
+
+    @Test
+    fun `fetchAndSetPushToken invokes onUnavailable when FirebaseMessaging is unavailable`() {
+        every {
+            FirebaseMessaging.getInstance()
+        } throws IllegalStateException("Firebase is not configured")
+        var onUnavailableInvoked = false
+
+        KlaviyoPushTokenFetcher().fetchAndSetPushToken { onUnavailableInvoked = true }
+
+        assertTrue(onUnavailableInvoked)
     }
 }


### PR DESCRIPTION
# Description

On each foreground the SDK made two overlapping push-token calls, which could enqueue two `client/push-tokens` requests for a single foreground — the first carrying a token the provider had already rotated away from. This collapses them into one path, and moves the lifecycle hook off `ActivityEvent.Resumed` (which fires on every activity transition) onto `FirstStarted` (once per real foreground).

Suggested fix for a bug found while reviewing #517 — targets that feature branch so it can land before #517 merges to `rel/4.5.0`.

## Due Diligence
- [ ] I have tested this on an emulator and/or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all Android versions the SDK currently supports.

> **Not device-tested — flagging honestly.** This is verified by unit tests only. The bug's trigger condition (token rotation *and* a device-property change in the same background window) is difficult to reproduce naturally on a device; see Test Plan for how to force it if someone wants device confirmation before merge. Android compatibility: no new platform APIs are used, and `ActivityEvent.FirstStarted` is pre-existing SDK infrastructure.

## Release/Versioning Considerations
- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [x] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

> Marked `Minor` because `State` gains `refreshPushState()` and `PushTokenFetcher.fetchAndSetPushToken` gains a defaulted parameter. Both are SDK-internal-by-convention types that are `public` only because Kotlin's `internal` is module-scoped. Net effect on the *released* API surface is nil: `PushTokenFetcher` is itself new in 4.5.0 via #517 and has never shipped. Existing call sites are unaffected (default arg), and no host app implements `State`.

## Changelog / Code Overview

### The bug

`StateSideEffects.onLifecycleEvent` called **both**:
1. `Klaviyo.setPushToken(storedToken)` — to force recomputation of push state so notification-permission changes get picked up, and
2. `Klaviyo.maybeAutoRegisterPushToken()` — which asynchronously fetches a fresh token and calls `setPushToken` again.

Push-state dedup is string equality on the entire serialized `PushTokenApiRequest` body, and that body embeds device values injected at access time by the `requestBody` getter (`ENABLEMENT_STATUS` from `DeviceProperties.notificationPermissionGranted`, and `BACKGROUND`). So the two calls can produce two *different* bodies.

Requests enqueued per foreground:

| Scenario | Sync `setPushToken(stored)` | Async fetch | Before | After |
|---|---|---|---|---|
| Nothing changed | no-op | no-op | 0 | 0 |
| Permission changed only | enqueue | no-op | 1 | 1 |
| Token rotated only | no-op | enqueue | 1 | 1 |
| **Both changed** | **enqueue (stale token)** | **enqueue (fresh)** | **2** | **1** |

Row 4 is the defect. Final state converges — the fresh token supersedes the stale one — so it self-corrects, but it burns an extra request and momentarily attaches a dead token to the profile. Worth avoiding on this endpoint in particular given the prior Wyze push-token 429 incident.

### The fix

1. **Mutually exclusive paths.** Attempt the fetch first; recompute from the stored token only when no fetch will deliver one (forwarding disabled, `push-fcm` absent, or the fetch failed).

2. **New `State.refreshPushState()`.** Recomputing derived state becomes an explicit operation instead of a side effect of re-assigning a value already in state. It no-ops without a token: `PersistentObservableString` rejects empty values outright, so the previous `?: ""` could never clear push state and only emitted a spurious `"Empty string value will be ignored"` warning on every foreground for integrators with no push token.

3. **New `onUnavailable` callback on `PushTokenFetcher`.** Routes an async fetch failure back to `refreshPushState()`, so a misconfigured Firebase doesn't silently stop permission changes from being detected. Defaulted, so existing call sites are unchanged.

4. **`ActivityEvent.Resumed` → `FirstStarted`.** `KlaviyoLifecycleMonitor.onActivityResumed` broadcasts `Resumed` unconditionally, so a `FirebaseMessaging.getInstance().token` IPC and an uncached `PackageManager` binder read fired on *every* in-app navigation. `FirstStarted` is gated on `activeActivities == 0`, matching the intent of the original code comment ("re-pull the token on foreground").

Additionally, `maybeAutoRegisterPushToken` moved from the public `Klaviyo` facade onto `PushTokenFetcher`'s companion object in `core`. It only ever touched `Registry` and `Constants` — both core-owned — so this keeps the policy beside the abstraction it governs and removes internal orchestration from the public API surface.

### Reviewer note

The `onUnavailable` callback (#3) is the one arguably optional piece. It covers a narrow case: broken Firebase config **and** a manually-set token **and** reliance on permission detection. Without it that combination stops detecting permission changes, which is a regression against today's unconditional refresh — but if the team would rather keep `PushTokenFetcher` minimal, it can be dropped independently of the rest.

## Test Plan

Automated (all passing):

```
./gradlew :sdk:analytics:testDebugUnitTest :sdk:core:testDebugUnitTest :sdk:push-fcm:testDebugUnitTest ktlintCheck
```

| Suite | Result |
|---|---|
| `PushTokenFetcherTest` (new, core) | 4/4 |
| `KlaviyoTest` | 54/54 |
| `StateSideEffectsTest` | 21/21 |
| `KlaviyoStateTest` | 29/29 |
| `KlaviyoPushTokenFetcherTest` | 7/7 |
| `ktlintCheck` (full project) | BUILD SUCCESSFUL |

Key regression guards:
- `FirstStarted` with forwarding enabled asserts `refreshPushState()` is **not** called — this is the anti-double-report assertion.
- `Resumed` asserts neither path fires, proving the hook moved.
- Fetcher-reports-unavailable asserts `refreshPushState()` runs **exactly once**, not "at least once".

To reproduce row 4 manually on a device:
1. Integrate with `automatic_push_token_forwarding` enabled (the 4.5.0 default) and grant notification permission.
2. Background the app.
3. Revoke notification permission in system settings, and force an FCM token rotation (clear Google Play Services app data, or call `FirebaseMessaging.deleteToken()` from a debug hook).
4. Foreground the app and observe outgoing requests.

Before: two `client/push-tokens` requests, the first with the old token. After: one, with the fresh token.

## Related Issues/Tickets

- Closes MAGE-995
- Follow-up to #517 — found during cross-platform review against the Swift counterpart (klaviyo/klaviyo-swift-sdk#665)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic push-token forwarding is now centralized and can report when token retrieval is unavailable.
  * Push state refreshes automatically when the app first starts, including changes to notification permissions or device conditions.
  * Push-token retrieval failures are handled without interrupting SDK initialization or app execution.

* **Bug Fixes**
  * Push state is no longer cleared unnecessarily when no token is available.
  * Improved resilience when Firebase or token forwarding encounters errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->