### PR TITLE
feat: client list subscriptions (rel/4.5.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ send them timely push notifications via [FCM (Firebase Cloud Messaging)](https:/
 - [Initialization](#initialization)
 - [Profile Identification](#profile-identification)
 - [Event Tracking](#event-tracking)
+- [Subscriptions](#subscriptions)
 - [Push Notifications](#push-notifications)
   - [Prerequisites](#prerequisites)
   - [Setup](#setup)
@@ -383,6 +384,83 @@ Additional event properties can be specified as part of the `Event` object:
    Klaviyo.createEvent(event);
    ```
 </details>
+
+## Subscriptions
+
+The SDK can subscribe the currently identified profile to a Klaviyo list and record marketing or
+transactional consent via the
+[Create Client Subscription API](https://developers.klaviyo.com/en/reference/create_client_subscription).
+WhatsApp BSUID support is coming soon.
+
+Identify the profile before subscribing (see [Profile Identification](#profile-identification)): the
+email address keys the email channel, and the phone number keys the SMS and WhatsApp channels. If a
+requested channel is missing its identifier, the request is dropped and a warning is logged.
+
+Subscriptions to push notifications are not created through this API — use the existing
+[`Klaviyo.setPushToken`](#collecting-push-tokens) registration path instead.
+
+Request consent for specific channels and sub-types. Email supports `MARKETING` and `OPEN_TRACKING`;
+SMS and WhatsApp support `MARKETING` and `TRANSACTIONAL`:
+
+<details open>
+   <summary>Kotlin</summary>
+
+   ```kotlin
+   import com.klaviyo.analytics.Klaviyo
+   import com.klaviyo.analytics.model.Subscription
+
+   Klaviyo.setEmail("kermit@example.com").setPhoneNumber("+15005550006")
+
+   val subscription = Subscription(
+       listId = "YOUR_LIST_ID",
+       channels = Subscription.Channels(
+           email = setOf(Subscription.Channels.Email.MARKETING),
+           sms = setOf(Subscription.Channels.Messaging.MARKETING)
+       )
+   )
+   Klaviyo.createSubscription(subscription)
+   ```
+</details>
+
+<details>
+   <summary>Java</summary>
+
+   ```java
+   import com.klaviyo.analytics.Klaviyo;
+   import com.klaviyo.analytics.model.Subscription;
+   import java.util.EnumSet;
+
+   Klaviyo.setEmail("kermit@example.com").setPhoneNumber("+15005550006");
+
+   Subscription.Channels channels = new Subscription.Channels(
+       EnumSet.of(Subscription.Channels.Email.MARKETING),
+       EnumSet.of(Subscription.Channels.Messaging.MARKETING),
+       null
+   );
+   Klaviyo.createSubscription(new Subscription("YOUR_LIST_ID", channels));
+   ```
+</details>
+
+Alternatively, grant marketing consent on every channel the profile has an identifier for and let
+Klaviyo apply its default channels:
+
+<details open>
+   <summary>Kotlin</summary>
+
+   ```kotlin
+   Klaviyo.createSubscription(Subscription.allAvailableMarketing(listId = "YOUR_LIST_ID"))
+   ```
+</details>
+
+<details>
+   <summary>Java</summary>
+
+   ```java
+   Klaviyo.createSubscription(Subscription.allAvailableMarketing("YOUR_LIST_ID"));
+   ```
+</details>
+
+Both entry points accept an optional `customSource` label describing where the signup originated.
 
 ## Push Notifications
 

--- a/sample/README.md
+++ b/sample/README.md
@@ -20,6 +20,10 @@ Follow these instructions to run the sample app on your own device or emulator.
 - Clone the repository and open the project in Android Studio.
 - Add your public Klaviyo API key to the `./local.properties` file in the root of the project: `klaviyoPublicApiKey=apiKey`
   Or, replace `KLAVIYO_PUBLIC_KEY` in [SampleApplication.kt](./src/main/java/com/klaviyo/sample/SampleApplication.kt).
+- To try the list-subscription demo, set `subscriptionListId` in
+  [SampleApplication.kt](./src/main/java/com/klaviyo/sample/SampleApplication.kt) to a list ID from your account.
+  Leaving it `null` hides the "Subscribe to email marketing" toggle. When set, toggle it on before tapping
+  **Set Profile** to subscribe the profile after its email is set.
 - Add your `google-services.json` file to the [`sample`](.) directory. You can use the same file you use for your 
   own application, or register a new app in your project from the firebase console.
 - Open [build.gradle](./build.gradle) and replace `applicationId "${klaviyoGroupId}.sample"`

--- a/sample/src/main/java/com/klaviyo/sample/SampleApplication.kt
+++ b/sample/src/main/java/com/klaviyo/sample/SampleApplication.kt
@@ -13,6 +13,13 @@ import com.klaviyo.forms.registerFormLifecycleHandler
 import com.klaviyo.location.registerGeofencing
 
 class SampleApplication : Application() {
+
+    companion object {
+        // OPTIONAL SETUP NOTE: To demo list subscriptions, set a list ID from your account.
+        // Leave null to hide the subscribe toggle entirely.
+        val subscriptionListId: String? = null
+    }
+
     override fun onCreate() {
         super.onCreate()
 

--- a/sample/src/main/java/com/klaviyo/sample/SampleView.kt
+++ b/sample/src/main/java/com/klaviyo/sample/SampleView.kt
@@ -29,6 +29,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -38,6 +39,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.text.input.ImeAction
@@ -74,6 +76,7 @@ private object UiConstants {
     const val EMAIL_LABEL = "Email"
     const val PHONE_LABEL = "Phone Number"
     const val PUSH_TOKEN_LABEL = "Push Token"
+    const val SUBSCRIBE_TO_MARKETING = "Subscribe to email marketing"
 
     // Button Text
     const val SET_PROFILE = "Set Profile"
@@ -193,6 +196,9 @@ fun SampleView(
                     viewModel::resetProfile,
                     UiConstants.PROFILE_RESET
                 ),
+                isSubscriptionDemoEnabled = viewModel.isSubscriptionDemoEnabled,
+                subscribeToMarketing = viewModel.subscribeToMarketing,
+                onSubscribeToMarketingChange = viewModel::updateSubscribeToMarketing,
                 createTestEvent = executeWithToast(
                     viewModel::createTestEvent,
                     UiConstants.TEST_EVENT_CREATED
@@ -247,6 +253,9 @@ private fun SampleViewContent(
     setPhoneNumber: () -> Unit = {},
     setProfile: () -> Unit = {},
     resetProfile: () -> Unit = {},
+    isSubscriptionDemoEnabled: Boolean = false,
+    subscribeToMarketing: Boolean = false,
+    onSubscribeToMarketingChange: (Boolean) -> Unit = {},
     createTestEvent: () -> Unit = {},
     createViewedProductEvent: () -> Unit = {},
     registerForInAppForms: () -> Unit = {},
@@ -321,6 +330,20 @@ private fun SampleViewContent(
                 )
             }
         )
+        // Collect marketing consent at "sign up" (Set Profile), shown only when a list ID is configured
+        if (isSubscriptionDemoEnabled) {
+            ViewRow(horizontalArrangement = Arrangement.SpaceBetween) {
+                Text(text = UiConstants.SUBSCRIBE_TO_MARKETING)
+                Switch(
+                    checked = subscribeToMarketing,
+                    onCheckedChange = onSubscribeToMarketingChange,
+                    modifier = Modifier.semantics {
+                        testTag = SampleTestTags.TOGGLE_SUBSCRIBE_MARKETING
+                        contentDescription = UiConstants.SUBSCRIBE_TO_MARKETING
+                    }
+                )
+            }
+        }
         ViewRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
             ActionButton(
                 text = UiConstants.SET_PROFILE,

--- a/sample/src/main/java/com/klaviyo/sample/SampleViewModel.kt
+++ b/sample/src/main/java/com/klaviyo/sample/SampleViewModel.kt
@@ -12,6 +12,7 @@ import com.klaviyo.analytics.Klaviyo
 import com.klaviyo.analytics.model.Event
 import com.klaviyo.analytics.model.EventKey
 import com.klaviyo.analytics.model.EventMetric
+import com.klaviyo.analytics.model.Subscription
 import com.klaviyo.core.Registry
 import com.klaviyo.forms.registerForInAppForms
 import com.klaviyo.forms.unregisterFromInAppForms
@@ -118,6 +119,11 @@ class SampleViewModel : ViewModel() {
             .setExternalId(externalId)
             .setEmail(email)
             .setPhoneNumber(phoneNumber)
+
+        // Collect marketing consent at "sign up": subscribe after the identifiers are set.
+        if (subscribeToMarketing) {
+            subscribeToList()
+        }
     }
 
     @UiThread
@@ -125,6 +131,8 @@ class SampleViewModel : ViewModel() {
         updateExternalId("")
         updateEmail("")
         updatePhoneNumber("")
+        // Clear consent intent so it isn't silently carried to the next profile
+        subscribeToMarketing = false
         Klaviyo.resetProfile()
     }
 
@@ -142,6 +150,36 @@ class SampleViewModel : ViewModel() {
             .setValue(99.99)
 
         Klaviyo.createEvent(event)
+    }
+
+    // Subscription demo state
+    var subscribeToMarketing by mutableStateOf(false)
+        private set
+
+    /** Whether the subscribe-to-list demo is configured (see [SampleApplication.subscriptionListId]). */
+    val isSubscriptionDemoEnabled: Boolean
+        get() = SampleApplication.subscriptionListId != null
+
+    @UiThread
+    fun updateSubscribeToMarketing(value: Boolean) {
+        subscribeToMarketing = value
+    }
+
+    /**
+     * Requests email marketing consent for the tracked profile. Requires an email on the profile;
+     * the SDK logs a warning and drops the request if one isn't set.
+     */
+    private fun subscribeToList() {
+        val listId = SampleApplication.subscriptionListId ?: return
+        Klaviyo.createSubscription(
+            Subscription(
+                listId = listId,
+                channels = Subscription.Channels(
+                    email = setOf(Subscription.Channels.Email.MARKETING)
+                ),
+                customSource = SUBSCRIPTION_SOURCE
+            )
+        )
     }
 
     // In-App Forms actions
@@ -230,5 +268,9 @@ class SampleViewModel : ViewModel() {
         // Clean up geofence sync subscription to prevent memory leak
         // Note: this is an advanced API used for demonstration, not necessary for a typical integration
         Registry.getOrNull<LocationManager>()?.offGeofenceSync(::refreshCurrentGeofencesOnSync)
+    }
+
+    companion object {
+        private const val SUBSCRIPTION_SOURCE = "Android Sample App"
     }
 }

--- a/sample/src/main/java/com/klaviyo/sample/TestTags.kt
+++ b/sample/src/main/java/com/klaviyo/sample/TestTags.kt
@@ -11,6 +11,9 @@ object SampleTestTags {
     const val BTN_SET_PROFILE = "btn_set_profile"
     const val BTN_RESET_PROFILE = "btn_reset_profile"
 
+    // Subscription section
+    const val TOGGLE_SUBSCRIBE_MARKETING = "toggle_subscribe_marketing"
+
     // Events section
     const val BTN_CREATE_TEST_EVENT = "btn_create_test_event"
     const val BTN_VIEWED_PRODUCT = "btn_viewed_product"

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -13,6 +13,7 @@ import com.klaviyo.analytics.model.EventKey
 import com.klaviyo.analytics.model.EventMetric
 import com.klaviyo.analytics.model.Profile
 import com.klaviyo.analytics.model.ProfileKey
+import com.klaviyo.analytics.model.Subscription
 import com.klaviyo.analytics.networking.ApiClient
 import com.klaviyo.analytics.networking.KlaviyoApiClient
 import com.klaviyo.analytics.state.KlaviyoState
@@ -312,6 +313,27 @@ object Klaviyo {
     @JvmOverloads
     fun createEvent(metric: EventMetric, value: Double? = null): Klaviyo =
         createEvent(Event(metric).setValue(value))
+
+    /**
+     * Subscribes the currently tracked profile to a Klaviyo list, requesting the consent described
+     * by the [Subscription].
+     *
+     * The request is validated against the current profile's identifiers: if a requested channel
+     * needs an identifier the profile is missing, or no consent sub-types are selected, the request
+     * is dropped and a warning is logged. As with other profile methods, [initialize] must be called
+     * first; once enqueued, delivery is handled by the persisted request queue (including retries
+     * and offline replay).
+     *
+     * @param subscription The list and consent to request
+     * @return Returns [Klaviyo] for call chaining
+     */
+    @JvmStatic
+    fun createSubscription(subscription: Subscription): Klaviyo = safeApply {
+        Registry.get<ApiClient>().enqueueSubscription(
+            subscription,
+            Registry.get<State>().getAsProfile()
+        )
+    }
 
     /**
      * From an opened push Intent, creates an [EventMetric.OPENED_PUSH] [Event]

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/model/Subscription.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/model/Subscription.kt
@@ -1,0 +1,97 @@
+package com.klaviyo.analytics.model
+
+/**
+ * Represents a request to subscribe the current profile to a Klaviyo list, with optional
+ * per-channel marketing/transactional consent.
+ *
+ * Consent is expressed through [channels]. A `null` [channels] value grants the server's default
+ * of MARKETING consent on every channel the profile has an identifier for, and is only reachable
+ * through [allAvailableMarketing] — the public constructor requires [channels] so a broad grant is
+ * never the result of an omitted argument.
+ */
+class Subscription private constructor(
+    /**
+     * ID of the Klaviyo list to subscribe the profile to.
+     */
+    val listId: String,
+
+    /**
+     * Optional signup-source label stored as the consent record's `$source`. Omitted from the
+     * request when `null`.
+     */
+    val customSource: String?,
+
+    /**
+     * Channels and consent sub-types to request, or `null` to defer to the server default
+     * (see [allAvailableMarketing]).
+     */
+    val channels: Channels?
+) {
+
+    /**
+     * Creates a subscription request for the given [channels].
+     *
+     * @param listId ID of the Klaviyo list to subscribe the profile to.
+     * @param channels Channels and consent sub-types to request consent for.
+     * @param customSource Optional signup-source label. Omitted from the request when `null`.
+     */
+    @JvmOverloads
+    constructor(
+        listId: String,
+        channels: Channels,
+        customSource: String? = null
+        // Private ctor params are ordered (listId, customSource, channels) so its JVM signature
+        // doesn't clash with this constructor's.
+    ) : this(listId, customSource, channels)
+
+    /**
+     * Channels and consent sub-types to request. Mirrors the API's `subscriptions` object: each
+     * channel exposes only the consent sub-types the API supports for it, so invalid combinations
+     * (transactional email, open-tracking SMS) cannot be expressed.
+     */
+    class Channels @JvmOverloads constructor(
+        email: Set<Email>? = null,
+        sms: Set<Messaging>? = null,
+        whatsapp: Set<Messaging>? = null
+    ) {
+        /**
+         * Consent sub-types to request on the EMAIL channel, or `null` to leave EMAIL untouched.
+         */
+        val email: Set<Email>? = email?.toSet()
+
+        /**
+         * Consent sub-types to request on the SMS channel, or `null` to leave SMS untouched.
+         */
+        val sms: Set<Messaging>? = sms?.toSet()
+
+        /**
+         * Consent sub-types to request on the WhatsApp channel, or `null` to leave WhatsApp untouched.
+         */
+        val whatsapp: Set<Messaging>? = whatsapp?.toSet()
+
+        /**
+         * Consent sub-types supported on the EMAIL channel.
+         */
+        enum class Email { MARKETING, OPEN_TRACKING }
+
+        /**
+         * Consent sub-types supported on the SMS and WhatsApp channels.
+         */
+        enum class Messaging { MARKETING, TRANSACTIONAL }
+    }
+
+    companion object {
+        /**
+         * Creates a subscription that grants MARKETING consent on every channel the profile has an
+         * identifier for (email → email marketing, phone → SMS marketing). Mirrors the server's
+         * default behavior when no consent object is sent, but requesting it is a deliberate call.
+         *
+         * @param listId ID of the Klaviyo list to subscribe the profile to.
+         * @param customSource Optional signup-source label. Omitted from the request when `null`.
+         */
+        @JvmStatic
+        @JvmOverloads
+        fun allAvailableMarketing(listId: String, customSource: String? = null): Subscription =
+            Subscription(listId, customSource, null)
+    }
+}

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/ApiClient.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/ApiClient.kt
@@ -2,6 +2,7 @@ package com.klaviyo.analytics.networking
 
 import com.klaviyo.analytics.model.Event
 import com.klaviyo.analytics.model.Profile
+import com.klaviyo.analytics.model.Subscription
 import com.klaviyo.analytics.networking.requests.AggregateEventPayload
 import com.klaviyo.analytics.networking.requests.ApiRequest
 import com.klaviyo.analytics.networking.requests.FetchGeofencesCallback
@@ -97,6 +98,18 @@ interface ApiClient {
      * @return The API request that was enqueued
      */
     fun enqueueEvent(event: Event, profile: Profile): ApiRequest
+
+    /**
+     * Queue an API request to subscribe a [Profile] to a Klaviyo list
+     *
+     * The request is validated against the given [profile]'s identifiers when it is built; if the
+     * requested consent cannot be satisfied it is dropped and `null` is returned.
+     *
+     * @param subscription
+     * @param profile
+     * @return The API request that was enqueued, or `null` if it was dropped in validation
+     */
+    fun enqueueSubscription(subscription: Subscription, profile: Profile): ApiRequest?
 
     /**
      * For sending aggregate analytics for IAF - not to be called directly

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/KlaviyoApiClient.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/KlaviyoApiClient.kt
@@ -4,6 +4,7 @@ import android.os.Handler
 import androidx.annotation.WorkerThread
 import com.klaviyo.analytics.model.Event
 import com.klaviyo.analytics.model.Profile
+import com.klaviyo.analytics.model.Subscription
 import com.klaviyo.analytics.networking.requests.AggregateEventApiRequest
 import com.klaviyo.analytics.networking.requests.AggregateEventPayload
 import com.klaviyo.analytics.networking.requests.ApiRequest
@@ -18,6 +19,7 @@ import com.klaviyo.analytics.networking.requests.ProfileApiRequest
 import com.klaviyo.analytics.networking.requests.PushTokenApiRequest
 import com.klaviyo.analytics.networking.requests.ResolveDestinationCallback
 import com.klaviyo.analytics.networking.requests.ResolveDestinationResult
+import com.klaviyo.analytics.networking.requests.SubscriptionApiRequest
 import com.klaviyo.analytics.networking.requests.UniversalClickTrackRequest
 import com.klaviyo.analytics.networking.requests.UnregisterPushTokenApiRequest
 import com.klaviyo.core.Registry
@@ -80,6 +82,12 @@ internal object KlaviyoApiClient : ApiClient {
     override fun enqueuePushToken(token: String, profile: Profile): ApiRequest =
         PushTokenApiRequest(token, profile).also {
             Registry.log.verbose("Enqueuing Push Token request")
+            enqueueRequest(it)
+        }
+
+    override fun enqueueSubscription(subscription: Subscription, profile: Profile): ApiRequest? =
+        SubscriptionApiRequest.from(subscription, profile)?.also {
+            Registry.log.verbose("Enqueuing Subscription request")
             enqueueRequest(it)
         }
 

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequestDecoder.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/KlaviyoApiRequestDecoder.kt
@@ -30,6 +30,7 @@ internal object KlaviyoApiRequestDecoder {
                 time,
                 uuid
             )
+            SubscriptionApiRequest::class.simpleName -> SubscriptionApiRequest(time, uuid)
             AggregateEventApiRequest::class.simpleName -> AggregateEventApiRequest(time, uuid)
             UniversalClickTrackRequest::class.simpleName -> UniversalClickTrackRequest(time, uuid)
             FetchGeofencesRequest::class.simpleName -> FetchGeofencesRequest(null, null, time, uuid)

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/SubscriptionApiRequest.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/SubscriptionApiRequest.kt
@@ -1,0 +1,173 @@
+package com.klaviyo.analytics.networking.requests
+
+import com.klaviyo.analytics.model.Profile
+import com.klaviyo.analytics.model.ProfileKey
+import com.klaviyo.analytics.model.Subscription
+import com.klaviyo.core.Registry
+
+/**
+ * Defines the content of an API request to subscribe a [Profile] to a Klaviyo list
+ *
+ * Using V3 API
+ *
+ * @constructor
+ */
+internal class SubscriptionApiRequest(
+    queuedTime: Long? = null,
+    uuid: String? = null
+) : KlaviyoApiRequest(PATH, RequestMethod.POST, queuedTime, uuid) {
+
+    companion object {
+        private const val PATH = "client/subscriptions"
+
+        private const val SUBSCRIPTION = "subscription"
+        private const val CUSTOM_SOURCE = "custom_source"
+        private const val RELATIONSHIPS = "relationships"
+        private const val SUBSCRIPTIONS = "subscriptions"
+        private const val LIST = "list"
+        private const val ID = "id"
+
+        private const val CHANNEL_EMAIL = "email"
+        private const val CHANNEL_SMS = "sms"
+        private const val CHANNEL_WHATSAPP = "whatsapp"
+
+        private const val MARKETING = "marketing"
+        private const val OPEN_TRACKING = "open_tracking"
+        private const val TRANSACTIONAL = "transactional"
+
+        private const val CONSENT = "consent"
+        private const val SUBSCRIBED = "SUBSCRIBED"
+
+        private val subscribedConsent = mapOf(CONSENT to SUBSCRIBED)
+
+        /**
+         * Build a validated subscription request, or return `null` (logging a warning) when the
+         * requested consent cannot be satisfied by [profile]. Validation runs at enqueue time so a
+         * buffered subscription is checked against the latest available profile identifiers.
+         *
+         * @return The request to enqueue, or `null` if it should be dropped
+         */
+        fun from(subscription: Subscription, profile: Profile): SubscriptionApiRequest? {
+            val channels = subscription.channels
+
+            if (channels == null) {
+                // allAvailableMarketing defers to the server default, but needs an identifier to act on
+                if (profile.email.isNullOrEmpty() && profile.phoneNumber.isNullOrEmpty()) {
+                    Registry.log.warning(
+                        "Dropping subscription: allAvailableMarketing requires an email or phone identifier"
+                    )
+                    return null
+                }
+            } else {
+                if (channels.needsEmail && profile.email.isNullOrEmpty()) {
+                    Registry.log.warning(
+                        "Dropping subscription: email consent requested but profile has no email"
+                    )
+                    return null
+                }
+                if (channels.needsPhone && profile.phoneNumber.isNullOrEmpty()) {
+                    Registry.log.warning(
+                        "Dropping subscription: SMS/WhatsApp consent requested but profile has no phone number"
+                    )
+                    return null
+                }
+                // No channel named a consent sub-type: nothing to send
+                if (!channels.needsEmail && !channels.needsPhone) {
+                    Registry.log.warning(
+                        "Dropping subscription: no consent sub-types were selected"
+                    )
+                    return null
+                }
+            }
+
+            return SubscriptionApiRequest(subscription, profile)
+        }
+
+        fun formatBody(subscription: Subscription, profile: Profile): Array<Pair<String, Any>> {
+            val profileData = mapOf(
+                DATA to mapOf(
+                    TYPE to PROFILE,
+                    ATTRIBUTES to filteredMapOf(
+                        ProfileKey.EMAIL.name to (profile.email ?: ""),
+                        ProfileKey.PHONE_NUMBER.name to (profile.phoneNumber ?: ""),
+                        ProfileKey.EXTERNAL_ID.name to (profile.externalId ?: ""),
+                        ProfileKey.ANONYMOUS_ID.name to (profile.anonymousId ?: ""),
+                        // Omitted entirely for allAvailableMarketing so the server applies defaults
+                        SUBSCRIPTIONS to (subscription.channels?.toApiConsent() ?: emptyMap<String, Any>())
+                    )
+                )
+            )
+
+            return arrayOf(
+                DATA to mapOf(
+                    TYPE to SUBSCRIPTION,
+                    ATTRIBUTES to filteredMapOf(
+                        CUSTOM_SOURCE to (subscription.customSource ?: ""),
+                        PROFILE to profileData
+                    ),
+                    RELATIONSHIPS to mapOf(
+                        LIST to mapOf(
+                            DATA to mapOf(
+                                TYPE to LIST,
+                                ID to subscription.listId
+                            )
+                        )
+                    )
+                )
+            )
+        }
+
+        /** Whether the requested channels need an email identifier on the profile. */
+        private val Subscription.Channels.needsEmail: Boolean
+            get() = !email.isNullOrEmpty()
+
+        /** Whether the requested channels need a phone number identifier on the profile. */
+        private val Subscription.Channels.needsPhone: Boolean
+            get() = !sms.isNullOrEmpty() || !whatsapp.isNullOrEmpty()
+
+        /**
+         * Maps the requested channels to the API's `subscriptions` object, or `null` when no consent
+         * sub-types were selected (nothing to send).
+         */
+        private fun Subscription.Channels.toApiConsent(): Map<String, Any>? = filteredMapOf(
+            CHANNEL_EMAIL to emailConsent(email),
+            CHANNEL_SMS to messagingConsent(sms),
+            CHANNEL_WHATSAPP to messagingConsent(whatsapp)
+        ).ifEmpty { null }
+
+        private fun emailConsent(set: Set<Subscription.Channels.Email>?): Map<String, Any> =
+            set?.let {
+                filteredMapOf(
+                    MARKETING to consentIf(it.contains(Subscription.Channels.Email.MARKETING)),
+                    OPEN_TRACKING to consentIf(
+                        it.contains(Subscription.Channels.Email.OPEN_TRACKING)
+                    )
+                )
+            } ?: emptyMap()
+
+        private fun messagingConsent(set: Set<Subscription.Channels.Messaging>?): Map<String, Any> =
+            set?.let {
+                filteredMapOf(
+                    MARKETING to consentIf(it.contains(Subscription.Channels.Messaging.MARKETING)),
+                    TRANSACTIONAL to consentIf(
+                        it.contains(Subscription.Channels.Messaging.TRANSACTIONAL)
+                    )
+                )
+            } ?: emptyMap()
+
+        private fun consentIf(selected: Boolean): Map<String, String> =
+            if (selected) subscribedConsent else emptyMap()
+    }
+
+    override var type: String = "Create Subscription"
+
+    override var query: Map<String, String> = mapOf(
+        COMPANY_ID to Registry.config.apiKey
+    )
+
+    override val successCodes: IntRange get() = HTTP_ACCEPTED..HTTP_ACCEPTED
+
+    constructor(subscription: Subscription, profile: Profile) : this() {
+        body = jsonMapOf(*formatBody(subscription, profile))
+    }
+}

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoJavaApiTest.java
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoJavaApiTest.java
@@ -10,9 +10,11 @@ import com.klaviyo.analytics.model.EventKey;
 import com.klaviyo.analytics.model.EventMetric;
 import com.klaviyo.analytics.model.Profile;
 import com.klaviyo.analytics.model.ProfileKey;
+import com.klaviyo.analytics.model.Subscription;
 import com.klaviyo.fixtures.KlaviyoMock;
 
 import java.io.Serializable;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -491,6 +493,38 @@ public class KlaviyoJavaApiTest {
 
         ProfileKey customKey = new ProfileKey.CUSTOM("my_custom_field");
         assertNotNull(customKey);
+    }
+
+    @Test
+    public void testCreateSubscriptionWithChannels() {
+        Subscription.Channels channels = new Subscription.Channels(
+                EnumSet.of(Subscription.Channels.Email.MARKETING),
+                EnumSet.of(Subscription.Channels.Messaging.MARKETING),
+                null
+        );
+        Subscription subscription = new Subscription("list-123", channels);
+
+        Klaviyo result1 = Klaviyo.INSTANCE.createSubscription(subscription);
+        assertEquals(Klaviyo.INSTANCE, result1);
+
+        Klaviyo result2 = Klaviyo.createSubscription(subscription);
+        assertEquals(Klaviyo.INSTANCE, result2);
+
+        KlaviyoMock.verifyCreateSubscriptionCalled(2);
+    }
+
+    @Test
+    public void testCreateSubscriptionAllAvailableMarketing() {
+        Subscription subscription = Subscription.allAvailableMarketing("list-123");
+        Subscription withSource = Subscription.allAvailableMarketing("list-123", "signup form");
+
+        Klaviyo result1 = Klaviyo.createSubscription(subscription);
+        assertEquals(Klaviyo.INSTANCE, result1);
+
+        Klaviyo result2 = Klaviyo.createSubscription(withSource);
+        assertEquals(Klaviyo.INSTANCE, result2);
+
+        KlaviyoMock.verifyCreateSubscriptionCalled(2);
     }
 
     @Test

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoTest.kt
@@ -12,6 +12,7 @@ import com.klaviyo.analytics.model.EventKey
 import com.klaviyo.analytics.model.EventMetric
 import com.klaviyo.analytics.model.Profile
 import com.klaviyo.analytics.model.ProfileKey
+import com.klaviyo.analytics.model.Subscription
 import com.klaviyo.analytics.networking.ApiClient
 import com.klaviyo.analytics.networking.requests.ResolveDestinationResult
 import com.klaviyo.analytics.state.KlaviyoState
@@ -134,6 +135,7 @@ internal class KlaviyoTest : BaseTest() {
         every { enqueueProfile(capture(capturedProfile)) } returns mockk(relaxed = true)
         every { enqueueEvent(any(), any()) } returns mockk(relaxed = true)
         every { enqueuePushToken(any(), any()) } returns mockk(relaxed = true)
+        every { enqueueSubscription(any(), capture(capturedProfile)) } returns mockk(relaxed = true)
     }
 
     private val mockBuilder = mockk<Config.Builder>().apply {
@@ -229,6 +231,34 @@ internal class KlaviyoTest : BaseTest() {
         Klaviyo.createEvent(testEvent)
         verify { mockApiClient.enqueueEvent(testEvent, any()) }
         assertEquals(count, 1)
+    }
+
+    @Test
+    fun `createSubscription enqueues a subscription for the current profile`() {
+        Klaviyo.setEmail(EMAIL)
+        val subscription = Subscription.allAvailableMarketing(listId = "listId")
+
+        Klaviyo.createSubscription(subscription)
+
+        verify { mockApiClient.enqueueSubscription(subscription, any()) }
+        assertEquals(EMAIL, capturedProfile.captured.email)
+    }
+
+    @Test
+    fun `createSubscription before initialization is safely ignored`() {
+        // Simulate pre-initialization by removing the services initialize() registers
+        Registry.unregister<State>()
+        Registry.unregister<ApiClient>()
+
+        val subscription = Subscription.allAvailableMarketing(listId = "listId")
+        // Must not crash the host even though the SDK is not initialized
+        Klaviyo.createSubscription(subscription)
+
+        // Re-initialize: the pre-init call is dropped, not buffered/replayed (matches setProfile/setEmail)
+        Registry.register<ApiClient>(mockApiClient)
+        Klaviyo.initialize(apiKey = API_KEY, applicationContext = mockContext)
+
+        verify(exactly = 0) { mockApiClient.enqueueSubscription(any(), any()) }
     }
 
     @Test

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/SubscriptionApiRequestTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/SubscriptionApiRequestTest.kt
@@ -1,0 +1,246 @@
+package com.klaviyo.analytics.networking.requests
+
+import com.klaviyo.analytics.model.Profile
+import com.klaviyo.analytics.model.Subscription
+import io.mockk.verify
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+internal class SubscriptionApiRequestTest : BaseApiRequestTest<SubscriptionApiRequest>() {
+
+    override val expectedPath = "client/subscriptions"
+
+    private val listId = "abc123"
+
+    private val fullChannels = Subscription.Channels(
+        email = setOf(
+            Subscription.Channels.Email.MARKETING,
+            Subscription.Channels.Email.OPEN_TRACKING
+        ),
+        sms = setOf(
+            Subscription.Channels.Messaging.MARKETING,
+            Subscription.Channels.Messaging.TRANSACTIONAL
+        ),
+        whatsapp = setOf(
+            Subscription.Channels.Messaging.MARKETING,
+            Subscription.Channels.Messaging.TRANSACTIONAL
+        )
+    )
+
+    override fun makeTestRequest(): SubscriptionApiRequest =
+        SubscriptionApiRequest(Subscription(listId, fullChannels), stubProfile)
+
+    @Test
+    fun `JSON interoperability`() = testJsonInterop(makeTestRequest())
+
+    @Test
+    fun `Formats full channel body correctly`() {
+        val expectJson = """{
+            "data": {
+                "type": "subscription",
+                "attributes": {
+                    "profile": {
+                        "data": {
+                            "type": "profile",
+                            "attributes": {
+                                "email": "$EMAIL",
+                                "phone_number": "$PHONE",
+                                "external_id": "$EXTERNAL_ID",
+                                "anonymous_id": "$ANON_ID",
+                                "subscriptions": {
+                                    "email": {
+                                        "marketing": { "consent": "SUBSCRIBED" },
+                                        "open_tracking": { "consent": "SUBSCRIBED" }
+                                    },
+                                    "sms": {
+                                        "marketing": { "consent": "SUBSCRIBED" },
+                                        "transactional": { "consent": "SUBSCRIBED" }
+                                    },
+                                    "whatsapp": {
+                                        "marketing": { "consent": "SUBSCRIBED" },
+                                        "transactional": { "consent": "SUBSCRIBED" }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "relationships": {
+                    "list": {
+                        "data": { "type": "list", "id": "$listId" }
+                    }
+                }
+            }
+        }"""
+
+        val request = SubscriptionApiRequest(Subscription(listId, fullChannels), stubProfile)
+
+        compareJson(JSONObject(expectJson), JSONObject(request.requestBody!!))
+    }
+
+    @Test
+    fun `Includes custom source when provided`() {
+        val request = SubscriptionApiRequest(
+            Subscription(listId, fullChannels, customSource = "signup form"),
+            stubProfile
+        )
+
+        val attributes = JSONObject(request.requestBody!!)
+            .getJSONObject("data")
+            .getJSONObject("attributes")
+
+        assert(attributes.getString("custom_source") == "signup form")
+    }
+
+    @Test
+    fun `allAvailableMarketing omits subscriptions object`() {
+        val request = SubscriptionApiRequest(
+            Subscription.allAvailableMarketing(listId),
+            stubProfile
+        )
+
+        val profileAttributes = JSONObject(request.requestBody!!)
+            .getJSONObject("data")
+            .getJSONObject("attributes")
+            .getJSONObject("profile")
+            .getJSONObject("data")
+            .getJSONObject("attributes")
+
+        // subscriptions is omitted so the server applies its default marketing consent...
+        assert(!profileAttributes.has("subscriptions"))
+        // ...but the profile identifiers are still sent so the server can key channels on them
+        assert(profileAttributes.getString("email") == EMAIL)
+        assert(profileAttributes.getString("phone_number") == PHONE)
+        assert(profileAttributes.getString("external_id") == EXTERNAL_ID)
+        assert(profileAttributes.getString("anonymous_id") == ANON_ID)
+    }
+
+    @Test
+    fun `Serializes email-only channel`() {
+        val expectJson = """{
+            "email": {
+                "marketing": { "consent": "SUBSCRIBED" }
+            }
+        }"""
+        val channels = Subscription.Channels(
+            email = setOf(Subscription.Channels.Email.MARKETING)
+        )
+
+        val request = SubscriptionApiRequest(Subscription(listId, channels), stubProfile)
+
+        compareJson(JSONObject(expectJson), subscriptionsOf(request))
+    }
+
+    @Test
+    fun `Serializes sms-only channel`() {
+        val expectJson = """{
+            "sms": {
+                "transactional": { "consent": "SUBSCRIBED" }
+            }
+        }"""
+        val channels = Subscription.Channels(
+            sms = setOf(Subscription.Channels.Messaging.TRANSACTIONAL)
+        )
+
+        val request = SubscriptionApiRequest(Subscription(listId, channels), stubProfile)
+
+        compareJson(JSONObject(expectJson), subscriptionsOf(request))
+    }
+
+    @Test
+    fun `Drops request when email consent requested but profile has no email`() {
+        val channels = Subscription.Channels(
+            email = setOf(Subscription.Channels.Email.MARKETING)
+        )
+
+        val request = SubscriptionApiRequest.from(
+            Subscription(listId, channels),
+            Profile().setPhoneNumber(PHONE)
+        )
+
+        assertDropped(request)
+    }
+
+    @Test
+    fun `Drops request when messaging consent requested but profile has no phone`() {
+        val channels = Subscription.Channels(
+            sms = setOf(Subscription.Channels.Messaging.MARKETING)
+        )
+
+        val request = SubscriptionApiRequest.from(
+            Subscription(listId, channels),
+            Profile().setEmail(EMAIL)
+        )
+
+        assertDropped(request)
+    }
+
+    @Test
+    fun `Drops request when no consent sub-types are selected`() {
+        val request = SubscriptionApiRequest.from(
+            Subscription(listId, Subscription.Channels()),
+            stubProfile
+        )
+
+        assertDropped(request)
+    }
+
+    @Test
+    fun `Drops allAvailableMarketing when profile has no identifiers`() {
+        val request = SubscriptionApiRequest.from(
+            Subscription.allAvailableMarketing(listId),
+            Profile()
+        )
+
+        assertDropped(request)
+    }
+
+    @Test
+    fun `Channels defensively copies consent sets`() {
+        val mutableEmail = mutableSetOf(Subscription.Channels.Email.MARKETING)
+        val channels = Subscription.Channels(email = mutableEmail)
+
+        // Mutating the caller's set after construction must not affect the model...
+        mutableEmail.add(Subscription.Channels.Email.OPEN_TRACKING)
+        assertEquals(setOf(Subscription.Channels.Email.MARKETING), channels.email)
+
+        // ...nor the serialized request payload
+        val request = SubscriptionApiRequest(Subscription(listId, channels), stubProfile)
+        val emailConsent = subscriptionsOf(request).getJSONObject("email")
+        assert(emailConsent.has("marketing"))
+        assert(!emailConsent.has("open_tracking"))
+    }
+
+    @Test
+    fun `Builds request when validation passes`() {
+        val request = SubscriptionApiRequest.from(
+            Subscription(listId, fullChannels),
+            stubProfile
+        )
+
+        assert(request != null)
+        verify(exactly = 0) { spyLog.warning(any<String>(), any()) }
+    }
+
+    /**
+     * Asserts a subscription was dropped in validation: no request built, and a warning logged.
+     */
+    private fun assertDropped(request: SubscriptionApiRequest?) {
+        assertNull(request)
+        verify { spyLog.warning(any<String>(), null) }
+    }
+
+    /**
+     * Extracts the `subscriptions` object from a built request body for focused assertions.
+     */
+    private fun subscriptionsOf(request: SubscriptionApiRequest): JSONObject =
+        JSONObject(request.requestBody!!)
+            .getJSONObject("data")
+            .getJSONObject("attributes")
+            .getJSONObject("profile")
+            .getJSONObject("data")
+            .getJSONObject("attributes")
+            .getJSONObject("subscriptions")
+}

--- a/sdk/fixtures/src/main/java/com/klaviyo/fixtures/KlaviyoMock.kt
+++ b/sdk/fixtures/src/main/java/com/klaviyo/fixtures/KlaviyoMock.kt
@@ -60,6 +60,7 @@ object KlaviyoMock {
         every { Klaviyo.resetProfile() } returns Klaviyo
         every { Klaviyo.createEvent(any<Event>()) } returns Klaviyo
         every { Klaviyo.createEvent(any<EventMetric>(), any()) } returns Klaviyo
+        every { Klaviyo.createSubscription(any()) } returns Klaviyo
         every { Klaviyo.handlePush(any()) } returns Klaviyo
         every { Klaviyo.registerDeepLinkHandler(any()) } returns Klaviyo
         every { Klaviyo.unregisterDeepLinkHandler() } returns Klaviyo
@@ -166,6 +167,12 @@ object KlaviyoMock {
     @JvmOverloads
     fun verifyCreateEventWithMetricCalled(metric: EventMetric, count: Int = 1) {
         verify(exactly = count) { Klaviyo.createEvent(metric, any()) }
+    }
+
+    @JvmStatic
+    @JvmOverloads
+    fun verifyCreateSubscriptionCalled(count: Int = 1) {
+        verify(exactly = count) { Klaviyo.createSubscription(any()) }
     }
 
     @JvmStatic


### PR DESCRIPTION
# Description

All work associated with client-side list subscriptions for 4.5.0: a new public `Klaviyo.createSubscription(...)` API, its request/model layer, and a sample app demo.

- https://github.com/klaviyo/klaviyo-android-sdk/pull/514 — `feat(analytics): add createSubscription API (MAGE-855)`
- https://github.com/klaviyo/klaviyo-android-sdk/pull/526 — `feat(sample): add list subscription demo (MAGE-945)`

## Due Diligence
<!-- Best practices before submitting, add additional notes below -->
- [x] I have tested this on an emulator and/or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all Android versions the SDK currently supports.

Each constituent PR was reviewed and verified independently; this PR only rolls the feature branch up into the release branch. No new code is introduced here.

## Release/Versioning Considerations
- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [x] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [x] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

Planned for 4.5.0. Additive public API only — no breaking changes. README changes land on the release branch so docs go live with the release.

## Changelog / Code Overview

**Public API** (`sdk/analytics`)
- `Klaviyo.createSubscription(subscription)` enqueues `POST /client/subscriptions` to subscribe the current profile to a list, with optional per-channel consent.
- `Subscription` + `Subscription.Channels` model (enum `Set`s mirroring the iOS `OptionSet`s). `Subscription.allAvailableMarketing` is the only path to the server-default broad grant, so a broad grant can't happen by accident.
- `ApiClient.enqueueSubscription` delegates to the existing persisted request queue; registered in `KlaviyoApiRequestDecoder` so queued requests survive process death.
- `SubscriptionApiRequest` builds the JSON:API payload and validates at enqueue time, dropping + warning when a requested channel lacks its identifier or no sub-types are selected.
- `Channels` consent sets are defensively copied so a caller mutating a passed-in `Set` can't alter a queued request.

**Sample app**
- Optional "Subscribe to email marketing" toggle on the profile screen, shown only when `SampleApplication.subscriptionListId` is configured. Mirrors the iOS demo (swift-sdk #682 / MAGE-944).

**Docs**
- README gains a Subscriptions section (Kotlin + Java) covering per-channel consent and `allAvailableMarketing`, and notes that push subscriptions are *not* created through this API (`setPushToken` remains the registration path).

**Tests**
- `SubscriptionApiRequestTest` (payload shape, per-channel validation/drop cases, defensive-copy regression), `KlaviyoTest` coverage for the facade, `KlaviyoJavaApiTest` for Java interop, plus a `KlaviyoMock` fixture helper.

## Test Plan

1. Set `SampleApplication.subscriptionListId` to a list ID in your test account and install the sample app.
2. Enter an email on the profile screen, enable **Subscribe to email marketing**, tap **Set Profile**.
3. Confirm a `POST /client/subscriptions/` fires with the profile's email and the list ID, and that the profile appears as subscribed to that list in Klaviyo.
4. Repeat with the toggle off to confirm no subscription request is sent.
5. Verify a subscription requested for a channel with no matching identifier is dropped with a warning rather than sent.

## Related Issues/Tickets

- MAGE-855 — `createSubscription` API
- MAGE-945 — sample app list subscription demo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added subscription support for adding profiles to lists with email, SMS, and WhatsApp consent options.
  * Added support for marketing, transactional, and open-tracking consent types.
  * Added an optional custom source label and a convenience option for all available marketing channels.
  * Subscription requests are queued for reliable delivery and safely skipped when required profile details are unavailable.

* **Documentation**
  * Added SDK usage examples and guidance for configuring the subscription demo.

* **Sample App**
  * Added an optional “Subscribe to email marketing” toggle and list subscription workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->