### PR TITLE
fix(push): dispatch deep links once the host has a resumed activity (MAGE-1020)

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -32,15 +32,21 @@ To opt out and retain manual control, see
 
 ### `DeepLinkHandler` callback timing
 
-A handler registered via `Klaviyo.registerDeepLinkHandler` is now invoked once your app has a
-resumed `Activity`, rather than immediately. This makes the callback safe to navigate from on a
-cold start — previously a notification tap that launched your app from a terminated state invoked
-the handler before any `Activity` existed, so a `NavController` or `Activity`-based route had
-nothing to navigate and the link was dropped.
+A handler registered via `Klaviyo.registerDeepLinkHandler` now waits for your app to have a resumed
+`Activity` before being invoked, rather than firing immediately. This makes the callback safe to
+navigate from on a cold start — previously a notification tap that launched your app from a
+terminated state invoked the handler before any `Activity` existed, so a `NavController` or
+`Activity`-based route had nothing to navigate and the link was dropped.
 
-No action is required, but note that the callback can now arrive slightly later than the call that
-triggered it. Most visibly, if you call `Klaviyo.handlePush(intent)` from an `Activity`'s
-`onCreate`, your handler is invoked at `onResume` rather than inline.
+No action is required, but note two things:
+
+- The callback can arrive slightly later than the call that triggered it. Most visibly, if you call
+  `Klaviyo.handlePush(intent)` from an `Activity`'s `onCreate`, your handler is invoked at
+  `onResume` rather than inline.
+- The wait is bounded. If no `Activity` resumes within a short grace period, the SDK invokes your
+  handler anyway as a best effort rather than dropping the link — so this is a "resume or timeout"
+  contract, not a guarantee that an `Activity` exists. A handler that depends on one should fail
+  gracefully if it is unavailable.
 
 ### Rollout summary
 

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -30,6 +30,18 @@ manually on app startup.
 To opt out and retain manual control, see
 [Option A — Automatic Integration](./README.md#option-a--automatic-integration) in the README.
 
+### `DeepLinkHandler` callback timing
+
+A handler registered via `Klaviyo.registerDeepLinkHandler` is now invoked once your app has a
+resumed `Activity`, rather than immediately. This makes the callback safe to navigate from on a
+cold start — previously a notification tap that launched your app from a terminated state invoked
+the handler before any `Activity` existed, so a `NavController` or `Activity`-based route had
+nothing to navigate and the link was dropped.
+
+No action is required, but note that the callback can now arrive slightly later than the call that
+triggered it. Most visibly, if you call `Klaviyo.handlePush(intent)` from an `Activity`'s
+`onCreate`, your handler is invoked at `onResume` rather than inline.
+
 ### Rollout summary
 
 | Behavior | This release (4.5.0) | Future major release |

--- a/README.md
+++ b/README.md
@@ -1149,12 +1149,17 @@ You should register this from your `Application` or main `Activity`'s `.onCreate
 the application lifecycle to handle any link that launches the app from a terminated state. This handler will be invoked for
 *any* deep link originating from the Klaviyo SDK, including push notifications, universal tracking links, or In-App Forms.
 
+The SDK invokes your handler once your app has a resumed `Activity`, so it is always safe to navigate from it — including
+when a notification tap cold-starts your app from a terminated state. As a result the callback may arrive slightly after
+the event that triggered it (for example at `onResume` rather than inline during `onCreate`).
+
 > **Push notification taps with automatic open tracking:** When `automatic_push_open_tracking` is enabled and you have
-> registered a handler, the SDK invokes your handler and then brings your app's existing task to the foreground **without**
-> clearing its back stack or delivering an intent to your launcher `Activity`. Whatever you navigate to from the handler —
-> another `Activity`, a `Fragment` transaction, a Compose `NavController` route — stays on top. Because no intent is delivered
-> on this path, do your routing in the handler callback rather than in `onNewIntent`. If no handler is registered, the SDK
-> instead sends your app an `ACTION_VIEW` intent carrying the link, which you should handle in `onCreate`/`onNewIntent`.
+> registered a handler, the SDK brings your app's existing task to the foreground — creating it if your app was not
+> running — **without** clearing its back stack or delivering an intent to your launcher `Activity`, then invokes your
+> handler. Whatever you navigate to from the handler — another `Activity`, a `Fragment` transaction, a Compose
+> `NavController` route — stays on top. Because no intent is delivered on this path, do your routing in the handler
+> callback rather than in `onNewIntent`. If no handler is registered, the SDK instead sends your app an `ACTION_VIEW`
+> intent carrying the link, which you should handle in `onCreate`/`onNewIntent`.
 
 <details open>
    <summary>Kotlin</summary>

--- a/README.md
+++ b/README.md
@@ -1149,17 +1149,21 @@ You should register this from your `Application` or main `Activity`'s `.onCreate
 the application lifecycle to handle any link that launches the app from a terminated state. This handler will be invoked for
 *any* deep link originating from the Klaviyo SDK, including push notifications, universal tracking links, or In-App Forms.
 
-The SDK invokes your handler once your app has a resumed `Activity`, so it is always safe to navigate from it — including
-when a notification tap cold-starts your app from a terminated state. As a result the callback may arrive slightly after
-the event that triggered it (for example at `onResume` rather than inline during `onCreate`).
+The SDK waits for your app to have a resumed `Activity` before invoking your handler, so it is normally safe to navigate
+from it — including when a notification tap cold-starts your app from a terminated state. As a result the callback may
+arrive slightly after the event that triggered it (for example at `onResume` rather than inline during `onCreate`). If no
+`Activity` resumes within a short grace period, the SDK invokes your handler anyway as a best effort rather than dropping
+the link, so a handler that depends on an `Activity` should fail gracefully if none is available.
 
 > **Push notification taps with automatic open tracking:** When `automatic_push_open_tracking` is enabled and you have
-> registered a handler, the SDK brings your app's existing task to the foreground — creating it if your app was not
-> running — **without** clearing its back stack or delivering an intent to your launcher `Activity`, then invokes your
-> handler. Whatever you navigate to from the handler — another `Activity`, a `Fragment` transaction, a Compose
-> `NavController` route — stays on top. Because no intent is delivered on this path, do your routing in the handler
-> callback rather than in `onNewIntent`. If no handler is registered, the SDK instead sends your app an `ACTION_VIEW`
-> intent carrying the link, which you should handle in `onCreate`/`onNewIntent`.
+> registered a handler, the SDK brings your app's task to the foreground — creating it if your app was not running —
+> **without** clearing its back stack and **without** sending an `ACTION_VIEW` intent carrying the link, then invokes
+> your handler. Whatever you navigate to from the handler — another `Activity`, a `Fragment` transaction, a Compose
+> `NavController` route — stays on top. On a warm tap no new intent reaches your launcher `Activity` at all; on a cold
+> start it is created by the ordinary launch intent, which carries no deep link data. Either way the link reaches you
+> *only* through the handler, so do your routing in the callback rather than from `getIntent()` or `onNewIntent`. If no
+> handler is registered, the SDK instead sends your app an `ACTION_VIEW` intent carrying the link, which you should
+> handle in `onCreate`/`onNewIntent`.
 
 <details open>
    <summary>Kotlin</summary>

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/linking/DeepLinking.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/linking/DeepLinking.kt
@@ -14,6 +14,8 @@ import com.klaviyo.core.Constants.SENDTO_SCHEMES
 import com.klaviyo.core.Constants.WEB_SCHEMES
 import com.klaviyo.core.Registry
 import com.klaviyo.core.lifecycle.LifecycleMonitor.Companion.ACTIVITY_TRANSITION_GRACE_PERIOD
+import com.klaviyo.core.lifecycle.LifecycleMonitor.Companion.COLD_START_GRACE_PERIOD
+import com.klaviyo.core.safeApply
 import com.klaviyo.core.safeLaunch
 import com.klaviyo.core.utils.startActivityIfResolved
 import kotlinx.coroutines.CoroutineScope
@@ -46,19 +48,57 @@ object DeepLinking {
      * Handle a deep link by invoking a registered [DeepLinkHandler] if available,
      * otherwise broadcast it as an intent to be handled by the host app's activity.
      *
+     * Either way, dispatch waits for a resumed activity — the intent branch needs one to start
+     * from, and a handler typically navigates via a `NavController`, a `Fragment` transaction, or
+     * an activity it holds, none of which exist before the host has one. There is often no resumed
+     * activity at this point: it is null for the whole window between the outgoing activity's
+     * `onPause` and the incoming one's `onResume`, and for the entire cold start that a
+     * notification tap kicks off.
+     *
      * @param uri The deep link URI to be handled by the host app
      */
     fun handleDeepLink(uri: Uri) {
-        Registry.getOrNull<DeepLinkHandler>()?.let { handler ->
-            // Invoke host app's deep link handler on UI thread
-            Registry.threadHelper.runOnUiThread {
-                handler.invoke(uri)
-            }
-        } ?: run {
+        // Branch explicitly rather than with an elvis on the handler lookup: postponing returns a
+        // nullable cancellation token, so `?.let { … } ?: sendDeepLinkIntent(uri)` would broadcast
+        // an intent *as well as* invoking the handler whenever that token came back null.
+        val handler = Registry.getOrNull<DeepLinkHandler>()
+
+        if (handler == null) {
             // Sending an intent doesn't require main thread
             sendDeepLinkIntent(uri)
+            return
+        }
+
+        Registry.lifecycleMonitor.runWithCurrentOrNextActivity(
+            timeout = COLD_START_GRACE_PERIOD,
+            onTimeout = {
+                // Best effort rather than silently dropping the link: this is what every
+                // invocation did before deferral, so the outcome is never worse than not waiting.
+                Registry.log.warning(
+                    "No activity resumed within ${COLD_START_GRACE_PERIOD}ms; " +
+                        "invoking deep link handler anyway"
+                )
+                invokeHandler(handler, uri)
+            }
+        ) {
+            invokeHandler(handler, uri)
         }
     }
+
+    /**
+     * Invoke the host app's deep link handler on the UI thread.
+     *
+     * The guard sits inside the UI-thread job, not around it, since `runOnUiThread` posts rather
+     * than runs inline when called off the main thread. It is needed because [handleDeepLink] may
+     * defer this past its caller's own error handling — a throwing handler would otherwise
+     * propagate out of a lifecycle callback and crash the host app. Callers that already wrap
+     * `handleDeepLink` in [safeApply] therefore nest, which is harmless here: the inner guard has
+     * no subsequent work to halt.
+     */
+    private fun invokeHandler(handler: DeepLinkHandler, uri: Uri) =
+        Registry.threadHelper.runOnUiThread {
+            safeApply { handler.invoke(uri) }
+        }
 
     /**
      * Handle a Klaviyo universal tracking link by resolving it to a destination URL asynchronously,

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/linking/DeepLinking.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/linking/DeepLinking.kt
@@ -14,7 +14,6 @@ import com.klaviyo.core.Constants.SENDTO_SCHEMES
 import com.klaviyo.core.Constants.WEB_SCHEMES
 import com.klaviyo.core.Registry
 import com.klaviyo.core.lifecycle.LifecycleMonitor.Companion.ACTIVITY_TRANSITION_GRACE_PERIOD
-import com.klaviyo.core.lifecycle.LifecycleMonitor.Companion.COLD_START_GRACE_PERIOD
 import com.klaviyo.core.safeApply
 import com.klaviyo.core.safeLaunch
 import com.klaviyo.core.utils.startActivityIfResolved
@@ -32,6 +31,17 @@ fun interface DeepLinkHandler {
  * Utility for handling any deep links into the host application originating from Klaviyo
  */
 object DeepLinking {
+
+    /**
+     * How long [handleDeepLink] waits for a resumed activity before invoking the host's handler
+     * anyway. Sized for a cold start, which has to fork the process, run `Application.onCreate`,
+     * and draw a frame — orders of magnitude beyond
+     * [ACTIVITY_TRANSITION_GRACE_PERIOD], which only has to bridge one activity handing off to the
+     * next. Generous on purpose: this is a deadline rather than a delay, since the job runs the
+     * moment an activity resumes, and expiring early means falling back to a best-effort
+     * invocation that cannot navigate.
+     */
+    internal const val COLD_START_GRACE_PERIOD = 10_000L
 
     /**
      * Shortcut to check if the developer has registered a [DeepLinkHandler].

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoPushOpenHandlerTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoPushOpenHandlerTest.kt
@@ -175,7 +175,7 @@ internal class KlaviyoPushOpenHandlerTest : BaseTest() {
     }
 
     @Test
-    fun `handlePush tracks and dismisses synchronously while postponing the deep link`() {
+    fun `handlePush tracks the open synchronously while postponing the deep link`() {
         val (getCapturedUri) = setupDeepLinkHandler()
         val testUri = mockk<Uri>()
         // Cold start: nothing is resumed yet, so the handler has nowhere to navigate. Capture the
@@ -194,7 +194,18 @@ internal class KlaviyoPushOpenHandlerTest : BaseTest() {
             )
         )
 
-        verifyOpenedPushEventEnqueued()
+        // Matched on this delivery rather than via verifyOpenedPushEventEnqueued's exactly-1: the
+        // pre-init queue lives on the Klaviyo object, so initialize() in setup can replay an
+        // opened_push queued by an earlier test in this class and inflate the count.
+        verify(exactly = 1) {
+            mockApiClient.enqueueEvent(
+                match { event ->
+                    event.metric == EventMetric.OPENED_PUSH &&
+                        event[EventKey.CUSTOM("_k")].toString().contains("cold-start")
+                },
+                any()
+            )
+        }
         assertEquals(null, getCapturedUri())
 
         job.captured.invoke(mockActivity)

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoPushOpenHandlerTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoPushOpenHandlerTest.kt
@@ -1,5 +1,6 @@
 package com.klaviyo.analytics
 
+import android.app.Activity
 import android.app.Application
 import android.content.Intent
 import android.net.Uri
@@ -169,6 +170,34 @@ internal class KlaviyoPushOpenHandlerTest : BaseTest() {
         val testUri = mockk<Uri>()
 
         Klaviyo.handlePush(mockIntent(stubIntentExtras, testUri))
+
+        assertEquals(testUri, getCapturedUri())
+    }
+
+    @Test
+    fun `handlePush tracks and dismisses synchronously while postponing the deep link`() {
+        val (getCapturedUri) = setupDeepLinkHandler()
+        val testUri = mockk<Uri>()
+        // Cold start: nothing is resumed yet, so the handler has nowhere to navigate. Capture the
+        // postponed job rather than running it, to prove the open is still tracked right away.
+        val job = slot<(Activity) -> Unit>()
+        every {
+            Registry.lifecycleMonitor.runWithCurrentOrNextActivity(any(), any(), capture(job))
+        } returns null
+
+        Klaviyo.handlePush(
+            mockIntent(
+                mapOf(
+                    "com.klaviyo._k" to """{"m":"01GK4P5W6AV4V3APTJ727JKSKQ","tm":"cold-start"}"""
+                ),
+                testUri
+            )
+        )
+
+        verifyOpenedPushEventEnqueued()
+        assertEquals(null, getCapturedUri())
+
+        job.captured.invoke(mockActivity)
 
         assertEquals(testUri, getCapturedUri())
     }

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/linking/DeepLinkingTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/linking/DeepLinkingTest.kt
@@ -7,7 +7,7 @@ import android.net.Uri
 import android.os.Bundle
 import com.klaviyo.core.Registry
 import com.klaviyo.core.config.KlaviyoConfig
-import com.klaviyo.core.lifecycle.LifecycleMonitor.Companion.COLD_START_GRACE_PERIOD
+import com.klaviyo.core.lifecycle.LifecycleMonitor.Companion.ACTIVITY_TRANSITION_GRACE_PERIOD
 import com.klaviyo.fixtures.BaseTest
 import com.klaviyo.fixtures.MockIntent
 import io.mockk.CapturingSlot
@@ -127,7 +127,7 @@ internal class DeepLinkingTest : BaseTest() {
     }
 
     @Test
-    fun `handleDeepLink waits for the cold start grace period`() {
+    fun `handleDeepLink waits long enough for a cold start, not just an activity transition`() {
         Registry.register<DeepLinkHandler>(mockk<DeepLinkHandler>(relaxed = true))
         val timeout = slot<Long>()
         every {
@@ -136,7 +136,13 @@ internal class DeepLinkingTest : BaseTest() {
 
         DeepLinking.handleDeepLink(mockUri)
 
-        assertEquals(COLD_START_GRACE_PERIOD, timeout.captured)
+        assertEquals(DeepLinking.COLD_START_GRACE_PERIOD, timeout.captured)
+        // The value, not just the constant: a cold start has to fork a process and draw a frame, so
+        // reusing the inter-activity grace period here would expire long before the host is up.
+        assertTrue(
+            "Expected a cold-start scale timeout, got ${timeout.captured}ms",
+            timeout.captured > ACTIVITY_TRANSITION_GRACE_PERIOD
+        )
     }
 
     @Test

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/linking/DeepLinkingTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/linking/DeepLinkingTest.kt
@@ -155,7 +155,7 @@ internal class DeepLinkingTest : BaseTest() {
         onTimeout.captured.invoke()
 
         assertEquals(mockUri, invokedUri)
-        verify { spyLog.warning(any(), any()) }
+        verify { spyLog.warning(any(), null) }
     }
 
     @Test

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/linking/DeepLinkingTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/linking/DeepLinkingTest.kt
@@ -6,17 +6,23 @@ import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Bundle
 import com.klaviyo.core.Registry
+import com.klaviyo.core.config.KlaviyoConfig
+import com.klaviyo.core.lifecycle.LifecycleMonitor.Companion.COLD_START_GRACE_PERIOD
 import com.klaviyo.fixtures.BaseTest
 import com.klaviyo.fixtures.MockIntent
+import io.mockk.CapturingSlot
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
 import io.mockk.mockkStatic
+import io.mockk.slot
 import io.mockk.unmockkAll
 import io.mockk.verify
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -76,16 +82,16 @@ internal class DeepLinkingTest : BaseTest() {
 
         assertEquals(mockUri, invokedUri)
         verify(exactly = 1) { mockThreadHelper.runOnUiThread(any()) }
+        // The two branches are mutually exclusive: a registered handler owns the navigation, so
+        // broadcasting an intent as well would deliver it twice.
+        verify(exactly = 0) { testActivity.startActivity(any()) }
+        verify(exactly = 0) { mockActivity.startActivity(any()) }
     }
 
     @Test
     fun `handleDeepLink broadcasts intent when no handler registered`() {
         every { testActivity.startActivity(any()) } returns Unit
-        every { Registry.lifecycleMonitor.runWithCurrentOrNextActivity(any(), any()) } answers {
-            val callback = secondArg<(Activity) -> Unit>()
-            callback(testActivity)
-            null
-        }
+        runWithActivityImmediately()
 
         DeepLinking.handleDeepLink(mockUri)
 
@@ -98,15 +104,99 @@ internal class DeepLinkingTest : BaseTest() {
         every { anyConstructed<Intent>().resolveActivity(any()) } returns null
 
         every { testActivity.startActivity(any()) } returns Unit
-        every { Registry.lifecycleMonitor.runWithCurrentOrNextActivity(any(), any()) } answers {
-            val callback = secondArg<(Activity) -> Unit>()
-            callback(testActivity)
-            null
-        }
+        runWithActivityImmediately()
 
         DeepLinking.handleDeepLink(mockUri)
 
         verify(inverse = true) { testActivity.startActivity(any()) }
+    }
+
+    @Test
+    fun `handleDeepLink postpones handler until an activity resumes`() {
+        var invokedUri: Uri? = null
+        Registry.register<DeepLinkHandler>(DeepLinkHandler { uri -> invokedUri = uri })
+        val job = capturePostponedJob()
+
+        DeepLinking.handleDeepLink(mockUri)
+
+        assertNull("Handler must not fire before an activity resumes", invokedUri)
+
+        job.captured.invoke(testActivity)
+
+        assertEquals(mockUri, invokedUri)
+    }
+
+    @Test
+    fun `handleDeepLink waits for the cold start grace period`() {
+        Registry.register<DeepLinkHandler>(mockk<DeepLinkHandler>(relaxed = true))
+        val timeout = slot<Long>()
+        every {
+            Registry.lifecycleMonitor.runWithCurrentOrNextActivity(capture(timeout), any(), any())
+        } returns null
+
+        DeepLinking.handleDeepLink(mockUri)
+
+        assertEquals(COLD_START_GRACE_PERIOD, timeout.captured)
+    }
+
+    @Test
+    fun `handleDeepLink invokes handler anyway when no activity resumes in time`() {
+        var invokedUri: Uri? = null
+        Registry.register<DeepLinkHandler>(DeepLinkHandler { uri -> invokedUri = uri })
+        val onTimeout = slot<() -> Unit>()
+        every {
+            Registry.lifecycleMonitor.runWithCurrentOrNextActivity(any(), capture(onTimeout), any())
+        } returns null
+
+        DeepLinking.handleDeepLink(mockUri)
+
+        assertNull("Handler must not fire before the timeout elapses", invokedUri)
+
+        onTimeout.captured.invoke()
+
+        assertEquals(mockUri, invokedUri)
+        verify { spyLog.warning(any(), any()) }
+    }
+
+    @Test
+    fun `handleDeepLink does not propagate an exception from the host handler`() {
+        Registry.register<DeepLinkHandler>(
+            DeepLinkHandler { throw RuntimeException("host handler blew up") }
+        )
+
+        // safeCall re-throws in debug builds to avoid development blindness, so this asserts the
+        // production behavior the guard exists for: a throwing handler must not crash the host.
+        mockkObject(KlaviyoConfig)
+        every { KlaviyoConfig.isDebugBuild } returns false
+
+        DeepLinking.handleDeepLink(mockUri)
+
+        verify { spyLog.error(any(), any<Exception>()) }
+    }
+
+    /**
+     * Stub the postponement helper to run its job immediately with [testActivity].
+     * [BaseTest] does this with its own `mockActivity`; these cases assert on `testActivity`.
+     */
+    private fun runWithActivityImmediately() {
+        every {
+            Registry.lifecycleMonitor.runWithCurrentOrNextActivity(any(), any(), any())
+        } answers {
+            thirdArg<(Activity) -> Unit>().invoke(testActivity)
+            null
+        }
+    }
+
+    /**
+     * Stub the postponement helper to capture its job without running it, standing in for a host
+     * with no resumed activity — a cold start, or an activity transition in progress.
+     */
+    private fun capturePostponedJob(): CapturingSlot<(Activity) -> Unit> {
+        val job = slot<(Activity) -> Unit>()
+        every {
+            Registry.lifecycleMonitor.runWithCurrentOrNextActivity(any(), any(), capture(job))
+        } returns null
+        return job
     }
 
     @Test

--- a/sdk/core/src/main/java/com/klaviyo/core/lifecycle/LifecycleMonitor.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/lifecycle/LifecycleMonitor.kt
@@ -119,15 +119,19 @@ interface LifecycleMonitor {
     /**
      * Helper function to run a task immediately if there is a current activity,
      * or wait for the next resumed activity if resumed within the optional timeout.
-     * Returns a token that can be used to cancel the pending task if needed.
      *
-     * Exactly one of [job] and [onTimeout] is ever invoked: without [onTimeout], a job that
-     * outlives its timeout is dropped, so callers that must not lose the work should supply a
-     * best-effort fallback rather than relying on the resume arriving in time.
+     * Exactly one of [job] and [onTimeout] is invoked, unless the returned token cancels the wait
+     * first. Without [onTimeout], a job that outlives its timeout is dropped, so callers that must
+     * not lose the work should supply a best-effort fallback rather than relying on the resume
+     * arriving in time.
      *
      * @param timeout How long to wait for a resumed activity, or null to wait indefinitely
      * @param onTimeout Invoked instead of [job] if [timeout] elapses with no resumed activity
      * @param job Invoked with the current activity, or the next one to resume
+     * @return null if [job] already ran against the current activity, otherwise a token that
+     *  abandons the pending wait. Both [Clock.Cancellable.cancel] and [Clock.Cancellable.runNow]
+     *  abandon it — there is no way to "run now" a job that is waiting precisely because it has no
+     *  activity to run against — and neither runs [job] or [onTimeout].
      */
     fun runWithCurrentOrNextActivity(
         timeout: Long? = null,
@@ -139,11 +143,12 @@ interface LifecycleMonitor {
             return null
         }
 
-        // The timeout runs off the observer's thread, so claim the outcome atomically: a resume
-        // racing the timer must not fire both branches.
+        // The timeout fires on the clock's own thread, so claim the outcome atomically: a resume
+        // racing the timer — or a caller abandoning the wait — must not let two branches run.
         val settled = AtomicBoolean(false)
         var observer: ActivityObserver? = null
-        val cancelToken: Clock.Cancellable? = timeout?.let { delay ->
+
+        val timeoutTask: Clock.Cancellable? = timeout?.let { delay ->
             Registry.clock.schedule(delay) {
                 if (!settled.compareAndSet(false, true)) return@schedule
                 Registry.log.verbose("Removing postponed observer after timeout ${delay}ms")
@@ -151,25 +156,40 @@ interface LifecycleMonitor {
                 onTimeout?.invoke()
             }
         }
+
         observer = { event ->
             event.takeIf<ActivityEvent.Resumed>()?.let { resumed ->
                 if (settled.compareAndSet(false, true)) {
                     Registry.log.verbose("Invoking postponed observer on resume")
                     observer?.let { offActivityEvent(it) }
-                    cancelToken?.cancel()
+                    timeoutTask?.cancel()
                     job(resumed.activity)
                 }
             }
         }
 
-        // The timeout runs on the clock's own thread, so it can beat us here and de-register an
-        // observer we have not registered yet. Registering afterwards would leave one that can
-        // never fire — settled is already claimed — and that nothing will ever remove.
-        if (settled.get()) return cancelToken
-
         onActivityEvent(observer)
 
-        return cancelToken
+        // Reconcile with a timeout that fired while we were registering: its own de-registration
+        // was a no-op against an observer that did not exist yet, and it has already claimed
+        // `settled`, so without this the observer could neither fire nor ever be removed.
+        if (settled.get()) {
+            offActivityEvent(observer)
+        }
+
+        return object : Clock.Cancellable {
+            override fun cancel(): Boolean {
+                if (!settled.compareAndSet(false, true)) return false
+                Registry.log.verbose("Abandoning postponed observer")
+                offActivityEvent(observer)
+                timeoutTask?.cancel()
+                return true
+            }
+
+            override fun runNow() {
+                cancel()
+            }
+        }
     }
 
     companion object {
@@ -178,13 +198,5 @@ interface LifecycleMonitor {
          * In testing, this was rarely exceeds 10ms, allowing some extra time for safety.
          */
         const val ACTIVITY_TRANSITION_GRACE_PERIOD = 50L
-
-        /**
-         * Allow for a cold start to produce its first resumed activity: the host process has to
-         * fork, run `Application.onCreate`, and draw a frame, which is orders of magnitude beyond
-         * [ACTIVITY_TRANSITION_GRACE_PERIOD]. Generous on purpose — waiting costs nothing, whereas
-         * timing out early means falling back to a best-effort that cannot navigate.
-         */
-        const val COLD_START_GRACE_PERIOD = 10_000L
     }
 }

--- a/sdk/core/src/main/java/com/klaviyo/core/lifecycle/LifecycleMonitor.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/lifecycle/LifecycleMonitor.kt
@@ -170,11 +170,26 @@ interface LifecycleMonitor {
 
         onActivityEvent(observer)
 
-        // Reconcile with a timeout that fired while we were registering: its own de-registration
-        // was a no-op against an observer that did not exist yet, and it has already claimed
-        // `settled`, so without this the observer could neither fire nor ever be removed.
+        // Reconcile with whatever raced us while we were registering. Two racers: the timeout runs
+        // on the clock's own thread, and callers can be off the main thread while activity resumes
+        // broadcast on it.
         if (settled.get()) {
+            // The timeout claimed the outcome. Its own de-registration was a no-op against an
+            // observer that did not exist yet, so without this the observer could neither fire nor
+            // ever be removed.
             offActivityEvent(observer)
+        } else {
+            // An activity may have resumed and broadcast before the observer existed, which would
+            // otherwise leave us waiting out the whole timeout for a resume that already happened.
+            currentActivity?.let { activity ->
+                if (settled.compareAndSet(false, true)) {
+                    Registry.log.verbose("Activity resumed while registering postponed observer")
+                    offActivityEvent(observer)
+                    timeoutTask?.cancel()
+                    job(activity)
+                    return null
+                }
+            }
         }
 
         return object : Clock.Cancellable {

--- a/sdk/core/src/main/java/com/klaviyo/core/lifecycle/LifecycleMonitor.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/lifecycle/LifecycleMonitor.kt
@@ -161,6 +161,12 @@ interface LifecycleMonitor {
                 }
             }
         }
+
+        // The timeout runs on the clock's own thread, so it can beat us here and de-register an
+        // observer we have not registered yet. Registering afterwards would leave one that can
+        // never fire — settled is already claimed — and that nothing will ever remove.
+        if (settled.get()) return cancelToken
+
         onActivityEvent(observer)
 
         return cancelToken

--- a/sdk/core/src/main/java/com/klaviyo/core/lifecycle/LifecycleMonitor.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/lifecycle/LifecycleMonitor.kt
@@ -8,6 +8,7 @@ import com.klaviyo.core.Registry
 import com.klaviyo.core.config.Clock
 import com.klaviyo.core.utils.AdvancedAPI
 import com.klaviyo.core.utils.takeIf
+import java.util.concurrent.atomic.AtomicBoolean
 
 typealias ActivityObserver = (activity: ActivityEvent) -> Unit
 
@@ -119,9 +120,18 @@ interface LifecycleMonitor {
      * Helper function to run a task immediately if there is a current activity,
      * or wait for the next resumed activity if resumed within the optional timeout.
      * Returns a token that can be used to cancel the pending task if needed.
+     *
+     * Exactly one of [job] and [onTimeout] is ever invoked: without [onTimeout], a job that
+     * outlives its timeout is dropped, so callers that must not lose the work should supply a
+     * best-effort fallback rather than relying on the resume arriving in time.
+     *
+     * @param timeout How long to wait for a resumed activity, or null to wait indefinitely
+     * @param onTimeout Invoked instead of [job] if [timeout] elapses with no resumed activity
+     * @param job Invoked with the current activity, or the next one to resume
      */
     fun runWithCurrentOrNextActivity(
         timeout: Long? = null,
+        onTimeout: (() -> Unit)? = null,
         job: (activity: Activity) -> Unit
     ): Clock.Cancellable? {
         currentActivity?.let { activity ->
@@ -129,19 +139,26 @@ interface LifecycleMonitor {
             return null
         }
 
+        // The timeout runs off the observer's thread, so claim the outcome atomically: a resume
+        // racing the timer must not fire both branches.
+        val settled = AtomicBoolean(false)
         var observer: ActivityObserver? = null
         val cancelToken: Clock.Cancellable? = timeout?.let { delay ->
             Registry.clock.schedule(delay) {
+                if (!settled.compareAndSet(false, true)) return@schedule
                 Registry.log.verbose("Removing postponed observer after timeout ${delay}ms")
                 observer?.let { offActivityEvent(it) }
+                onTimeout?.invoke()
             }
         }
         observer = { event ->
-            event.takeIf<ActivityEvent.Resumed>()?.let { event ->
-                Registry.log.verbose("Invoking postponed observer on resume")
-                job(event.activity)
-                observer?.let { offActivityEvent(it) }
-                cancelToken?.cancel()
+            event.takeIf<ActivityEvent.Resumed>()?.let { resumed ->
+                if (settled.compareAndSet(false, true)) {
+                    Registry.log.verbose("Invoking postponed observer on resume")
+                    observer?.let { offActivityEvent(it) }
+                    cancelToken?.cancel()
+                    job(resumed.activity)
+                }
             }
         }
         onActivityEvent(observer)
@@ -155,5 +172,13 @@ interface LifecycleMonitor {
          * In testing, this was rarely exceeds 10ms, allowing some extra time for safety.
          */
         const val ACTIVITY_TRANSITION_GRACE_PERIOD = 50L
+
+        /**
+         * Allow for a cold start to produce its first resumed activity: the host process has to
+         * fork, run `Application.onCreate`, and draw a frame, which is orders of magnitude beyond
+         * [ACTIVITY_TRANSITION_GRACE_PERIOD]. Generous on purpose — waiting costs nothing, whereas
+         * timing out early means falling back to a best-effort that cannot navigate.
+         */
+        const val COLD_START_GRACE_PERIOD = 10_000L
     }
 }

--- a/sdk/core/src/test/java/com/klaviyo/core/lifecycle/KlaviyoLifecycleMonitorTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/lifecycle/KlaviyoLifecycleMonitorTest.kt
@@ -5,7 +5,9 @@ import com.klaviyo.core.Registry
 import com.klaviyo.core.utils.AdvancedAPI
 import com.klaviyo.core.utils.takeIf
 import com.klaviyo.fixtures.BaseTest
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
 import io.mockk.unmockkObject
 import io.mockk.verify
 import org.junit.After
@@ -318,6 +320,43 @@ class KlaviyoLifecycleMonitorTest : BaseTest() {
 
         assert(!called) { "Callback should not run after runNow" }
         assert(!timedOut) { "Fallback should not run after runNow" }
+    }
+
+    @Test
+    fun `runWithCurrentOrNextActivity picks up an activity that resumed while registering`() {
+        var called = false
+        var timedOut = false
+        val resumedActivity = mockk<Activity>()
+
+        // Stand in for a caller running off the main thread: an activity resumes and broadcasts
+        // between the initial currentActivity check and the observer's registration, so the
+        // observer never sees the event. Expressed as the two reads the implementation makes —
+        // null first, then present — since the interleaving itself can't be injected from a test.
+        // Without the post-registration recheck the job would wait out the whole timeout for a
+        // resume that already happened.
+        mockkObject(KlaviyoLifecycleMonitor)
+        try {
+            every { KlaviyoLifecycleMonitor.currentActivity } returnsMany listOf(
+                null,
+                resumedActivity
+            )
+
+            val token = KlaviyoLifecycleMonitor.runWithCurrentOrNextActivity(
+                timeout = 100,
+                onTimeout = { timedOut = true }
+            ) { activity ->
+                called = true
+                assertEquals(resumedActivity, activity)
+            }
+
+            assert(called) { "Job should run against the activity that resumed during registration" }
+            assertEquals(null, token)
+
+            staticClock.execute(150)
+            assert(!timedOut) { "Fallback should not run after the job already ran" }
+        } finally {
+            unmockkObject(KlaviyoLifecycleMonitor)
+        }
     }
 
     @Test

--- a/sdk/core/src/test/java/com/klaviyo/core/lifecycle/KlaviyoLifecycleMonitorTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/lifecycle/KlaviyoLifecycleMonitorTest.kt
@@ -265,4 +265,67 @@ class KlaviyoLifecycleMonitorTest : BaseTest() {
 
         assertEquals(1, callCount)
     }
+
+    @Test
+    fun `runWithCurrentOrNextActivity returns null when the job ran against the current activity`() {
+        @OptIn(AdvancedAPI::class)
+        KlaviyoLifecycleMonitor.assignCurrentActivity(mockk())
+
+        val token = KlaviyoLifecycleMonitor.runWithCurrentOrNextActivity(timeout = 100) { }
+
+        assertEquals(null, token)
+    }
+
+    @Test
+    fun `cancelling the returned token abandons the job without running either branch`() {
+        var called = false
+        var timedOut = false
+
+        val token = KlaviyoLifecycleMonitor.runWithCurrentOrNextActivity(
+            timeout = 100,
+            onTimeout = { timedOut = true }
+        ) { _ ->
+            called = true
+        }
+
+        assert(token?.cancel() == true) { "Cancelling a pending job should report success" }
+
+        KlaviyoLifecycleMonitor.onActivityResumed(mockk())
+        staticClock.execute(150)
+
+        assert(!called) { "Callback should not run after cancellation" }
+        assert(!timedOut) { "Fallback should not run after cancellation — this is not a deadline" }
+    }
+
+    @Test
+    fun `runNow on the returned token abandons the job rather than invoking the fallback`() {
+        var called = false
+        var timedOut = false
+
+        // KlaviyoPresentationManager cancels a postponed present via runNow, so it must not be a
+        // back door into the timeout fallback.
+        val token = KlaviyoLifecycleMonitor.runWithCurrentOrNextActivity(
+            timeout = 100,
+            onTimeout = { timedOut = true }
+        ) { _ ->
+            called = true
+        }
+
+        token?.runNow()
+
+        KlaviyoLifecycleMonitor.onActivityResumed(mockk())
+        staticClock.execute(150)
+
+        assert(!called) { "Callback should not run after runNow" }
+        assert(!timedOut) { "Fallback should not run after runNow" }
+    }
+
+    @Test
+    fun `cancelling the returned token after the job ran reports failure`() {
+        val token = KlaviyoLifecycleMonitor.runWithCurrentOrNextActivity(timeout = 100) { }
+
+        KlaviyoLifecycleMonitor.onActivityResumed(mockk())
+
+        assert(token?.cancel() == false) { "Cancelling a settled job should report failure" }
+    }
 }

--- a/sdk/core/src/test/java/com/klaviyo/core/lifecycle/KlaviyoLifecycleMonitorTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/lifecycle/KlaviyoLifecycleMonitorTest.kt
@@ -212,4 +212,57 @@ class KlaviyoLifecycleMonitorTest : BaseTest() {
         KlaviyoLifecycleMonitor.onActivityResumed(mockk())
         assert(!called) { "Callback should not be called if timed out" }
     }
+
+    @Test
+    fun `runWithCurrentOrNextActivity invokes onTimeout if activity is not resumed in time`() {
+        var called = false
+        var timedOut = false
+
+        KlaviyoLifecycleMonitor.runWithCurrentOrNextActivity(
+            timeout = 100,
+            onTimeout = { timedOut = true }
+        ) { _ ->
+            called = true
+        }
+
+        assert(!timedOut) { "Fallback should not be called yet" }
+        staticClock.execute(150)
+        assert(timedOut) { "Fallback should be called once timed out" }
+        assert(!called) { "Callback should not be called if timed out" }
+    }
+
+    @Test
+    fun `runWithCurrentOrNextActivity does not invoke onTimeout once the job has run`() {
+        var called = false
+        var timedOut = false
+
+        KlaviyoLifecycleMonitor.runWithCurrentOrNextActivity(
+            timeout = 100,
+            onTimeout = { timedOut = true }
+        ) { _ ->
+            called = true
+        }
+
+        KlaviyoLifecycleMonitor.onActivityResumed(mockk())
+        staticClock.execute(150)
+
+        assert(called) { "Callback should be called after activity resumed" }
+        assert(!timedOut) { "Fallback should not be called after the job already ran" }
+    }
+
+    @Test
+    fun `runWithCurrentOrNextActivity runs the job at most once`() {
+        var callCount = 0
+
+        KlaviyoLifecycleMonitor.runWithCurrentOrNextActivity(
+            timeout = 100
+        ) { _ ->
+            callCount++
+        }
+
+        KlaviyoLifecycleMonitor.onActivityResumed(mockk())
+        KlaviyoLifecycleMonitor.onActivityResumed(mockk())
+
+        assertEquals(1, callCount)
+    }
 }

--- a/sdk/fixtures/src/main/java/com/klaviyo/fixtures/BaseTest.kt
+++ b/sdk/fixtures/src/main/java/com/klaviyo/fixtures/BaseTest.kt
@@ -109,9 +109,12 @@ abstract class BaseTest {
         every { offActivityEvent(any()) } returns Unit
         every { currentActivity } returns mockActivity
 
+        // Default: an activity is always available, so postponed jobs run immediately and the
+        // timeout fallback never fires. Tests exercising the deferred path re-stub this.
         val slotJob = slot<(activity: Activity) -> Unit>()
         every {
             runWithCurrentOrNextActivity(
+                any(),
                 any(),
                 capture(slotJob)
             )

--- a/sdk/forms/src/test/java/com/klaviyo/forms/presentation/KlaviyoPresentationManagerTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/presentation/KlaviyoPresentationManagerTest.kt
@@ -416,7 +416,7 @@ class KlaviyoPresentationManagerTest : BaseTest() {
         // runWithCurrentOrNextActivity must return our host activity for floating window tests
         val slotJob = slot<(activity: Activity) -> Unit>()
         every {
-            mockLifecycleMonitor.runWithCurrentOrNextActivity(any(), capture(slotJob))
+            mockLifecycleMonitor.runWithCurrentOrNextActivity(any(), any(), capture(slotJob))
         } answers {
             slotJob.captured.invoke(mockHostActivity)
             null

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivity.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivity.kt
@@ -128,16 +128,20 @@ internal class KlaviyoTrampolineActivity : Activity() {
          * - Deep link present and no [DeepLinkHandler][com.klaviyo.analytics.linking.DeepLinkHandler]
          *   registered → `ACTION_VIEW` into the host, falling back to the launcher if unresolvable.
          * - Deep link present and a handler registered → launcher intent flagged only to bring the
-         *   host's task to the front. `handlePush` already dispatched the handler, so an additional
-         *   `ACTION_VIEW` would double-deliver navigation, and clearing the back stack would undo it.
+         *   host's task to the front (creating it on a cold start), which is what gives the deferred
+         *   handler an activity to navigate from. `handlePush` already routed the link to the
+         *   handler, so an additional `ACTION_VIEW` would double-deliver navigation, and clearing
+         *   the back stack would undo it.
          * - No deep link (`open_app`) → launcher intent with the same flags as the non-trampoline
          *   content intent it replaces.
          */
         private fun startDestination(intent: Intent, context: Context) {
             val deepLink = intent.data
             // Read once so the destination and its flags can't be decided from different state.
-            // `handlePush` above dispatches this link to the host's handler synchronously on the
-            // main thread, so by now the host may already have navigated. (A repeat tap of the
+            // `handlePush` above hands this link to the host's handler, which `DeepLinking` defers
+            // until an activity resumes — i.e. until the intent we start below has brought the host
+            // up. That ordering is why the launcher intent must not clear the task: it is what
+            // creates the destination the handler then navigates on top of. (A repeat tap of the
             // same delivery is deduped inside `handlePush` and navigates nothing — still the right
             // branch, since there is no reason to tear down what the first tap navigated to.)
             val handlerOwnsNavigation = deepLink != null && DeepLinking.isHandlerRegistered

--- a/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivityTest.kt
+++ b/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivityTest.kt
@@ -8,6 +8,7 @@ import com.klaviyo.analytics.Klaviyo
 import com.klaviyo.analytics.linking.DeepLinking
 import com.klaviyo.core.Constants.PACKAGE_PREFIX
 import com.klaviyo.core.Constants.TRACKING_PARAMETER
+import com.klaviyo.core.Registry
 import com.klaviyo.fixtures.BaseTest
 import io.mockk.every
 import io.mockk.mockk
@@ -164,10 +165,29 @@ class KlaviyoTrampolineActivityTest : BaseTest() {
         verify(exactly = 0) { DeepLinking.makeDeepLinkIntent(any(), any(), any()) }
         verify { DeepLinking.makeLaunchIntent(mockTrampolineContext, any()) }
         verify { mockTrampolineContext.startActivity(mockLaunchIntent) }
-        // The handler runs synchronously inside handlePush, so it may already have navigated:
-        // CLEAR_TOP would finish that destination and SINGLE_TOP would re-deliver an ACTION_MAIN
-        // intent to the launcher activity. Assigned, not added, because makeLaunchIntent bakes in
-        // SINGLE_TOP — see DeepLinkingTest's makeLaunchIntent coverage.
+        // The handler either has navigated already or is postponed until this intent resumes the
+        // host: CLEAR_TOP would finish that destination and SINGLE_TOP would re-deliver an
+        // ACTION_MAIN intent to the launcher activity. Assigned, not added, because
+        // makeLaunchIntent bakes in SINGLE_TOP — see DeepLinkingTest's makeLaunchIntent coverage.
+        verify { mockLaunchIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK) }
+        verify(exactly = 0) { mockLaunchIntent.addFlags(any()) }
+    }
+
+    @Test
+    fun `handleTrampolineIntent with deep link and handler registered brings host to front on cold start`() {
+        val intent = klaviyoIntent()
+        val deepLink = mockk<Uri>(relaxed = true)
+        every { intent.data } returns deepLink
+        every { DeepLinking.isHandlerRegistered } returns true
+        // Cold start: no activity exists yet, so DeepLinking postpones the handler until the
+        // intent started here resumes the host. Dispatch must not depend on that state — this
+        // launch is what creates the task the handler will navigate on top of.
+        every { Registry.lifecycleMonitor.currentActivity } returns null
+
+        KlaviyoTrampolineActivity.handleTrampolineIntent(intent, mockTrampolineContext)
+
+        verify { DeepLinking.makeLaunchIntent(mockTrampolineContext, any()) }
+        verify { mockTrampolineContext.startActivity(mockLaunchIntent) }
         verify { mockLaunchIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK) }
         verify(exactly = 0) { mockLaunchIntent.addFlags(any()) }
     }

--- a/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivityTest.kt
+++ b/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivityTest.kt
@@ -181,7 +181,9 @@ class KlaviyoTrampolineActivityTest : BaseTest() {
         every { DeepLinking.isHandlerRegistered } returns true
         // Cold start: no activity exists yet, so DeepLinking postpones the handler until the
         // intent started here resumes the host. Dispatch must not depend on that state — this
-        // launch is what creates the task the handler will navigate on top of.
+        // launch is what creates the task the handler will navigate on top of. The assertions
+        // therefore match the warm-tap test above on purpose: that equivalence *is* the invariant,
+        // and it would break if dispatch ever started branching on activity state.
         every { Registry.lifecycleMonitor.currentActivity } returns null
 
         KlaviyoTrampolineActivity.handleTrampolineIntent(intent, mockTrampolineContext)


### PR DESCRIPTION
# Description

With `automatic_push_open_tracking` enabled, a notification tap that **cold-starts** the app invoked the host's registered `DeepLinkHandler` while zero Activities existed, so a handler that navigates had nothing to navigate and the deep link was lost. Handler dispatch is now postponed until the host has a resumed Activity.

## Due Diligence

- [x] I have tested this on an emulator and/or a physical device.
  - Pixel 10 emulator, API 37 (`google_apis_playstore`). Verified against the pre-fix SDK as a control — results in the Test Plan below.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all Android versions the SDK currently supports.
  - Only `AtomicBoolean` and existing SDK abstractions are used; nothing version-gated.

## Release/Versioning Considerations

- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [x] Contains readme or migration guide changes.
  - Stacked on `asb/mage-1004-trampoline-clear-top` (→ `rel/4.5.0`), so docs only go live with the 4.5.0 release.
- [x] This is planned work for an upcoming release.
  - Fixes a defect in the unreleased automatic push integration, so it should ship in 4.5.0 alongside the feature it affects.

No version bump in this PR — deferred to the release-branch merge per convention.

> **Stacked PR:** targets #529 (MAGE-1004), not `rel/4.5.0`. Review that one first. The two defects are independent — `CLEAR_TOP` is a no-op at cold start with no task to clear — but this PR edits comments and tests #529 introduced.

## Changelog / Code Overview

**Root cause.** `KlaviyoTrampolineActivity.handleTrampolineIntent` calls `Klaviyo.handlePush(intent)` **before** `dispatchDestination` starts the host app. `handlePush` reaches `DeepLinking.handleDeepLink`, which invoked the handler through `Registry.threadHelper.runOnUiThread` — and since the trampoline's `onCreate` is already on the main looper, that ran **inline**:

```
KlaviyoTrampolineActivity.onCreate
  └─ handleTrampolineIntent
       ├─ Klaviyo.handlePush(intent)     ← handler fires here, with zero Activities alive
       └─ dispatchDestination            ← host app starts here
```

On a cold start there is no Activity to navigate: a `NavController`, a `Fragment` transaction, or an `Activity` the handler holds all require one. The follow-up launcher intent carries `intent.extras` but not `data`, so `getIntent().data` is null in the host and the link is unrecoverable — it survives only in the undocumented `com.klaviyo.url` extra.

This is an ordering bug, not a flags bug. It needs both the flag **and** a handler registered from `Application.onCreate` (the pattern the README recommends and the sample app uses).

**Fix.** `handleDeepLink` postpones the handler until an Activity resumes, via the existing `LifecycleMonitor.runWithCurrentOrNextActivity`. That helper short-circuits and runs inline when an Activity is already current, so this is a **no-op for every case that already worked**. The trampoline registers the postponed job before it starts the host, so the launcher intent is what supplies the Activity — on a cold start that yields the launcher Activity with the deep link destination on top, which is the correct back stack.

Two things fell out of the trace and are worth knowing:

- `currentActivity` is set only in `onActivityResumed` and cleared in `onActivityPaused`, and the outgoing Activity's `onPause` completes before the incoming one's `onCreate`. So it is null on **warm** taps too — those work today only because the paused Activity object is still alive. Deferral therefore changes warm-tap timing as well as cold, and makes both deterministic.
- `KlaviyoNativeBridge` already documents this contract ("`handleDeepLink` alleviates that race by postponing until the next activity resumes if the current activity is null"), but it was only true of the *no-handler* branch. Forms CTAs with a registered handler had the same latent gap; the central fix closes it and makes the comment accurate.

**`runWithCurrentOrNextActivity` gained a real fallback.** Its timeout previously only de-registered the observer — it never ran the job — so adopting it as-is would have traded "handler fires uselessly" for "handler never fires." It now takes an optional `onTimeout`, and an `AtomicBoolean` claims the outcome so exactly one of the two runs; previously a resume racing the timer could fire both. The deep link path passes a best-effort fallback that invokes the handler anyway, so the outcome is never worse than not waiting.

**Two follow-up commits tightened that helper**, both from self-review:

- The observer could still leak. Checking the claim flag *before* registering only covered a timeout that fired before the observer existed; one landing between that check and the registration still left an observer that could neither fire nor be removed. It now registers first and reconciles afterwards, which covers both orderings.
- Cancellation and expiry shared a code path. `KlaviyoPresentationManager` abandons a postponed present via `runNow()` on the returned token, which executed the timeout body — harmless while that body only de-registered the observer, but once it invokes `onTimeout`, "cancel" would have triggered the fallback. The helper now returns its own token whose `cancel()` and `runNow()` both abandon the wait and run neither branch. That also makes `cancel()` do what it always claimed: previously it stopped the timer while leaving the observer registered, so the job still ran on the next resume.

**Exception safety.** The postponed invocation runs outside its caller's error handling, so `invokeHandler` guards it with `safeApply` — *inside* the `runOnUiThread` job, since that posts rather than runs inline when called off the main thread. Without this, a throwing host handler would propagate out of a lifecycle callback.

**Docs.** README states the handler is invoked once the app has a resumed Activity; MIGRATION_GUIDE calls out that a handler invoked from `handlePush` inside `Activity.onCreate` now fires at `onResume` rather than inline.

### Tradeoffs worth a reviewer's opinion

1. **`COLD_START_GRACE_PERIOD = 10s.`** This is a deadline, not a delay — the wait only happens when nothing is resumed, so no user is looking at a blocked screen, and the job fires the instant an Activity resumes. A *shorter* timeout would make things worse, since the fallback fires into a state where nothing can navigate. Open to a different number, but I'd argue against per-caller timeouts: the semantics ("wait for something navigable") are uniform.
2. **Stale navigation window.** If a push-triggered launch stalls and the user instead opens the app by another route within the grace period, the pending job fires on that resume with the older URI. There is no clean way to correlate a `Resumed` event with a specific launch intent. I think this is acceptable — the user did tap that push seconds earlier — but it is a real consequence of a generous timeout, and it scales with whatever number we pick in (1).
3. **`LifecycleMonitor` signature.** Inserting `onTimeout` changes the `$default` bridge of a default method on a public interface. All `sdk/*` artifacts version and publish together, so a consumer can't realistically mix versions, and this method isn't documented public API — but flagging it rather than assuming. If we want to signal intent, `@AdvancedAPI` is the existing mechanism (as on `assignCurrentActivity`), though adding it now is itself a source break for any caller.

## Test Plan

Unit — `./gradlew test` and `./gradlew ktlintCheck` are green across all modules. Targeted:

```
./gradlew :sdk:core:testDebugUnitTest --tests "com.klaviyo.core.lifecycle.KlaviyoLifecycleMonitorTest"
./gradlew :sdk:analytics:testDebugUnitTest --tests "com.klaviyo.analytics.linking.DeepLinkingTest"
```

New coverage: postponement and resume dispatch, the timeout fallback, exception safety, `onTimeout` mutual exclusion with the job, at-most-once job invocation, and that a registered handler never *also* broadcasts an intent — that last one caught a genuine double-dispatch bug during development, where the original `?.let { … } ?: sendDeepLinkIntent(uri)` shape started returning the postponement helper's nullable `Cancellable`, firing the elvis as well.

Manual — Pixel 10 emulator, API 37. Notifications were posted through `KlaviyoNotification.displayNotification` from temporary, uncommitted sample scaffolding, so the tap exercised the real trampoline content intent without an FCM round trip. The scaffolding was reverted; nothing in this PR touches `sample/`.

Staged with `am kill` rather than `force-stop`, since force-stop clears the app's notifications along with the process. Note "cold start" here means *no Activity exists* — FCM starts the process to run `KlaviyoPushService`, so `Application.onCreate` and `registerDeepLinkHandler` have already run by tap time. That is the real-world shape and what the bug depends on.

Back stacks read from `dumpsys activity activities`, top first:

| Case | Result |
|---|---|
| **Cold start, pre-fix SDK** (control) | `SampleActivity` ← resumed, **`SampleDetailActivity` stranded behind it**, `SampleActivity` |
| **Cold start, with fix** | **`SampleDetailActivity` ← resumed**, `SampleActivity`, `SampleActivity` |
| **Warm tap, with fix** | **`SampleDetailActivity` ← resumed**, `SampleActivity`, `SampleActivity` |
| **`manual` flavor, cold start** | **`SampleDetailActivity` ← resumed**, `SampleActivity` — no trampoline involved, as expected |

The control reproduces the reported inversion exactly, and the fix inverts it back. Log evidence from the cold-start run, 52 ms apart, showing the designed ordering — trampoline brings the host up, then the handler navigates:

```
12:00:21.180  Trampoline dispatched deep link via handler; bringing host to front
12:00:21.232  Invoking postponed observer on resume
```

`$opened_push` was enqueued and flushed (202) on every run, and `No activity resumed within 10000ms` never appeared — so the fallback was not reached and the 10 s constant has headroom on this hardware.

The `manual` flavor is the most useful regression case, since it is where the documented timing change is observable: its `SampleActivity` calls `Klaviyo.handlePush(intent)` itself from `onCreate`, and the postponed-observer log confirms the callback now arrives at `onResume` instead of inline — with the navigation still landing correctly.

Universal links were also verified on the emulator by serving a resolvable `/u/` link locally, since the SDK uses the tracking
link itself as the request base URL.

@glenn-klaviyo additionally ran a manual pass on a **physical Pixel 7** ([comment](https://github.com/klaviyo/klaviyo-android-sdk/pull/530#issuecomment-5184041535)) covering both flavors — cold-start deep link (3x), warm tap, cold start with no deep link, and forms CTAs to both an external URL and an in-app deep link. All pass, with 52-88ms between trampoline dispatch and the deferred handler, matching the emulator. That closes the two gaps listed here previously: the forms CTA in-app route (no form in my test account had an Android deep-link route) and physical-device coverage.

Still not exercised by hand: the `COLD_START_GRACE_PERIOD` timeout fallback, which isn't practically reproducible without stalling the host past 10s — covered by unit tests in `KlaviyoLifecycleMonitorTest` and `DeepLinkingTest`. Note also that a cold start is unreachable through the forms CTA path at all, since a form cannot display without a resumed Activity.

## Related Issues/Tickets

- Related to MAGE-1020
- Stacked on #529 (MAGE-1004)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deep-link handlers now run after the app’s activity resumes, including during cold starts.
  * Push-open tracking occurs immediately while navigation waits for an available activity.
  * Prevented duplicate deep-link launches and preserved existing task back stacks.
  * Added a fallback for cases where no activity resumes within the grace period.

* **Documentation**
  * Updated migration and deep-link guidance to explain the revised handling behavior and cold-start considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

