### PR TITLE
fix(push): dispatch trampoline deep links once the host has resumed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1149,6 +1149,18 @@ You should register this from your `Application` or main `Activity`'s `.onCreate
 the application lifecycle to handle any link that launches the app from a terminated state. This handler will be invoked for
 *any* deep link originating from the Klaviyo SDK, including push notifications, universal tracking links, or In-App Forms.
 
+> **Push notification taps with automatic open tracking:** When `automatic_push_open_tracking` is enabled and you have
+> registered a handler, the SDK brings your app to the foreground if it is not already running, then invokes your handler
+> once your app has a resumed `Activity` — so it is safe to navigate from the callback even when the tap cold-starts your
+> app from a terminated state. Your back stack is never cleared, and the SDK does **not** send an `ACTION_VIEW` intent
+> carrying the link, so whatever you navigate to from the handler — another `Activity`, a `Fragment` transaction, a
+> Compose `NavController` route — stays on top. On a warm tap no new intent reaches your launcher `Activity` at all; on a
+> cold start it is created by the ordinary launch intent, which carries no deep link data. Either way the link reaches
+> you *only* through the handler, so do your routing in the callback rather than from `getIntent()` or `onNewIntent()`.
+> If your app fails to produce a resumed `Activity` within a couple of seconds, the link is dropped rather than delivered
+> to a handler that would have nothing to navigate. If no handler is registered, the SDK instead sends your app an
+> `ACTION_VIEW` intent carrying the link, which you should handle in `onCreate()`/`onNewIntent()`.
+
 <details open>
    <summary>Kotlin</summary>
 

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -53,6 +53,16 @@
             </intent-filter>
         </activity>
 
+        <!--
+            Sample App Only: the destination the deep link handler navigates to. Declared with the
+            default task affinity so it stacks on top of SampleActivity in the same task, which is
+            what makes the back-stack behavior after a notification tap observable.
+        -->
+        <activity
+                android:name=".SampleDetailActivity"
+                android:exported="false"
+                android:theme="@style/Theme.KlaviyoAndroidSdk"/>
+
         <!-- Optional: Set the Klaviyo SDK logging level (1=verbose, 2=debug etc) -->
         <meta-data
                 android:name="com.klaviyo.core.log_level"

--- a/sample/src/main/java/com/klaviyo/sample/SampleApplication.kt
+++ b/sample/src/main/java/com/klaviyo/sample/SampleApplication.kt
@@ -33,6 +33,7 @@ class SampleApplication : Application() {
                 // OPTIONAL SETUP NOTE: Register a callback to handle any deep links from Klaviyo notifications, in-app forms, or universal tracking links
                 // If not using a deep link handler, Klaviyo will send an Intent to your app with the deep link in intent.data
                 showToast("Deep link to: $uri")
+                startActivity(SampleDetailActivity.intent(this, uri.toString()))
             }
             .registerFormLifecycleHandler { event ->
                 // OPTIONAL SETUP NOTE: Register a callback to receive form lifecycle events

--- a/sample/src/main/java/com/klaviyo/sample/SampleDetailActivity.kt
+++ b/sample/src/main/java/com/klaviyo/sample/SampleDetailActivity.kt
@@ -1,0 +1,79 @@
+package com.klaviyo.sample
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.klaviyo.sample.ui.theme.KlaviyoAndroidSdkTheme
+
+/**
+ * SETUP NOTE: A second screen the sample's deep link handler navigates to, so notification taps
+ * have a visible destination on top of [SampleActivity]. After tapping a deep link notification,
+ * this screen should still be on top of the back stack.
+ *
+ * Your app does not need an Activity like this — navigate however you already do (a second
+ * Activity, a Fragment transaction, a Compose NavController route).
+ */
+class SampleDetailActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val deepLink = intent?.getStringExtra(EXTRA_DEEP_LINK)
+
+        setContent {
+            KlaviyoAndroidSdkTheme {
+                Surface(modifier = Modifier.fillMaxSize()) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .systemBarsPadding()
+                            .padding(24.dp),
+                        verticalArrangement = Arrangement.spacedBy(16.dp)
+                    ) {
+                        Text(
+                            text = "Deep Link Destination",
+                            style = MaterialTheme.typography.headlineSmall
+                        )
+                        Text(
+                            text = deepLink ?: "No deep link provided",
+                            style = MaterialTheme.typography.bodyMedium
+                        )
+                        OutlinedButton(onClick = { finish() }) {
+                            Text("Back")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    companion object {
+        private const val EXTRA_DEEP_LINK = "deep_link"
+
+        /**
+         * Build an intent that opens this screen on top of the app's existing task.
+         *
+         * [Intent.FLAG_ACTIVITY_NEW_TASK] is required because the sample's deep link handler is
+         * registered from [SampleApplication] and therefore starts this from an application
+         * context. Since this Activity uses the app's default task affinity, the flag adds it to
+         * the existing task rather than creating a separate one.
+         */
+        fun intent(context: Context, deepLink: String) =
+            Intent(context, SampleDetailActivity::class.java)
+                .putExtra(EXTRA_DEEP_LINK, deepLink)
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    }
+}

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -345,7 +345,9 @@ object Klaviyo {
      * @param intent the [Intent] from opening a notification
      */
     @JvmStatic
-    fun handlePush(intent: Intent?): Klaviyo = handlePush(intent, dispatchDeepLink = true)
+    fun handlePush(intent: Intent?): Klaviyo = apply {
+        handlePush(intent, dispatchDeepLink = true)
+    }
 
     /**
      * [handlePush] with control over the final deep-link dispatch stage, for SDK entry points that
@@ -360,13 +362,15 @@ object Klaviyo {
      *
      * @param intent the [Intent] from opening a notification
      * @param dispatchDeepLink whether to invoke a registered [DeepLinkHandler] with the link
+     * @return true if this call handled the delivery, false if [intent] was not a Klaviyo
+     *  notification or the delivery was already handled in this process. A caller that takes
+     *  ownership of delivering the link should skip that work when this is false, or a repeat
+     *  tap of the same notification navigates the host a second time.
      */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     @JvmSynthetic
-    fun handlePush(intent: Intent?, dispatchDeepLink: Boolean): Klaviyo {
+    fun handlePush(intent: Intent?, dispatchDeepLink: Boolean): Boolean =
         KlaviyoPushOpenHandler.handle(intent, preInitQueue, dispatchDeepLink)
-        return this
-    }
 
     /**
      * Handles a universal link [Intent], by resolving the destination [Uri] asynchronously

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import androidx.annotation.RestrictTo
 import androidx.core.net.toUri
 import com.klaviyo.analytics.linking.DeepLinkHandler
 import com.klaviyo.analytics.linking.DeepLinking
@@ -344,8 +345,26 @@ object Klaviyo {
      * @param intent the [Intent] from opening a notification
      */
     @JvmStatic
-    fun handlePush(intent: Intent?): Klaviyo {
-        KlaviyoPushOpenHandler.handle(intent, preInitQueue)
+    fun handlePush(intent: Intent?): Klaviyo = handlePush(intent, dispatchDeepLink = true)
+
+    /**
+     * [handlePush] with control over the final deep-link dispatch stage, for SDK entry points that
+     * deliver the link themselves.
+     *
+     * When [dispatchDeepLink] is false, the push open is still tracked and the notification still
+     * dismissed, and the delivery is still recorded for de-duplication, so a subsequent
+     * [handlePush] call for the same delivery short-circuits. Only the registered
+     * [DeepLinkHandler] invocation is suppressed.
+     *
+     * Public only to cross module boundaries within the SDK; not part of the supported API.
+     *
+     * @param intent the [Intent] from opening a notification
+     * @param dispatchDeepLink whether to invoke a registered [DeepLinkHandler] with the link
+     */
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    @JvmSynthetic
+    fun handlePush(intent: Intent?, dispatchDeepLink: Boolean): Klaviyo {
+        KlaviyoPushOpenHandler.handle(intent, preInitQueue, dispatchDeepLink)
         return this
     }
 

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/KlaviyoPushOpenHandler.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/KlaviyoPushOpenHandler.kt
@@ -35,8 +35,17 @@ internal object KlaviyoPushOpenHandler {
     /**
      * Core push-open handling: guards, event enqueue, notification dismissal, deep-link dispatch.
      * Called by [Klaviyo.handlePush]; not meant for direct use outside this module.
+     *
+     * @param dispatchDeepLink When false, every stage still runs except the final deep-link
+     *  dispatch — including recording the delivery in [handledPushDeliveries], so a later call for
+     *  the same delivery still short-circuits. Callers pass false when they take ownership of
+     *  delivering the link themselves.
      */
-    internal fun handle(intent: Intent?, preInitQueue: Queue<Operation<Unit>>) {
+    internal fun handle(
+        intent: Intent?,
+        preInitQueue: Queue<Operation<Unit>>,
+        dispatchDeepLink: Boolean = true
+    ) {
         if (intent == null || !Klaviyo.isKlaviyoNotificationIntent(intent)) {
             Registry.log.verbose("Non-Klaviyo intent ignored")
             return
@@ -74,6 +83,8 @@ internal object KlaviyoPushOpenHandler {
                     .cancel(notificationTag, Constants.NOTIFICATION_ID)
             }
         }
+
+        if (!dispatchDeepLink) return
 
         // If the notification carries a deep link and a handler is registered, invoke it. Otherwise
         // do nothing — the host already received the appropriate intent.

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/KlaviyoPushOpenHandler.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/KlaviyoPushOpenHandler.kt
@@ -45,10 +45,10 @@ internal object KlaviyoPushOpenHandler {
         intent: Intent?,
         preInitQueue: Queue<Operation<Unit>>,
         dispatchDeepLink: Boolean = true
-    ) {
+    ): Boolean {
         if (intent == null || !Klaviyo.isKlaviyoNotificationIntent(intent)) {
             Registry.log.verbose("Non-Klaviyo intent ignored")
-            return
+            return false
         }
 
         // Dedup guard: track each push delivery at most once per process. The trampoline calls
@@ -59,7 +59,7 @@ internal object KlaviyoPushOpenHandler {
         val deliveryId = intent.pushDeliveryId
         if (deliveryId != null && !handledPushDeliveries.markOnce(deliveryId)) {
             Registry.log.verbose("Ignoring duplicate push open")
-            return
+            return false
         }
 
         // Create and enqueue an $opened_push. safeApply(preInitQueue) buffers this for replay if
@@ -84,7 +84,7 @@ internal object KlaviyoPushOpenHandler {
             }
         }
 
-        if (!dispatchDeepLink) return
+        if (!dispatchDeepLink) return true
 
         // If the notification carries a deep link and a handler is registered, invoke it. Otherwise
         // do nothing — the host already received the appropriate intent.
@@ -94,6 +94,8 @@ internal object KlaviyoPushOpenHandler {
                 DeepLinking.handleDeepLink(deepLink)
             }
         }
+
+        return true
     }
 
     /**

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/linking/DeepLinking.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/linking/DeepLinking.kt
@@ -108,16 +108,23 @@ object DeepLinking {
     /**
      * Sends a deep link intent to the host application.
      *
-     * Dispatched from the application context with [Intent.FLAG_ACTIVITY_NEW_TASK], so it does not
-     * depend on the host having a resumed activity.
+     * Uses the resumed activity when there is one, and the application context with
+     * [Intent.FLAG_ACTIVITY_NEW_TASK] otherwise, so a link is never dropped for want of an activity
+     * that this intent does not actually need — only a package name and package manager.
+     *
+     * Note that a dispatch from the application context while the host is in the background may be
+     * blocked by the platform's background activity launch restrictions.
      *
      * @param uri The deep link URI to be attached to the intent
      */
     private fun sendDeepLinkIntent(uri: Uri) {
-        val context = Registry.config.applicationContext
-        makeDeepLinkIntent(uri, context)
-            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-            .startActivityIfResolved(context)
+        Registry.lifecycleMonitor.currentActivity?.let { activity ->
+            makeDeepLinkIntent(uri, activity).startActivityIfResolved(activity)
+        } ?: Registry.config.applicationContext.let { context ->
+            makeDeepLinkIntent(uri, context)
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                .startActivityIfResolved(context)
+        }
     }
 
     /**

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/linking/DeepLinking.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/linking/DeepLinking.kt
@@ -13,7 +13,6 @@ import com.klaviyo.core.Constants.DIAL_SCHEME
 import com.klaviyo.core.Constants.SENDTO_SCHEMES
 import com.klaviyo.core.Constants.WEB_SCHEMES
 import com.klaviyo.core.Registry
-import com.klaviyo.core.lifecycle.LifecycleMonitor.Companion.ACTIVITY_TRANSITION_GRACE_PERIOD
 import com.klaviyo.core.safeLaunch
 import com.klaviyo.core.utils.startActivityIfResolved
 import kotlinx.coroutines.CoroutineScope
@@ -109,14 +108,16 @@ object DeepLinking {
     /**
      * Sends a deep link intent to the host application.
      *
+     * Dispatched from the application context with [Intent.FLAG_ACTIVITY_NEW_TASK], so it does not
+     * depend on the host having a resumed activity.
+     *
      * @param uri The deep link URI to be attached to the intent
      */
     private fun sendDeepLinkIntent(uri: Uri) {
-        Registry.lifecycleMonitor.runWithCurrentOrNextActivity(
-            ACTIVITY_TRANSITION_GRACE_PERIOD
-        ) { context ->
-            makeDeepLinkIntent(uri, context).startActivityIfResolved(context)
-        }
+        val context = Registry.config.applicationContext
+        makeDeepLinkIntent(uri, context)
+            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            .startActivityIfResolved(context)
     }
 
     /**

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoPushOpenHandlerTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoPushOpenHandlerTest.kt
@@ -271,6 +271,47 @@ internal class KlaviyoPushOpenHandlerTest : BaseTest() {
     }
 
     @Test
+    fun `handlePush without deep link dispatch still tracks and dismisses`() {
+        val mockNotificationManager = mockk<NotificationManagerCompat>(relaxed = true)
+        mockkStatic(NotificationManagerCompat::class)
+        every { NotificationManagerCompat.from(any()) } returns mockNotificationManager
+        val (getCapturedUri) = setupDeepLinkHandler()
+        val notificationTag = "no-dispatch-tag"
+
+        Klaviyo.handlePush(
+            mockIntent(
+                deliveryExtras("no-dispatch-tracks") +
+                    mapOf(Constants.NOTIFICATION_TAG_EXTRA to notificationTag),
+                mockk<Uri>()
+            ),
+            dispatchDeepLink = false
+        )
+
+        verifyOpenedPushEventEnqueued()
+        verify { mockNotificationManager.cancel(notificationTag, Constants.NOTIFICATION_ID) }
+        assertEquals(null, getCapturedUri())
+        verify(inverse = true) { DeepLinking.handleDeepLink(any()) }
+    }
+
+    @Test
+    fun `handlePush without deep link dispatch still records the delivery for dedup`() {
+        // The trampoline suppresses dispatch to deliver the link itself, so a leftover manual
+        // handlePush call from the host must still short-circuit rather than double-deliver.
+        val (getCapturedUri) = setupDeepLinkHandler()
+        val testUri = mockk<Uri>()
+
+        Klaviyo.handlePush(
+            deliveryIntent("no-dispatch-dedup", testUri),
+            dispatchDeepLink = false
+        )
+        Klaviyo.handlePush(deliveryIntent("no-dispatch-dedup", testUri))
+
+        verifyOpenedPushEventEnqueued()
+        assertEquals(null, getCapturedUri())
+        verify(inverse = true) { DeepLinking.handleDeepLink(any()) }
+    }
+
+    @Test
     fun `handlePush tracks distinct deliveries independently`() {
         Klaviyo.handlePush(deliveryIntent("dedup-distinct-A"))
         Klaviyo.handlePush(deliveryIntent("dedup-distinct-B"))

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/linking/DeepLinkingTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/linking/DeepLinkingTest.kt
@@ -80,33 +80,32 @@ internal class DeepLinkingTest : BaseTest() {
 
     @Test
     fun `handleDeepLink broadcasts intent when no handler registered`() {
-        every { testActivity.startActivity(any()) } returns Unit
-        every { Registry.lifecycleMonitor.runWithCurrentOrNextActivity(any(), any()) } answers {
-            val callback = secondArg<(Activity) -> Unit>()
-            callback(testActivity)
-            null
-        }
+        val deepLinkIntent = MockIntent.setupIntentMocking()
 
         DeepLinking.handleDeepLink(mockUri)
 
-        verify { testActivity.startActivity(any()) }
+        verify { mockContext.startActivity(deepLinkIntent.intent) }
         verify(exactly = 0) { mockThreadHelper.runOnUiThread(any()) }
+        // Dispatched from the application context, so it never waits on a resumed activity.
+        verify(exactly = 0) {
+            mockLifecycleMonitor.runWithCurrentOrNextActivity(any(), any())
+        }
+        verify(exactly = 0) {
+            mockLifecycleMonitor.runWithCurrentOrNextActivity(any(), any(), any())
+        }
+        verify(exactly = 0) { testActivity.startActivity(any()) }
+        // NEW_TASK is required to start an activity from a non-activity context.
+        assertEquals(Intent.FLAG_ACTIVITY_NEW_TASK, deepLinkIntent.flags.captured)
     }
 
     @Test
     fun `handleDeepLink sends no intent if link is unsupported`() {
-        every { anyConstructed<Intent>().resolveActivity(any()) } returns null
-
-        every { testActivity.startActivity(any()) } returns Unit
-        every { Registry.lifecycleMonitor.runWithCurrentOrNextActivity(any(), any()) } answers {
-            val callback = secondArg<(Activity) -> Unit>()
-            callback(testActivity)
-            null
-        }
+        val deepLinkIntent = MockIntent.setupIntentMocking()
+        every { deepLinkIntent.intent.resolveActivity(any()) } returns null
 
         DeepLinking.handleDeepLink(mockUri)
 
-        verify(inverse = true) { testActivity.startActivity(any()) }
+        verify(inverse = true) { mockContext.startActivity(any()) }
     }
 
     @Test

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/linking/DeepLinkingTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/linking/DeepLinkingTest.kt
@@ -79,21 +79,39 @@ internal class DeepLinkingTest : BaseTest() {
     }
 
     @Test
-    fun `handleDeepLink broadcasts intent when no handler registered`() {
-        val deepLinkIntent = MockIntent.setupIntentMocking()
+    fun `handleDeepLink broadcasts intent from the resumed activity when there is one`() {
+        MockIntent.setupIntentMocking()
+        every { mockLifecycleMonitor.currentActivity } returns testActivity
 
         DeepLinking.handleDeepLink(mockUri)
 
-        verify { mockContext.startActivity(deepLinkIntent.intent) }
+        verify(exactly = 1) { testActivity.startActivity(any()) }
+        verify(exactly = 0) { mockContext.startActivity(any()) }
         verify(exactly = 0) { mockThreadHelper.runOnUiThread(any()) }
-        // Dispatched from the application context, so it never waits on a resumed activity.
+        // Never waits: the intent needs a package name and package manager, not a resumed activity.
         verify(exactly = 0) {
             mockLifecycleMonitor.runWithCurrentOrNextActivity(any(), any())
         }
         verify(exactly = 0) {
             mockLifecycleMonitor.runWithCurrentOrNextActivity(any(), any(), any())
         }
+    }
+
+    @Test
+    fun `handleDeepLink broadcasts intent from application context when no activity is resumed`() {
+        val deepLinkIntent = MockIntent.setupIntentMocking()
+        every { mockLifecycleMonitor.currentActivity } returns null
+
+        DeepLinking.handleDeepLink(mockUri)
+
+        verify { mockContext.startActivity(deepLinkIntent.intent) }
         verify(exactly = 0) { testActivity.startActivity(any()) }
+        verify(exactly = 0) {
+            mockLifecycleMonitor.runWithCurrentOrNextActivity(any(), any())
+        }
+        verify(exactly = 0) {
+            mockLifecycleMonitor.runWithCurrentOrNextActivity(any(), any(), any())
+        }
         // NEW_TASK is required to start an activity from a non-activity context.
         assertEquals(Intent.FLAG_ACTIVITY_NEW_TASK, deepLinkIntent.flags.captured)
     }

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivity.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivity.kt
@@ -10,6 +10,7 @@ import com.klaviyo.analytics.Klaviyo
 import com.klaviyo.analytics.Klaviyo.isKlaviyoNotificationIntent
 import com.klaviyo.analytics.linking.DeepLinking
 import com.klaviyo.core.Registry
+import com.klaviyo.core.safeApply
 import com.klaviyo.core.utils.activityResolved
 import com.klaviyo.core.utils.startActivityIfResolved
 
@@ -30,6 +31,14 @@ import com.klaviyo.core.utils.startActivityIfResolved
  * flashes onscreen, or becomes the cold-start task root.
  */
 internal class KlaviyoTrampolineActivity : Activity() {
+    /**
+     * Dispatch must run from here, not [onResume], for the postponed deep link handler to observe
+     * the host's resume rather than this activity's. Two Android behaviors make that so:
+     * - `Application.ActivityLifecycleCallbacks.onActivityResumed` fires before an activity's own
+     *   `onResume` body, so by `onResume` this activity is already the tracked current activity.
+     * - [finish] during `onCreate` skips `onStart` and `onResume` entirely, so this activity never
+     *   broadcasts a resume of its own.
+     */
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         process(intent)
@@ -71,6 +80,13 @@ internal class KlaviyoTrampolineActivity : Activity() {
         internal const val BROWSER_URL_EXTRA = "_klaviyo.browser_url"
 
         /**
+         * How long to wait for a host activity to resume before dropping a deep link bound for a
+         * registered [DeepLinkHandler][com.klaviyo.analytics.linking.DeepLinkHandler]. On-device
+         * cold starts resolved well inside this window.
+         */
+        internal const val HANDLER_DISPATCH_TIMEOUT = 2_000L
+
+        /**
          * Build a trampoline intent that dispatches [url] to its external handler
          * via [DeepLinking.makeExternalIntent].
          *
@@ -109,7 +125,9 @@ internal class KlaviyoTrampolineActivity : Activity() {
                 )
                 return
             }
-            Klaviyo.handlePush(intent)
+            // The trampoline owns deep link delivery from here: either as an ACTION_VIEW intent or,
+            // when a handler is registered, postponed until the host has a resumed activity.
+            Klaviyo.handlePush(intent, dispatchDeepLink = false)
             dispatchDestination(intent, context)
         }
 
@@ -125,15 +143,22 @@ internal class KlaviyoTrampolineActivity : Activity() {
         /**
          * Forward a body/`deep_link`/`open_app` tap into the host app.
          *
-         * - Deep link present and no [DeepLinkHandler][com.klaviyo.analytics.linking.DeepLinkHandler]
-         *   registered → `ACTION_VIEW` into the host, falling back to the launcher if unresolvable.
-         * - Handler registered, or no deep link → launcher only. `handlePush` already dispatched the
-         *   handler, so an additional `ACTION_VIEW` would double-deliver navigation.
+         * - Deep link present and a [DeepLinkHandler][com.klaviyo.analytics.linking.DeepLinkHandler]
+         *   registered → [dispatchToHandler].
+         * - Deep link present and no handler registered → `ACTION_VIEW` into the host, falling back
+         *   to the launcher if unresolvable.
+         * - No deep link (`open_app`) → launcher only.
          */
         private fun startDestination(intent: Intent, context: Context) {
             val deepLink = intent.data
+
+            if (deepLink != null && DeepLinking.isHandlerRegistered) {
+                dispatchToHandler(deepLink, intent, context)
+                return
+            }
+
             val destination: Intent? = when {
-                deepLink != null && !DeepLinking.isHandlerRegistered -> {
+                deepLink != null -> {
                     val viewIntent = DeepLinking.makeDeepLinkIntent(
                         deepLink,
                         context,
@@ -150,13 +175,7 @@ internal class KlaviyoTrampolineActivity : Activity() {
                     }
                 }
                 else -> {
-                    if (deepLink != null) {
-                        Registry.log.verbose(
-                            "Trampoline dispatching deep link via handler; launching host"
-                        )
-                    } else {
-                        Registry.log.verbose("Trampoline dispatching launch intent")
-                    }
+                    Registry.log.verbose("Trampoline dispatching launch intent")
                     DeepLinking.makeLaunchIntent(context, intent.extras)
                 }
             }
@@ -173,6 +192,48 @@ internal class KlaviyoTrampolineActivity : Activity() {
                 )
             }?.startActivityIfResolved(context)
                 ?: Registry.log.warning("No launch intent found for host app; nothing to start")
+        }
+
+        /**
+         * Deliver [deepLink] to the registered
+         * [DeepLinkHandler][com.klaviyo.analytics.linking.DeepLinkHandler] once the host has a
+         * resumed activity, bringing the host's task to the foreground first.
+         *
+         * The wait is registered before anything is started, so a resume cannot be missed.
+         *
+         * The launcher intent carries [Intent.FLAG_ACTIVITY_NEW_TASK] alone, which resumes the
+         * host's task as the user left it, creating it if the app was not running, without clearing
+         * the back stack the handler is about to navigate on top of.
+         *
+         * The link is dropped rather than delivered if no activity resumes within
+         * [HANDLER_DISPATCH_TIMEOUT].
+         */
+        private fun dispatchToHandler(deepLink: Uri, intent: Intent, context: Context) {
+            val pendingDispatch = Registry.lifecycleMonitor.runWithCurrentOrNextActivity(
+                HANDLER_DISPATCH_TIMEOUT,
+                onTimeout = {
+                    Registry.log.warning(
+                        "No activity resumed within ${HANDLER_DISPATCH_TIMEOUT}ms, dropping deep link"
+                    )
+                }
+            ) {
+                // Invoked from within the host's ActivityLifecycleCallbacks broadcast, so a failure
+                // here must not escape into the host's own callbacks.
+                safeApply { DeepLinking.handleDeepLink(deepLink) }
+            }
+
+            val launchIntent = DeepLinking.makeLaunchIntent(context, intent.extras)
+            if (launchIntent == null) {
+                Registry.log.warning("No launch intent found for host app; nothing to start")
+                pendingDispatch?.cancel()
+                return
+            }
+
+            Registry.log.verbose("Trampoline launching host to dispatch deep link")
+            // Assigned rather than added because makeLaunchIntent bakes in SINGLE_TOP and
+            // Intent.removeFlags requires API 26, above our minSdk.
+            launchIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+            launchIntent.startActivityIfResolved(context)
         }
     }
 }

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivity.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivity.kt
@@ -127,17 +127,21 @@ internal class KlaviyoTrampolineActivity : Activity() {
             }
             // The trampoline owns deep link delivery from here: either as an ACTION_VIEW intent or,
             // when a handler is registered, postponed until the host has a resumed activity.
-            Klaviyo.handlePush(intent, dispatchDeepLink = false)
-            dispatchDestination(intent, context)
+            val isNewDelivery = Klaviyo.handlePush(intent, dispatchDeepLink = false)
+            dispatchDestination(intent, context, isNewDelivery)
         }
 
-        private fun dispatchDestination(intent: Intent, context: Context) {
+        private fun dispatchDestination(
+            intent: Intent,
+            context: Context,
+            isNewDelivery: Boolean
+        ) {
             intent.getStringExtra(BROWSER_URL_EXTRA)?.let { url ->
                 Registry.log.verbose("Trampoline dispatching external intent")
                 DeepLinking.makeExternalIntent(url.toUri()).startActivityIfResolved(context)
                 return
             }
-            startDestination(intent, context)
+            startDestination(intent, context, isNewDelivery)
         }
 
         /**
@@ -149,11 +153,15 @@ internal class KlaviyoTrampolineActivity : Activity() {
          *   to the launcher if unresolvable.
          * - No deep link (`open_app`) → launcher only.
          */
-        private fun startDestination(intent: Intent, context: Context) {
+        private fun startDestination(
+            intent: Intent,
+            context: Context,
+            isNewDelivery: Boolean
+        ) {
             val deepLink = intent.data
 
             if (deepLink != null && DeepLinking.isHandlerRegistered) {
-                dispatchToHandler(deepLink, intent, context)
+                dispatchToHandler(deepLink, intent, context, isNewDelivery)
                 return
             }
 
@@ -208,18 +216,29 @@ internal class KlaviyoTrampolineActivity : Activity() {
          * The link is dropped rather than delivered if no activity resumes within
          * [HANDLER_DISPATCH_TIMEOUT].
          */
-        private fun dispatchToHandler(deepLink: Uri, intent: Intent, context: Context) {
-            val pendingDispatch = Registry.lifecycleMonitor.runWithCurrentOrNextActivity(
-                HANDLER_DISPATCH_TIMEOUT,
-                onTimeout = {
-                    Registry.log.warning(
-                        "No activity resumed within ${HANDLER_DISPATCH_TIMEOUT}ms, dropping deep link"
-                    )
+        private fun dispatchToHandler(
+            deepLink: Uri,
+            intent: Intent,
+            context: Context,
+            isNewDelivery: Boolean
+        ) {
+            val pendingDispatch = if (isNewDelivery) {
+                Registry.lifecycleMonitor.runWithCurrentOrNextActivity(
+                    HANDLER_DISPATCH_TIMEOUT,
+                    onTimeout = {
+                        Registry.log.warning(
+                            "No activity resumed within ${HANDLER_DISPATCH_TIMEOUT}ms, " +
+                                "dropping deep link"
+                        )
+                    }
+                ) {
+                    // Invoked from within the host's ActivityLifecycleCallbacks broadcast, so a
+                    // failure here must not escape into the host's own callbacks.
+                    safeApply { DeepLinking.handleDeepLink(deepLink) }
                 }
-            ) {
-                // Invoked from within the host's ActivityLifecycleCallbacks broadcast, so a failure
-                // here must not escape into the host's own callbacks.
-                safeApply { DeepLinking.handleDeepLink(deepLink) }
+            } else {
+                Registry.log.verbose("Duplicate push open; bringing host to front only")
+                null
             }
 
             val launchIntent = DeepLinking.makeLaunchIntent(context, intent.extras)

--- a/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivityTest.kt
+++ b/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivityTest.kt
@@ -54,7 +54,7 @@ class KlaviyoTrampolineActivityTest : BaseTest() {
         mockkStatic(Uri::class)
         every { Uri.parse(any()) } returns mockk(relaxed = true)
         every { Klaviyo.handlePush(any()) } returns Klaviyo
-        every { Klaviyo.handlePush(any(), any()) } returns Klaviyo
+        every { Klaviyo.handlePush(any(), any()) } returns true
         every { DeepLinking.makeExternalIntent(any()) } returns mockBrowserIntent
         every { DeepLinking.makeDeepLinkIntent(any(), any(), any()) } returns mockDeepLinkIntent
         every { DeepLinking.makeLaunchIntent(any(), any()) } returns mockLaunchIntent
@@ -202,6 +202,22 @@ class KlaviyoTrampolineActivityTest : BaseTest() {
         postponedDispatch?.invoke(mockActivity)
 
         verify(exactly = 1) { DeepLinking.handleDeepLink(deepLink) }
+    }
+
+    @Test
+    fun `duplicate delivery brings the host to the front without dispatching again`() {
+        // Dispatch moved out of handlePush, so it no longer sits behind that dedup guard. Without
+        // honoring the reported outcome, a re-delivered intent navigates the host a second time.
+        val deepLink = mockk<Uri>(relaxed = true)
+        val intent = handlerIntent(deepLink)
+        every { Klaviyo.handlePush(intent, false) } returns false
+
+        KlaviyoTrampolineActivity.handleTrampolineIntent(intent, mockTrampolineContext)
+
+        verify(exactly = 0) {
+            mockLifecycleMonitor.runWithCurrentOrNextActivity(any(), any(), any())
+        }
+        verify { mockTrampolineContext.startActivity(mockLaunchIntent) }
     }
 
     @Test

--- a/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivityTest.kt
+++ b/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivityTest.kt
@@ -1,5 +1,6 @@
 package com.klaviyo.pushFcm
 
+import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
@@ -8,6 +9,8 @@ import com.klaviyo.analytics.Klaviyo
 import com.klaviyo.analytics.linking.DeepLinking
 import com.klaviyo.core.Constants.PACKAGE_PREFIX
 import com.klaviyo.core.Constants.TRACKING_PARAMETER
+import com.klaviyo.core.config.Clock
+import com.klaviyo.core.config.KlaviyoConfig
 import com.klaviyo.fixtures.BaseTest
 import io.mockk.every
 import io.mockk.mockk
@@ -16,7 +19,9 @@ import io.mockk.mockkStatic
 import io.mockk.unmockkObject
 import io.mockk.unmockkStatic
 import io.mockk.verify
+import io.mockk.verifyOrder
 import org.junit.After
+import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Test
 
@@ -30,6 +35,13 @@ class KlaviyoTrampolineActivityTest : BaseTest() {
         every { packageManager } returns trampolineContextPackageManager
         every { startActivity(any()) } returns Unit
     }
+    private val mockPendingDispatch = mockk<Clock.Cancellable>(relaxed = true)
+
+    /** The postponed deep link dispatch, captured instead of run, so tests can drive its timing. */
+    private var postponedDispatch: ((Activity) -> Unit)? = null
+
+    /** The fallback the postponed dispatch registered for when no activity resumes in time. */
+    private var postponedTimeout: (() -> Unit)? = null
 
     @Before
     override fun setup() {
@@ -42,9 +54,11 @@ class KlaviyoTrampolineActivityTest : BaseTest() {
         mockkStatic(Uri::class)
         every { Uri.parse(any()) } returns mockk(relaxed = true)
         every { Klaviyo.handlePush(any()) } returns Klaviyo
+        every { Klaviyo.handlePush(any(), any()) } returns Klaviyo
         every { DeepLinking.makeExternalIntent(any()) } returns mockBrowserIntent
         every { DeepLinking.makeDeepLinkIntent(any(), any(), any()) } returns mockDeepLinkIntent
         every { DeepLinking.makeLaunchIntent(any(), any()) } returns mockLaunchIntent
+        every { DeepLinking.handleDeepLink(any()) } returns Unit
         // No deep link handler registered by default; flip per-test for the handler branch.
         every { DeepLinking.isHandlerRegistered } returns false
         // Make intents appear resolvable so startActivityIfResolved actually dispatches to
@@ -52,6 +66,16 @@ class KlaviyoTrampolineActivityTest : BaseTest() {
         every { mockBrowserIntent.resolveActivity(any()) } returns mockk()
         every { mockDeepLinkIntent.resolveActivity(any()) } returns mockk()
         every { mockLaunchIntent.resolveActivity(any()) } returns mockk()
+
+        postponedDispatch = null
+        postponedTimeout = null
+        every {
+            mockLifecycleMonitor.runWithCurrentOrNextActivity(any(), any(), any())
+        } answers {
+            postponedTimeout = secondArg()
+            postponedDispatch = thirdArg()
+            mockPendingDispatch
+        }
     }
 
     @After
@@ -84,7 +108,7 @@ class KlaviyoTrampolineActivityTest : BaseTest() {
 
         KlaviyoTrampolineActivity.handleTrampolineIntent(intent, mockTrampolineContext)
 
-        verify { Klaviyo.handlePush(intent) }
+        verify { Klaviyo.handlePush(intent, false) }
         // Assert the exact URL from the extra round-trips through Uri.parse and into
         // makeExternalIntent — catches regressions where a string is mangled, swallowed,
         // or replaced silently with something else.
@@ -98,7 +122,7 @@ class KlaviyoTrampolineActivityTest : BaseTest() {
 
         KlaviyoTrampolineActivity.handleTrampolineIntent(intent, mockTrampolineContext)
 
-        verify { Klaviyo.handlePush(intent) }
+        verify { Klaviyo.handlePush(intent, false) }
         verify(exactly = 0) { DeepLinking.makeExternalIntent(any()) }
         verify(exactly = 0) { DeepLinking.makeDeepLinkIntent(any(), any(), any()) }
         verify { DeepLinking.makeLaunchIntent(mockTrampolineContext, any()) }
@@ -113,7 +137,7 @@ class KlaviyoTrampolineActivityTest : BaseTest() {
 
         KlaviyoTrampolineActivity.handleTrampolineIntent(intent, mockTrampolineContext)
 
-        verify { Klaviyo.handlePush(intent) }
+        verify { Klaviyo.handlePush(intent, false) }
         verify(exactly = 0) { mockTrampolineContext.startActivity(any()) }
         // Mirrors the non-trampoline diagnostic so a missing launcher is still debuggable.
         verify { spyLog.warning(any(), null) }
@@ -128,26 +152,120 @@ class KlaviyoTrampolineActivityTest : BaseTest() {
 
         KlaviyoTrampolineActivity.handleTrampolineIntent(intent, mockTrampolineContext)
 
-        verify { Klaviyo.handlePush(intent) }
+        verify { Klaviyo.handlePush(intent, false) }
         verify { DeepLinking.makeDeepLinkIntent(deepLink, mockTrampolineContext, intent) }
         verify { mockTrampolineContext.startActivity(mockDeepLinkIntent) }
         verify(exactly = 0) { DeepLinking.makeLaunchIntent(any(), any()) }
     }
 
-    @Test
-    fun `handleTrampolineIntent with deep link but handler registered launches host without ACTION_VIEW`() {
-        val intent = klaviyoIntent()
-        val deepLink = mockk<Uri>(relaxed = true)
-        every { intent.data } returns deepLink
-        // handlePush already dispatched the registered handler — a VIEW intent would double-deliver.
+    /** A body tap carrying a deep link, with a host deep link handler registered. */
+    private fun handlerIntent(deepLink: Uri): Intent = klaviyoIntent().also {
+        every { it.data } returns deepLink
         every { DeepLinking.isHandlerRegistered } returns true
+    }
+
+    @Test
+    fun `handleTrampolineIntent with deep link and handler brings host to the front`() {
+        val deepLink = mockk<Uri>(relaxed = true)
+        val intent = handlerIntent(deepLink)
 
         KlaviyoTrampolineActivity.handleTrampolineIntent(intent, mockTrampolineContext)
 
-        verify { Klaviyo.handlePush(intent) }
+        verify { Klaviyo.handlePush(intent, false) }
+        // The handler owns navigation, so no ACTION_VIEW carrying the link.
         verify(exactly = 0) { DeepLinking.makeDeepLinkIntent(any(), any(), any()) }
         verify { DeepLinking.makeLaunchIntent(mockTrampolineContext, any()) }
         verify { mockTrampolineContext.startActivity(mockLaunchIntent) }
+        // NEW_TASK alone: CLEAR_TOP would tear down whatever the handler navigates to, and
+        // SINGLE_TOP would re-deliver an intent to the launcher activity.
+        verify { mockLaunchIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK }
+        verify(exactly = 0) { mockLaunchIntent.addFlags(any()) }
+    }
+
+    @Test
+    fun `handleTrampolineIntent postpones handler dispatch until an activity resumes`() {
+        val deepLink = mockk<Uri>(relaxed = true)
+        val intent = handlerIntent(deepLink)
+
+        KlaviyoTrampolineActivity.handleTrampolineIntent(intent, mockTrampolineContext)
+
+        verify {
+            mockLifecycleMonitor.runWithCurrentOrNextActivity(
+                KlaviyoTrampolineActivity.HANDLER_DISPATCH_TIMEOUT,
+                any(),
+                any()
+            )
+        }
+        verify(exactly = 0) { DeepLinking.handleDeepLink(any()) }
+
+        assertNotNull(postponedDispatch)
+        postponedDispatch?.invoke(mockActivity)
+
+        verify(exactly = 1) { DeepLinking.handleDeepLink(deepLink) }
+    }
+
+    @Test
+    fun `postponed handler dispatch contains a throwing handler`() {
+        // The postponed job runs inside the host's ActivityLifecycleCallbacks broadcast, so an
+        // exception escaping it would crash the host app rather than the SDK.
+        mockkObject(KlaviyoConfig)
+        try {
+            every { KlaviyoConfig.isDebugBuild } returns false
+            val deepLink = mockk<Uri>(relaxed = true)
+            every {
+                DeepLinking.handleDeepLink(deepLink)
+            } throws RuntimeException("host handler blew up")
+
+            KlaviyoTrampolineActivity.handleTrampolineIntent(
+                handlerIntent(deepLink),
+                mockTrampolineContext
+            )
+            assertNotNull(postponedDispatch)
+            postponedDispatch?.invoke(mockActivity)
+
+            verify { spyLog.error(any(), any<Exception>()) }
+        } finally {
+            unmockkObject(KlaviyoConfig)
+        }
+    }
+
+    @Test
+    fun `handleTrampolineIntent registers the postponed dispatch before starting the host`() {
+        val intent = handlerIntent(mockk(relaxed = true))
+
+        KlaviyoTrampolineActivity.handleTrampolineIntent(intent, mockTrampolineContext)
+
+        // Registering after the launch could miss a resume that beats the registration.
+        verifyOrder {
+            mockLifecycleMonitor.runWithCurrentOrNextActivity(any(), any(), any())
+            mockTrampolineContext.startActivity(mockLaunchIntent)
+        }
+    }
+
+    @Test
+    fun `postponed handler dispatch is dropped rather than invoked when it times out`() {
+        val intent = handlerIntent(mockk(relaxed = true))
+
+        KlaviyoTrampolineActivity.handleTrampolineIntent(intent, mockTrampolineContext)
+        assertNotNull(postponedTimeout)
+        postponedTimeout?.invoke()
+
+        // Invoking a handler that needs an activity when none resumed would lose the link anyway.
+        verify(exactly = 0) { DeepLinking.handleDeepLink(any()) }
+        verify { spyLog.warning(any(), null) }
+    }
+
+    @Test
+    fun `handleTrampolineIntent abandons the postponed dispatch when host has no launch intent`() {
+        val intent = handlerIntent(mockk(relaxed = true))
+        every { DeepLinking.makeLaunchIntent(any(), any()) } returns null
+
+        KlaviyoTrampolineActivity.handleTrampolineIntent(intent, mockTrampolineContext)
+
+        // Nothing will bring the host up, so don't park an observer for the process lifetime.
+        verify { mockPendingDispatch.cancel() }
+        verify(exactly = 0) { mockTrampolineContext.startActivity(any()) }
+        verify { spyLog.warning(any(), null) }
     }
 
     @Test
@@ -176,7 +294,7 @@ class KlaviyoTrampolineActivityTest : BaseTest() {
 
         KlaviyoTrampolineActivity.handleTrampolineIntent(intent, mockTrampolineContext)
 
-        verify(exactly = 0) { Klaviyo.handlePush(any()) }
+        verify(exactly = 0) { Klaviyo.handlePush(any(), any()) }
         verify(exactly = 0) { DeepLinking.makeExternalIntent(any()) }
         verify(exactly = 0) { mockTrampolineContext.startActivity(any()) }
         verify { spyLog.warning(any(), null) }
@@ -186,7 +304,7 @@ class KlaviyoTrampolineActivityTest : BaseTest() {
     fun `handleTrampolineIntent ignores null intent`() {
         KlaviyoTrampolineActivity.handleTrampolineIntent(null, mockTrampolineContext)
 
-        verify(exactly = 0) { Klaviyo.handlePush(any()) }
+        verify(exactly = 0) { Klaviyo.handlePush(any(), any()) }
         verify(exactly = 0) { DeepLinking.makeExternalIntent(any()) }
         verify(exactly = 0) { mockTrampolineContext.startActivity(any()) }
         verify { spyLog.warning(any(), null) }
@@ -203,7 +321,7 @@ class KlaviyoTrampolineActivityTest : BaseTest() {
 
         KlaviyoTrampolineActivity.handleTrampolineIntent(intent, mockTrampolineContext)
 
-        verify { Klaviyo.handlePush(intent) }
+        verify { Klaviyo.handlePush(intent, false) }
         verify { DeepLinking.makeExternalIntent(parsedUri) }
         verify { mockTrampolineContext.startActivity(mockBrowserIntent) }
     }


### PR DESCRIPTION
# Description
A notification tap that cold-starts the app reached a registered `DeepLinkHandler` before any `Activity` existed, so a handler routing through a `NavController`, a fragment transaction, or a held `Activity` had nothing to navigate and the link was lost. The trampoline now postpones the handler invocation until the host has a resumed `Activity`.

**Stacked on #531** — review that one first. This PR's diff is against `ecm/lifecycle-monitor-postponed-activity`.

Supersedes #529 and #530, which diagnose the same bug correctly. The difference is scope: those put the wait inside `DeepLinking.handleDeepLink`, the shared funnel for all three deep-link origins, which retimes form CTAs, universal links, and manual `Klaviyo.handlePush` calls. Original commits from those branches are preserved here via co-authorship.

## Due Diligence
- [x] I have tested this on an emulator and/or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all Android versions the SDK currently supports.

## Release/Versioning Considerations
- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [x] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [x] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

`Minor`: adds a `handlePush` overload. It is `@RestrictTo(LIBRARY_GROUP)` + `@JvmSynthetic`, so it is lint-blocked externally and invisible from Java, but it is still a Kotlin-visible symbol.

## Changelog / Code Overview

**Scoping the retime.** `DeepLinking.handleDeepLink` is unchanged. Instead, `handlePush` gains an overload that runs tracking and dismissal but suppresses the final deep-link dispatch, so the trampoline can sequence dispatch itself:

```kotlin
@JvmStatic fun handlePush(intent: Intent?): Klaviyo            // unchanged
@RestrictTo(LIBRARY_GROUP) @JvmSynthetic
fun handlePush(intent: Intent?, dispatchDeepLink: Boolean): Boolean
```

The trampoline then registers the handler invocation against the next resumed `Activity`, and brings the host's task to the front with `FLAG_ACTIVITY_NEW_TASK`.

**Ordering is load-bearing in two places:**

1. The postponed dispatch is registered *before* the host is started, so a resume cannot beat the registration.
2. Dispatch is registered from `onCreate`, not `onResume`. `Application.ActivityLifecycleCallbacks.onActivityResumed` fires *before* an `Activity`'s own `onResume` body, so from `onResume` the trampoline itself would already be the tracked current activity and the handler would run against a dying translucent activity in a separate task. What makes `onCreate` safe is the existing `finish()` in the `finally`: finishing during `onCreate` skips `onStart`/`onResume` entirely, so the trampoline never broadcasts a resume of its own.

**Dedup.** Moving dispatch out of `handlePush` also moved it out from behind that function's de-duplication guard, so `handlePush` now reports whether it handled the delivery and the trampoline only postpones a dispatch when it did. A duplicate still brings the host to the front — matching what a repeat tap did before — without re-running navigation.

**Timeout.** If no activity resumes within 2s the link is dropped with a warning rather than delivered. Invoking a handler that needs an activity when none resumed would lose the link anyway, and falling back to `ACTION_VIEW` would send an intent a handler-registered host likely never wired up. Measured worst case on-device was ~112ms.

**Also fixed:** `sendDeepLinkIntent` waited up to 50ms for a `currentActivity` it used only for `packageName` and `packageManager`. It now uses the resumed activity when there is one and the application context with `NEW_TASK` otherwise, so it never waits.

## Behavior changes, stated precisely

`handleDeepLink` itself is untouched, but `sendDeepLinkIntent` is on its no-handler path, so:

| Flow | Changed? |
|---|---|
| Push open (handler registered) | Retimed — this is the fix |
| Push open (no handler) | No. `KlaviyoPushOpenHandler` only calls `handleDeepLink` when a handler is registered, so this never reaches `sendDeepLinkIntent` |
| Manual `Klaviyo.handlePush` | No |
| Form CTA / universal link (handler registered) | No |
| Form CTA / universal link (no handler) | Yes — no longer waits up to 50ms. Identical when an activity is resumed; previously the link could be dropped when one was not |

No `MIGRATION_GUIDE` entry for callback retiming, because no released callback path changes timing.

## Test Plan

`./gradlew test ktlintCheck` green.

Verified on an API 36 emulator (`automaticDebug`), posting real notifications through `KlaviyoNotification.displayNotification` and tapping them via UI so the genuine PendingIntent path runs, with the stack baselined immediately before each tap:

| State | Result |
|---|---|
| Foreground | `[SampleActivity]` → `[SampleActivity, SampleDetailActivity]`, same task, dispatch ~70ms |
| Backgrounded (process alive) | task resumed as-left, handler navigated on top, same task |
| Cold (process killed) | task created, handler navigated on top, dispatch ~112ms |

Two tests were mutation-checked to confirm they fail when the behavior they guard is removed: the crash-containment `safeApply` guard, and the duplicate-delivery guard.

**Known test gap:** the `onCreate`-not-`onResume` invariant is verified on-device and documented in the source, but not covered by a unit test — every test calls the static `handleTrampolineIntent` helper directly, and asserting it properly would need Robolectric, which this repo does not currently use.

## Open question for reviewers

`@RestrictTo(LIBRARY_GROUP)` is the first use of that annotation in this SDK. Neighboring cross-module-internal functions (`DeepLinking.sendLaunchIntent`, `makeLaunchIntent`, `makeDeepLinkIntent`) solve the same problem with plain `public fun` + KDoc. Kotlin `internal` is not an option here — it is compilation-module scoped and `push-fcm` is a separate Gradle module. Happy to drop the annotation for consistency if the team prefers the established pattern.

## Related Issues/Tickets
Supersedes #529 and #530. See https://github.com/klaviyo/klaviyo-android-sdk/pull/530#issuecomment-5197247941 for the full investigation.
