### PR TITLE
feat(sample): add list subscription demo (MAGE-945)

### DIFF
--- a/sample/README.md
+++ b/sample/README.md
@@ -20,6 +20,10 @@ Follow these instructions to run the sample app on your own device or emulator.
 - Clone the repository and open the project in Android Studio.
 - Add your public Klaviyo API key to the `./local.properties` file in the root of the project: `klaviyoPublicApiKey=apiKey`
   Or, replace `KLAVIYO_PUBLIC_KEY` in [SampleApplication.kt](./src/main/java/com/klaviyo/sample/SampleApplication.kt).
+- To try the list-subscription demo, set `subscriptionListId` in
+  [SampleApplication.kt](./src/main/java/com/klaviyo/sample/SampleApplication.kt) to a list ID from your account.
+  Leaving it `null` hides the "Subscribe to email marketing" toggle. When set, toggle it on before tapping
+  **Set Profile** to subscribe the profile after its email is set.
 - Add your `google-services.json` file to the [`sample`](.) directory. You can use the same file you use for your 
   own application, or register a new app in your project from the firebase console.
 - Open [build.gradle](./build.gradle) and replace `applicationId "${klaviyoGroupId}.sample"`

--- a/sample/src/main/java/com/klaviyo/sample/SampleApplication.kt
+++ b/sample/src/main/java/com/klaviyo/sample/SampleApplication.kt
@@ -13,6 +13,13 @@ import com.klaviyo.forms.registerFormLifecycleHandler
 import com.klaviyo.location.registerGeofencing
 
 class SampleApplication : Application() {
+
+    companion object {
+        // OPTIONAL SETUP NOTE: To demo list subscriptions, set a list ID from your account.
+        // Leave null to hide the subscribe toggle entirely.
+        val subscriptionListId: String? = null
+    }
+
     override fun onCreate() {
         super.onCreate()
 

--- a/sample/src/main/java/com/klaviyo/sample/SampleView.kt
+++ b/sample/src/main/java/com/klaviyo/sample/SampleView.kt
@@ -29,6 +29,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -38,6 +39,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.text.input.ImeAction
@@ -74,6 +76,7 @@ private object UiConstants {
     const val EMAIL_LABEL = "Email"
     const val PHONE_LABEL = "Phone Number"
     const val PUSH_TOKEN_LABEL = "Push Token"
+    const val SUBSCRIBE_TO_MARKETING = "Subscribe to email marketing"
 
     // Button Text
     const val SET_PROFILE = "Set Profile"
@@ -193,6 +196,9 @@ fun SampleView(
                     viewModel::resetProfile,
                     UiConstants.PROFILE_RESET
                 ),
+                isSubscriptionDemoEnabled = viewModel.isSubscriptionDemoEnabled,
+                subscribeToMarketing = viewModel.subscribeToMarketing,
+                onSubscribeToMarketingChange = viewModel::updateSubscribeToMarketing,
                 createTestEvent = executeWithToast(
                     viewModel::createTestEvent,
                     UiConstants.TEST_EVENT_CREATED
@@ -247,6 +253,9 @@ private fun SampleViewContent(
     setPhoneNumber: () -> Unit = {},
     setProfile: () -> Unit = {},
     resetProfile: () -> Unit = {},
+    isSubscriptionDemoEnabled: Boolean = false,
+    subscribeToMarketing: Boolean = false,
+    onSubscribeToMarketingChange: (Boolean) -> Unit = {},
     createTestEvent: () -> Unit = {},
     createViewedProductEvent: () -> Unit = {},
     registerForInAppForms: () -> Unit = {},
@@ -321,6 +330,20 @@ private fun SampleViewContent(
                 )
             }
         )
+        // Collect marketing consent at "sign up" (Set Profile), shown only when a list ID is configured
+        if (isSubscriptionDemoEnabled) {
+            ViewRow(horizontalArrangement = Arrangement.SpaceBetween) {
+                Text(text = UiConstants.SUBSCRIBE_TO_MARKETING)
+                Switch(
+                    checked = subscribeToMarketing,
+                    onCheckedChange = onSubscribeToMarketingChange,
+                    modifier = Modifier.semantics {
+                        testTag = SampleTestTags.TOGGLE_SUBSCRIBE_MARKETING
+                        contentDescription = UiConstants.SUBSCRIBE_TO_MARKETING
+                    }
+                )
+            }
+        }
         ViewRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
             ActionButton(
                 text = UiConstants.SET_PROFILE,

--- a/sample/src/main/java/com/klaviyo/sample/SampleViewModel.kt
+++ b/sample/src/main/java/com/klaviyo/sample/SampleViewModel.kt
@@ -12,6 +12,7 @@ import com.klaviyo.analytics.Klaviyo
 import com.klaviyo.analytics.model.Event
 import com.klaviyo.analytics.model.EventKey
 import com.klaviyo.analytics.model.EventMetric
+import com.klaviyo.analytics.model.Subscription
 import com.klaviyo.core.Registry
 import com.klaviyo.forms.registerForInAppForms
 import com.klaviyo.forms.unregisterFromInAppForms
@@ -118,6 +119,11 @@ class SampleViewModel : ViewModel() {
             .setExternalId(externalId)
             .setEmail(email)
             .setPhoneNumber(phoneNumber)
+
+        // Collect marketing consent at "sign up": subscribe after the identifiers are set.
+        if (subscribeToMarketing) {
+            subscribeToList()
+        }
     }
 
     @UiThread
@@ -125,6 +131,8 @@ class SampleViewModel : ViewModel() {
         updateExternalId("")
         updateEmail("")
         updatePhoneNumber("")
+        // Clear consent intent so it isn't silently carried to the next profile
+        subscribeToMarketing = false
         Klaviyo.resetProfile()
     }
 
@@ -142,6 +150,36 @@ class SampleViewModel : ViewModel() {
             .setValue(99.99)
 
         Klaviyo.createEvent(event)
+    }
+
+    // Subscription demo state
+    var subscribeToMarketing by mutableStateOf(false)
+        private set
+
+    /** Whether the subscribe-to-list demo is configured (see [SampleApplication.subscriptionListId]). */
+    val isSubscriptionDemoEnabled: Boolean
+        get() = SampleApplication.subscriptionListId != null
+
+    @UiThread
+    fun updateSubscribeToMarketing(value: Boolean) {
+        subscribeToMarketing = value
+    }
+
+    /**
+     * Requests email marketing consent for the tracked profile. Requires an email on the profile;
+     * the SDK logs a warning and drops the request if one isn't set.
+     */
+    private fun subscribeToList() {
+        val listId = SampleApplication.subscriptionListId ?: return
+        Klaviyo.createSubscription(
+            Subscription(
+                listId = listId,
+                channels = Subscription.Channels(
+                    email = setOf(Subscription.Channels.Email.MARKETING)
+                ),
+                customSource = SUBSCRIPTION_SOURCE
+            )
+        )
     }
 
     // In-App Forms actions
@@ -230,5 +268,9 @@ class SampleViewModel : ViewModel() {
         // Clean up geofence sync subscription to prevent memory leak
         // Note: this is an advanced API used for demonstration, not necessary for a typical integration
         Registry.getOrNull<LocationManager>()?.offGeofenceSync(::refreshCurrentGeofencesOnSync)
+    }
+
+    companion object {
+        private const val SUBSCRIPTION_SOURCE = "Android Sample App"
     }
 }

--- a/sample/src/main/java/com/klaviyo/sample/TestTags.kt
+++ b/sample/src/main/java/com/klaviyo/sample/TestTags.kt
@@ -11,6 +11,9 @@ object SampleTestTags {
     const val BTN_SET_PROFILE = "btn_set_profile"
     const val BTN_RESET_PROFILE = "btn_reset_profile"
 
+    // Subscription section
+    const val TOGGLE_SUBSCRIBE_MARKETING = "toggle_subscribe_marketing"
+
     // Events section
     const val BTN_CREATE_TEST_EVENT = "btn_create_test_event"
     const val BTN_VIEWED_PRODUCT = "btn_viewed_product"


### PR DESCRIPTION
# Description
Adds an optional list-subscription demo to the public sample app: a "Subscribe to email marketing" toggle on the profile screen that subscribes the tracked profile after **Set Profile**.

## Due Diligence
- [x] I have tested this on an emulator and/or a physical device.
  - Verified on emulator: toggling on + Set Profile builds and enqueues the correct `POST client/subscriptions` (right `list.id`, profile `email`, `custom_source: "Android Sample App"`), and the subscription lands in-account on a validated network. Note: the SDK only sends over an OS-validated network (gates on `NET_CAPABILITY_VALIDATED`), so a device/emulator without validated internet will queue the request without sending.
- [ ] I have added sufficient unit/integration tests of my changes.
  - Sample-app-only change; the `sample` module has no unit-test target (only a package-name instrumented stub).
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all Android versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
  - `sample/` is a demo app, not published to customers.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [x] Contains readme or migration guide changes.
  - `sample/README.md` only; targeting the `feat/subscription-methods-sdk` feature branch.
- [x] This is planned work for an upcoming release.

## Changelog / Code Overview
- **`SampleApplication.kt`** — new `subscriptionListId: String? = null` companion config next to the public key. `null` (default) hides the demo entirely, so the sample app is visually unchanged.
- **`SampleViewModel.kt`** — `subscribeToMarketing` toggle state + `isSubscriptionDemoEnabled`; `setProfile()` subscribes after setting identifiers when the toggle is on. Private `subscribeToList()` → `Klaviyo.createSubscription(Subscription.allAvailableMarketing(listId, customSource = "Android Sample App"))`.
- **`SampleView.kt`** — a "Subscribe to email marketing" `Switch` in the Profile section, rendered only when `isSubscriptionDemoEnabled`.
- **`TestTags.kt` / `sample/README.md`** — toggle test tag + setup note.

Consent is collected at "sign up" (Set Profile) rather than behind a standalone button — the pattern a third-party developer is most likely to copy. Depends on the `createSubscription` API from #514 (MAGE-855), already merged into this feature branch.

## Test Plan
1. Set `subscriptionListId` in `SampleApplication.kt` to a list ID from your account, and a real public key in `local.properties` (`klaviyoPublicApiKey`).
2. `./gradlew :sample:installDebug`.
3. On the profile screen, confirm the "Subscribe to email marketing" toggle appears below the phone field.
4. Enter an email, leave the toggle **off**, tap Set Profile — no subscription created.
5. Toggle **on**, tap Set Profile — the profile appears on the list in-account with `$source` = "Android Sample App".
6. Revert `subscriptionListId` to `null`, relaunch — the toggle is gone and the screen matches master.

## Related Issues/Tickets
Closes MAGE-945
Part of MAGE-855
