### PR TITLE
fix(push): keep trampoline from clearing DeepLinkHandler navigation (MAGE-1004)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1149,6 +1149,13 @@ You should register this from your `Application` or main `Activity`'s `.onCreate
 the application lifecycle to handle any link that launches the app from a terminated state. This handler will be invoked for
 *any* deep link originating from the Klaviyo SDK, including push notifications, universal tracking links, or In-App Forms.
 
+> **Push notification taps with automatic open tracking:** When `automatic_push_open_tracking` is enabled and you have
+> registered a handler, the SDK invokes your handler and then brings your app's existing task to the foreground **without**
+> clearing its back stack or delivering an intent to your launcher `Activity`. Whatever you navigate to from the handler —
+> another `Activity`, a `Fragment` transaction, a Compose `NavController` route — stays on top. Because no intent is delivered
+> on this path, do your routing in the handler callback rather than in `onNewIntent`. If no handler is registered, the SDK
+> instead sends your app an `ACTION_VIEW` intent carrying the link, which you should handle in `onCreate`/`onNewIntent`.
+
 <details open>
    <summary>Kotlin</summary>
 

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -53,6 +53,16 @@
             </intent-filter>
         </activity>
 
+        <!--
+            Sample App Only: the destination the deep link handler navigates to. Declared with the
+            default task affinity so it stacks on top of SampleActivity in the same task, which is
+            what makes the back-stack behavior after a notification tap observable.
+        -->
+        <activity
+                android:name=".SampleDetailActivity"
+                android:exported="false"
+                android:theme="@style/Theme.KlaviyoAndroidSdk"/>
+
         <!-- Optional: Set the Klaviyo SDK logging level (1=verbose, 2=debug etc) -->
         <meta-data
                 android:name="com.klaviyo.core.log_level"

--- a/sample/src/main/java/com/klaviyo/sample/SampleApplication.kt
+++ b/sample/src/main/java/com/klaviyo/sample/SampleApplication.kt
@@ -32,7 +32,10 @@ class SampleApplication : Application() {
             .registerDeepLinkHandler { uri ->
                 // OPTIONAL SETUP NOTE: Register a callback to handle any deep links from Klaviyo notifications, in-app forms, or universal tracking links
                 // If not using a deep link handler, Klaviyo will send an Intent to your app with the deep link in intent.data
+                // Navigating to a real screen here (rather than only showing a toast) is what makes
+                // it visible that a notification tap leaves your destination on top of the stack.
                 showToast("Deep link to: $uri")
+                startActivity(SampleDetailActivity.intent(this, uri.toString()))
             }
             .registerFormLifecycleHandler { event ->
                 // OPTIONAL SETUP NOTE: Register a callback to receive form lifecycle events

--- a/sample/src/main/java/com/klaviyo/sample/SampleDetailActivity.kt
+++ b/sample/src/main/java/com/klaviyo/sample/SampleDetailActivity.kt
@@ -1,0 +1,82 @@
+package com.klaviyo.sample
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.klaviyo.sample.ui.theme.KlaviyoAndroidSdkTheme
+
+/**
+ * SETUP NOTE: A second screen the sample's deep link handler navigates to, so notification taps
+ * have a visible destination on top of [SampleActivity] rather than only a toast.
+ *
+ * This exists to demonstrate the back-stack contract: after tapping a deep link notification, the
+ * screen your handler navigated to should still be on top. A toast could not show that, since
+ * nothing can pop it off the stack.
+ *
+ * Your app does not need an Activity like this — navigate however you already do (a second
+ * Activity, a Fragment transaction, a Compose NavController route).
+ */
+class SampleDetailActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val deepLink = intent?.getStringExtra(EXTRA_DEEP_LINK)
+
+        setContent {
+            KlaviyoAndroidSdkTheme {
+                Surface(modifier = Modifier.fillMaxSize()) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .systemBarsPadding()
+                            .padding(24.dp),
+                        verticalArrangement = Arrangement.spacedBy(16.dp)
+                    ) {
+                        Text(
+                            text = "Deep Link Destination",
+                            style = MaterialTheme.typography.headlineSmall
+                        )
+                        Text(
+                            text = deepLink ?: "No deep link provided",
+                            style = MaterialTheme.typography.bodyMedium
+                        )
+                        OutlinedButton(onClick = { finish() }) {
+                            Text("Back")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    companion object {
+        private const val EXTRA_DEEP_LINK = "deep_link"
+
+        /**
+         * Build an intent that opens this screen on top of the app's existing task.
+         *
+         * [Intent.FLAG_ACTIVITY_NEW_TASK] is required because the sample's deep link handler is
+         * registered from [SampleApplication] and therefore starts this from an application
+         * context. Since this Activity uses the app's default task affinity, the flag adds it to
+         * the existing task rather than creating a separate one.
+         */
+        fun intent(context: Context, deepLink: String) =
+            Intent(context, SampleDetailActivity::class.java)
+                .putExtra(EXTRA_DEEP_LINK, deepLink)
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    }
+}

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/linking/DeepLinking.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/linking/DeepLinking.kt
@@ -177,6 +177,9 @@ object DeepLinking {
     /**
      * Create an intent to launch the host application.
      *
+     * Note: callers that only need to bring an already-running host task to the front overwrite
+     * these flags rather than adding to them, so flags added here will not reach that path.
+     *
      * @param context The context used to access the package manager and set flags
      * @param extras Optional intent to copy extras from, useful for passing additional data
      */

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivity.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivity.kt
@@ -127,13 +127,23 @@ internal class KlaviyoTrampolineActivity : Activity() {
          *
          * - Deep link present and no [DeepLinkHandler][com.klaviyo.analytics.linking.DeepLinkHandler]
          *   registered → `ACTION_VIEW` into the host, falling back to the launcher if unresolvable.
-         * - Handler registered, or no deep link → launcher only. `handlePush` already dispatched the
-         *   handler, so an additional `ACTION_VIEW` would double-deliver navigation.
+         * - Deep link present and a handler registered → launcher intent flagged only to bring the
+         *   host's task to the front. `handlePush` already dispatched the handler, so an additional
+         *   `ACTION_VIEW` would double-deliver navigation, and clearing the back stack would undo it.
+         * - No deep link (`open_app`) → launcher intent with the same flags as the non-trampoline
+         *   content intent it replaces.
          */
         private fun startDestination(intent: Intent, context: Context) {
             val deepLink = intent.data
+            // Read once so the destination and its flags can't be decided from different state.
+            // `handlePush` above dispatches this link to the host's handler synchronously on the
+            // main thread, so by now the host may already have navigated. (A repeat tap of the
+            // same delivery is deduped inside `handlePush` and navigates nothing — still the right
+            // branch, since there is no reason to tear down what the first tap navigated to.)
+            val handlerOwnsNavigation = deepLink != null && DeepLinking.isHandlerRegistered
+
             val destination: Intent? = when {
-                deepLink != null && !DeepLinking.isHandlerRegistered -> {
+                deepLink != null && !handlerOwnsNavigation -> {
                     val viewIntent = DeepLinking.makeDeepLinkIntent(
                         deepLink,
                         context,
@@ -150,9 +160,9 @@ internal class KlaviyoTrampolineActivity : Activity() {
                     }
                 }
                 else -> {
-                    if (deepLink != null) {
+                    if (handlerOwnsNavigation) {
                         Registry.log.verbose(
-                            "Trampoline dispatching deep link via handler; launching host"
+                            "Trampoline dispatched deep link via handler; bringing host to front"
                         )
                     } else {
                         Registry.log.verbose("Trampoline dispatching launch intent")
@@ -162,15 +172,27 @@ internal class KlaviyoTrampolineActivity : Activity() {
             }
 
             destination?.apply {
-                // CLEAR_TOP mirrors the non-trampoline path (KlaviyoNotification adds it to the
-                // contentIntent, but it's consumed launching the trampoline rather than forwarded),
-                // preserving back-stack behavior. NEW_TASK is required here since we launch from the
-                // trampoline's own (taskAffinity="") task.
-                addFlags(
-                    Intent.FLAG_ACTIVITY_NEW_TASK or
-                        Intent.FLAG_ACTIVITY_SINGLE_TOP or
-                        Intent.FLAG_ACTIVITY_CLEAR_TOP
-                )
+                if (handlerOwnsNavigation) {
+                    // Launcher-icon semantics: resume the host's task exactly as the user left it.
+                    // The handler owns navigation, so CLEAR_TOP would finish whatever it just
+                    // navigated to, and SINGLE_TOP would re-deliver an ACTION_MAIN intent to the
+                    // launcher activity, resetting in-activity (Fragment/Compose) routing.
+                    //
+                    // Assigned rather than added because makeLaunchIntent bakes in SINGLE_TOP (see
+                    // DeepLinkingTest) and Intent.removeFlags requires API 26, above our minSdk.
+                    // getLaunchIntentForPackage sets exactly NEW_TASK, so nothing else is dropped.
+                    flags = Intent.FLAG_ACTIVITY_NEW_TASK
+                } else {
+                    // CLEAR_TOP mirrors the non-trampoline path (KlaviyoNotification adds it to the
+                    // contentIntent, but it's consumed launching the trampoline rather than
+                    // forwarded), preserving back-stack behavior. NEW_TASK is required here since we
+                    // launch from the trampoline's own (taskAffinity="") task.
+                    addFlags(
+                        Intent.FLAG_ACTIVITY_NEW_TASK or
+                            Intent.FLAG_ACTIVITY_SINGLE_TOP or
+                            Intent.FLAG_ACTIVITY_CLEAR_TOP
+                    )
+                }
             }?.startActivityIfResolved(context)
                 ?: Registry.log.warning("No launch intent found for host app; nothing to start")
         }

--- a/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivityTest.kt
+++ b/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivityTest.kt
@@ -31,6 +31,16 @@ class KlaviyoTrampolineActivityTest : BaseTest() {
         every { startActivity(any()) } returns Unit
     }
 
+    /**
+     * Flags the trampoline adds to every destination it owns, mirroring the non-trampoline content
+     * intent. Spelled out here rather than referencing the production expression so a change there
+     * fails these tests. The one exception is a deep link with a handler registered, which must
+     * only bring the host task to the front — see the MAGE-1004 regression test below.
+     */
+    private val resetFlags = Intent.FLAG_ACTIVITY_NEW_TASK or
+        Intent.FLAG_ACTIVITY_SINGLE_TOP or
+        Intent.FLAG_ACTIVITY_CLEAR_TOP
+
     @Before
     override fun setup() {
         super.setup()
@@ -103,6 +113,9 @@ class KlaviyoTrampolineActivityTest : BaseTest() {
         verify(exactly = 0) { DeepLinking.makeDeepLinkIntent(any(), any(), any()) }
         verify { DeepLinking.makeLaunchIntent(mockTrampolineContext, any()) }
         verify { mockTrampolineContext.startActivity(mockLaunchIntent) }
+        // No handler navigation to preserve on an open_app tap, so reset to root as before.
+        verify { mockLaunchIntent.addFlags(resetFlags) }
+        verify(exactly = 0) { mockLaunchIntent.setFlags(any()) }
     }
 
     @Test
@@ -132,10 +145,13 @@ class KlaviyoTrampolineActivityTest : BaseTest() {
         verify { DeepLinking.makeDeepLinkIntent(deepLink, mockTrampolineContext, intent) }
         verify { mockTrampolineContext.startActivity(mockDeepLinkIntent) }
         verify(exactly = 0) { DeepLinking.makeLaunchIntent(any(), any()) }
+        // The SDK owns this navigation, so it keeps the reset-to-root behavior.
+        verify { mockDeepLinkIntent.addFlags(resetFlags) }
+        verify(exactly = 0) { mockDeepLinkIntent.setFlags(any()) }
     }
 
     @Test
-    fun `handleTrampolineIntent with deep link but handler registered launches host without ACTION_VIEW`() {
+    fun `handleTrampolineIntent with deep link and handler registered brings host to front without clearing back stack`() {
         val intent = klaviyoIntent()
         val deepLink = mockk<Uri>(relaxed = true)
         every { intent.data } returns deepLink
@@ -148,6 +164,27 @@ class KlaviyoTrampolineActivityTest : BaseTest() {
         verify(exactly = 0) { DeepLinking.makeDeepLinkIntent(any(), any(), any()) }
         verify { DeepLinking.makeLaunchIntent(mockTrampolineContext, any()) }
         verify { mockTrampolineContext.startActivity(mockLaunchIntent) }
+        // The handler runs synchronously inside handlePush, so it may already have navigated:
+        // CLEAR_TOP would finish that destination and SINGLE_TOP would re-deliver an ACTION_MAIN
+        // intent to the launcher activity. Assigned, not added, because makeLaunchIntent bakes in
+        // SINGLE_TOP — see DeepLinkingTest's makeLaunchIntent coverage.
+        verify { mockLaunchIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK) }
+        verify(exactly = 0) { mockLaunchIntent.addFlags(any()) }
+    }
+
+    @Test
+    fun `handleTrampolineIntent with handler registered but no deep link still clears top`() {
+        val intent = klaviyoIntent() // open_app tap: handler registered, but no link to dispatch
+        every { DeepLinking.isHandlerRegistered } returns true
+
+        KlaviyoTrampolineActivity.handleTrampolineIntent(intent, mockTrampolineContext)
+
+        // Without a deep link the handler was never invoked, so there is no host navigation to
+        // preserve and this stays a plain launch — registering a handler must not change open_app.
+        verify { DeepLinking.makeLaunchIntent(mockTrampolineContext, any()) }
+        verify { mockTrampolineContext.startActivity(mockLaunchIntent) }
+        verify { mockLaunchIntent.addFlags(resetFlags) }
+        verify(exactly = 0) { mockLaunchIntent.setFlags(any()) }
     }
 
     @Test
@@ -165,6 +202,8 @@ class KlaviyoTrampolineActivityTest : BaseTest() {
         verify { DeepLinking.makeLaunchIntent(mockTrampolineContext, any()) }
         verify { mockTrampolineContext.startActivity(mockLaunchIntent) }
         verify(exactly = 0) { mockTrampolineContext.startActivity(mockDeepLinkIntent) }
+        // No handler ran for this tap, so the fallback keeps the reset-to-root behavior.
+        verify { mockLaunchIntent.addFlags(resetFlags) }
         // Degraded-but-handled (fell back to launcher) → WARNING, not ERROR.
         verify { spyLog.warning(any(), null) }
     }


### PR DESCRIPTION
# Description

With `automatic_push_open_tracking` enabled, the notification trampoline invoked the host's registered `DeepLinkHandler` and then started the host launcher intent with `CLEAR_TOP`, destroying whatever the handler had just navigated to. The launcher intent now only brings the host task to the front when the handler owns navigation.

## Due Diligence

- [x] I have tested this on an emulator and/or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all Android versions the SDK currently supports.
  - `FLAG_ACTIVITY_NEW_TASK` is available on every supported level. The flags are *assigned* rather than added specifically to avoid `Intent.removeFlags`, which is API 26 and above our minSdk of 23.

## Release/Versioning Considerations

- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [x] Contains readme or migration guide changes.
  - Targeting `rel/4.5.0` rather than `master`, so the README change only goes live with the 4.5.0 release.
- [x] This is planned work for an upcoming release.
  - Fixes a defect in the unreleased automatic push integration, so it should ship in 4.5.0 alongside the feature it affects.

No version bump in this PR — deferred to the release-branch merge per convention.

## Changelog / Code Overview

**Root cause.** `KlaviyoTrampolineActivity.handleTrampolineIntent` calls `Klaviyo.handlePush(intent)`, which reaches `DeepLinking.handleDeepLink` and invokes a registered `DeepLinkHandler` via `runOnUiThread`. Since the trampoline's `onCreate` is already on the main looper, that runs **inline** — the host navigates before the trampoline continues. `startDestination` then started the launcher intent with `NEW_TASK | SINGLE_TOP | CLEAR_TOP`:

- `CLEAR_TOP` on an `ACTION_MAIN`/`CATEGORY_LAUNCHER` intent finishes every Activity above the launcher Activity, destroying the handler's destination.
- `SINGLE_TOP` re-delivers `onNewIntent(ACTION_MAIN)` to the launcher Activity, which single-Activity apps commonly treat as a fresh home launch and use to reset routing.

Deterministic, not a race. Only affects hosts that enable the flag **and** register a handler.

**Fix.** `startDestination` now hoists `handlerOwnsNavigation` (a deep link is present *and* a handler is registered) and branches the flags on it:

- Handler owns navigation → `flags = FLAG_ACTIVITY_NEW_TASK` alone. Launcher-icon semantics: resume the existing task exactly as the user left it. Nothing finished, no `onNewIntent` delivered.
- Every other branch (`ACTION_VIEW` into the host, unresolvable deep-link fallback, `open_app`) → unchanged `NEW_TASK | SINGLE_TOP | CLEAR_TOP`.

Notes on the implementation:

- Flags are **assigned**, not added, because `DeepLinking.makeLaunchIntent` bakes in `SINGLE_TOP` and `Intent.removeFlags` is above our minSdk. Verified against AOSP that `getLaunchIntentForPackage` sets exactly `NEW_TASK` (with `setClassName` after), so action, category, package, and component all survive the overwrite.
- `makeLaunchIntent`'s public signature is untouched — a new parameter would be a binary break, and its two other callers legitimately want `CLEAR_TOP` + `SINGLE_TOP`.
- Extras are still forwarded. `Intent.filterEquals` ignores them, so they can't affect task matching, and on cold start they carry the delivery id that dedupes against a host also calling `handlePush`.

**Tests.** Intent flags now have coverage for the first time. The renamed handler-registered test is the regression test; the three untouched branches gained assertions that they keep the old flags; and a new test pins that `open_app` with a handler registered still resets to root (guarding against a "simplification" of the condition to just `isHandlerRegistered`).

**Sample app.** The deep link handler previously only showed a toast, which `CLEAR_TOP` cannot pop — so the sample could not reproduce this bug or demonstrate the fix. It now navigates to a new `SampleDetailActivity`, producing the `[SampleActivity, SampleDetailActivity]` stack the bug destroyed. Sample-only; nothing published changes.

**Docs.** The handler-owns-navigation contract was undocumented; added a note to the README's deep linking section, including that hosts should route from the handler callback rather than `onNewIntent` on this path.

## Test Plan

Unit:

```
./gradlew :sdk:push-fcm:testDebugUnitTest --tests "com.klaviyo.pushFcm.KlaviyoTrampolineActivityTest"
```

Full `./gradlew test` and `./gradlew ktlintCheck` are green.

To confirm the regression test is not vacuous, revert only the production file and re-run — exactly one test fails (the new regression test) and the other nine pass:

```
git checkout HEAD~1 -- sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivity.kt
```

Device (install the `automatic` flavor — flag on, and the sample always registers a handler):

```
./gradlew :sample:installAutomaticDebug
```

Send a push with `url` = `klaviyotest://detail`, then:

1. Tap it → `SampleDetailActivity` opens on top of `SampleActivity`.
2. Press Home so the detail screen stays top of the task.
3. Send and tap a second identical push.
4. **Expected: still on `SampleDetailActivity`.** Before the fix, `CLEAR_TOP` finished it and you land back on `SampleActivity`.

Verified. The trampoline log line distinguishes the paths: `Trampoline dispatched deep link via handler; bringing host to front` (fixed) vs `Trampoline dispatching deep link via handler; launching host` (previous). Stack shape via:

```
adb shell dumpsys activity activities | grep -E "ActivityRecord.*com.klaviyo.sample"
```

Reviewer note — remaining scenarios worth a second pair of eyes:

- **Task created three different ways** (launcher icon / previous notification tap / external `klaviyotest://` link), confirming the launcher intent brings the task forward rather than stacking a duplicate launcher Activity. This depends on task base-intent matching (`Intent.filterEquals` against the task's base intent) and can vary by OEM, so it is worth checking on a non-Pixel device. It is the one assumption that could not be settled from source.
- **`open_app` push** (no `url`) should still reset to root — the deliberately unchanged branch.
- **Cold start** ends with `SampleActivity` on top and `SampleDetailActivity` behind it. That is MAGE-1020, **not** a regression from this PR — `CLEAR_TOP` is a no-op with no task to clear, so before/after are identical.

## Related Issues/Tickets

- MAGE-1004 — https://linear.app/klaviyo/issue/MAGE-1004
- Originating review thread: https://github.com/klaviyo/klaviyo-android-sdk/pull/517#discussion_r3675630546
- MAGE-1020 — https://linear.app/klaviyo/issue/MAGE-1020 — related but **not** fixed here: on cold start the handler fires before any Activity exists, so the link is dropped. Independent of this fix and needs its own design.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deep links handled by a registered handler now open the destination while preserving the existing app navigation state.
  * The sample app includes a detail screen for viewing deep-linked content, with back navigation.
* **Bug Fixes**
  * Open-app actions continue to reset navigation appropriately, while handler-managed deep links avoid unnecessary relaunches or back-stack clearing.
* **Documentation**
  * Expanded deep-linking guidance to explain handler and default intent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->