### PR TITLE
fix(push): keep action buttons when the open_url link is unusable (PUSH-1095)

### DIFF
--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoNotification.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoNotification.kt
@@ -372,6 +372,9 @@ class KlaviyoNotification(private val message: RemoteMessage) {
                 is ActionButton.DeepLink -> ActionButton.DISPLAY_NAME_DEEP_LINK to " (scheme: ${button.url.toUri().scheme})"
                 is ActionButton.OpenUrl -> ActionButton.DISPLAY_NAME_OPEN_URL to " (scheme: ${button.url.toUri().scheme})"
                 is ActionButton.OpenApp -> ActionButton.DISPLAY_NAME_OPEN_APP to ""
+                is ActionButton.Degraded ->
+                    button.declaredAction to
+                        " (degraded to app launch${button.declaredUrl?.let { ": $it" } ?: ""})"
             }
             Registry.log.verbose(
                 "Added action button $index: '${button.label}' ($actionType)$destination"
@@ -414,7 +417,9 @@ class KlaviyoNotification(private val message: RemoteMessage) {
                 // and dismisses the notification — the browser would otherwise swallow the intent.
                 KlaviyoTrampolineActivity.forBrowserUrl(context, button.url)
             }
-            is ActionButton.OpenApp -> {
+            // A degraded button's declared destination is unusable, so it launches the app.
+            // Its declared action/url are still reported via appendActionButtonExtras.
+            is ActionButton.OpenApp, is ActionButton.Degraded -> {
                 if (autoTracking) {
                     KlaviyoTrampolineActivity.forDestination(context)
                 } else {

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoRemoteMessage.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoRemoteMessage.kt
@@ -65,12 +65,22 @@ object KlaviyoRemoteMessage {
             is ActionButton.DeepLink -> ActionButton.DISPLAY_NAME_DEEP_LINK
             is ActionButton.OpenUrl -> ActionButton.DISPLAY_NAME_OPEN_URL
             is ActionButton.OpenApp -> ActionButton.DISPLAY_NAME_OPEN_APP
+            // Report what the sender declared, not the app-launch we degraded to.
+            is ActionButton.Degraded -> button.declaredAction
         }
         putExtra(PACKAGE_PREFIX + "Button Action", actionName)
 
-        (button as? ActionButton.UrlBearing)?.let {
-            putExtra(PACKAGE_PREFIX + "Button Link", it.url)
+        // Enumerated over the sealed arms rather than matching on [ActionButton.UrlBearing], so
+        // adding a variant is a compile error here instead of silently yielding no link.
+        // [ActionButton.UrlBearing] remains part of the public surface for consumers that want
+        // to test for a destination without enumerating variants themselves.
+        val link = when (button) {
+            is ActionButton.DeepLink -> button.url
+            is ActionButton.OpenUrl -> button.url
+            is ActionButton.Degraded -> button.declaredUrl
+            is ActionButton.OpenApp -> null
         }
+        link?.let { putExtra(PACKAGE_PREFIX + "Button Link", it) }
     }
 
     /**
@@ -227,9 +237,13 @@ object KlaviyoRemoteMessage {
     /**
      * Parse action buttons from the iOS-aligned format
      *
-     * Validates and filters buttons to ensure only valid instances are returned.
-     * Invalid buttons (missing required fields, invalid format) are skipped with warnings.
-     * Maximum of 3 buttons are supported - additional buttons beyond this limit are ignored.
+     * A button renders as long as it has a valid id, label, and recognized action type -
+     * buttons missing those, or with an unrecognized action type, are skipped with warnings.
+     * A URL-shaped action (deep_link, open_url) with an unusable url (missing, or - for
+     * open_url - a disallowed/missing scheme) degrades to an app-launch (OpenApp) button rather
+     * than being dropped, so the marketer's button is never silently discarded; a warning is
+     * logged so the degradation stays diagnosable. Maximum of 3 rendered buttons are supported -
+     * additional buttons beyond this limit are ignored.
      *
      * Expected structure:
      * [{"id":"...", "label":"...", "action":"deep_link|open_app|open_url", "url":"..."}]
@@ -274,7 +288,17 @@ object KlaviyoRemoteMessage {
 
                     val actionType = jsonObject.optString("action", ActionButton.TYPE_OPEN_APP)
 
-                    // Create appropriate sealed class instance based on action type
+                    // Create appropriate sealed class instance based on action type.
+                    //
+                    // Render eligibility != action validity: a button with a valid id, label, and
+                    // recognized action type always renders. A URL-shaped action (deep_link,
+                    // open_url) with an unusable url (missing, or - for open_url - a scheme
+                    // outside the allowlist) degrades to an OpenApp button instead of being
+                    // dropped, so a tap falls back to simply launching the app. The allowlist
+                    // itself is enforced here only to decide render vs. degrade - it is not
+                    // weakened on the actual tap/dispatch path (KlaviyoNotification, RemoteMessage
+                    // .webUrl, KlaviyoTrampolineActivity), which never even see a disallowed
+                    // scheme for an action button since it never becomes an OpenUrl instance.
                     when (actionType) {
                         ActionButton.TYPE_DEEP_LINK -> {
                             jsonObject.optNonBlankString("url")?.let { url ->
@@ -285,9 +309,15 @@ object KlaviyoRemoteMessage {
                                 )
                             } ?: run {
                                 Registry.log.warning(
-                                    "Skipping DEEP_LINK action button $i: missing required url"
+                                    "DEEP_LINK action button $i missing required url; " +
+                                        "rendering as an app-launch button instead"
                                 )
-                                null
+                                ActionButton.Degraded(
+                                    id = id,
+                                    label = label,
+                                    declaredAction = ActionButton.DISPLAY_NAME_DEEP_LINK,
+                                    declaredUrl = null
+                                )
                             }
                         }
                         ActionButton.TYPE_OPEN_URL -> {
@@ -295,16 +325,28 @@ object KlaviyoRemoteMessage {
                             when {
                                 urlString == null -> {
                                     Registry.log.warning(
-                                        "Skipping OPEN_URL action button $i: missing required url"
+                                        "OPEN_URL action button $i missing required url; " +
+                                            "rendering as an app-launch button instead"
                                     )
-                                    null
+                                    ActionButton.Degraded(
+                                        id = id,
+                                        label = label,
+                                        declaredAction = ActionButton.DISPLAY_NAME_OPEN_URL,
+                                        declaredUrl = null
+                                    )
                                 }
                                 !urlString.hasAllowedOpenUrlScheme() -> {
                                     Registry.log.warning(
-                                        "Skipping OPEN_URL action button $i: scheme " +
-                                            "'${urlString.toUri().scheme}' is not allowed"
+                                        "OPEN_URL action button $i has disallowed scheme " +
+                                            "'${urlString.toUri().scheme}'; rendering as an " +
+                                            "app-launch button instead"
                                     )
-                                    null
+                                    ActionButton.Degraded(
+                                        id = id,
+                                        label = label,
+                                        declaredAction = ActionButton.DISPLAY_NAME_OPEN_URL,
+                                        declaredUrl = urlString
+                                    )
                                 }
                                 else -> ActionButton.OpenUrl(
                                     id = id,
@@ -348,7 +390,11 @@ object KlaviyoRemoteMessage {
         abstract val label: String
 
         /**
-         * Marker for action button variants that carry a destination URL.
+         * Marker for action button variants that carry a guaranteed-dispatchable destination URL.
+         *
+         * Note [Degraded] deliberately does **not** implement this: its `declaredUrl` is the url
+         * the SDK refused to dispatch, so treating it as url-bearing would invite a caller to
+         * open it.
          */
         interface UrlBearing {
             val url: String
@@ -379,6 +425,28 @@ object KlaviyoRemoteMessage {
             override val label: String,
             override val url: String
         ) : ActionButton(), UrlBearing
+
+        /**
+         * Button whose declared action cannot be honored, so a tap simply launches the app.
+         *
+         * Produced when a url-shaped action's url is missing, or — for [TYPE_OPEN_URL] — uses a
+         * scheme outside [ALLOWED_OPEN_URL_SCHEMES]. The button still renders rather than being
+         * dropped, and [declaredAction]/[declaredUrl] preserve what the sender configured so
+         * `$opened_push` metadata stays faithful (and matches iOS, which reports the declared
+         * action and link in the same situation).
+         *
+         * Being a distinct variant rather than a flag on [OpenApp] means every `when` over
+         * [ActionButton] must handle it explicitly, so no dispatch site can mistake a degraded
+         * button for a dispatchable one.
+         */
+        data class Degraded(
+            override val id: String,
+            override val label: String,
+            /** Display name of the action the sender declared, e.g. [DISPLAY_NAME_OPEN_URL]. */
+            val declaredAction: String,
+            /** The declared destination, or `null` when the payload carried no url at all. */
+            val declaredUrl: String?
+        ) : ActionButton()
 
         companion object {
             /**

--- a/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoNotificationTest.kt
+++ b/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoNotificationTest.kt
@@ -958,6 +958,39 @@ class KlaviyoNotificationTest : BaseTest() {
     }
 
     @Test
+    fun `degraded action button routes to app launch and never to the browser`() {
+        // The security-critical guard: Android bakes the PendingIntent at render time, so this
+        // is the only place that decides whether a degraded button's unusable url can reach
+        // forBrowserUrl/makeExternalIntent. It must not.
+        enableAutomaticPushOpenTracking()
+        val mockButtonIntent = mockk<Intent>(relaxed = true)
+        every { KlaviyoTrampolineActivity.forDestination(mockContext, null) } returns mockButtonIntent
+
+        with(KlaviyoRemoteMessage) {
+            every { mockRemoteMessage.notificationTag } returns "test_tag"
+            every { mockRemoteMessage.actionButtons } returns listOf(
+                ActionButton.Degraded(
+                    id = "open.url",
+                    label = "Open Website",
+                    declaredAction = ActionButton.DISPLAY_NAME_OPEN_URL,
+                    declaredUrl = "javascript:alert(1)"
+                )
+            )
+        }
+        every {
+            PendingIntent.getActivity(any(), any(), any(), any())
+        } returns mockk(relaxed = true)
+
+        notification.displayNotification(mockContext)
+
+        verify { KlaviyoTrampolineActivity.forDestination(mockContext, null) }
+        verify(exactly = 0) { KlaviyoTrampolineActivity.forBrowserUrl(any(), any()) }
+        // The declared action and link still reach $opened_push metadata (iOS parity).
+        verify { mockButtonIntent.putExtra("com.klaviyo.Button Action", "Open URL") }
+        verify { mockButtonIntent.putExtra("com.klaviyo.Button Link", "javascript:alert(1)") }
+    }
+
+    @Test
     fun `open_url tap targets trampoline even with automatic tracking on`() {
         enableAutomaticPushOpenTracking()
         with(KlaviyoRemoteMessage) {

--- a/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoRemoteMessageTest.kt
+++ b/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoRemoteMessageTest.kt
@@ -24,6 +24,7 @@ import io.mockk.verify
 import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 
@@ -347,7 +348,11 @@ class KlaviyoRemoteMessageTest : BaseTest() {
     }
 
     @Test
-    fun `Test DEEP_LINK Action Button without URL is skipped`() {
+    fun `Test DEEP_LINK Action Button without URL renders as a degraded app-launch button`() {
+        // Previously this button was dropped entirely (encoding the render-eligibility-vs-action-
+        // validity bug from PUSH-1095). A DEEP_LINK button missing its url still has a valid id,
+        // label, and recognized action type, so it must render - degrading to an app-launch button
+        // rather than disappearing.
         val actionButtonsData = listOf(
             mapOf(
                 "id" to "deep.link",
@@ -366,11 +371,17 @@ class KlaviyoRemoteMessageTest : BaseTest() {
         every { msg.data } returns messageWithActions
 
         val buttons = msg.actionButtons
-        assert(buttons == null)
+        assert(buttons != null)
+        assert(buttons?.size == 1)
+        val button = buttons?.get(0)
+        assert(button is ActionButton.Degraded)
+        assert(button?.id == "deep.link")
+        assert(button?.label == "Deep Link")
     }
 
     @Test
-    fun `Test DEEP_LINK Action Button with null URL is skipped`() {
+    fun `Test DEEP_LINK Action Button with null URL renders as a degraded app-launch button`() {
+        // Same relaxation as above for an explicit JSON null (as opposed to an absent key).
         val actionButtonsJson = JSONArray().put(
             JSONObject()
                 .put("id", "deep.link")
@@ -387,11 +398,16 @@ class KlaviyoRemoteMessageTest : BaseTest() {
         every { msg.data } returns messageWithActions
 
         val buttons = msg.actionButtons
-        assert(buttons == null)
+        assert(buttons != null)
+        assert(buttons?.size == 1)
+        val button = buttons?.get(0)
+        assert(button is ActionButton.Degraded)
+        assert(button?.id == "deep.link")
+        assert(button?.label == "Deep Link")
     }
 
     @Test
-    fun `Test parser filters out invalid buttons but keeps valid ones`() {
+    fun `Test parser skips unrecoverable buttons, downgrades URL-invalid ones, and keeps valid ones`() {
         val actionButtonsData = listOf(
             mapOf(
                 "id" to "valid.deep.link",
@@ -400,6 +416,7 @@ class KlaviyoRemoteMessageTest : BaseTest() {
                 "url" to "test://valid"
             ),
             mapOf(
+                // No longer dropped: renders as OpenApp since id/label/action are still valid.
                 "id" to "invalid.deep.link",
                 "label" to "Invalid - deep link no url",
                 "action" to "deep_link"
@@ -431,11 +448,13 @@ class KlaviyoRemoteMessageTest : BaseTest() {
 
         val buttons = msg.actionButtons
         assert(buttons != null)
-        assert(buttons?.size == 2)
+        assert(buttons?.size == 3)
         assert(buttons?.get(0) is ActionButton.DeepLink)
         assert(buttons?.get(0)?.label == "Valid Deep Link")
-        assert(buttons?.get(1) is ActionButton.OpenApp)
-        assert(buttons?.get(1)?.label == "Valid Button")
+        assert(buttons?.get(1) is ActionButton.Degraded)
+        assert(buttons?.get(1)?.label == "Invalid - deep link no url")
+        assert(buttons?.get(2) is ActionButton.OpenApp)
+        assert(buttons?.get(2)?.label == "Valid Button")
     }
 
     @Test
@@ -516,7 +535,9 @@ class KlaviyoRemoteMessageTest : BaseTest() {
                 "action" to "deep_link",
                 "url" to "test://2"
             ), // Valid
-            mapOf("id" to "invalid2", "label" to "Invalid", "action" to "deep_link"), // Invalid - no url
+            // Invalid - unsupported action type (a deep_link with no url no longer counts as
+            // invalid post-PUSH-1095: it downgrades to a valid, rendered OpenApp button instead).
+            mapOf("id" to "invalid2", "label" to "Invalid", "action" to "unsupported_action"),
             mapOf("id" to "valid3", "label" to "Valid 3", "action" to "open_app"), // Valid
             mapOf("id" to "valid4", "label" to "Valid 4", "action" to "open_app") // Should be ignored (>3 valid)
         )
@@ -675,7 +696,11 @@ class KlaviyoRemoteMessageTest : BaseTest() {
     }
 
     @Test
-    fun `actionButtons skips open_url with blocked scheme`() {
+    fun `actionButtons downgrades open_url with blocked scheme to a degraded app-launch button`() {
+        // Previously this dropped the button entirely (PUSH-1095): a dispatch-time security
+        // allowlist was being misused as a render-time eligibility gate. The button must still
+        // render - id/label/action are all valid - but the disallowed-scheme URL degrades the
+        // action so a tap falls back to launching the app rather than ever reaching the browser.
         val mockUri = mockk<Uri>(relaxed = true)
         every { mockUri.scheme } returns "intent"
         every { Uri.parse("intent://evil") } returns mockUri
@@ -695,7 +720,55 @@ class KlaviyoRemoteMessageTest : BaseTest() {
         val msg = mockk<RemoteMessage>()
         every { msg.data } returns messageWithActions
 
-        assert(msg.actionButtons == null)
+        val buttons = msg.actionButtons
+        assert(buttons != null)
+        assert(buttons?.size == 1)
+        val button = buttons?.get(0)
+        // Downgraded to OpenApp: it carries no url at all, so it is structurally impossible for
+        // the disallowed-scheme URL to ever reach the dispatch path (KlaviyoTrampolineActivity).
+        assert(button is ActionButton.Degraded)
+        assert(button?.id == "open.url")
+        assert(button?.label == "Open Website")
+    }
+
+    @Test
+    fun `actionButtons downgrades open_url with scheme-less url to a degraded app-launch button`() {
+        // Regression coverage for the exact PUSH-1095 repro: a scheme-less link like
+        // "www.cnn.com" parses to a null Uri.scheme, which is not in ALLOWED_OPEN_URL_SCHEMES.
+        // The button must still render.
+        val mockUri = mockk<Uri>(relaxed = true)
+        every { mockUri.scheme } returns null
+        every { Uri.parse("www.cnn.com") } returns mockUri
+
+        val actionButtonsData = listOf(
+            mapOf(
+                "id" to "open.url",
+                "label" to "Open Website",
+                "action" to "open_url",
+                "url" to "www.cnn.com"
+            )
+        )
+        val messageWithActions = stubMessage.toMutableMap().apply {
+            put(ACTION_BUTTONS_KEY, JSONArray(actionButtonsData).toString())
+        }
+
+        val msg = mockk<RemoteMessage>()
+        every { msg.data } returns messageWithActions
+
+        val buttons = msg.actionButtons
+        assert(buttons != null)
+        assert(buttons?.size == 1)
+        val button = buttons?.get(0)
+        assert(button is ActionButton.Degraded)
+        assert(button?.id == "open.url")
+        assert(button?.label == "Open Website")
+        // The declared action and destination survive the downgrade so the $opened_push
+        // metadata matches iOS, which reports "Open URL" plus the raw link for this payload.
+        assertEquals(
+            ActionButton.DISPLAY_NAME_OPEN_URL,
+            (button as ActionButton.Degraded).declaredAction
+        )
+        assertEquals("www.cnn.com", button.declaredUrl)
     }
 
     @Test
@@ -740,7 +813,7 @@ class KlaviyoRemoteMessageTest : BaseTest() {
     }
 
     @Test
-    fun `actionButtons skips open_url with missing url`() {
+    fun `actionButtons downgrades open_url with missing url to a degraded app-launch button`() {
         val actionButtonsData = listOf(
             mapOf(
                 "id" to "open.url",
@@ -755,11 +828,47 @@ class KlaviyoRemoteMessageTest : BaseTest() {
         val msg = mockk<RemoteMessage>()
         every { msg.data } returns messageWithActions
 
-        assert(msg.actionButtons == null)
+        val buttons = msg.actionButtons
+        assert(buttons != null)
+        assert(buttons?.size == 1)
+        val button = buttons?.get(0)
+        assert(button is ActionButton.Degraded)
+        assert(button?.id == "open.url")
+        assert(button?.label == "Open Website")
     }
 
     @Test
-    fun `actionButtons skips open_url with blank url`() {
+    fun `actionButtons downgrades open_url with blank url to a degraded app-launch button`() {
+        // optNonBlankString maps "" and null to the same result today; assert the blank case
+        // explicitly so a change to that helper cannot silently drop the button.
+        val actionButtonsData = listOf(
+            mapOf(
+                "id" to "open.url",
+                "label" to "Open Website",
+                "action" to "open_url",
+                "url" to "   "
+            )
+        )
+        val messageWithActions = stubMessage.toMutableMap().apply {
+            put(ACTION_BUTTONS_KEY, JSONArray(actionButtonsData).toString())
+        }
+
+        val msg = mockk<RemoteMessage>()
+        every { msg.data } returns messageWithActions
+
+        val buttons = msg.actionButtons
+        assert(buttons?.size == 1)
+        val button = buttons?.get(0)
+        assert(button is ActionButton.Degraded)
+        assertEquals(
+            ActionButton.DISPLAY_NAME_OPEN_URL,
+            (button as ActionButton.Degraded).declaredAction
+        )
+        assertEquals(null, button.declaredUrl)
+    }
+
+    @Test
+    fun `actionButtons downgrades open_url with null url to a degraded app-launch button`() {
         val actionButtonsJson = JSONArray().put(
             JSONObject()
                 .put("id", "open.url")
@@ -775,7 +884,13 @@ class KlaviyoRemoteMessageTest : BaseTest() {
         val msg = mockk<RemoteMessage>()
         every { msg.data } returns messageWithActions
 
-        assert(msg.actionButtons == null)
+        val buttons = msg.actionButtons
+        assert(buttons != null)
+        assert(buttons?.size == 1)
+        val button = buttons?.get(0)
+        assert(button is ActionButton.Degraded)
+        assert(button?.id == "open.url")
+        assert(button?.label == "Open Website")
     }
 
     @Test
@@ -795,5 +910,46 @@ class KlaviyoRemoteMessageTest : BaseTest() {
         verify { intent.putExtra("com.klaviyo.Button Label", "Open Website") }
         verify { intent.putExtra("com.klaviyo.Button Action", "Open URL") }
         verify { intent.putExtra("com.klaviyo.Button Link", "https://example.com") }
+    }
+
+    @Test
+    fun `appendActionButtonExtras for Degraded reports the declared action and link`() {
+        // A downgraded button launches the app, but $opened_push must still report what the
+        // sender configured — otherwise the misconfiguration is invisible in analytics and
+        // Android disagrees with iOS about the same message.
+        val intent = mockk<Intent>(relaxed = true)
+        val button = ActionButton.Degraded(
+            id = "open.url",
+            label = "Open Website",
+            declaredAction = ActionButton.DISPLAY_NAME_OPEN_URL,
+            declaredUrl = "www.cnn.com"
+        )
+
+        every { intent.putExtra(any<String>(), any<String>()) } returns intent
+
+        intent.appendActionButtonExtras(button)
+
+        verify { intent.putExtra("com.klaviyo.Button ID", "open.url") }
+        verify { intent.putExtra("com.klaviyo.Button Label", "Open Website") }
+        verify { intent.putExtra("com.klaviyo.Button Action", "Open URL") }
+        verify { intent.putExtra("com.klaviyo.Button Link", "www.cnn.com") }
+    }
+
+    @Test
+    fun `appendActionButtonExtras for Degraded omits the link when the payload had none`() {
+        val intent = mockk<Intent>(relaxed = true)
+        val button = ActionButton.Degraded(
+            id = "deep.link",
+            label = "Shop Now",
+            declaredAction = ActionButton.DISPLAY_NAME_DEEP_LINK,
+            declaredUrl = null
+        )
+
+        every { intent.putExtra(any<String>(), any<String>()) } returns intent
+
+        intent.appendActionButtonExtras(button)
+
+        verify { intent.putExtra("com.klaviyo.Button Action", "Deep Link") }
+        verify(exactly = 0) { intent.putExtra("com.klaviyo.Button Link", any<String>()) }
     }
 }


### PR DESCRIPTION
# Description
An `Open External URL` action button configured with a scheme-less link (e.g. `www.cnn.com`) rendered **no action buttons at all** on Android. The `open_url` scheme allowlist was being used as a render-time eligibility gate; url-shaped buttons with an unusable url now render as a new `ActionButton.Degraded` variant that launches the app, instead of being dropped.

Android counterpart to klaviyo/klaviyo-swift-sdk#691 (PUSH-1085).

## Due Diligence
- [ ] I have tested this on an emulator and/or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all Android versions the SDK currently supports.

> Not yet verified on a device/emulator — `ktlint` + the full `push-fcm` unit suite pass locally (see Test Plan). No version-specific APIs were introduced.

## Release/Versioning Considerations
- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [x] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

### ⚠️ Reviewer decision needed: sealed-class source compatibility
`object KlaviyoRemoteMessage` and its nested `sealed class ActionButton` are **public**, and `RemoteMessage.actionButtons` is a public extension property — so this is a real consumer surface, not hypothetical.

Adding the `Degraded` variant is **source-breaking** for any host app with an *exhaustive* `when` over `ActionButton`: their code will stop compiling until they add a branch. Nothing breaks at runtime, and binary compatibility is unaffected.

I judged this worth it, because a distinct variant is what makes the compiler force every dispatch site to handle degraded buttons — that exhaustiveness is the safety property this fix leans on. **If we'd rather keep this a `Patch`,** the alternative is a boolean flag plus declared-action/url fields on `OpenApp`, which gets identical analytics parity with no API break, at the cost of losing the compiler guarantee. Happy to switch if you prefer.

## Changelog / Code Overview

### Root cause
`"www.cnn.com".toUri().scheme` is `null`, which is not in `ALLOWED_OPEN_URL_SCHEMES`, so `hasAllowedOpenUrlScheme()` failed and the `TYPE_OPEN_URL` branch of `RemoteMessage.actionButtons` returned `null` — dropping the button. When it was the only button, `buttons.takeIf { it.isNotEmpty() }` returned `null` and `addActionButtons` returned early, so the notification rendered with **no buttons at all**.

Same layering mistake as iOS: **a dispatch-time security allowlist was doing render-time eligibility work.**

### Why Android's fix differs from iOS
This is the important review point. On iOS the `UNNotificationAction` carries no URL and `.foreground` opens the app regardless, so the allowlist can simply move to tap time.

Android has no equivalent seam. `KlaviyoNotification.createButtonAction` bakes the `PendingIntent` at **render time** (`is ActionButton.OpenUrl -> KlaviyoTrampolineActivity.forBrowserUrl(context, button.url)`), and `KlaviyoTrampolineActivity.dispatchDestination` hands the url straight to `DeepLinking.makeExternalIntent(...).startActivityIfResolved(context)` with no re-check. So the allowlist **must** stay in the parser. Keeping a bad url as `OpenUrl` would either bake a browser intent for `javascript:alert(1)`, or — for `www.cnn.com` — produce an intent nothing resolves, leaving a button that does *nothing at all*.

Hence `Degraded`: the button renders, a tap launches the app, and the unusable url structurally cannot reach `makeExternalIntent` because it never becomes an `OpenUrl` instance.

### The change
`sdk/push-fcm/.../KlaviyoRemoteMessage.kt`
- New `ActionButton.Degraded(id, label, declaredAction, declaredUrl)`.
- `TYPE_DEEP_LINK` missing url, `TYPE_OPEN_URL` missing url, and `TYPE_OPEN_URL` disallowed/missing scheme now produce `Degraded` instead of `null`. Structural problems (missing `id`/`label`, unrecognized `action`) still skip the button.
- `appendActionButtonExtras` reports `declaredAction`/`declaredUrl`, so `$opened_push` still carries `Button Action = "Open URL"` and `Button Link = "www.cnn.com"` — **matching iOS**. An earlier revision collapsed to `OpenApp`, which reported `"Open App"` with no `Button Link`; that was rejected because it hid the misconfiguration from analytics and disagreed with iOS about the same message.
- The link-selection `when` enumerates the sealed arms rather than matching `UrlBearing`, so adding a variant is a compile error rather than a silent `null`. `Degraded` deliberately does **not** implement `UrlBearing` — its `declaredUrl` is precisely the url we refused to dispatch, so it must not look dispatchable.

`sdk/push-fcm/.../KlaviyoNotification.kt`
- `is ActionButton.OpenApp, is ActionButton.Degraded ->` share the app-launch branch.
- Verbose log reports the declared action and notes the degradation.

**Unchanged, deliberately:** `ALLOWED_OPEN_URL_SCHEMES`, `hasAllowedOpenUrlScheme()`, `RemoteMessage.webUrl` (the body-tap gate), and `KlaviyoTrampolineActivity`.

### Why urls are not normalized to `https://`
Fender's validation (klaviyo/fender#66002) blocks scheme-less input rather than normalizing. Normalizing here would contradict that contract and diverge from iOS. That fender fix is editor-only — it notes API-created messages bypass validation entirely — which is why the SDK must still degrade gracefully.

## Test Plan

### Automated — `./gradlew :sdk:push-fcm:ktlintCheck :sdk:push-fcm:testDebugUnitTest`
```
BUILD SUCCESSFUL
```

| Suite | Tests | Failures |
|---|---|---|
| `KlaviyoNotificationTest` | 44 | 0 |
| `KlaviyoRemoteMessageTest` | 38 | 0 |
| `KlaviyoTrampolineActivityTest` | 9 | 0 |
| `KlaviyoPushServiceTest` | 7 | 0 |
| `KlaviyoPushTokenFetcherTest` | 9 | 0 |
| `KlaviyoPushTokenInitProviderTest` | 1 | 0 |
| **Total** | **108** | **0** |

**Added**
- `actionButtons downgrades open_url with scheme-less url to a degraded app-launch button` — the exact ticket repro, asserting `declaredAction`/`declaredUrl` survive.
- `actionButtons downgrades open_url with blank url to a degraded app-launch button` — closes a gap that predates this PR (no test ever exercised a truly blank `""` url; `optNonBlankString` collapses blank and null today, so this pins that).
- `appendActionButtonExtras for Degraded reports the declared action and link` and `… omits the link when the payload had none`.
- `degraded action button routes to app launch and never to the browser` (`KlaviyoNotificationTest`) — the **security regression guard**: a `Degraded` button with `javascript:alert(1)` must hit `forDestination` and never `forBrowserUrl`, while still emitting the declared analytics extras.

**Flipped (6)** — these pinned the drop-the-button bug; renamed and re-asserted against `Degraded`: two `DEEP_LINK … without/null URL`, the mixed valid/invalid parser test, and three `open_url` blocked-scheme / missing-url / null-url tests.

**Also adjusted:** the `MAX_ACTION_BUTTONS` cap test now uses an unsupported action type for its "invalid button" case, since a url-less `deep_link` no longer drops. Degraded buttons correctly occupy cap slots (shared `buttons.add` path).

### Manual repro (for the reviewer / QA)
1. Push with an action button, action = **Open External URL**, url = `www.cnn.com`.
2. Send preview, expand the notification.
   - **Before:** no buttons at all. **After:** the button renders.
3. Tap it → the app launches (a browser is not opened). Logcat: `OPEN_URL action button 0 has disallowed scheme 'null'; rendering as an app-launch button instead`.
4. Check the `$opened_push` event carries `Button Action = "Open URL"` and `Button Link = "www.cnn.com"`.
5. Regression: `https://www.cnn.com` still opens the browser; `mailto:`/`tel:`/`sms:`/`smsto:` still work; `javascript:alert(1)` renders a button that only launches the app.

## Related Issues/Tickets
- Related to PUSH-1095
- iOS counterpart: klaviyo/klaviyo-swift-sdk#691 (Related to PUSH-1085)
- Sender-side validation: klaviyo/fender#66002 (PUSH-1084)
