### PR TITLE
fix(core): settle postponed-activity waits atomically

### DIFF
--- a/sdk/core/src/main/java/com/klaviyo/core/lifecycle/LifecycleMonitor.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/lifecycle/LifecycleMonitor.kt
@@ -138,18 +138,14 @@ interface LifecycleMonitor {
      * next resumed activity, falling back to [onTimeout] if none resumes within [timeout].
      *
      * Exactly one of [job] and [onTimeout] is invoked, unless the returned token cancels the wait
-     * first.
-     *
-     * [onTimeout] has no default value, so a call supplying only a timeout and a trailing lambda
-     * resolves to the two-argument overload.
+     * first. The timeout should be at least long enough to avoid race conditions between the
+     * scheduling of the tasks, e.g. min [ACTIVITY_TRANSITION_GRACE_PERIOD] milliseconds.
      *
      * @param timeout How long to wait for a resumed activity, or null to wait indefinitely
      * @param onTimeout Invoked instead of [job] if [timeout] elapses with no resumed activity
      * @param job Invoked with the current activity, or the next one to resume
-     * @return null if the wait already settled before returning, otherwise a token that abandons
-     *  the pending wait. Both [Clock.Cancellable.cancel] and [Clock.Cancellable.runNow] abandon it
-     *  — there is no way to "run now" a job that is waiting precisely because it has no activity to
-     *  run against — and neither runs [job] or [onTimeout].
+     * @return A token to cancel the pending wait or attempt to run immediately against the
+     * current activity and abandon the wait, or null if [job] ran immediately.
      */
     fun runWithCurrentOrNextActivity(
         timeout: Long?,
@@ -161,11 +157,11 @@ interface LifecycleMonitor {
             return null
         }
 
-        // The timeout fires on the clock's own thread, so claim the outcome atomically: a resume
-        // racing the timer — or a caller abandoning the wait — must not let two branches run.
+        // Track atomically whether the task or timeout have run
         val settled = AtomicBoolean(false)
         var observer: ActivityObserver? = null
 
+        // Cancel the task if a specified timeout elapses, and invoke the optional timeout callback
         val timeoutTask: Clock.Cancellable? = timeout?.let { delay ->
             Registry.clock.schedule(delay) {
                 if (!settled.compareAndSet(false, true)) return@schedule
@@ -175,41 +171,31 @@ interface LifecycleMonitor {
             }
         }
 
+        // Invoke the job when the next activity resumes, and cancel the timeout task
+        val waitingTask: (activity: Activity, reason: String) -> Unit = { activity, reason ->
+            if (settled.compareAndSet(false, true)) {
+                Registry.log.verbose("Invoking postponed observer on $reason")
+                observer?.let { offActivityEvent(it) }
+                timeoutTask?.cancel()
+                job(activity)
+            } else {
+                Registry.log.verbose("Postponed observer already settled, ignoring $reason")
+            }
+        }
+
         observer = { event ->
             event.takeIf<ActivityEvent.Resumed>()?.let { resumed ->
-                if (settled.compareAndSet(false, true)) {
-                    Registry.log.verbose("Invoking postponed observer on resume")
-                    observer?.let { offActivityEvent(it) }
-                    timeoutTask?.cancel()
-                    job(resumed.activity)
-                }
+                waitingTask(resumed.activity, "resume")
             }
         }
 
         onActivityEvent(observer)
 
-        // Reconcile with whatever raced us while we were registering. The timeout runs on the
-        // clock's own thread, and callers can be off the main thread while activity resumes
-        // broadcast on it.
-        if (settled.get()) {
-            // Something claimed the outcome while we registered — a timeout that de-registered an
-            // observer that did not exist yet, or a resume that already ran the job. Either way the
-            // wait is over, so there is nothing left for a token to abandon.
-            offActivityEvent(observer)
-            return null
-        }
-
-        currentActivity?.let { activity ->
-            if (settled.compareAndSet(false, true)) {
-                Registry.log.verbose("Activity resumed while registering postponed observer")
-                offActivityEvent(observer)
-                timeoutTask?.cancel()
-                job(activity)
-                return null
-            }
-        }
-
         return object : Clock.Cancellable {
+            /**
+             * Cancel the wait for the next resumed activity, and cancel the timeout task if any.
+             * [onTimeout] is not invoked automatically, caller can do that manually if needed.
+             */
             override fun cancel(): Boolean {
                 if (!settled.compareAndSet(false, true)) return false
                 Registry.log.verbose("Abandoning postponed observer")
@@ -218,8 +204,16 @@ interface LifecycleMonitor {
                 return true
             }
 
+            /**
+             * Contract correctness: an option to attempt to invoke immediately. Not recommended.
+             */
             override fun runNow() {
-                cancel()
+                currentActivity?.let { activity ->
+                    waitingTask(activity, "runNow")
+                } ?: run {
+                    Registry.log.verbose("Postponed observer has no current activity, abandoning")
+                    cancel()
+                }
             }
         }
     }

--- a/sdk/core/src/main/java/com/klaviyo/core/lifecycle/LifecycleMonitor.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/lifecycle/LifecycleMonitor.kt
@@ -145,7 +145,8 @@ interface LifecycleMonitor {
      * @param onTimeout Invoked instead of [job] if [timeout] elapses with no resumed activity
      * @param job Invoked with the current activity, or the next one to resume
      * @return A token to cancel the pending wait or attempt to run immediately against the
-     * current activity and abandon the wait, or null if [job] ran immediately.
+     * current activity and abandon the wait, or null if the wait already settled — [job] ran
+     * against the current activity, or a resume or the timeout claimed it during registration.
      */
     fun runWithCurrentOrNextActivity(
         timeout: Long?,
@@ -190,6 +191,15 @@ interface LifecycleMonitor {
                 offActivityEvent(observer)
                 onTimeout?.invoke()
             }
+        }
+
+        // Activity resumes broadcast on the main thread and the timeout runs on the clock's own
+        // thread, so either can settle the wait before this returns. A settled wait has nothing
+        // left to abandon, and a resume that beat the assignment above left the timeout scheduled.
+        if (settled.get()) {
+            offActivityEvent(observer)
+            timeoutTask?.cancel()
+            return null
         }
 
         return object : Clock.Cancellable {

--- a/sdk/core/src/main/java/com/klaviyo/core/lifecycle/LifecycleMonitor.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/lifecycle/LifecycleMonitor.kt
@@ -160,16 +160,7 @@ interface LifecycleMonitor {
         // Track atomically whether the task or timeout have run
         val settled = AtomicBoolean(false)
         var observer: ActivityObserver? = null
-
-        // Cancel the task if a specified timeout elapses, and invoke the optional timeout callback
-        val timeoutTask: Clock.Cancellable? = timeout?.let { delay ->
-            Registry.clock.schedule(delay) {
-                if (!settled.compareAndSet(false, true)) return@schedule
-                Registry.log.verbose("Removing postponed observer after timeout ${delay}ms")
-                observer?.let { offActivityEvent(it) }
-                onTimeout?.invoke()
-            }
-        }
+        var timeoutTask: Clock.Cancellable? = null
 
         // Invoke the job when the next activity resumes, and cancel the timeout task
         val waitingTask: (activity: Activity, reason: String) -> Unit = { activity, reason ->
@@ -190,6 +181,16 @@ interface LifecycleMonitor {
         }
 
         onActivityEvent(observer)
+
+        // Cancel the task if a specified timeout elapses, and invoke the optional timeout callback
+        timeoutTask = timeout?.let { delay ->
+            Registry.clock.schedule(delay) {
+                if (!settled.compareAndSet(false, true)) return@schedule
+                Registry.log.verbose("Removing postponed observer after timeout ${delay}ms")
+                offActivityEvent(observer)
+                onTimeout?.invoke()
+            }
+        }
 
         return object : Clock.Cancellable {
             /**

--- a/sdk/core/src/main/java/com/klaviyo/core/lifecycle/LifecycleMonitor.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/lifecycle/LifecycleMonitor.kt
@@ -8,6 +8,7 @@ import com.klaviyo.core.Registry
 import com.klaviyo.core.config.Clock
 import com.klaviyo.core.utils.AdvancedAPI
 import com.klaviyo.core.utils.takeIf
+import java.util.concurrent.atomic.AtomicBoolean
 
 typealias ActivityObserver = (activity: ActivityEvent) -> Unit
 
@@ -118,10 +119,41 @@ interface LifecycleMonitor {
     /**
      * Helper function to run a task immediately if there is a current activity,
      * or wait for the next resumed activity if resumed within the optional timeout.
-     * Returns a token that can be used to cancel the pending task if needed.
+     *
+     * A job that outlives its timeout is dropped. Callers that need a fallback should use the
+     * [onTimeout] overload rather than relying on the resume arriving in time.
+     *
+     * @param timeout How long to wait for a resumed activity, or null to wait indefinitely
+     * @param job Invoked with the current activity, or the next one to resume
+     * @return null if [job] already ran against the current activity, otherwise a token that
+     *  abandons the pending wait.
      */
     fun runWithCurrentOrNextActivity(
         timeout: Long? = null,
+        job: (activity: Activity) -> Unit
+    ): Clock.Cancellable? = runWithCurrentOrNextActivity(timeout, null, job)
+
+    /**
+     * Helper function to run a task immediately if there is a current activity, or wait for the
+     * next resumed activity, falling back to [onTimeout] if none resumes within [timeout].
+     *
+     * Exactly one of [job] and [onTimeout] is invoked, unless the returned token cancels the wait
+     * first.
+     *
+     * [onTimeout] has no default value, so a call supplying only a timeout and a trailing lambda
+     * resolves to the two-argument overload.
+     *
+     * @param timeout How long to wait for a resumed activity, or null to wait indefinitely
+     * @param onTimeout Invoked instead of [job] if [timeout] elapses with no resumed activity
+     * @param job Invoked with the current activity, or the next one to resume
+     * @return null if [job] already ran against the current activity, otherwise a token that
+     *  abandons the pending wait. Both [Clock.Cancellable.cancel] and [Clock.Cancellable.runNow]
+     *  abandon it — there is no way to "run now" a job that is waiting precisely because it has no
+     *  activity to run against — and neither runs [job] or [onTimeout].
+     */
+    fun runWithCurrentOrNextActivity(
+        timeout: Long?,
+        onTimeout: (() -> Unit)?,
         job: (activity: Activity) -> Unit
     ): Clock.Cancellable? {
         currentActivity?.let { activity ->
@@ -129,24 +161,65 @@ interface LifecycleMonitor {
             return null
         }
 
+        // The timeout fires on the clock's own thread, so claim the outcome atomically: a resume
+        // racing the timer — or a caller abandoning the wait — must not let two branches run.
+        val settled = AtomicBoolean(false)
         var observer: ActivityObserver? = null
-        val cancelToken: Clock.Cancellable? = timeout?.let { delay ->
+
+        val timeoutTask: Clock.Cancellable? = timeout?.let { delay ->
             Registry.clock.schedule(delay) {
+                if (!settled.compareAndSet(false, true)) return@schedule
                 Registry.log.verbose("Removing postponed observer after timeout ${delay}ms")
                 observer?.let { offActivityEvent(it) }
+                onTimeout?.invoke()
             }
         }
+
         observer = { event ->
-            event.takeIf<ActivityEvent.Resumed>()?.let { event ->
-                Registry.log.verbose("Invoking postponed observer on resume")
-                job(event.activity)
-                observer?.let { offActivityEvent(it) }
-                cancelToken?.cancel()
+            event.takeIf<ActivityEvent.Resumed>()?.let { resumed ->
+                if (settled.compareAndSet(false, true)) {
+                    Registry.log.verbose("Invoking postponed observer on resume")
+                    observer?.let { offActivityEvent(it) }
+                    timeoutTask?.cancel()
+                    job(resumed.activity)
+                }
             }
         }
+
         onActivityEvent(observer)
 
-        return cancelToken
+        // Reconcile with whatever raced us while we were registering. The timeout runs on the
+        // clock's own thread, and callers can be off the main thread while activity resumes
+        // broadcast on it.
+        if (settled.get()) {
+            // The timeout already claimed the outcome, and de-registered an observer that did not
+            // exist yet.
+            offActivityEvent(observer)
+        } else {
+            currentActivity?.let { activity ->
+                if (settled.compareAndSet(false, true)) {
+                    Registry.log.verbose("Activity resumed while registering postponed observer")
+                    offActivityEvent(observer)
+                    timeoutTask?.cancel()
+                    job(activity)
+                    return null
+                }
+            }
+        }
+
+        return object : Clock.Cancellable {
+            override fun cancel(): Boolean {
+                if (!settled.compareAndSet(false, true)) return false
+                Registry.log.verbose("Abandoning postponed observer")
+                offActivityEvent(observer)
+                timeoutTask?.cancel()
+                return true
+            }
+
+            override fun runNow() {
+                cancel()
+            }
+        }
     }
 
     companion object {

--- a/sdk/core/src/main/java/com/klaviyo/core/lifecycle/LifecycleMonitor.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/lifecycle/LifecycleMonitor.kt
@@ -125,8 +125,9 @@ interface LifecycleMonitor {
      *
      * @param timeout How long to wait for a resumed activity, or null to wait indefinitely
      * @param job Invoked with the current activity, or the next one to resume
-     * @return null if [job] already ran against the current activity, otherwise a token that
-     *  abandons the pending wait.
+     * @return A token to cancel the pending wait or attempt to run immediately against the
+     * current activity and abandon the wait, or null if the wait already settled — [job] ran
+     * against the current activity, or a resume or the timeout claimed it during registration.
      */
     fun runWithCurrentOrNextActivity(
         timeout: Long? = null,

--- a/sdk/core/src/main/java/com/klaviyo/core/lifecycle/LifecycleMonitor.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/lifecycle/LifecycleMonitor.kt
@@ -146,10 +146,10 @@ interface LifecycleMonitor {
      * @param timeout How long to wait for a resumed activity, or null to wait indefinitely
      * @param onTimeout Invoked instead of [job] if [timeout] elapses with no resumed activity
      * @param job Invoked with the current activity, or the next one to resume
-     * @return null if [job] already ran against the current activity, otherwise a token that
-     *  abandons the pending wait. Both [Clock.Cancellable.cancel] and [Clock.Cancellable.runNow]
-     *  abandon it — there is no way to "run now" a job that is waiting precisely because it has no
-     *  activity to run against — and neither runs [job] or [onTimeout].
+     * @return null if the wait already settled before returning, otherwise a token that abandons
+     *  the pending wait. Both [Clock.Cancellable.cancel] and [Clock.Cancellable.runNow] abandon it
+     *  — there is no way to "run now" a job that is waiting precisely because it has no activity to
+     *  run against — and neither runs [job] or [onTimeout].
      */
     fun runWithCurrentOrNextActivity(
         timeout: Long?,
@@ -192,18 +192,20 @@ interface LifecycleMonitor {
         // clock's own thread, and callers can be off the main thread while activity resumes
         // broadcast on it.
         if (settled.get()) {
-            // The timeout already claimed the outcome, and de-registered an observer that did not
-            // exist yet.
+            // Something claimed the outcome while we registered — a timeout that de-registered an
+            // observer that did not exist yet, or a resume that already ran the job. Either way the
+            // wait is over, so there is nothing left for a token to abandon.
             offActivityEvent(observer)
-        } else {
-            currentActivity?.let { activity ->
-                if (settled.compareAndSet(false, true)) {
-                    Registry.log.verbose("Activity resumed while registering postponed observer")
-                    offActivityEvent(observer)
-                    timeoutTask?.cancel()
-                    job(activity)
-                    return null
-                }
+            return null
+        }
+
+        currentActivity?.let { activity ->
+            if (settled.compareAndSet(false, true)) {
+                Registry.log.verbose("Activity resumed while registering postponed observer")
+                offActivityEvent(observer)
+                timeoutTask?.cancel()
+                job(activity)
+                return null
             }
         }
 

--- a/sdk/core/src/test/java/com/klaviyo/core/lifecycle/KlaviyoLifecycleMonitorTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/lifecycle/KlaviyoLifecycleMonitorTest.kt
@@ -5,7 +5,9 @@ import com.klaviyo.core.Registry
 import com.klaviyo.core.utils.AdvancedAPI
 import com.klaviyo.core.utils.takeIf
 import com.klaviyo.fixtures.BaseTest
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
 import io.mockk.unmockkObject
 import io.mockk.verify
 import org.junit.After
@@ -211,5 +213,171 @@ class KlaviyoLifecycleMonitorTest : BaseTest() {
         staticClock.execute(150)
         KlaviyoLifecycleMonitor.onActivityResumed(mockk())
         assert(!called) { "Callback should not be called if timed out" }
+    }
+
+    @Test
+    fun `runWithCurrentOrNextActivity invokes onTimeout if activity is not resumed in time`() {
+        var called = false
+        var timedOut = false
+
+        KlaviyoLifecycleMonitor.runWithCurrentOrNextActivity(
+            timeout = 100,
+            onTimeout = { timedOut = true }
+        ) { _ ->
+            called = true
+        }
+
+        assert(!timedOut) { "Fallback should not be called yet" }
+        staticClock.execute(150)
+        assert(timedOut) { "Fallback should be called once timed out" }
+        assert(!called) { "Callback should not be called if timed out" }
+    }
+
+    @Test
+    fun `runWithCurrentOrNextActivity does not invoke onTimeout once the job has run`() {
+        var called = false
+        var timedOut = false
+
+        KlaviyoLifecycleMonitor.runWithCurrentOrNextActivity(
+            timeout = 100,
+            onTimeout = { timedOut = true }
+        ) { _ ->
+            called = true
+        }
+
+        KlaviyoLifecycleMonitor.onActivityResumed(mockk())
+        staticClock.execute(150)
+
+        assert(called) { "Callback should be called after activity resumed" }
+        assert(!timedOut) { "Fallback should not be called after the job already ran" }
+    }
+
+    @Test
+    fun `runWithCurrentOrNextActivity runs the job at most once`() {
+        var callCount = 0
+
+        KlaviyoLifecycleMonitor.runWithCurrentOrNextActivity(
+            timeout = 100
+        ) { _ ->
+            callCount++
+        }
+
+        KlaviyoLifecycleMonitor.onActivityResumed(mockk())
+        KlaviyoLifecycleMonitor.onActivityResumed(mockk())
+
+        assertEquals(1, callCount)
+    }
+
+    @Test
+    fun `runWithCurrentOrNextActivity returns null when the job ran against the current activity`() {
+        @OptIn(AdvancedAPI::class)
+        KlaviyoLifecycleMonitor.assignCurrentActivity(mockk())
+
+        val token = KlaviyoLifecycleMonitor.runWithCurrentOrNextActivity(timeout = 100) { }
+
+        assertEquals(null, token)
+    }
+
+    @Test
+    fun `cancelling the returned token abandons the job without running either branch`() {
+        var called = false
+        var timedOut = false
+
+        val token = KlaviyoLifecycleMonitor.runWithCurrentOrNextActivity(
+            timeout = 100,
+            onTimeout = { timedOut = true }
+        ) { _ ->
+            called = true
+        }
+
+        assert(token?.cancel() == true) { "Cancelling a pending job should report success" }
+
+        KlaviyoLifecycleMonitor.onActivityResumed(mockk())
+        staticClock.execute(150)
+
+        assert(!called) { "Callback should not run after cancellation" }
+        assert(!timedOut) { "Fallback should not run after cancellation — this is not a deadline" }
+    }
+
+    @Test
+    fun `runNow on the returned token abandons the job rather than invoking the fallback`() {
+        var called = false
+        var timedOut = false
+
+        // KlaviyoPresentationManager cancels a postponed present via runNow, so it must not be a
+        // back door into the timeout fallback.
+        val token = KlaviyoLifecycleMonitor.runWithCurrentOrNextActivity(
+            timeout = 100,
+            onTimeout = { timedOut = true }
+        ) { _ ->
+            called = true
+        }
+
+        token?.runNow()
+
+        KlaviyoLifecycleMonitor.onActivityResumed(mockk())
+        staticClock.execute(150)
+
+        assert(!called) { "Callback should not run after runNow" }
+        assert(!timedOut) { "Fallback should not run after runNow" }
+    }
+
+    @Test
+    fun `runWithCurrentOrNextActivity picks up an activity that resumed while registering`() {
+        var called = false
+        var timedOut = false
+        val resumedActivity = mockk<Activity>()
+
+        // An activity resumes and broadcasts between the initial currentActivity check and the
+        // observer's registration, so the observer never sees the event. Driven through the two
+        // reads the implementation makes — null first, then present.
+        mockkObject(KlaviyoLifecycleMonitor)
+        // This registers a real observer on the monitor singleton. Capture it so the test removes
+        // it regardless of whether the code under test does; a leaked observer would otherwise fail
+        // unrelated tests in this class rather than this one.
+        var registeredObserver: ActivityObserver? = null
+        try {
+            every { KlaviyoLifecycleMonitor.currentActivity } returnsMany listOf(
+                null,
+                resumedActivity
+            )
+            every { KlaviyoLifecycleMonitor.onActivityEvent(any()) } answers {
+                registeredObserver = firstArg()
+                callOriginal()
+            }
+
+            val token = KlaviyoLifecycleMonitor.runWithCurrentOrNextActivity(
+                timeout = 100,
+                onTimeout = { timedOut = true }
+            ) { activity ->
+                called = true
+                assertEquals(resumedActivity, activity)
+            }
+
+            assert(called) { "Job should run against the activity that resumed during registration" }
+            assertEquals(null, token)
+
+            staticClock.execute(150)
+            assert(!timedOut) { "Fallback should not run after the job already ran" }
+
+            // A settled wait must leave no observer behind, or a later resume runs the job again.
+            registeredObserver?.let {
+                verify { KlaviyoLifecycleMonitor.offActivityEvent(it) }
+            }
+        } finally {
+            unmockkObject(KlaviyoLifecycleMonitor)
+            // Defensive: if the assertion above ever fails, the leaked observer would otherwise
+            // fail unrelated tests in this class rather than this one.
+            registeredObserver?.let { KlaviyoLifecycleMonitor.offActivityEvent(it) }
+        }
+    }
+
+    @Test
+    fun `cancelling the returned token after the job ran reports failure`() {
+        val token = KlaviyoLifecycleMonitor.runWithCurrentOrNextActivity(timeout = 100) { }
+
+        KlaviyoLifecycleMonitor.onActivityResumed(mockk())
+
+        assert(token?.cancel() == false) { "Cancelling a settled job should report failure" }
     }
 }

--- a/sdk/core/src/test/java/com/klaviyo/core/lifecycle/KlaviyoLifecycleMonitorTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/lifecycle/KlaviyoLifecycleMonitorTest.kt
@@ -5,7 +5,9 @@ import com.klaviyo.core.Registry
 import com.klaviyo.core.utils.AdvancedAPI
 import com.klaviyo.core.utils.takeIf
 import com.klaviyo.fixtures.BaseTest
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
 import io.mockk.unmockkObject
 import io.mockk.verify
 import org.junit.After
@@ -342,6 +344,50 @@ class KlaviyoLifecycleMonitorTest : BaseTest() {
 
         assert(!called) { "Job should not run when runNow found no activity" }
         assert(!timedOut) { "Fallback should not run once the wait was abandoned" }
+    }
+
+    @Test
+    fun `returns no token when a resume settles the wait while registering`() {
+        var invokedWith: Activity? = null
+        var timedOut = false
+        val resumedActivity = mockk<Activity>()
+        var registeredObserver: ActivityObserver? = null
+
+        mockkObject(KlaviyoLifecycleMonitor)
+        try {
+            every { KlaviyoLifecycleMonitor.currentActivity } returns null
+            // Resumes broadcast on the main thread, so one can land between the observer's
+            // registration and the return, before the timeout task has been assigned.
+            every { KlaviyoLifecycleMonitor.onActivityEvent(any()) } answers {
+                registeredObserver = firstArg()
+                callOriginal()
+                KlaviyoLifecycleMonitor.onActivityResumed(resumedActivity)
+            }
+
+            val token = KlaviyoLifecycleMonitor.runWithCurrentOrNextActivity(
+                timeout = 100,
+                onTimeout = { timedOut = true }
+            ) { activity ->
+                invokedWith = activity
+            }
+
+            assertEquals(resumedActivity, invokedWith)
+            // A settled wait has nothing left to abandon, so handing back a token would let a
+            // caller treat it as still pending.
+            assertEquals(null, token)
+            // The resume ran before timeoutTask was assigned, so it could not cancel the timeout.
+            assert(staticClock.scheduledTasks.isEmpty()) {
+                "A settled wait should leave no timeout scheduled"
+            }
+            registeredObserver?.let { verify { KlaviyoLifecycleMonitor.offActivityEvent(it) } }
+
+            staticClock.execute(150)
+            assert(!timedOut) { "Fallback should not run after the job already ran" }
+        } finally {
+            unmockkObject(KlaviyoLifecycleMonitor)
+            // Defensive: a leaked observer would otherwise fail unrelated tests in this class.
+            registeredObserver?.let { KlaviyoLifecycleMonitor.offActivityEvent(it) }
+        }
     }
 
     @Test

--- a/sdk/core/src/test/java/com/klaviyo/core/lifecycle/KlaviyoLifecycleMonitorTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/lifecycle/KlaviyoLifecycleMonitorTest.kt
@@ -5,9 +5,7 @@ import com.klaviyo.core.Registry
 import com.klaviyo.core.utils.AdvancedAPI
 import com.klaviyo.core.utils.takeIf
 import com.klaviyo.fixtures.BaseTest
-import io.mockk.every
 import io.mockk.mockk
-import io.mockk.mockkObject
 import io.mockk.unmockkObject
 import io.mockk.verify
 import org.junit.After
@@ -299,13 +297,37 @@ class KlaviyoLifecycleMonitorTest : BaseTest() {
         assert(!timedOut) { "Fallback should not run after cancellation — this is not a deadline" }
     }
 
+    @OptIn(AdvancedAPI::class)
     @Test
-    fun `runNow on the returned token abandons the job rather than invoking the fallback`() {
+    fun `runNow on the returned token invokes the job against the current activity`() {
+        var invokedWith: Activity? = null
+        var timedOut = false
+        val activity = mockk<Activity>()
+
+        val token = KlaviyoLifecycleMonitor.runWithCurrentOrNextActivity(
+            timeout = 100,
+            onTimeout = { timedOut = true }
+        ) { resumed ->
+            invokedWith = resumed
+        }
+
+        KlaviyoLifecycleMonitor.assignCurrentActivity(activity)
+        token?.runNow()
+
+        assertEquals(activity, invokedWith)
+
+        // The wait is settled, so a later resume or the timeout must not run anything again.
+        KlaviyoLifecycleMonitor.onActivityResumed(mockk())
+        staticClock.execute(150)
+        assertEquals(activity, invokedWith)
+        assert(!timedOut) { "Fallback should not run after the job was invoked" }
+    }
+
+    @Test
+    fun `runNow abandons the wait when there is no current activity`() {
         var called = false
         var timedOut = false
 
-        // KlaviyoPresentationManager cancels a postponed present via runNow, so it must not be a
-        // back door into the timeout fallback.
         val token = KlaviyoLifecycleMonitor.runWithCurrentOrNextActivity(
             timeout = 100,
             onTimeout = { timedOut = true }
@@ -318,93 +340,8 @@ class KlaviyoLifecycleMonitorTest : BaseTest() {
         KlaviyoLifecycleMonitor.onActivityResumed(mockk())
         staticClock.execute(150)
 
-        assert(!called) { "Callback should not run after runNow" }
-        assert(!timedOut) { "Fallback should not run after runNow" }
-    }
-
-    @Test
-    fun `runWithCurrentOrNextActivity picks up an activity that resumed while registering`() {
-        var called = false
-        var timedOut = false
-        val resumedActivity = mockk<Activity>()
-
-        // An activity resumes and broadcasts between the initial currentActivity check and the
-        // observer's registration, so the observer never sees the event. Driven through the two
-        // reads the implementation makes — null first, then present.
-        mockkObject(KlaviyoLifecycleMonitor)
-        // This registers a real observer on the monitor singleton. Capture it so the test removes
-        // it regardless of whether the code under test does; a leaked observer would otherwise fail
-        // unrelated tests in this class rather than this one.
-        var registeredObserver: ActivityObserver? = null
-        try {
-            every { KlaviyoLifecycleMonitor.currentActivity } returnsMany listOf(
-                null,
-                resumedActivity
-            )
-            every { KlaviyoLifecycleMonitor.onActivityEvent(any()) } answers {
-                registeredObserver = firstArg()
-                callOriginal()
-            }
-
-            val token = KlaviyoLifecycleMonitor.runWithCurrentOrNextActivity(
-                timeout = 100,
-                onTimeout = { timedOut = true }
-            ) { activity ->
-                called = true
-                assertEquals(resumedActivity, activity)
-            }
-
-            assert(called) { "Job should run against the activity that resumed during registration" }
-            assertEquals(null, token)
-
-            staticClock.execute(150)
-            assert(!timedOut) { "Fallback should not run after the job already ran" }
-
-            // A settled wait must leave no observer behind, or a later resume runs the job again.
-            registeredObserver?.let {
-                verify { KlaviyoLifecycleMonitor.offActivityEvent(it) }
-            }
-        } finally {
-            unmockkObject(KlaviyoLifecycleMonitor)
-            // Defensive: if the assertion above ever fails, the leaked observer would otherwise
-            // fail unrelated tests in this class rather than this one.
-            registeredObserver?.let { KlaviyoLifecycleMonitor.offActivityEvent(it) }
-        }
-    }
-
-    @Test
-    fun `returns no token when the wait settles while registering`() {
-        var called = false
-        var timedOut = false
-
-        mockkObject(KlaviyoLifecycleMonitor)
-        var registeredObserver: ActivityObserver? = null
-        try {
-            every { KlaviyoLifecycleMonitor.currentActivity } returns null
-            // Settle the wait during registration, the way the clock's own thread can.
-            every { KlaviyoLifecycleMonitor.onActivityEvent(any()) } answers {
-                registeredObserver = firstArg()
-                callOriginal()
-                staticClock.execute(150)
-            }
-
-            val token = KlaviyoLifecycleMonitor.runWithCurrentOrNextActivity(
-                timeout = 100,
-                onTimeout = { timedOut = true }
-            ) { called = true }
-
-            // A settled wait has nothing left to abandon, so handing back a token would let a
-            // caller treat it as still pending.
-            assertEquals(null, token)
-            assert(timedOut) { "Fallback should have run" }
-            assert(!called) { "Job should not run once the timeout claimed the outcome" }
-            registeredObserver?.let {
-                verify { KlaviyoLifecycleMonitor.offActivityEvent(it) }
-            }
-        } finally {
-            unmockkObject(KlaviyoLifecycleMonitor)
-            registeredObserver?.let { KlaviyoLifecycleMonitor.offActivityEvent(it) }
-        }
+        assert(!called) { "Job should not run when runNow found no activity" }
+        assert(!timedOut) { "Fallback should not run once the wait was abandoned" }
     }
 
     @Test

--- a/sdk/core/src/test/java/com/klaviyo/core/lifecycle/KlaviyoLifecycleMonitorTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/lifecycle/KlaviyoLifecycleMonitorTest.kt
@@ -373,6 +373,41 @@ class KlaviyoLifecycleMonitorTest : BaseTest() {
     }
 
     @Test
+    fun `returns no token when the wait settles while registering`() {
+        var called = false
+        var timedOut = false
+
+        mockkObject(KlaviyoLifecycleMonitor)
+        var registeredObserver: ActivityObserver? = null
+        try {
+            every { KlaviyoLifecycleMonitor.currentActivity } returns null
+            // Settle the wait during registration, the way the clock's own thread can.
+            every { KlaviyoLifecycleMonitor.onActivityEvent(any()) } answers {
+                registeredObserver = firstArg()
+                callOriginal()
+                staticClock.execute(150)
+            }
+
+            val token = KlaviyoLifecycleMonitor.runWithCurrentOrNextActivity(
+                timeout = 100,
+                onTimeout = { timedOut = true }
+            ) { called = true }
+
+            // A settled wait has nothing left to abandon, so handing back a token would let a
+            // caller treat it as still pending.
+            assertEquals(null, token)
+            assert(timedOut) { "Fallback should have run" }
+            assert(!called) { "Job should not run once the timeout claimed the outcome" }
+            registeredObserver?.let {
+                verify { KlaviyoLifecycleMonitor.offActivityEvent(it) }
+            }
+        } finally {
+            unmockkObject(KlaviyoLifecycleMonitor)
+            registeredObserver?.let { KlaviyoLifecycleMonitor.offActivityEvent(it) }
+        }
+    }
+
+    @Test
     fun `cancelling the returned token after the job ran reports failure`() {
         val token = KlaviyoLifecycleMonitor.runWithCurrentOrNextActivity(timeout = 100) { }
 

--- a/sdk/forms/src/main/java/com/klaviyo/forms/presentation/KlaviyoPresentationManager.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/presentation/KlaviyoPresentationManager.kt
@@ -436,8 +436,8 @@ internal class KlaviyoPresentationManager() : PresentationManager {
      * Clear timers and observers to stop any delayed side effects
      */
     private fun clearTimers() {
-        // Run this cancel job now to stop any postponed form presentation
-        cancelPostponedPresent?.runNow().also { cancelPostponedPresent = null }
+        // Abandon any postponed form presentation. Not runNow(), which would present the form.
+        cancelPostponedPresent?.cancel().also { cancelPostponedPresent = null }
         // Cancel the timeout for dismissing the overlay activity
         dismissOnTimeout?.cancel().also { dismissOnTimeout = null }
         // Unregister any pending rotation observer to prevent re-presentation after dismiss

--- a/sdk/forms/src/test/java/com/klaviyo/forms/presentation/KlaviyoPresentationManagerTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/presentation/KlaviyoPresentationManagerTest.kt
@@ -7,6 +7,7 @@ import android.content.res.Configuration
 import android.view.View
 import android.view.WindowManager
 import com.klaviyo.core.Registry
+import com.klaviyo.core.config.Clock
 import com.klaviyo.core.lifecycle.ActivityEvent
 import com.klaviyo.core.lifecycle.ActivityObserver
 import com.klaviyo.core.lifecycle.LifecycleMonitor
@@ -278,6 +279,23 @@ class KlaviyoPresentationManagerTest : BaseTest() {
             PresentationState.Hidden,
             manager.presentationState
         )
+    }
+
+    @Test
+    fun `dismiss abandons a postponed presentation rather than running it`() {
+        // The postponed present is left pending, so dismiss has a live token to act on.
+        val pendingPresent = mockk<Clock.Cancellable>(relaxed = true)
+        every {
+            mockLifecycleMonitor.runWithCurrentOrNextActivity(any(), any())
+        } returns pendingPresent
+
+        val manager = KlaviyoPresentationManager()
+        manager.present(null)
+        manager.dismiss()
+
+        // runNow would invoke the job, presenting the form the user just dismissed.
+        verify { pendingPresent.cancel() }
+        verify(exactly = 0) { pendingPresent.runNow() }
     }
 
     @Test


### PR DESCRIPTION
# Description
Fixes a race in `LifecycleMonitor.runWithCurrentOrNextActivity` that could let two outcomes run for a single wait, corrects `runNow` so it actually runs the job, and adds an `onTimeout` overload for callers that must not silently drop deferred work.

Extracted from #530 so it can be reviewed and land on its own. It is independent of the deep-link dispatch work in #533 → #534 — those branches do not touch this code — and it benefits the three callers that already exist on `rel/4.5.0`. Original commits by @aahiltn, preserved via co-authorship.

## Due Diligence
- [x] I have tested this on an emulator and/or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all Android versions the SDK currently supports.

## Release/Versioning Considerations
- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [x] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

`Minor` because it adds a public overload to `LifecycleMonitor`. The existing two-argument signature is deliberately untouched — see below.

## Changelog / Code Overview

### 1. The race

`runWithCurrentOrNextActivity` had three possible outcomes — job runs, timeout expires, caller cancels — with nothing arbitrating between them:

- The timeout fires on the clock's own thread while activity resumes broadcast on the main thread, so a resume racing the timer could invoke the job while the observer was already being torn down.
- The returned token didn't abandon a pending wait. `cancel()` cancelled the timeout but left the observer registered, so a later resume still ran the job the caller had given up on.

An `AtomicBoolean` now claims the outcome, so exactly one of job / timeout / cancellation wins.

**This is reachable today, and one instance is user-visible.** `SystemClock.schedule` uses a real `java.util.Timer` thread, and `KlaviyoPresentationManager.dismiss()` → `clearTimers()` can run on that thread while a postponed present fires on the main thread. Concretely, the `cancel()` bug meant dismissing an in-app form that was waiting to re-present did **not** abandon that wait — the observer stayed registered, so a later unrelated activity resume could re-present a form the user had already dismissed.

### 2. `runNow` now runs the job

`runNow()` aliased `cancel()`, so a caller asking to run the job immediately got nothing at all. That is inconsistent with both other `Clock.Cancellable` implementations — `SystemClock` and `StaticClock` each invoke their task — and the original justification ("there is no way to run now a job waiting precisely because it has no activity") was wrong: by the time a caller reaches for `runNow`, there often *is* a current activity.

It now invokes the job against `currentActivity`, falling back to `cancel()` when there is none, so the token always resolves to something rather than silently no-oping.

**This exposed a latent bug in forms.** `KlaviyoPresentationManager.clearTimers()` called `runNow()` *intending it to cancel* — its comment read "Run this cancel job now to stop any postponed form presentation." With `runNow` fixed, that would have presented the form the user just dismissed. It now calls `cancel()` directly, which is what it always meant. Covered by a new regression test in `KlaviyoPresentationManagerTest`.

### 3. Observer registration precedes its timeout

The timeout task captured `observer` before it was assigned, so a timeout elapsing during setup removed nothing and left the observer registered on the process-scoped monitor permanently. Registering first means the timeout always has a real reference to remove. Reported by CodeRabbit.

No regression test: the leaked observer never invokes the job (`settled` is already true, so dispatch short-circuits), and intercepting `onActivityEvent`/`offActivityEvent` does not work because `runWithCurrentOrNextActivity` is a default method on the interface — its internal calls dispatch on `this`, which neither `spyk` nor `mockkObject` intercepts. Asserting it would require exposing `activityObservers` or restructuring the function, which is more invasive than the two lines it guards.

### 4. What was deliberately **not** kept

An earlier revision reconciled a resume landing in the window between the initial `currentActivity` check and the observer's registration. That window requires a caller running off the main thread *and* a timeout short enough to race its own scheduling. Judged too remote to carry the complexity; the KDoc now warns callers against timeouts near `ACTIVITY_TRANSITION_GRACE_PERIOD` instead. Two tests that only covered that block were removed with it.

### 5. Why an overload rather than a defaulted parameter

Inserting `onTimeout` into the existing signature would change that function's JVM descriptor and break binary compatibility for already-compiled callers — `LifecycleMonitor` is public and reachable via `Registry.lifecycleMonitor`. Verified by compiling `:sdk:core` on both `origin/rel/4.5.0` and this branch and diffing `javap`: the 2-arg overload's descriptor and its `$default` synthetic bridge in `LifecycleMonitor$DefaultImpls` are byte-for-byte identical. `-Xjvm-default` is not set anywhere in the repo, so interface defaults compile to the `DefaultImpls` pattern already used by `PushTokenFetcher`. `onTimeout` has no default value, so a two-argument call site resolves only to the two-argument overload.

That choice is load-bearing for review: `BaseTest.kt` is **unchanged** in this PR. In #530, where the parameter was inserted mid-signature, it needed edits to add an extra `any()` matcher. Its absence here is the evidence that existing call sites still compile untouched.

**Existing callers** (all pre-date this change): `DeepLinking.sendDeepLinkIntent`, and two in `KlaviyoPresentationManager`. None adopt `onTimeout` yet — it is plumbing for future use.

## Test Plan

`./gradlew test ktlintCheck` green.

`KlaviyoLifecycleMonitorTest` covers resume-vs-timeout arbitration, cancellation abandoning a pending wait, `runNow` invoking the job against the current activity, and `runNow` abandoning the wait when there is none. `KlaviyoPresentationManagerTest` adds the dismiss-doesn't-present regression.

**Being precise about what the tests prove.** `StaticClock` is fully synchronous, so no test exercises a real cross-thread interleaving — the arbitration is verified by reasoning about the `AtomicBoolean` gate, not by a concurrency test. Reviewers should not read the suite as proof the race itself is covered.

Both behavioral fixes were mutation-checked: reverting `clearTimers` to `runNow()` fails the new forms test, and the `runNow` tests fail against the old alias.

## Related Issues/Tickets
Extracted from #530 (closed). See https://github.com/klaviyo/klaviyo-android-sdk/pull/530#issuecomment-5197247941 for the full investigation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved postponed activity actions so they execute only once when an activity resumes.
  - Added timeout handling for actions that cannot run within the configured period.
  - Cancelled actions no longer execute later or trigger timeout callbacks.
  - Dismissing a pending form now properly cancels its scheduled presentation instead of displaying it unexpectedly.
  - Added support for manually triggering eligible postponed actions immediately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->