### PR TITLE
feat(analytics): dedupe push open tracking without suppressing deep links

### DIFF
--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import androidx.annotation.RestrictTo
 import androidx.core.net.toUri
 import com.klaviyo.analytics.linking.DeepLinkHandler
 import com.klaviyo.analytics.linking.DeepLinking
@@ -344,9 +345,26 @@ object Klaviyo {
      * @param intent the [Intent] from opening a notification
      */
     @JvmStatic
-    fun handlePush(intent: Intent?): Klaviyo {
-        KlaviyoPushOpenHandler.handle(intent, preInitQueue)
-        return this
+    fun handlePush(intent: Intent?): Klaviyo = handlePush(intent, dispatchDeepLink = true)
+
+    /**
+     * [handlePush] with control over the deep-link dispatch stage, for SDK entry points that
+     * deliver the link to the host themselves.
+     *
+     * When [dispatchDeepLink] is false the push open is still tracked and the notification still
+     * dismissed, and the delivery is still recorded, so a later [handlePush] call for the same
+     * delivery does not track it again. That later call does still invoke a registered
+     * [DeepLinkHandler], since dispatch is never deduplicated.
+     *
+     * Public only to cross module boundaries within the SDK; not part of the supported API.
+     *
+     * @param intent the [Intent] from opening a notification
+     * @param dispatchDeepLink whether to invoke a registered [DeepLinkHandler] with the link
+     */
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    @JvmSynthetic
+    fun handlePush(intent: Intent?, dispatchDeepLink: Boolean): Klaviyo = apply {
+        KlaviyoPushOpenHandler.handle(intent, preInitQueue, dispatchDeepLink)
     }
 
     /**

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -4,7 +4,6 @@ import android.app.Application
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
-import androidx.annotation.RestrictTo
 import androidx.core.net.toUri
 import com.klaviyo.analytics.linking.DeepLinkHandler
 import com.klaviyo.analytics.linking.DeepLinking
@@ -345,26 +344,9 @@ object Klaviyo {
      * @param intent the [Intent] from opening a notification
      */
     @JvmStatic
-    fun handlePush(intent: Intent?): Klaviyo = handlePush(intent, dispatchDeepLink = true)
-
-    /**
-     * [handlePush] with control over the deep-link dispatch stage, for SDK entry points that
-     * deliver the link to the host themselves.
-     *
-     * When [dispatchDeepLink] is false the push open is still tracked and the notification still
-     * dismissed, and the delivery is still recorded, so a later [handlePush] call for the same
-     * delivery does not track it again. That later call does still invoke a registered
-     * [DeepLinkHandler], since dispatch is never deduplicated.
-     *
-     * Public only to cross module boundaries within the SDK; not part of the supported API.
-     *
-     * @param intent the [Intent] from opening a notification
-     * @param dispatchDeepLink whether to invoke a registered [DeepLinkHandler] with the link
-     */
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    @JvmSynthetic
-    fun handlePush(intent: Intent?, dispatchDeepLink: Boolean): Klaviyo = apply {
-        KlaviyoPushOpenHandler.handle(intent, preInitQueue, dispatchDeepLink)
+    fun handlePush(intent: Intent?): Klaviyo {
+        KlaviyoPushOpenHandler.handle(intent, preInitQueue)
+        return this
     }
 
     /**

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -344,9 +344,8 @@ object Klaviyo {
      * @param intent the [Intent] from opening a notification
      */
     @JvmStatic
-    fun handlePush(intent: Intent?): Klaviyo {
+    fun handlePush(intent: Intent?): Klaviyo = apply {
         KlaviyoPushOpenHandler.handle(intent, preInitQueue)
-        return this
     }
 
     /**

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/KlaviyoPushOpenHandler.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/KlaviyoPushOpenHandler.kt
@@ -58,9 +58,8 @@ internal object KlaviyoPushOpenHandler {
         // forwards the same intent to the host, so a manual handlePush call (or singleTask
         // re-entry) would otherwise double-track one tap. A delivery with no id is never deduped.
         val deliveryId = intent.pushDeliveryId
-        val isNewDelivery = deliveryId == null || handledPushDeliveries.markOnce(deliveryId)
 
-        if (isNewDelivery) {
+        if (deliveryId == null || handledPushDeliveries.markOnce(deliveryId)) {
             // Create and enqueue an $opened_push. safeApply(preInitQueue) buffers this for replay
             // if handlePush runs before initialize(), and guards against unexpected failures.
             safeApply(preInitQueue) {

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/KlaviyoPushOpenHandler.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/KlaviyoPushOpenHandler.kt
@@ -37,18 +37,11 @@ internal object KlaviyoPushOpenHandler {
      * Called by [Klaviyo.handlePush]; not meant for direct use outside this module.
      *
      * Tracking and dismissal happen at most once per delivery. Deep-link dispatch is not deduped:
-     * an SDK entry point that suppresses it may forward the same intent to the host, whose own
-     * [Klaviyo.handlePush] call must still reach a registered
+     * an intent flagged with [Constants.SUPPRESS_DEEP_LINK_EXTRA] may be forwarded to the host
+     * without the flag, so the host's own [Klaviyo.handlePush] call still reaches a registered
      * [DeepLinkHandler][com.klaviyo.analytics.linking.DeepLinkHandler].
-     *
-     * @param dispatchDeepLink Whether to invoke a registered handler with the intent's deep link.
-     *  Pass false when the caller delivers the link itself.
      */
-    internal fun handle(
-        intent: Intent?,
-        preInitQueue: Queue<Operation<Unit>>,
-        dispatchDeepLink: Boolean = true
-    ) {
+    internal fun handle(intent: Intent?, preInitQueue: Queue<Operation<Unit>>) {
         if (intent == null || !Klaviyo.isKlaviyoNotificationIntent(intent)) {
             Registry.log.verbose("Non-Klaviyo intent ignored")
             return
@@ -87,7 +80,10 @@ internal object KlaviyoPushOpenHandler {
             Registry.log.verbose("Ignoring duplicate push open")
         }
 
-        if (!dispatchDeepLink) return
+        if (intent.getBooleanExtra(Constants.SUPPRESS_DEEP_LINK_EXTRA, false)) {
+            Registry.log.verbose("Deep link delivered by intent; not invoking handler")
+            return
+        }
 
         // If the notification carries a deep link and a handler is registered, invoke it. Otherwise
         // do nothing — the host already received the appropriate intent.

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/KlaviyoPushOpenHandler.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/KlaviyoPushOpenHandler.kt
@@ -28,6 +28,13 @@ internal object KlaviyoPushOpenHandler {
     private val handledPushDeliveries = BoundedIdSet()
 
     /**
+     * Push delivery IDs whose deep link has already been dispatched to a registered handler.
+     * Tracked separately from [handledPushDeliveries] because a caller may suppress dispatch while
+     * still recording the open, so the two stages do not advance together.
+     */
+    private val dispatchedDeepLinks = BoundedIdSet()
+
+    /**
      * Key within the `_k` tracking payload whose value uniquely identifies a single push delivery.
      */
     private const val PUSH_DELIVERY_KEY = "tm"
@@ -36,10 +43,10 @@ internal object KlaviyoPushOpenHandler {
      * Core push-open handling: guards, event enqueue, notification dismissal, deep-link dispatch.
      * Called by [Klaviyo.handlePush]; not meant for direct use outside this module.
      *
-     * Tracking and dismissal happen at most once per delivery. Deep-link dispatch is not deduped:
-     * an intent flagged with [Constants.SUPPRESS_DEEP_LINK_EXTRA] may be forwarded to the host
-     * without the flag, so the host's own [Klaviyo.handlePush] call still reaches a registered
-     * [DeepLinkHandler][com.klaviyo.analytics.linking.DeepLinkHandler].
+     * Tracking/dismissal and deep-link dispatch each happen at most once per delivery, counted
+     * separately: an intent flagged with [Constants.SUPPRESS_DEEP_LINK_HANDLER_EXTRA] records the open
+     * without consuming the dispatch, so the unflagged copy forwarded to the host still reaches a
+     * registered [DeepLinkHandler][com.klaviyo.analytics.linking.DeepLinkHandler].
      */
     internal fun handle(intent: Intent?, preInitQueue: Queue<Operation<Unit>>) {
         if (intent == null || !Klaviyo.isKlaviyoNotificationIntent(intent)) {
@@ -80,7 +87,9 @@ internal object KlaviyoPushOpenHandler {
             Registry.log.verbose("Ignoring duplicate push open")
         }
 
-        if (intent.getBooleanExtra(Constants.SUPPRESS_DEEP_LINK_EXTRA, false)) {
+        // Returns before marking the delivery below, so the unflagged intent forwarded to the host
+        // still has its dispatch available.
+        if (intent.getBooleanExtra(Constants.SUPPRESS_DEEP_LINK_HANDLER_EXTRA, false)) {
             Registry.log.verbose("Deep link delivered by intent; not invoking handler")
             return
         }
@@ -90,7 +99,13 @@ internal object KlaviyoPushOpenHandler {
         safeApply {
             val deepLink = intent.data
             if (deepLink != null && DeepLinking.isHandlerRegistered) {
-                DeepLinking.handleDeepLink(deepLink)
+                // Dispatch is tracked separately from the open above: an entry point may suppress
+                // dispatch while still tracking, so one delivery can reach this point twice.
+                if (deliveryId == null || dispatchedDeepLinks.markOnce(deliveryId)) {
+                    DeepLinking.handleDeepLink(deepLink)
+                } else {
+                    Registry.log.verbose("Ignoring duplicate deep link dispatch")
+                }
             }
         }
     }

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/KlaviyoPushOpenHandler.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/KlaviyoPushOpenHandler.kt
@@ -2,6 +2,7 @@ package com.klaviyo.analytics
 
 import android.content.Intent
 import androidx.core.app.NotificationManagerCompat
+import com.klaviyo.analytics.linking.DeepLinkHandler
 import com.klaviyo.analytics.linking.DeepLinking
 import com.klaviyo.analytics.model.Event
 import com.klaviyo.analytics.model.EventKey
@@ -44,9 +45,9 @@ internal object KlaviyoPushOpenHandler {
      * Called by [Klaviyo.handlePush]; not meant for direct use outside this module.
      *
      * Tracking/dismissal and deep-link dispatch each happen at most once per delivery, counted
-     * separately: an intent flagged with [Constants.SUPPRESS_DEEP_LINK_HANDLER_EXTRA] records the open
-     * without consuming the dispatch, so the unflagged copy forwarded to the host still reaches a
-     * registered [DeepLinkHandler][com.klaviyo.analytics.linking.DeepLinkHandler].
+     * separately: an intent flagged with [Constants.SUPPRESS_DEEP_LINK_HANDLER_EXTRA] records the
+     * open without consuming the dispatch, so the unflagged copy forwarded to the host still
+     * reaches a registered [DeepLinkHandler].
      */
     internal fun handle(intent: Intent?, preInitQueue: Queue<Operation<Unit>>) {
         if (intent == null || !Klaviyo.isKlaviyoNotificationIntent(intent)) {

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/KlaviyoPushOpenHandler.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/KlaviyoPushOpenHandler.kt
@@ -35,45 +35,59 @@ internal object KlaviyoPushOpenHandler {
     /**
      * Core push-open handling: guards, event enqueue, notification dismissal, deep-link dispatch.
      * Called by [Klaviyo.handlePush]; not meant for direct use outside this module.
+     *
+     * Tracking and dismissal happen at most once per delivery. Deep-link dispatch is not deduped:
+     * an SDK entry point that suppresses it may forward the same intent to the host, whose own
+     * [Klaviyo.handlePush] call must still reach a registered
+     * [DeepLinkHandler][com.klaviyo.analytics.linking.DeepLinkHandler].
+     *
+     * @param dispatchDeepLink Whether to invoke a registered handler with the intent's deep link.
+     *  Pass false when the caller delivers the link itself.
      */
-    internal fun handle(intent: Intent?, preInitQueue: Queue<Operation<Unit>>) {
+    internal fun handle(
+        intent: Intent?,
+        preInitQueue: Queue<Operation<Unit>>,
+        dispatchDeepLink: Boolean = true
+    ) {
         if (intent == null || !Klaviyo.isKlaviyoNotificationIntent(intent)) {
             Registry.log.verbose("Non-Klaviyo intent ignored")
             return
         }
 
-        // Dedup guard: track each push delivery at most once per process. The trampoline calls
-        // handlePush and forwards the same intent to the host, so a leftover manual handlePush call
-        // (or singleTask re-entry) would otherwise double-track one tap. The first call to see a
-        // delivery records it and proceeds; a later call for the same delivery short-circuits — no
-        // event, dismissal, or deep link.
+        // Track each push delivery at most once per process. The trampoline calls handlePush and
+        // forwards the same intent to the host, so a manual handlePush call (or singleTask
+        // re-entry) would otherwise double-track one tap. A delivery with no id is never deduped.
         val deliveryId = intent.pushDeliveryId
-        if (deliveryId != null && !handledPushDeliveries.markOnce(deliveryId)) {
-            Registry.log.verbose("Ignoring duplicate push open")
-            return
-        }
+        val isNewDelivery = deliveryId == null || handledPushDeliveries.markOnce(deliveryId)
 
-        // Create and enqueue an $opened_push. safeApply(preInitQueue) buffers this for replay if
-        // handlePush runs before initialize(), and guards against unexpected failures.
-        safeApply(preInitQueue) {
-            val state = Registry.get<State>()
-            val event = Event(EventMetric.OPENED_PUSH)
-            event.appendKlaviyoExtras(intent)
-            state.pushToken?.let { event[EventKey.PUSH_TOKEN] = it }
-            // Not using Klaviyo.createEvent here to avoid nesting safeApply calls
-            state.createEvent(event, state.getAsProfile())
-        }
-
-        // Dismiss the notification if opened via an action button. Body taps auto-cancel via
-        // setAutoCancel(true) on the builder; action button taps don't (standard Android behavior).
-        safeApply {
-            val notificationTag = intent.getStringExtra(Constants.NOTIFICATION_TAG_EXTRA)
-            if (notificationTag != null) {
-                NotificationManagerCompat
-                    .from(Registry.config.applicationContext)
-                    .cancel(notificationTag, Constants.NOTIFICATION_ID)
+        if (isNewDelivery) {
+            // Create and enqueue an $opened_push. safeApply(preInitQueue) buffers this for replay
+            // if handlePush runs before initialize(), and guards against unexpected failures.
+            safeApply(preInitQueue) {
+                val state = Registry.get<State>()
+                val event = Event(EventMetric.OPENED_PUSH)
+                event.appendKlaviyoExtras(intent)
+                state.pushToken?.let { event[EventKey.PUSH_TOKEN] = it }
+                // Not using Klaviyo.createEvent here to avoid nesting safeApply calls
+                state.createEvent(event, state.getAsProfile())
             }
+
+            // Dismiss the notification if opened via an action button. Body taps auto-cancel via
+            // setAutoCancel(true) on the builder; action button taps don't (standard Android
+            // behavior).
+            safeApply {
+                val notificationTag = intent.getStringExtra(Constants.NOTIFICATION_TAG_EXTRA)
+                if (notificationTag != null) {
+                    NotificationManagerCompat
+                        .from(Registry.config.applicationContext)
+                        .cancel(notificationTag, Constants.NOTIFICATION_ID)
+                }
+            }
+        } else {
+            Registry.log.verbose("Ignoring duplicate push open")
         }
+
+        if (!dispatchDeepLink) return
 
         // If the notification carries a deep link and a handler is registered, invoke it. Otherwise
         // do nothing — the host already received the appropriate intent.

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoPushOpenHandlerTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoPushOpenHandlerTest.kt
@@ -29,6 +29,7 @@ import io.mockk.slot
 import io.mockk.unmockkAll
 import io.mockk.unmockkStatic
 import io.mockk.verify
+import java.util.Queue
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -104,6 +105,7 @@ internal class KlaviyoPushOpenHandlerTest : BaseTest() {
     @After
     override fun cleanup() {
         unmockkAll()
+        drainPreInitQueue()
         Registry.unregister<DeepLinkHandler>()
         Registry.unregister<Config>()
         Registry.unregister<State>()
@@ -112,6 +114,17 @@ internal class KlaviyoPushOpenHandlerTest : BaseTest() {
         super.cleanup()
         unmockDeviceProperties()
     }
+
+    /**
+     * Empty [Klaviyo]'s private pre-init queue between tests. A test that makes `enqueueEvent` throw
+     * a [com.klaviyo.core.config.KlaviyoException] leaves the operation queued for replay, and since
+     * [Klaviyo] is an object that queue outlives `unmockkAll`. The next `initialize` would drain it
+     * and enqueue that stale event against the following test's mock.
+     */
+    private fun drainPreInitQueue() = Klaviyo::class.java
+        .getDeclaredField("preInitQueue")
+        .also { it.isAccessible = true }
+        .let { (it.get(Klaviyo) as Queue<*>).clear() }
 
     private fun verifyOpenedPushEventEnqueued() = verify(exactly = 1) {
         mockApiClient.enqueueEvent(
@@ -237,6 +250,15 @@ internal class KlaviyoPushOpenHandlerTest : BaseTest() {
     private fun deliveryIntent(deliveryId: String, uri: Uri? = null): Intent =
         mockIntent(deliveryExtras(deliveryId), uri)
 
+    /**
+     * A delivery intent flagged with [Constants.SUPPRESS_DEEP_LINK_EXTRA], as the trampoline stamps
+     * its own intents before forwarding an unflagged copy to the host.
+     */
+    private fun suppressedIntent(deliveryId: String, uri: Uri? = null): Intent =
+        deliveryIntent(deliveryId, uri).apply {
+            every { getBooleanExtra(Constants.SUPPRESS_DEEP_LINK_EXTRA, false) } returns true
+        }
+
     /** A Klaviyo intent whose `_k` payload omits `tm`, relying on the generated uid as the key. */
     private fun tmLessIntent(notificationUid: String): Intent =
         mockIntent(
@@ -263,14 +285,11 @@ internal class KlaviyoPushOpenHandlerTest : BaseTest() {
     }
 
     @Test
-    fun `handlePush with dispatchDeepLink false tracks and dismisses without invoking the handler`() {
+    fun `handlePush on a suppressed intent tracks and dismisses without invoking the handler`() {
         val (getCapturedUri) = setupDeepLinkHandler()
         val testUri = mockk<Uri>()
 
-        Klaviyo.handlePush(
-            deliveryIntent("suppressed-dispatch", testUri),
-            dispatchDeepLink = false
-        )
+        Klaviyo.handlePush(suppressedIntent("suppressed-dispatch", testUri))
 
         verifyOpenedPushEventEnqueued()
         assertEquals(null, getCapturedUri())
@@ -278,16 +297,13 @@ internal class KlaviyoPushOpenHandlerTest : BaseTest() {
     }
 
     @Test
-    fun `handlePush after a suppressed dispatch invokes the handler without tracking again`() {
-        // The trampoline suppresses dispatch and forwards the intent; a host that still calls
-        // handlePush must reach their handler, and must not produce a second $opened_push.
+    fun `handlePush after a suppressed intent invokes the handler without tracking again`() {
+        // The trampoline handles its flagged intent, then forwards an unflagged copy; a host that
+        // still calls handlePush must reach their handler, without a second $opened_push.
         val (getCapturedUri) = setupDeepLinkHandler()
         val testUri = mockk<Uri>()
 
-        Klaviyo.handlePush(
-            deliveryIntent("suppressed-then-manual", testUri),
-            dispatchDeepLink = false
-        )
+        Klaviyo.handlePush(suppressedIntent("suppressed-then-manual", testUri))
         Klaviyo.handlePush(deliveryIntent("suppressed-then-manual", testUri))
 
         verifyOpenedPushEventEnqueued()

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoPushOpenHandlerTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoPushOpenHandlerTest.kt
@@ -13,6 +13,7 @@ import com.klaviyo.analytics.networking.ApiClient
 import com.klaviyo.analytics.state.State
 import com.klaviyo.analytics.state.StateSideEffects
 import com.klaviyo.core.Constants
+import com.klaviyo.core.KlaviyoException
 import com.klaviyo.core.Registry
 import com.klaviyo.core.config.Config
 import com.klaviyo.core.config.MissingAPIKey
@@ -29,6 +30,7 @@ import io.mockk.slot
 import io.mockk.unmockkAll
 import io.mockk.unmockkStatic
 import io.mockk.verify
+import java.util.Queue
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -104,6 +106,7 @@ internal class KlaviyoPushOpenHandlerTest : BaseTest() {
     @After
     override fun cleanup() {
         unmockkAll()
+        drainPreInitQueue()
         Registry.unregister<DeepLinkHandler>()
         Registry.unregister<Config>()
         Registry.unregister<State>()
@@ -112,6 +115,17 @@ internal class KlaviyoPushOpenHandlerTest : BaseTest() {
         super.cleanup()
         unmockDeviceProperties()
     }
+
+    /**
+     * Empty [Klaviyo]'s private pre-init queue between tests. A test that makes `enqueueEvent` throw
+     * a [KlaviyoException] leaves the operation queued for replay, and since [Klaviyo] is an object
+     * that queue outlives `unmockkAll`. The next `initialize` would drain it and enqueue that stale
+     * event against the following test's mock.
+     */
+    private fun drainPreInitQueue() = Klaviyo::class.java
+        .getDeclaredField("preInitQueue")
+        .also { it.isAccessible = true }
+        .let { (it.get(Klaviyo) as Queue<*>).clear() }
 
     private fun verifyOpenedPushEventEnqueued() = verify(exactly = 1) {
         mockApiClient.enqueueEvent(

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoPushOpenHandlerTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoPushOpenHandlerTest.kt
@@ -13,6 +13,7 @@ import com.klaviyo.analytics.networking.ApiClient
 import com.klaviyo.analytics.state.State
 import com.klaviyo.analytics.state.StateSideEffects
 import com.klaviyo.core.Constants
+import com.klaviyo.core.KlaviyoException
 import com.klaviyo.core.Registry
 import com.klaviyo.core.config.Config
 import com.klaviyo.core.config.MissingAPIKey
@@ -117,9 +118,9 @@ internal class KlaviyoPushOpenHandlerTest : BaseTest() {
 
     /**
      * Empty [Klaviyo]'s private pre-init queue between tests. A test that makes `enqueueEvent` throw
-     * a [com.klaviyo.core.config.KlaviyoException] leaves the operation queued for replay, and since
-     * [Klaviyo] is an object that queue outlives `unmockkAll`. The next `initialize` would drain it
-     * and enqueue that stale event against the following test's mock.
+     * a [KlaviyoException] leaves the operation queued for replay, and since [Klaviyo] is an object
+     * that queue outlives `unmockkAll`. The next `initialize` would drain it and enqueue that stale
+     * event against the following test's mock.
      */
     private fun drainPreInitQueue() = Klaviyo::class.java
         .getDeclaredField("preInitQueue")
@@ -316,12 +317,25 @@ internal class KlaviyoPushOpenHandlerTest : BaseTest() {
     fun `handlePush on a suppressed intent tracks and dismisses without invoking the handler`() {
         val (getCapturedUri) = setupDeepLinkHandler()
         val testUri = mockk<Uri>()
+        val tag = "suppressed-dispatch-tag"
+        val notificationManager = mockk<NotificationManagerCompat>(relaxed = true)
+        mockkStatic(NotificationManagerCompat::class)
+        every { NotificationManagerCompat.from(any()) } returns notificationManager
+        val intent = suppressedIntent("suppressed-dispatch", testUri).apply {
+            every { getStringExtra(Constants.NOTIFICATION_TAG_EXTRA) } returns tag
+        }
 
-        Klaviyo.handlePush(suppressedIntent("suppressed-dispatch", testUri))
+        try {
+            Klaviyo.handlePush(intent)
 
-        verifyOpenedPushEventEnqueued()
-        assertEquals(null, getCapturedUri())
-        verify(exactly = 0) { DeepLinking.handleDeepLink(any()) }
+            // Suppression scopes to the handler only; the open and dismissal still happen.
+            verifyOpenedPushEventEnqueued()
+            verify(exactly = 1) { notificationManager.cancel(tag, Constants.NOTIFICATION_ID) }
+            assertEquals(null, getCapturedUri())
+            verify(exactly = 0) { DeepLinking.handleDeepLink(any()) }
+        } finally {
+            unmockkStatic(NotificationManagerCompat::class)
+        }
     }
 
     @Test

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoPushOpenHandlerTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoPushOpenHandlerTest.kt
@@ -251,12 +251,12 @@ internal class KlaviyoPushOpenHandlerTest : BaseTest() {
         mockIntent(deliveryExtras(deliveryId), uri)
 
     /**
-     * A delivery intent flagged with [Constants.SUPPRESS_DEEP_LINK_EXTRA], as the trampoline stamps
-     * its own intents before forwarding an unflagged copy to the host.
+     * A delivery intent flagged with [Constants.SUPPRESS_DEEP_LINK_HANDLER_EXTRA], as the trampoline
+     * stamps its own intents before forwarding an unflagged copy to the host.
      */
     private fun suppressedIntent(deliveryId: String, uri: Uri? = null): Intent =
         deliveryIntent(deliveryId, uri).apply {
-            every { getBooleanExtra(Constants.SUPPRESS_DEEP_LINK_EXTRA, false) } returns true
+            every { getBooleanExtra(Constants.SUPPRESS_DEEP_LINK_HANDLER_EXTRA, false) } returns true
         }
 
     /** A Klaviyo intent whose `_k` payload omits `tm`, relying on the generated uid as the key. */
@@ -269,10 +269,8 @@ internal class KlaviyoPushOpenHandlerTest : BaseTest() {
         )
 
     @Test
-    fun `handlePush tracks exactly one opened_push when a delivery is handled twice`() {
-        // The trampoline tracks first, then forwards the same intent (same tm) to a host that still
-        // calls handlePush manually. Tracking happens once; dispatch is not deduped, so the host's
-        // own call still reaches their handler.
+    fun `handlePush tracks and dispatches once when a delivery is handled twice`() {
+        // A host calling handlePush twice for one tap gets one event and one navigation.
         val (getCapturedUri) = setupDeepLinkHandler()
         val testUri = mockk<Uri>()
 
@@ -280,6 +278,36 @@ internal class KlaviyoPushOpenHandlerTest : BaseTest() {
         Klaviyo.handlePush(deliveryIntent("dedup-twice-distinct-intents", testUri))
 
         verifyOpenedPushEventEnqueued()
+        assertEquals(testUri, getCapturedUri())
+        verify(exactly = 1) { DeepLinking.handleDeepLink(testUri) }
+    }
+
+    @Test
+    fun `handlePush dispatches once when a suppressed intent precedes two unflagged calls`() {
+        // The suppressed call must not consume the dispatch, and the two that follow must
+        // collapse to one navigation.
+        val (getCapturedUri) = setupDeepLinkHandler()
+        val testUri = mockk<Uri>()
+
+        Klaviyo.handlePush(suppressedIntent("suppressed-then-two", testUri))
+        Klaviyo.handlePush(deliveryIntent("suppressed-then-two", testUri))
+        Klaviyo.handlePush(deliveryIntent("suppressed-then-two", testUri))
+
+        verifyOpenedPushEventEnqueued()
+        assertEquals(testUri, getCapturedUri())
+        verify(exactly = 1) { DeepLinking.handleDeepLink(testUri) }
+    }
+
+    @Test
+    fun `handlePush dispatches a deep link with no delivery id every time`() {
+        // No tm and no uid → nothing is deduped, matching the tracking stage's behavior.
+        val (getCapturedUri) = setupDeepLinkHandler()
+        val testUri = mockk<Uri>()
+        val noKey = mapOf("com.klaviyo.body" to "Message body", "com.klaviyo._k" to "{}")
+
+        Klaviyo.handlePush(mockIntent(noKey, testUri))
+        Klaviyo.handlePush(mockIntent(noKey, testUri))
+
         assertEquals(testUri, getCapturedUri())
         verify(exactly = 2) { DeepLinking.handleDeepLink(testUri) }
     }

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoPushOpenHandlerTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoPushOpenHandlerTest.kt
@@ -13,7 +13,6 @@ import com.klaviyo.analytics.networking.ApiClient
 import com.klaviyo.analytics.state.State
 import com.klaviyo.analytics.state.StateSideEffects
 import com.klaviyo.core.Constants
-import com.klaviyo.core.KlaviyoException
 import com.klaviyo.core.Registry
 import com.klaviyo.core.config.Config
 import com.klaviyo.core.config.MissingAPIKey
@@ -30,7 +29,6 @@ import io.mockk.slot
 import io.mockk.unmockkAll
 import io.mockk.unmockkStatic
 import io.mockk.verify
-import java.util.Queue
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -106,7 +104,6 @@ internal class KlaviyoPushOpenHandlerTest : BaseTest() {
     @After
     override fun cleanup() {
         unmockkAll()
-        drainPreInitQueue()
         Registry.unregister<DeepLinkHandler>()
         Registry.unregister<Config>()
         Registry.unregister<State>()
@@ -115,17 +112,6 @@ internal class KlaviyoPushOpenHandlerTest : BaseTest() {
         super.cleanup()
         unmockDeviceProperties()
     }
-
-    /**
-     * Empty [Klaviyo]'s private pre-init queue between tests. A test that makes `enqueueEvent` throw
-     * a [KlaviyoException] leaves the operation queued for replay, and since [Klaviyo] is an object
-     * that queue outlives `unmockkAll`. The next `initialize` would drain it and enqueue that stale
-     * event against the following test's mock.
-     */
-    private fun drainPreInitQueue() = Klaviyo::class.java
-        .getDeclaredField("preInitQueue")
-        .also { it.isAccessible = true }
-        .let { (it.get(Klaviyo) as Queue<*>).clear() }
 
     private fun verifyOpenedPushEventEnqueued() = verify(exactly = 1) {
         mockApiClient.enqueueEvent(

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoPushOpenHandlerTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoPushOpenHandlerTest.kt
@@ -27,6 +27,7 @@ import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.slot
 import io.mockk.unmockkAll
+import io.mockk.unmockkStatic
 import io.mockk.verify
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -248,7 +249,8 @@ internal class KlaviyoPushOpenHandlerTest : BaseTest() {
     @Test
     fun `handlePush tracks exactly one opened_push when a delivery is handled twice`() {
         // The trampoline tracks first, then forwards the same intent (same tm) to a host that still
-        // calls handlePush manually; only one open, dismissal, and deep link result.
+        // calls handlePush manually. Tracking happens once; dispatch is not deduped, so the host's
+        // own call still reaches their handler.
         val (getCapturedUri) = setupDeepLinkHandler()
         val testUri = mockk<Uri>()
 
@@ -257,7 +259,63 @@ internal class KlaviyoPushOpenHandlerTest : BaseTest() {
 
         verifyOpenedPushEventEnqueued()
         assertEquals(testUri, getCapturedUri())
+        verify(exactly = 2) { DeepLinking.handleDeepLink(testUri) }
+    }
+
+    @Test
+    fun `handlePush with dispatchDeepLink false tracks and dismisses without invoking the handler`() {
+        val (getCapturedUri) = setupDeepLinkHandler()
+        val testUri = mockk<Uri>()
+
+        Klaviyo.handlePush(
+            deliveryIntent("suppressed-dispatch", testUri),
+            dispatchDeepLink = false
+        )
+
+        verifyOpenedPushEventEnqueued()
+        assertEquals(null, getCapturedUri())
+        verify(exactly = 0) { DeepLinking.handleDeepLink(any()) }
+    }
+
+    @Test
+    fun `handlePush after a suppressed dispatch invokes the handler without tracking again`() {
+        // The trampoline suppresses dispatch and forwards the intent; a host that still calls
+        // handlePush must reach their handler, and must not produce a second $opened_push.
+        val (getCapturedUri) = setupDeepLinkHandler()
+        val testUri = mockk<Uri>()
+
+        Klaviyo.handlePush(
+            deliveryIntent("suppressed-then-manual", testUri),
+            dispatchDeepLink = false
+        )
+        Klaviyo.handlePush(deliveryIntent("suppressed-then-manual", testUri))
+
+        verifyOpenedPushEventEnqueued()
+        assertEquals(testUri, getCapturedUri())
         verify(exactly = 1) { DeepLinking.handleDeepLink(testUri) }
+    }
+
+    @Test
+    fun `handlePush dismisses a notification only once across repeat deliveries`() {
+        val tag = "dedup-dismiss-tag"
+        val notificationManager = mockk<NotificationManagerCompat>(relaxed = true)
+        mockkStatic(NotificationManagerCompat::class)
+        every { NotificationManagerCompat.from(any()) } returns notificationManager
+        val intent = mockIntent(
+            mapOf(
+                "com.klaviyo._k" to """{"m":"01GK4P5W6AV4V3APTJ727JKSKQ","tm":"dedup-dismiss"}""",
+                Constants.NOTIFICATION_TAG_EXTRA to tag
+            )
+        )
+
+        try {
+            Klaviyo.handlePush(intent)
+            Klaviyo.handlePush(intent)
+
+            verify(exactly = 1) { notificationManager.cancel(tag, Constants.NOTIFICATION_ID) }
+        } finally {
+            unmockkStatic(NotificationManagerCompat::class)
+        }
     }
 
     @Test

--- a/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
@@ -46,13 +46,14 @@ object Constants {
 
     /**
      * Intent extra marking an intent whose deep link is delivered to the host by another means, so
-     * `Klaviyo.handlePush` skips invoking a registered `DeepLinkHandler` for it. Absent → dispatch.
+     * `Klaviyo.handlePush` skips invoking a registered `DeepLinkHandler` for it. The link itself is
+     * still delivered — only the handler call is suppressed. Absent → handler is invoked.
      *
      * Set on the trampoline's own intents and removed before the intent is forwarded to the host, so
      * a host that calls `handlePush` itself still reaches its handler.
      * Uses [INTERNAL_PREFIX] to stay out of analytics event properties, like [NOTIFICATION_TAG_EXTRA].
      */
-    const val SUPPRESS_DEEP_LINK_EXTRA = INTERNAL_PREFIX + "suppress_deep_link"
+    const val SUPPRESS_DEEP_LINK_HANDLER_EXTRA = INTERNAL_PREFIX + "suppress_deep_link_handler"
 
     /**
      * Manifest `<meta-data>` key a host app sets to opt into automatic push open tracking.

--- a/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
@@ -45,6 +45,16 @@ object Constants {
     const val NOTIFICATION_UID_EXTRA = INTERNAL_PREFIX + "notification_uid"
 
     /**
+     * Intent extra marking an intent whose deep link is delivered to the host by another means, so
+     * `Klaviyo.handlePush` skips invoking a registered `DeepLinkHandler` for it. Absent → dispatch.
+     *
+     * Set on the trampoline's own intents and removed before the intent is forwarded to the host, so
+     * a host that calls `handlePush` itself still reaches its handler.
+     * Uses [INTERNAL_PREFIX] to stay out of analytics event properties, like [NOTIFICATION_TAG_EXTRA].
+     */
+    const val SUPPRESS_DEEP_LINK_EXTRA = INTERNAL_PREFIX + "suppress_deep_link"
+
+    /**
      * Manifest `<meta-data>` key a host app sets to opt into automatic push open tracking.
      *
      * Lives in core (not push-fcm) because telemetry's push token request must read it, and core

--- a/sdk/fixtures/src/main/java/com/klaviyo/fixtures/BaseTest.kt
+++ b/sdk/fixtures/src/main/java/com/klaviyo/fixtures/BaseTest.kt
@@ -8,6 +8,7 @@ import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Handler
 import android.os.HandlerThread
+import com.klaviyo.analytics.Klaviyo
 import com.klaviyo.core.BuildConfig
 import com.klaviyo.core.PushTokenFetcher
 import com.klaviyo.core.Registry
@@ -25,6 +26,7 @@ import io.mockk.unmockkObject
 import java.lang.reflect.Field
 import java.lang.reflect.Method
 import java.lang.reflect.Modifier
+import java.util.Queue
 import kotlinx.coroutines.test.StandardTestDispatcher
 import org.json.JSONObject
 import org.junit.After
@@ -173,7 +175,21 @@ abstract class BaseTest {
     @After
     open fun cleanup() {
         Registry.unregister<PushTokenFetcher>()
+        drainPreInitQueue()
         unmockkObject(Registry)
+    }
+
+    /**
+     * Empty [Klaviyo]'s private pre-init queue. An operation that throws a `KlaviyoException` is
+     * queued for replay, and since [Klaviyo] is an object that queue outlives `unmockkAll` and the
+     * test class itself. The next `initialize` in any test would drain it and replay that stale
+     * operation against a different test's mocks.
+     */
+    protected fun drainPreInitQueue() = runCatching {
+        Klaviyo::class.java
+            .getDeclaredField("preInitQueue")
+            .also { it.isAccessible = true }
+            .let { (it.get(Klaviyo) as Queue<*>).clear() }
     }
 
     /**

--- a/sdk/fixtures/src/main/java/com/klaviyo/fixtures/BaseTest.kt
+++ b/sdk/fixtures/src/main/java/com/klaviyo/fixtures/BaseTest.kt
@@ -8,7 +8,6 @@ import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Handler
 import android.os.HandlerThread
-import com.klaviyo.analytics.Klaviyo
 import com.klaviyo.core.BuildConfig
 import com.klaviyo.core.PushTokenFetcher
 import com.klaviyo.core.Registry
@@ -26,7 +25,6 @@ import io.mockk.unmockkObject
 import java.lang.reflect.Field
 import java.lang.reflect.Method
 import java.lang.reflect.Modifier
-import java.util.Queue
 import kotlinx.coroutines.test.StandardTestDispatcher
 import org.json.JSONObject
 import org.junit.After
@@ -175,21 +173,7 @@ abstract class BaseTest {
     @After
     open fun cleanup() {
         Registry.unregister<PushTokenFetcher>()
-        drainPreInitQueue()
         unmockkObject(Registry)
-    }
-
-    /**
-     * Empty [Klaviyo]'s private pre-init queue. An operation that throws a `KlaviyoException` is
-     * queued for replay, and since [Klaviyo] is an object that queue outlives `unmockkAll` and the
-     * test class itself. The next `initialize` in any test would drain it and replay that stale
-     * operation against a different test's mocks.
-     */
-    protected fun drainPreInitQueue() = runCatching {
-        Klaviyo::class.java
-            .getDeclaredField("preInitQueue")
-            .also { it.isAccessible = true }
-            .let { (it.get(Klaviyo) as Queue<*>).clear() }
     }
 
     /**


### PR DESCRIPTION
# Description
Splits push-open de-duplication into two independently-counted stages — open tracking/dismissal, and deep-link dispatch — each at-most-once per delivery, and lets a caller that delivers the deep link itself suppress dispatch via an intent extra.

Prerequisite for #534, which changes notification taps to deliver deep links by intent. No behavior change on its own beyond the dedup split described below.

## Due Diligence
- [x] I have tested this on an emulator and/or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all Android versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

`handlePush` keeps its single published signature — no public API change. It is now expression-bodied (`= apply { ... }`) to match every other `: Klaviyo` builder on the facade, which compiles to the identical JVM signature (verified with `javap`); plain `apply` rather than `safeApply`, since `KlaviyoPushOpenHandler.handle` already wraps its own work and the codebase warns against nesting the two.

## Changelog / Code Overview

`KlaviyoPushOpenHandler.handle` deduped all of its work behind one guard — a second `handlePush` call for the same delivery returned immediately having done nothing. That single guard is wrong once an SDK entry point handles a tap and then forwards the same intent to the host: the host's own `handlePush` call could no longer reach their registered `DeepLinkHandler`.

The fix is two counters, not zero. Each stage is at-most-once per delivery, tracked in its own `BoundedIdSet`:

| Stage | Deduped | Counter |
|---|---|---|
| `$opened_push` event | yes, first caller wins | `handledPushDeliveries` |
| Notification dismissal | yes | (same) |
| `DeepLinkHandler` invocation | yes, first caller wins | `dispatchedDeepLinks` |

They need separate counters because they do not advance together: a suppressed intent records the open while leaving dispatch unconsumed.

**Ordering constraint.** The suppression check returns *before* the dispatch mark. Marking there would consume the slot belonging to the unflagged intent forwarded to the host — silently dropping the handler call and reintroducing the exact bug this PR fixes. Mutation-checked in both directions.

Resulting semantics, all covered by tests:

- No delivery id (no `tm`, no `NOTIFICATION_UID_EXTRA`) → neither stage is deduped. Unchanged.
- A host calling `handlePush` twice → one event, one navigation.
- Suppressed call, then two unflagged calls → one event, one navigation.
- Non-Klaviyo or null intent → still returns before any stage.

### Suppressing dispatch

A caller that delivers the deep link by another means stamps `Constants.SUPPRESS_DEEP_LINK_HANDLER_EXTRA` on the intent it hands to `handlePush`, and forwards a copy without it. `handle` skips the dispatch stage when the flag is present; tracking and dismissal are unaffected.

An earlier revision of this PR added a `handlePush(intent, dispatchDeepLink)` overload instead. The extra is a better fit: it needs no new public method on the facade (Kotlin `internal` does not cross Gradle module boundaries, so the overload had to be `public` + `@RestrictTo` + `@JvmSynthetic`), it keeps this a `Patch`, and it matches how `BROWSER_URL_EXTRA` already carries internal trampoline routing state on the same intents. Both use the `_klaviyo.` prefix so they stay out of analytics event properties.

The flag must not survive the hop to the host — #534 removes it before forwarding, with a test per destination.

## Test Plan

`./gradlew test ktlintCheck` green.

New tests cover: a suppressed intent still tracks/dismisses/marks the delivery; a later unflagged call invokes the handler without tracking again; a suppressed call followed by two unflagged calls yields exactly one navigation; a delivery with no id dispatches every time; dismissal happens once across repeat deliveries.

Mutation-checked three ways — restoring the whole-function short-circuit, disabling the dispatch counter, and marking dispatch inside the suppression branch each fail the relevant tests.

Exercised end-to-end on an API 36 emulator as part of #534: exactly one `$opened_push` per notification tap.

### Unrelated test-isolation fix

`handlePush continues deep link handling even if opened_push processing fails` stubs `enqueueEvent` to throw `MissingAPIKey`. That is a `KlaviyoException`, so `safeApply(preInitQueue)` queues the operation for replay — and because `Klaviyo` is an object, the queue outlives `unmockkAll()`. The next test's `initialize()` drained it and enqueued a stale `$opened_push` against that test's mock.

This was latent on `rel/4.5.0`; any test asserting `exactly = 1` that happened to run next would fail. Cleanup now clears the queue between tests.

## Related Issues/Tickets
Prerequisite for #534.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved push-open handling to prevent duplicate tracking and notification dismissal for the same delivery.
  * Ensured deep links are dispatched once per delivery while preserving navigation for forwarded notifications.
  * Maintained support for repeated deep-link dispatches when delivery identifiers are unavailable.
  * Added handling for suppressed deep-link callbacks without blocking link delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->