### PR TITLE
fix(push): deliver notification deep links by intent under automatic tracking

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -21,6 +21,16 @@ This flag defaults to **off** in 4.5.0 and is expected to become the default (op
 major release. For setup instructions, see
 [Option A — Automatic Integration](./README.md#option-a--automatic-integration) in the README.
 
+**Deep links are delivered by `Intent` when this flag is enabled.** A notification tap sends your app
+an `Intent` with the destination URL on `intent.data`, and a registered `DeepLinkHandler` is not
+invoked for the tap. If you use a handler today and enable this flag, move your routing into
+`onCreate` and `onNewIntent` — both, since a process killed with its task still in recents restores
+the original intent into `onCreate` and delivers the new one to `onNewIntent`. Your handler continues
+to receive links from In-App Forms, universal tracking links, and any `Klaviyo.handlePush(intent)`
+call you make yourself.
+
+Nothing changes when the flag is off.
+
 ### `automatic_push_token_forwarding` (default **on**)
 
 When this flag is enabled (which is the **default**), the SDK automatically registers the device's

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -22,12 +22,30 @@ major release. For setup instructions, see
 [Option A — Automatic Integration](./README.md#option-a--automatic-integration) in the README.
 
 **Deep links are delivered by `Intent` when this flag is enabled.** A notification tap sends your app
-an `Intent` with the destination URL on `intent.data`, and a registered `DeepLinkHandler` is not
-invoked for the tap. If you use a handler today and enable this flag, move your routing into
-`onCreate` and `onNewIntent` — both, since a process killed with its task still in recents restores
-the original intent into `onCreate` and delivers the new one to `onNewIntent`. Your handler continues
-to receive links from In-App Forms, universal tracking links, and any `Klaviyo.handlePush(intent)`
-call you make yourself.
+an `Intent` carrying the destination URL, and a registered `DeepLinkHandler` is not invoked for the
+tap. If you use a handler today and enable this flag, move your routing into `onCreate` and
+`onNewIntent` — both, since a process killed with its task still in recents restores the original
+intent into `onCreate` and delivers the new one to `onNewIntent`. Your handler continues to receive
+links from In-App Forms, universal tracking links, and any `Klaviyo.handlePush(intent)` call you make
+yourself.
+
+Read the destination with `Klaviyo.getKlaviyoDeepLink(intent)` rather than `intent.data`. The SDK
+only sets `data` when one of your activities declares a matching `intent-filter`; otherwise the tap
+arrives as a launcher intent carrying the URL in its extras, and the accessor reads it in both cases.
+It returns `null` for non-Klaviyo intents, so it is safe to call unconditionally.
+
+```kotlin
+override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    // Only on a fresh start — after a configuration change the same intent is re-delivered.
+    if (savedInstanceState == null) onNewIntent(intent)
+}
+
+override fun onNewIntent(intent: Intent?) {
+    super.onNewIntent(intent)
+    Klaviyo.getKlaviyoDeepLink(intent)?.let { navigate(it) }
+}
+```
 
 Nothing changes when the flag is off.
 

--- a/README.md
+++ b/README.md
@@ -520,8 +520,8 @@ push integration that otherwise require code in your app:
 - **Push open tracking** (`automatic_push_open_tracking`) — **opt-in** (off by default). Set it to
   `true` and the SDK detects when a user taps a Klaviyo notification and records the `Opened Push`
   event for you, so you do **not** need to call `Klaviyo.handlePush(intent)` anywhere. Notification
-  taps deliver the deep link to your app as an `Intent` — see
-  [Deep links with automatic open tracking](#deep-links-with-automatic-open-tracking) below.
+  taps deliver the deep link to your app as an `Intent`, on `intent.data`, rather than to a
+  registered handler — see [Deep Linking](#deep-linking).
 - **Push token registration** (`automatic_push_token_forwarding`) — **on by default**. The SDK
   fetches the current FCM token and registers it with Klaviyo automatically, so you don't need to
   call `Klaviyo.setPushToken(...)` yourself. Set it to `false` to opt out.
@@ -567,40 +567,6 @@ That's it. With both flags set, `initialize()` covers both concerns above:
 - **Open tracking** records an `Opened Push` event for every Klaviyo notification tap.
 - **Token registration** happens at `initialize()` **and** again on every app foreground, so
   token rotations are picked up on those events.
-
-#### Deep links with automatic open tracking
-
-A notification tap delivers the destination URL to your app as an `Intent`, with the URL on
-`intent.data` — the same shape the SDK sends in [Option B](#option-b--manual-integration). A
-registered `DeepLinkHandler` is **not** invoked for these taps; the intent is the delivery
-mechanism.
-
-Read the link in **both** `onCreate` and `onNewIntent`. Both are required: if your process has been
-killed while its task is still in the recents list, Android re-creates your activity from the saved
-task, so `onCreate` sees the *original* intent and the new one arrives at `onNewIntent`.
-
-<details open>
-   <summary>Kotlin</summary>
-
-   ```kotlin
-   class MainActivity : ComponentActivity() {
-       override fun onCreate(savedInstanceState: Bundle?) {
-           super.onCreate(savedInstanceState)
-           intent?.data?.let(::handleDeepLink)
-       }
-
-       override fun onNewIntent(intent: Intent) {
-           super.onNewIntent(intent)
-           setIntent(intent)
-           intent.data?.let(::handleDeepLink)
-       }
-   }
-   ```
-</details>
-
-If you also call `Klaviyo.handlePush(intent)` — for example because you already had that wiring —
-it remains safe: the `Opened Push` event is recorded only once per notification, and your registered
-`DeepLinkHandler` is invoked by your call. Take care not to navigate twice in that case.
 
 #### Displaying notifications
 

--- a/README.md
+++ b/README.md
@@ -520,8 +520,8 @@ push integration that otherwise require code in your app:
 - **Push open tracking** (`automatic_push_open_tracking`) — **opt-in** (off by default). Set it to
   `true` and the SDK detects when a user taps a Klaviyo notification and records the `Opened Push`
   event for you, so you do **not** need to call `Klaviyo.handlePush(intent)` anywhere. Notification
-  taps deliver the deep link to your app as an `Intent`, on `intent.data`, rather than to a
-  registered handler — see [Deep Linking](#deep-linking).
+  taps deliver the deep link to your app as an `Intent` rather than to a registered handler — see
+  [Deep Linking](#deep-linking).
 - **Push token registration** (`automatic_push_token_forwarding`) — **on by default**. The SDK
   fetches the current FCM token and registers it with Klaviyo automatically, so you don't need to
   call `Klaviyo.setPushToken(...)` yourself. Set it to `false` to opt out.
@@ -1154,6 +1154,41 @@ deep links from In-App Forms, universal tracking links, and any push notificatio
 > ⚠️ **With `automatic_push_open_tracking` enabled, notification taps deliver an `Intent` rather than invoking this handler.**
 > See [Option A — Automatic Integration](#option-a--automatic-integration). Your intent-handling code needs to work regardless,
 > since a link can always arrive that way, so route from the intent and treat this callback as an addition rather than a replacement.
+
+Read a tapped notification's destination from the `Intent` with `Klaviyo.getKlaviyoDeepLink(intent)`
+(`Intent.klaviyoDeepLink` in Kotlin), rather than reading `intent.data` directly. The SDK only sets
+`data` when one of your activities declares a matching `intent-filter`; otherwise the tap arrives as
+a launcher intent carrying the URL in its extras, and this accessor reads it either way. It returns
+`null` for intents that did not originate from a Klaviyo notification, so it is safe to call
+unconditionally. Handle both `onCreate` and `onNewIntent`: when the process has been killed but its
+task is still in recents, Android restores the original intent into `onCreate` and delivers the new
+one to `onNewIntent`.
+
+<details open>
+   <summary>Kotlin</summary>
+
+   ```kotlin
+   override fun onNewIntent(intent: Intent?) {
+       super.onNewIntent(intent)
+       Klaviyo.getKlaviyoDeepLink(intent)?.let { handleDeepLink(it) }
+   }
+   ```
+</details>
+
+<details>
+   <summary>Java</summary>
+
+   ```java
+   @Override
+   protected void onNewIntent(Intent intent) {
+       super.onNewIntent(intent);
+       Uri deepLink = Klaviyo.getKlaviyoDeepLink(intent);
+       if (deepLink != null) {
+           handleDeepLink(deepLink);
+       }
+   }
+   ```
+</details>
 
 <details open>
    <summary>Kotlin</summary>

--- a/README.md
+++ b/README.md
@@ -519,7 +519,9 @@ push integration that otherwise require code in your app:
 
 - **Push open tracking** (`automatic_push_open_tracking`) — **opt-in** (off by default). Set it to
   `true` and the SDK detects when a user taps a Klaviyo notification and records the `Opened Push`
-  event for you, so you do **not** need to call `Klaviyo.handlePush(intent)` anywhere.
+  event for you, so you do **not** need to call `Klaviyo.handlePush(intent)` anywhere. Notification
+  taps deliver the deep link to your app as an `Intent` — see
+  [Deep links with automatic open tracking](#deep-links-with-automatic-open-tracking) below.
 - **Push token registration** (`automatic_push_token_forwarding`) — **on by default**. The SDK
   fetches the current FCM token and registers it with Klaviyo automatically, so you don't need to
   call `Klaviyo.setPushToken(...)` yourself. Set it to `false` to opt out.
@@ -565,6 +567,40 @@ That's it. With both flags set, `initialize()` covers both concerns above:
 - **Open tracking** records an `Opened Push` event for every Klaviyo notification tap.
 - **Token registration** happens at `initialize()` **and** again on every app foreground, so
   token rotations are picked up on those events.
+
+#### Deep links with automatic open tracking
+
+A notification tap delivers the destination URL to your app as an `Intent`, with the URL on
+`intent.data` — the same shape the SDK sends in [Option B](#option-b--manual-integration). A
+registered `DeepLinkHandler` is **not** invoked for these taps; the intent is the delivery
+mechanism.
+
+Read the link in **both** `onCreate` and `onNewIntent`. Both are required: if your process has been
+killed while its task is still in the recents list, Android re-creates your activity from the saved
+task, so `onCreate` sees the *original* intent and the new one arrives at `onNewIntent`.
+
+<details open>
+   <summary>Kotlin</summary>
+
+   ```kotlin
+   class MainActivity : ComponentActivity() {
+       override fun onCreate(savedInstanceState: Bundle?) {
+           super.onCreate(savedInstanceState)
+           intent?.data?.let(::handleDeepLink)
+       }
+
+       override fun onNewIntent(intent: Intent) {
+           super.onNewIntent(intent)
+           setIntent(intent)
+           intent.data?.let(::handleDeepLink)
+       }
+   }
+   ```
+</details>
+
+If you also call `Klaviyo.handlePush(intent)` — for example because you already had that wiring —
+it remains safe: the `Opened Push` event is recorded only once per notification, and your registered
+`DeepLinkHandler` is invoked by your call. Take care not to navigate twice in that case.
 
 #### Displaying notifications
 
@@ -1147,7 +1183,11 @@ you can centralize your logic and reduce duplication of code as you complete the
 **Optional**: register a deep link handler callback with `Klaviyo.registerDeepLinkHandler()`.
 You should register this from your `Application` or main `Activity`'s `.onCreate()` method, so that it is available early enough in
 the application lifecycle to handle any link that launches the app from a terminated state. This handler will be invoked for
-*any* deep link originating from the Klaviyo SDK, including push notifications, universal tracking links, or In-App Forms.
+deep links from In-App Forms, universal tracking links, and any push notification you pass to `Klaviyo.handlePush(intent)` yourself.
+
+> ⚠️ **With `automatic_push_open_tracking` enabled, notification taps deliver an `Intent` rather than invoking this handler.**
+> See [Option A — Automatic Integration](#option-a--automatic-integration). Your intent-handling code needs to work regardless,
+> since a link can always arrive that way, so route from the intent and treat this callback as an addition rather than a replacement.
 
 <details open>
    <summary>Kotlin</summary>

--- a/sample/src/automatic/java/com/klaviyo/sample/SampleActivity.kt
+++ b/sample/src/automatic/java/com/klaviyo/sample/SampleActivity.kt
@@ -54,7 +54,11 @@ class SampleActivity : ComponentActivity() {
             )
         }
 
-        onNewIntent(intent)
+        // Only on a fresh start: after a configuration change the same intent is re-delivered,
+        // which would navigate a second time.
+        if (savedInstanceState == null) {
+            onNewIntent(intent)
+        }
     }
 
     override fun onNewIntent(intent: Intent?) {
@@ -73,7 +77,7 @@ class SampleActivity : ComponentActivity() {
 
         // SETUP NOTE (Automatic / Option A): A notification tap delivers its deep link here, on the
         // intent's data, rather than to a registered deep link handler. Handle it in BOTH onCreate
-        // (via the call above) and onNewIntent: when your process has been killed but its task is
+        // (via the call above) and onNewIntent: when the process has been killed but its task is
         // still in recents, Android restores the original intent into onCreate and delivers the new
         // one here.
         intent?.data?.let { deepLink ->

--- a/sample/src/automatic/java/com/klaviyo/sample/SampleActivity.kt
+++ b/sample/src/automatic/java/com/klaviyo/sample/SampleActivity.kt
@@ -23,7 +23,8 @@ import com.klaviyo.analytics.model.EventMetric
  *    (no FirebaseMessaging fetch, no Klaviyo.setPushToken() call). Contrast with the `manual` flavor's onCreate.
  *  - Push opens (automatic_push_open_tracking): the SDK automatically detects when a user taps a push notification
  *    and reports the open event via Klaviyo.handlePush() for you, so there is no handlePush() call in
- *    onNewIntent. Contrast with the `manual` flavor's onNewIntent.
+ *    onNewIntent. Contrast with the `manual` flavor's onNewIntent. Deep links arrive as an Intent, which
+ *    this Activity reads in both onCreate and onNewIntent.
  * Displaying notifications still relies on the auto-registered KlaviyoPushService from :sdk:push-fcm.
  * See the main README's "Push Notifications" section (Option A) and sample/README.md.
  */
@@ -68,7 +69,17 @@ class SampleActivity : ComponentActivity() {
 
         // SETUP NOTE (Automatic / Option A): No Klaviyo.handlePush(intent) here.
         // Because com.klaviyo.push.automatic_push_open_tracking is enabled, the SDK automatically detects
-        // notification taps, reports the open, and invokes your deep link handler for you.
+        // notification taps and reports the open for you.
+
+        // SETUP NOTE (Automatic / Option A): A notification tap delivers its deep link here, on the
+        // intent's data, rather than to a registered deep link handler. Handle it in BOTH onCreate
+        // (via the call above) and onNewIntent: when your process has been killed but its task is
+        // still in recents, Android restores the original intent into onCreate and delivers the new
+        // one here.
+        intent?.data?.let { deepLink ->
+            showToast("Deep link from intent: $deepLink")
+            startActivity(SampleDetailActivity.intent(this, deepLink.toString()))
+        }
     }
 
     private val requestPermissionLauncher = registerForActivityResult(

--- a/sample/src/automatic/java/com/klaviyo/sample/SampleActivity.kt
+++ b/sample/src/automatic/java/com/klaviyo/sample/SampleActivity.kt
@@ -75,12 +75,12 @@ class SampleActivity : ComponentActivity() {
         // Because com.klaviyo.push.automatic_push_open_tracking is enabled, the SDK automatically detects
         // notification taps and reports the open for you.
 
-        // SETUP NOTE (Automatic / Option A): A notification tap delivers its deep link here, on the
-        // intent's data, rather than to a registered deep link handler. Handle it in BOTH onCreate
-        // (via the call above) and onNewIntent: when the process has been killed but its task is
-        // still in recents, Android restores the original intent into onCreate and delivers the new
-        // one here.
-        intent?.data?.let { deepLink ->
+        // SETUP NOTE (Automatic / Option A): A notification tap delivers its deep link here on the
+        // Intent, rather than to a registered deep link handler. Handle it in BOTH onCreate (via
+        // the call above) and onNewIntent: when the process has been killed but its task is still
+        // in recents, Android restores the original intent into onCreate and delivers the new one
+        // here. getKlaviyoDeepLink reads the link whether or not a matching intent-filter exists.
+        Klaviyo.getKlaviyoDeepLink(intent)?.let { deepLink ->
             showToast("Deep link from intent: $deepLink")
             startActivity(SampleDetailActivity.intent(this, deepLink.toString()))
         }

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -53,6 +53,16 @@
             </intent-filter>
         </activity>
 
+        <!--
+            Sample App Only: the destination this app navigates to for a deep link. Declared with the
+            default task affinity so it stacks on top of SampleActivity in the same task, which is
+            what makes the back-stack behavior after a notification tap observable.
+        -->
+        <activity
+                android:name=".SampleDetailActivity"
+                android:exported="false"
+                android:theme="@style/Theme.KlaviyoAndroidSdk"/>
+
         <!-- Optional: Set the Klaviyo SDK logging level (1=verbose, 2=debug etc) -->
         <meta-data
                 android:name="com.klaviyo.core.log_level"

--- a/sample/src/main/java/com/klaviyo/sample/SampleApplication.kt
+++ b/sample/src/main/java/com/klaviyo/sample/SampleApplication.kt
@@ -30,8 +30,11 @@ class SampleApplication : Application() {
             .registerForInAppForms() // Register for In-App Forms immediately on app launch (this app has no splash screen)
             .registerGeofencing() // Start geofencing monitoring
             .registerDeepLinkHandler { uri ->
-                // OPTIONAL SETUP NOTE: Register a callback to handle any deep links from Klaviyo notifications, in-app forms, or universal tracking links
-                // If not using a deep link handler, Klaviyo will send an Intent to your app with the deep link in intent.data
+                // OPTIONAL SETUP NOTE: Register a callback to handle deep links from in-app forms,
+                // universal tracking links, and any push intent you pass to Klaviyo.handlePush().
+                // With automatic_push_open_tracking enabled (the `automatic` flavor), notification
+                // taps instead deliver the link as an Intent — see that flavor's SampleActivity.
+                // If no handler is registered, Klaviyo sends an Intent with the link in intent.data.
                 showToast("Deep link to: $uri")
             }
             .registerFormLifecycleHandler { event ->

--- a/sample/src/main/java/com/klaviyo/sample/SampleDetailActivity.kt
+++ b/sample/src/main/java/com/klaviyo/sample/SampleDetailActivity.kt
@@ -18,13 +18,23 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.klaviyo.sample.ui.theme.KlaviyoAndroidSdkTheme
 
+private object DetailUiConstants {
+    const val TITLE = "Deep Link Destination"
+    const val NO_DEEP_LINK = "No deep link provided"
+    const val BACK = "Back"
+}
+
 /**
- * SETUP NOTE: A second screen the sample's deep link handler navigates to, so notification taps
- * have a visible destination on top of [SampleActivity] rather than only a toast.
+ * SETUP NOTE: A second screen the sample navigates to when a notification tap delivers a deep link,
+ * so taps have a visible destination on top of [SampleActivity] rather than only a toast.
+ *
+ * Started from the `automatic` flavor's `SampleActivity`, which reads the link off the tap Intent
+ * via `Klaviyo.getKlaviyoDeepLink`. The handler registered in [SampleApplication] only shows a
+ * toast; under `automatic_push_open_tracking` it is not invoked for notification taps at all.
  *
  * This exists to demonstrate the back-stack contract: after tapping a deep link notification, the
- * screen your handler navigated to should still be on top. A toast could not show that, since
- * nothing can pop it off the stack.
+ * screen you navigated to should still be on top. A toast could not show that, since nothing can
+ * pop it off the stack.
  *
  * Your app does not need an Activity like this — navigate however you already do (a second
  * Activity, a Fragment transaction, a Compose NavController route).
@@ -47,15 +57,15 @@ class SampleDetailActivity : ComponentActivity() {
                         verticalArrangement = Arrangement.spacedBy(16.dp)
                     ) {
                         Text(
-                            text = "Deep Link Destination",
+                            text = DetailUiConstants.TITLE,
                             style = MaterialTheme.typography.headlineSmall
                         )
                         Text(
-                            text = deepLink ?: "No deep link provided",
+                            text = deepLink ?: DetailUiConstants.NO_DEEP_LINK,
                             style = MaterialTheme.typography.bodyMedium
                         )
                         OutlinedButton(onClick = { finish() }) {
-                            Text("Back")
+                            Text(DetailUiConstants.BACK)
                         }
                     }
                 }
@@ -69,14 +79,11 @@ class SampleDetailActivity : ComponentActivity() {
         /**
          * Build an intent that opens this screen on top of the app's existing task.
          *
-         * [Intent.FLAG_ACTIVITY_NEW_TASK] is required because the sample's deep link handler is
-         * registered from [SampleApplication] and therefore starts this from an application
-         * context. Since this Activity uses the app's default task affinity, the flag adds it to
-         * the existing task rather than creating a separate one.
+         * Started from an Activity context, so no flags are needed: it stacks onto the caller's
+         * task, which is what makes the post-tap back stack observable.
          */
         fun intent(context: Context, deepLink: String) =
             Intent(context, SampleDetailActivity::class.java)
                 .putExtra(EXTRA_DEEP_LINK, deepLink)
-                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
     }
 }

--- a/sample/src/main/java/com/klaviyo/sample/SampleDetailActivity.kt
+++ b/sample/src/main/java/com/klaviyo/sample/SampleDetailActivity.kt
@@ -1,0 +1,82 @@
+package com.klaviyo.sample
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.klaviyo.sample.ui.theme.KlaviyoAndroidSdkTheme
+
+/**
+ * SETUP NOTE: A second screen the sample's deep link handler navigates to, so notification taps
+ * have a visible destination on top of [SampleActivity] rather than only a toast.
+ *
+ * This exists to demonstrate the back-stack contract: after tapping a deep link notification, the
+ * screen your handler navigated to should still be on top. A toast could not show that, since
+ * nothing can pop it off the stack.
+ *
+ * Your app does not need an Activity like this — navigate however you already do (a second
+ * Activity, a Fragment transaction, a Compose NavController route).
+ */
+class SampleDetailActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val deepLink = intent?.getStringExtra(EXTRA_DEEP_LINK)
+
+        setContent {
+            KlaviyoAndroidSdkTheme {
+                Surface(modifier = Modifier.fillMaxSize()) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .systemBarsPadding()
+                            .padding(24.dp),
+                        verticalArrangement = Arrangement.spacedBy(16.dp)
+                    ) {
+                        Text(
+                            text = "Deep Link Destination",
+                            style = MaterialTheme.typography.headlineSmall
+                        )
+                        Text(
+                            text = deepLink ?: "No deep link provided",
+                            style = MaterialTheme.typography.bodyMedium
+                        )
+                        OutlinedButton(onClick = { finish() }) {
+                            Text("Back")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    companion object {
+        private const val EXTRA_DEEP_LINK = "deep_link"
+
+        /**
+         * Build an intent that opens this screen on top of the app's existing task.
+         *
+         * [Intent.FLAG_ACTIVITY_NEW_TASK] is required because the sample's deep link handler is
+         * registered from [SampleApplication] and therefore starts this from an application
+         * context. Since this Activity uses the app's default task affinity, the flag adds it to
+         * the existing task rather than creating a separate one.
+         */
+        fun intent(context: Context, deepLink: String) =
+            Intent(context, SampleDetailActivity::class.java)
+                .putExtra(EXTRA_DEEP_LINK, deepLink)
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    }
+}

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -445,7 +445,7 @@ object Klaviyo {
      * Read a non-empty [PACKAGE_PREFIX]-scoped payload URL off this intent, or null.
      */
     private fun Intent.payloadUrl(key: String): Uri? =
-        getStringExtra(PACKAGE_PREFIX + key)?.takeIf { it.isNotEmpty() }?.toUri()
+        getStringExtra(PACKAGE_PREFIX + key)?.takeIf { it.isNotBlank() }?.toUri()
 
     /**
      * The destination URL of the Klaviyo notification tap that delivered this [Intent], or null if

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -19,6 +19,7 @@ import com.klaviyo.analytics.state.State
 import com.klaviyo.analytics.state.StateSideEffects
 import com.klaviyo.core.Constants.PACKAGE_PREFIX
 import com.klaviyo.core.Constants.TRACKING_PARAMETER
+import com.klaviyo.core.Constants.URL_PARAMETER
 import com.klaviyo.core.Operation
 import com.klaviyo.core.PushTokenFetcher
 import com.klaviyo.core.Registry
@@ -416,6 +417,32 @@ object Klaviyo {
      */
     @JvmStatic
     fun isKlaviyoNotificationIntent(intent: Intent?): Boolean = intent.isKlaviyoNotificationIntent
+
+    /**
+     * The destination URL of the Klaviyo notification tap that delivered this [Intent], or null if
+     * it carried none.
+     *
+     * Reads the intent `data` when present, else the URL from the notification payload. Both are
+     * populated for a Klaviyo notification tap: `data` is set when an activity declares a matching
+     * intent-filter, and the payload value is always present, so this returns the link either way.
+     *
+     * Safe to call from `onCreate` and `onNewIntent` on any intent, Klaviyo or not.
+     */
+    val Intent?.klaviyoDeepLink: Uri?
+        @JvmSynthetic
+        @JvmName("_klaviyoDeepLink")
+        get() = this?.takeIf { it.isKlaviyoNotificationIntent }?.let { intent ->
+            intent.data ?: intent.getStringExtra(PACKAGE_PREFIX + URL_PARAMETER)
+                ?.takeIf { it.isNotEmpty() }
+                ?.toUri()
+        }
+
+    /**
+     * The destination URL of the Klaviyo notification tap that delivered this [Intent], or null if
+     * it carried none. Java-friendly static method.
+     */
+    @JvmStatic
+    fun getKlaviyoDeepLink(intent: Intent?): Uri? = intent.klaviyoDeepLink
 
     /**
      * Determine if an intent is a Klaviyo click-tracking universal/app link

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/Klaviyo.kt
@@ -17,6 +17,7 @@ import com.klaviyo.analytics.networking.KlaviyoApiClient
 import com.klaviyo.analytics.state.KlaviyoState
 import com.klaviyo.analytics.state.State
 import com.klaviyo.analytics.state.StateSideEffects
+import com.klaviyo.core.Constants.BUTTON_LINK_PARAMETER
 import com.klaviyo.core.Constants.PACKAGE_PREFIX
 import com.klaviyo.core.Constants.TRACKING_PARAMETER
 import com.klaviyo.core.Constants.URL_PARAMETER
@@ -426,16 +427,25 @@ object Klaviyo {
      * populated for a Klaviyo notification tap: `data` is set when an activity declares a matching
      * intent-filter, and the payload value is always present, so this returns the link either way.
      *
+     * For an action button tap this is the button's own destination, which may differ from the
+     * notification body's.
+     *
      * Safe to call from `onCreate` and `onNewIntent` on any intent, Klaviyo or not.
      */
     val Intent?.klaviyoDeepLink: Uri?
         @JvmSynthetic
         @JvmName("_klaviyoDeepLink")
         get() = this?.takeIf { it.isKlaviyoNotificationIntent }?.let { intent ->
-            intent.data ?: intent.getStringExtra(PACKAGE_PREFIX + URL_PARAMETER)
-                ?.takeIf { it.isNotEmpty() }
-                ?.toUri()
+            intent.data
+                ?: intent.payloadUrl(BUTTON_LINK_PARAMETER)
+                ?: intent.payloadUrl(URL_PARAMETER)
         }
+
+    /**
+     * Read a non-empty [PACKAGE_PREFIX]-scoped payload URL off this intent, or null.
+     */
+    private fun Intent.payloadUrl(key: String): Uri? =
+        getStringExtra(PACKAGE_PREFIX + key)?.takeIf { it.isNotEmpty() }?.toUri()
 
     /**
      * The destination URL of the Klaviyo notification tap that delivered this [Intent], or null if

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoJavaApiTest.java
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoJavaApiTest.java
@@ -335,6 +335,17 @@ public class KlaviyoJavaApiTest {
     }
 
     @Test
+    public void testGetKlaviyoDeepLink() {
+        Uri result1 = Klaviyo.INSTANCE.getKlaviyoDeepLink(mockIntent);
+        assertEquals(KlaviyoMock.getMockDeepLink(), result1);
+
+        Uri result2 = Klaviyo.getKlaviyoDeepLink(mockIntent);
+        assertEquals(KlaviyoMock.getMockDeepLink(), result2);
+
+        KlaviyoMock.verifyGetKlaviyoDeepLinkCalled(2);
+    }
+
+    @Test
     public void testIsKlaviyoUniversalTrackingIntent() {
         boolean result1 = Klaviyo.INSTANCE.isKlaviyoUniversalTrackingIntent(mockIntent);
         assertTrue(result1);

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoPushOpenHandlerTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoPushOpenHandlerTest.kt
@@ -549,4 +549,45 @@ internal class KlaviyoPushOpenHandlerTest : BaseTest() {
         assertEquals("Test message", body)
         assertEquals("Test title", title)
     }
+
+    // --- getKlaviyoDeepLink: reads the link whether or not an intent-filter matched ---
+
+    @Test
+    fun `getKlaviyoDeepLink returns the intent data when an activity resolved the link`() {
+        val testUri = mockk<Uri>()
+
+        val link = Klaviyo.getKlaviyoDeepLink(mockIntent(stubIntentExtras, testUri))
+
+        assertEquals(testUri, link)
+    }
+
+    @Test
+    fun `getKlaviyoDeepLink falls back to the payload url when the intent has no data`() {
+        // The unresolvable case: the trampoline sends a launcher intent, which carries no data.
+        val parsed = mockk<Uri>()
+        every { Uri.parse("klaviyotest://detail/1") } returns parsed
+        val extras = mapOf(
+            "com.klaviyo._k" to requireNotNull(stubIntentExtras["com.klaviyo._k"]),
+            "com.klaviyo.url" to "klaviyotest://detail/1"
+        )
+
+        val link = Klaviyo.getKlaviyoDeepLink(mockIntent(extras))
+
+        assertEquals(parsed, link)
+    }
+
+    @Test
+    fun `getKlaviyoDeepLink returns null for a klaviyo intent carrying no link`() {
+        assertEquals(null, Klaviyo.getKlaviyoDeepLink(mockIntent(stubIntentExtras)))
+    }
+
+    @Test
+    fun `getKlaviyoDeepLink returns null for non-klaviyo and null intents`() {
+        // Safe to call unconditionally from onCreate/onNewIntent, so a host app's own deep link
+        // must not be mistaken for a Klaviyo one.
+        val testUri = mockk<Uri>()
+
+        assertEquals(null, Klaviyo.getKlaviyoDeepLink(null))
+        assertEquals(null, Klaviyo.getKlaviyoDeepLink(mockIntent(mapOf("other" to "x"), testUri)))
+    }
 }

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoPushOpenHandlerTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoPushOpenHandlerTest.kt
@@ -577,6 +577,35 @@ internal class KlaviyoPushOpenHandlerTest : BaseTest() {
     }
 
     @Test
+    fun `getKlaviyoDeepLink prefers the tapped button's link over the notification body's`() {
+        // An action button intent carries both: its own destination and, via appendKlaviyoExtras,
+        // the body's url. Returning the body's would navigate somewhere the user did not tap.
+        val buttonUri = mockk<Uri>()
+        every { Uri.parse("klaviyotest://order/123") } returns buttonUri
+        every { Uri.parse("klaviyotest://detail/1") } returns mockk()
+        val extras = mapOf(
+            "com.klaviyo._k" to requireNotNull(stubIntentExtras["com.klaviyo._k"]),
+            "com.klaviyo.url" to "klaviyotest://detail/1",
+            "com.klaviyo.Button Link" to "klaviyotest://order/123"
+        )
+
+        assertEquals(buttonUri, Klaviyo.getKlaviyoDeepLink(mockIntent(extras)))
+    }
+
+    @Test
+    fun `getKlaviyoDeepLink reads a button link when the notification body has no url`() {
+        // An open_app body with a deep_link button: there is no com.klaviyo.url to fall back on.
+        val buttonUri = mockk<Uri>()
+        every { Uri.parse("klaviyotest://order/123") } returns buttonUri
+        val extras = mapOf(
+            "com.klaviyo._k" to requireNotNull(stubIntentExtras["com.klaviyo._k"]),
+            "com.klaviyo.Button Link" to "klaviyotest://order/123"
+        )
+
+        assertEquals(buttonUri, Klaviyo.getKlaviyoDeepLink(mockIntent(extras)))
+    }
+
+    @Test
     fun `getKlaviyoDeepLink returns null for a klaviyo intent carrying no link`() {
         assertEquals(null, Klaviyo.getKlaviyoDeepLink(mockIntent(stubIntentExtras)))
     }

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoPushOpenHandlerTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoPushOpenHandlerTest.kt
@@ -606,6 +606,18 @@ internal class KlaviyoPushOpenHandlerTest : BaseTest() {
     }
 
     @Test
+    fun `getKlaviyoDeepLink ignores a blank payload url`() {
+        // toUri() happily returns a non-null, useless Uri for whitespace, so an empty check alone
+        // would hand the host a link to navigate to.
+        val extras = mapOf(
+            "com.klaviyo._k" to requireNotNull(stubIntentExtras["com.klaviyo._k"]),
+            "com.klaviyo.url" to "   "
+        )
+
+        assertEquals(null, Klaviyo.getKlaviyoDeepLink(mockIntent(extras)))
+    }
+
+    @Test
     fun `getKlaviyoDeepLink returns null for a klaviyo intent carrying no link`() {
         assertEquals(null, Klaviyo.getKlaviyoDeepLink(mockIntent(stubIntentExtras)))
     }

--- a/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
@@ -27,6 +27,13 @@ object Constants {
     const val TRACKING_PARAMETER = "_k"
 
     /**
+     * Payload key holding a notification's destination URL. Copied onto every tap intent as
+     * [PACKAGE_PREFIX] + this key, so the URL is readable even when no activity declares a matching
+     * intent-filter and the intent's `data` is therefore unset.
+     */
+    const val URL_PARAMETER = "url"
+
+    /**
      * Intent extra key for the notification tag, used to dismiss the notification
      * when an action button is tapped and [handlePush] processes the intent.
      *

--- a/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/Constants.kt
@@ -34,6 +34,14 @@ object Constants {
     const val URL_PARAMETER = "url"
 
     /**
+     * Intent extra key holding the destination URL of the action button that was tapped, stamped
+     * only on action button intents. Takes precedence over [URL_PARAMETER] when reading a tap's
+     * destination: a button carries its own URL, and the body's [URL_PARAMETER] is present on the
+     * same intent regardless of which button was tapped.
+     */
+    const val BUTTON_LINK_PARAMETER = "Button Link"
+
+    /**
      * Intent extra key for the notification tag, used to dismiss the notification
      * when an action button is tapped and [handlePush] processes the intent.
      *

--- a/sdk/fixtures/src/main/java/com/klaviyo/fixtures/KlaviyoMock.kt
+++ b/sdk/fixtures/src/main/java/com/klaviyo/fixtures/KlaviyoMock.kt
@@ -38,6 +38,12 @@ object KlaviyoMock {
     val mockUri: Uri = mockk(relaxed = true)
 
     /**
+     * Distinct from [mockUri] so a test can tell a returned deep link apart from any other Uri.
+     */
+    @JvmStatic
+    val mockDeepLink: Uri = mockk(relaxed = true)
+
+    /**
      * Sets up mocks for all Klaviyo public API methods.
      * Call this in @Before setup methods.
      */
@@ -80,12 +86,14 @@ object KlaviyoMock {
         every { Klaviyo.run { any<Intent>().isKlaviyoNotificationIntent } } returns true
         every { Klaviyo.run { any<Intent>().isKlaviyoUniversalTrackingIntent } } returns true
         every { Klaviyo.run { any<Uri>().isKlaviyoUniversalTrackingUri } } returns true
+        every { Klaviyo.run { any<Intent>().klaviyoDeepLink } } returns mockDeepLink
 
         // Static wrapper methods for the extension properties (Java-friendly)
         every { Klaviyo.isKlaviyoIntent(any()) } returns true
         every { Klaviyo.isKlaviyoNotificationIntent(any()) } returns true
         every { Klaviyo.isKlaviyoUniversalTrackingIntent(any()) } returns true
         every { Klaviyo.isKlaviyoUniversalTrackingUri(any()) } returns true
+        every { Klaviyo.getKlaviyoDeepLink(any()) } returns mockDeepLink
 
         // Mock createEvent with single param (thanks to @JvmOverloads)
         every { Klaviyo.createEvent(any<EventMetric>()) } returns Klaviyo
@@ -215,6 +223,12 @@ object KlaviyoMock {
     @JvmOverloads
     fun verifyIsKlaviyoNotificationIntentCalled(count: Int = 1) {
         verify(exactly = count) { Klaviyo.isKlaviyoNotificationIntent(any()) }
+    }
+
+    @JvmStatic
+    @JvmOverloads
+    fun verifyGetKlaviyoDeepLinkCalled(count: Int = 1) {
+        verify(exactly = count) { Klaviyo.getKlaviyoDeepLink(any()) }
     }
 
     @JvmStatic

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoNotification.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoNotification.kt
@@ -286,11 +286,8 @@ class KlaviyoNotification(private val message: RemoteMessage) {
         if (deepLink != null) {
             // With automatic tracking on, route through the trampoline carrying the deep link as
             // intent data so it calls handlePush; otherwise target the host directly as before.
-            //
-            // Unlike makeResolvedDeepLinkIntent, we keep the deep link on the intent even when no
-            // Activity resolves it: this is intentional so a registered DeepLinkHandler receives
-            // every link regardless of intent-filter resolution (the common single-Activity case).
-            // The trampoline only consults Activity resolvability when no handler is registered.
+            // The trampoline resolves the link itself when the tap happens, rather than here at
+            // build time.
             val intent = if (autoTracking) {
                 KlaviyoTrampolineActivity.forDestination(context, deepLink)
             } else {
@@ -397,8 +394,6 @@ class KlaviyoNotification(private val message: RemoteMessage) {
                 val uri = button.url.toUri()
                 // With auto-tracking on, route through the trampoline carrying the deep link as
                 // intent data so it calls handlePush; otherwise target the host directly as before.
-                // See makeOpenedIntent: the deep link is deliberately kept even when unresolvable so
-                // a registered DeepLinkHandler still receives it.
                 if (autoTracking) {
                     KlaviyoTrampolineActivity.forDestination(context, uri)
                 } else {

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoNotification.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoNotification.kt
@@ -67,7 +67,7 @@ class KlaviyoNotification(private val message: RemoteMessage) {
         internal const val SMALL_ICON_KEY = "small_icon"
         internal const val TITLE_KEY = "title"
         internal const val BODY_KEY = "body"
-        internal const val URL_KEY = "url"
+        internal const val URL_KEY = Constants.URL_PARAMETER
         internal const val IMAGE_KEY = "image_url"
         internal const val SOUND_KEY = "sound"
         internal const val COLOR_KEY = "color"

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoRemoteMessage.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoRemoteMessage.kt
@@ -15,6 +15,7 @@ import androidx.core.graphics.toColorInt
 import androidx.core.net.toUri
 import com.google.firebase.messaging.CommonNotificationBuilder
 import com.google.firebase.messaging.RemoteMessage
+import com.klaviyo.core.Constants.BUTTON_LINK_PARAMETER
 import com.klaviyo.core.Constants.PACKAGE_PREFIX
 import com.klaviyo.core.Constants.TRACKING_PARAMETER
 import com.klaviyo.core.Registry
@@ -69,7 +70,7 @@ object KlaviyoRemoteMessage {
         putExtra(PACKAGE_PREFIX + "Button Action", actionName)
 
         (button as? ActionButton.UrlBearing)?.let {
-            putExtra(PACKAGE_PREFIX + "Button Link", it.url)
+            putExtra(PACKAGE_PREFIX + BUTTON_LINK_PARAMETER, it.url)
         }
     }
 

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivity.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivity.kt
@@ -146,8 +146,8 @@ internal class KlaviyoTrampolineActivity : Activity() {
                         viewIntent
                     } else {
                         Registry.log.warning(
-                            "No activity resolves deep link $deepLink; " +
-                                "launching host with the link attached"
+                            "No activity resolves scheme '${deepLink.scheme}'; " +
+                                "launching host with the deep link attached"
                         )
                         DeepLinking.makeLaunchIntent(context, intent.extras)?.apply {
                             data = deepLink

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivity.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivity.kt
@@ -131,8 +131,12 @@ internal class KlaviyoTrampolineActivity : Activity() {
          * Forward a body/`deep_link`/`open_app` tap into the host app.
          *
          * - Deep link that an activity can handle → `ACTION_VIEW`, so the OS routes it.
-         * - Deep link with no matching intent filter → launcher intent carrying the link as its
-         *   data, which the host can still read from `getIntent()` or `onNewIntent`.
+         * - Deep link with no matching intent filter → launcher intent, with the link left off its
+         *   `data`. AOSP treats a `MAIN`/`LAUNCHER` intent with `data` as not a main intent
+         *   (`ActivityRecord.isMainIntent`), and under `CLEAR_TOP` the started intent becomes the
+         *   task's base intent, which is persisted across reboots and re-fired when recents
+         *   restores a trimmed task. The URL rides the payload extras regardless, so
+         *   `Klaviyo.getKlaviyoDeepLink(intent)` reads it in both cases.
          * - No deep link → launcher intent.
          */
         private fun startDestination(intent: Intent, context: Context) {
@@ -149,12 +153,10 @@ internal class KlaviyoTrampolineActivity : Activity() {
                         viewIntent
                     } else {
                         Registry.log.warning(
-                            "No activity resolves scheme '${deepLink.scheme}'; " +
-                                "launching host with the deep link attached"
+                            "No activity resolves scheme '${deepLink.scheme}'; launching host. " +
+                                "Read the link via Klaviyo.getKlaviyoDeepLink(intent)."
                         )
-                        DeepLinking.makeLaunchIntent(context, intent.extras)?.apply {
-                            data = deepLink
-                        }
+                        DeepLinking.makeLaunchIntent(context, intent.extras)
                     }
                 }
                 else -> {

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivity.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivity.kt
@@ -9,15 +9,15 @@ import androidx.core.net.toUri
 import com.klaviyo.analytics.Klaviyo
 import com.klaviyo.analytics.Klaviyo.isKlaviyoNotificationIntent
 import com.klaviyo.analytics.linking.DeepLinking
+import com.klaviyo.core.Constants
 import com.klaviyo.core.Registry
 import com.klaviyo.core.utils.activityResolved
 import com.klaviyo.core.utils.startActivityIfResolved
 
 /**
  * Transparent trampoline [Activity] used to intercept Klaviyo notification taps so the
- * SDK can run side effects (e.g. tracking `$opened_push`, dismissing the notification,
- * invoking the registered deep link handler) before forwarding the user to the actual
- * destination.
+ * SDK can run side effects (tracking `$opened_push`, dismissing the notification) before
+ * forwarding the user to the actual destination.
  *
  * Dispatch is driven by intent contents, not by any flag:
  * - `open_url` payloads embed a browser URL as [BROWSER_URL_EXTRA] and route to the browser.
@@ -88,6 +88,10 @@ internal class KlaviyoTrampolineActivity : Activity() {
          * enabled. The trampoline runs `Klaviyo.handlePush` then forwards to the host app, dispatching
          * to [deepLink] (carried as the intent `data`) when present, otherwise to the launcher.
          *
+         * Carries [Constants.SUPPRESS_DEEP_LINK_HANDLER_EXTRA] so that `handlePush` call does not
+         * also invoke a registered handler; the flag is removed from the intent forwarded to the
+         * host.
+         *
          * Uses [Intent.setClassName] instead of the `Intent(Context, Class)` constructor — same test
          * seam as [forBrowserUrl]. Callers append their own Klaviyo extras for parity with the
          * non-trampoline intents they replace.
@@ -95,6 +99,7 @@ internal class KlaviyoTrampolineActivity : Activity() {
         internal fun forDestination(context: Context, deepLink: Uri? = null): Intent = Intent().apply {
             setClassName(context.packageName, KlaviyoTrampolineActivity::class.java.name)
             deepLink?.let { data = it }
+            putExtra(Constants.SUPPRESS_DEEP_LINK_HANDLER_EXTRA, true)
         }
 
         /**
@@ -109,9 +114,7 @@ internal class KlaviyoTrampolineActivity : Activity() {
                 )
                 return
             }
-            // The deep link reaches the host on the intent forwarded below, so a registered
-            // handler is not invoked here. A host that also calls handlePush still gets one.
-            Klaviyo.handlePush(intent, dispatchDeepLink = false)
+            Klaviyo.handlePush(intent)
             dispatchDestination(intent, context)
         }
 
@@ -161,6 +164,10 @@ internal class KlaviyoTrampolineActivity : Activity() {
             }
 
             destination?.apply {
+                // Both destinations copy this intent's extras, which must not include the
+                // suppression flag: the host's own handlePush has to reach its handler.
+                removeExtra(Constants.SUPPRESS_DEEP_LINK_HANDLER_EXTRA)
+
                 // CLEAR_TOP mirrors the non-trampoline path (KlaviyoNotification adds it to the
                 // contentIntent, but it's consumed launching the trampoline rather than forwarded),
                 // preserving back-stack behavior. NEW_TASK is required here since we launch from the

--- a/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivity.kt
+++ b/sdk/push-fcm/src/main/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivity.kt
@@ -109,7 +109,9 @@ internal class KlaviyoTrampolineActivity : Activity() {
                 )
                 return
             }
-            Klaviyo.handlePush(intent)
+            // The deep link reaches the host on the intent forwarded below, so a registered
+            // handler is not invoked here. A host that also calls handlePush still gets one.
+            Klaviyo.handlePush(intent, dispatchDeepLink = false)
             dispatchDestination(intent, context)
         }
 
@@ -125,15 +127,15 @@ internal class KlaviyoTrampolineActivity : Activity() {
         /**
          * Forward a body/`deep_link`/`open_app` tap into the host app.
          *
-         * - Deep link present and no [DeepLinkHandler][com.klaviyo.analytics.linking.DeepLinkHandler]
-         *   registered → `ACTION_VIEW` into the host, falling back to the launcher if unresolvable.
-         * - Handler registered, or no deep link → launcher only. `handlePush` already dispatched the
-         *   handler, so an additional `ACTION_VIEW` would double-deliver navigation.
+         * - Deep link that an activity can handle → `ACTION_VIEW`, so the OS routes it.
+         * - Deep link with no matching intent filter → launcher intent carrying the link as its
+         *   data, which the host can still read from `getIntent()` or `onNewIntent`.
+         * - No deep link → launcher intent.
          */
         private fun startDestination(intent: Intent, context: Context) {
             val deepLink = intent.data
             val destination: Intent? = when {
-                deepLink != null && !DeepLinking.isHandlerRegistered -> {
+                deepLink != null -> {
                     val viewIntent = DeepLinking.makeDeepLinkIntent(
                         deepLink,
                         context,
@@ -144,19 +146,16 @@ internal class KlaviyoTrampolineActivity : Activity() {
                         viewIntent
                     } else {
                         Registry.log.warning(
-                            "Trampoline could not resolve deep link; falling back to launcher"
+                            "No activity resolves deep link $deepLink; " +
+                                "launching host with the link attached"
                         )
-                        DeepLinking.makeLaunchIntent(context, intent.extras)
+                        DeepLinking.makeLaunchIntent(context, intent.extras)?.apply {
+                            data = deepLink
+                        }
                     }
                 }
                 else -> {
-                    if (deepLink != null) {
-                        Registry.log.verbose(
-                            "Trampoline dispatching deep link via handler; launching host"
-                        )
-                    } else {
-                        Registry.log.verbose("Trampoline dispatching launch intent")
-                    }
+                    Registry.log.verbose("Trampoline dispatching launch intent")
                     DeepLinking.makeLaunchIntent(context, intent.extras)
                 }
             }

--- a/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivityTest.kt
+++ b/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivityTest.kt
@@ -6,6 +6,7 @@ import android.content.pm.PackageManager
 import android.net.Uri
 import com.klaviyo.analytics.Klaviyo
 import com.klaviyo.analytics.linking.DeepLinking
+import com.klaviyo.core.Constants
 import com.klaviyo.core.Constants.PACKAGE_PREFIX
 import com.klaviyo.core.Constants.TRACKING_PARAMETER
 import com.klaviyo.fixtures.BaseTest
@@ -41,7 +42,7 @@ class KlaviyoTrampolineActivityTest : BaseTest() {
         mockkObject(DeepLinking)
         mockkStatic(Uri::class)
         every { Uri.parse(any()) } returns mockk(relaxed = true)
-        every { Klaviyo.handlePush(any(), any()) } returns Klaviyo
+        every { Klaviyo.handlePush(any()) } returns Klaviyo
         every { DeepLinking.makeExternalIntent(any()) } returns mockBrowserIntent
         every { DeepLinking.makeDeepLinkIntent(any(), any(), any()) } returns mockDeepLinkIntent
         every { DeepLinking.makeLaunchIntent(any(), any()) } returns mockLaunchIntent
@@ -82,7 +83,7 @@ class KlaviyoTrampolineActivityTest : BaseTest() {
 
         KlaviyoTrampolineActivity.handleTrampolineIntent(intent, mockTrampolineContext)
 
-        verify { Klaviyo.handlePush(intent, false) }
+        verify { Klaviyo.handlePush(intent) }
         // Assert the exact URL from the extra round-trips through Uri.parse and into
         // makeExternalIntent — catches regressions where a string is mangled, swallowed,
         // or replaced silently with something else.
@@ -96,7 +97,7 @@ class KlaviyoTrampolineActivityTest : BaseTest() {
 
         KlaviyoTrampolineActivity.handleTrampolineIntent(intent, mockTrampolineContext)
 
-        verify { Klaviyo.handlePush(intent, false) }
+        verify { Klaviyo.handlePush(intent) }
         verify(exactly = 0) { DeepLinking.makeExternalIntent(any()) }
         verify(exactly = 0) { DeepLinking.makeDeepLinkIntent(any(), any(), any()) }
         verify { DeepLinking.makeLaunchIntent(mockTrampolineContext, any()) }
@@ -111,7 +112,7 @@ class KlaviyoTrampolineActivityTest : BaseTest() {
 
         KlaviyoTrampolineActivity.handleTrampolineIntent(intent, mockTrampolineContext)
 
-        verify { Klaviyo.handlePush(intent, false) }
+        verify { Klaviyo.handlePush(intent) }
         verify(exactly = 0) { mockTrampolineContext.startActivity(any()) }
         // Mirrors the non-trampoline diagnostic so a missing launcher is still debuggable.
         verify { spyLog.warning(any(), null) }
@@ -124,7 +125,7 @@ class KlaviyoTrampolineActivityTest : BaseTest() {
         every { intent.data } returns deepLink
         KlaviyoTrampolineActivity.handleTrampolineIntent(intent, mockTrampolineContext)
 
-        verify { Klaviyo.handlePush(intent, false) }
+        verify { Klaviyo.handlePush(intent) }
         verify { DeepLinking.makeDeepLinkIntent(deepLink, mockTrampolineContext, intent) }
         verify { mockTrampolineContext.startActivity(mockDeepLinkIntent) }
         verify(exactly = 0) { DeepLinking.makeLaunchIntent(any(), any()) }
@@ -140,7 +141,7 @@ class KlaviyoTrampolineActivityTest : BaseTest() {
         KlaviyoTrampolineActivity.handleTrampolineIntent(intent, mockTrampolineContext)
 
         // The link reaches the host on this intent, so the handler is not invoked here.
-        verify { Klaviyo.handlePush(intent, false) }
+        verify { Klaviyo.handlePush(intent) }
         verify(exactly = 0) { DeepLinking.handleDeepLink(any()) }
         verify { DeepLinking.makeDeepLinkIntent(deepLink, mockTrampolineContext, intent) }
         verify { mockTrampolineContext.startActivity(mockDeepLinkIntent) }
@@ -179,6 +180,27 @@ class KlaviyoTrampolineActivityTest : BaseTest() {
     }
 
     @Test
+    fun `handleTrampolineIntent strips the suppression flag from the deep link intent`() {
+        val intent = klaviyoIntent()
+        every { intent.data } returns mockk<Uri>(relaxed = true)
+
+        KlaviyoTrampolineActivity.handleTrampolineIntent(intent, mockTrampolineContext)
+
+        // Both destinations copy this intent's extras. If the flag survived, the host's own
+        // handlePush would silently stop invoking their registered handler.
+        verify { mockDeepLinkIntent.removeExtra(Constants.SUPPRESS_DEEP_LINK_HANDLER_EXTRA) }
+    }
+
+    @Test
+    fun `handleTrampolineIntent strips the suppression flag from the launcher intent`() {
+        val intent = klaviyoIntent()
+
+        KlaviyoTrampolineActivity.handleTrampolineIntent(intent, mockTrampolineContext)
+
+        verify { mockLaunchIntent.removeExtra(Constants.SUPPRESS_DEEP_LINK_HANDLER_EXTRA) }
+    }
+
+    @Test
     fun `handleTrampolineIntent ignores non-Klaviyo intent`() {
         val intent = mockk<Intent>(relaxed = true)
         every { intent.getStringExtra(any()) } returns null
@@ -212,7 +234,7 @@ class KlaviyoTrampolineActivityTest : BaseTest() {
 
         KlaviyoTrampolineActivity.handleTrampolineIntent(intent, mockTrampolineContext)
 
-        verify { Klaviyo.handlePush(intent, false) }
+        verify { Klaviyo.handlePush(intent) }
         verify { DeepLinking.makeExternalIntent(parsedUri) }
         verify { mockTrampolineContext.startActivity(mockBrowserIntent) }
     }

--- a/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivityTest.kt
+++ b/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivityTest.kt
@@ -10,6 +10,7 @@ import com.klaviyo.core.Constants
 import com.klaviyo.core.Constants.PACKAGE_PREFIX
 import com.klaviyo.core.Constants.TRACKING_PARAMETER
 import com.klaviyo.fixtures.BaseTest
+import com.klaviyo.fixtures.MockIntent
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -18,6 +19,8 @@ import io.mockk.unmockkObject
 import io.mockk.unmockkStatic
 import io.mockk.verify
 import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Before
 import org.junit.Test
 
@@ -180,6 +183,30 @@ class KlaviyoTrampolineActivityTest : BaseTest() {
         verify(exactly = 0) { mockLaunchIntent.data = any() }
         verify { DeepLinking.makeLaunchIntent(mockTrampolineContext, intent.extras) }
         verify { mockTrampolineContext.startActivity(mockLaunchIntent) }
+    }
+
+    @Test
+    fun `forDestination flags its own intent to suppress the deep link handler`() {
+        // The strip tests below only prove the flag is removed on the way out. Without this, the
+        // whole suite still passes if forDestination stops setting it — and the trampoline's
+        // handlePush call would silently start double-dispatching to the host's handler.
+        val constructed = MockIntent.setupIntentMocking().intent
+        // setupIntentMocking doesn't stub putExtra, so stub it here rather than widening a fixture
+        // that every intent-building test depends on. Capturing the key/value pairs is more robust
+        // across build variants than verifying on anyConstructed<Intent>().
+        val keys = mutableListOf<String>()
+        val values = mutableListOf<Boolean>()
+        every { anyConstructed<Intent>().putExtra(any<String>(), any<Boolean>()) } answers {
+            keys += firstArg<String>()
+            values += secondArg<Boolean>()
+            constructed
+        }
+
+        KlaviyoTrampolineActivity.forDestination(mockTrampolineContext)
+
+        val index = keys.indexOf(Constants.SUPPRESS_DEEP_LINK_HANDLER_EXTRA)
+        assertNotEquals("Trampoline intents must carry the suppression flag", -1, index)
+        assertEquals(true, values[index])
     }
 
     @Test

--- a/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivityTest.kt
+++ b/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivityTest.kt
@@ -41,12 +41,10 @@ class KlaviyoTrampolineActivityTest : BaseTest() {
         mockkObject(DeepLinking)
         mockkStatic(Uri::class)
         every { Uri.parse(any()) } returns mockk(relaxed = true)
-        every { Klaviyo.handlePush(any()) } returns Klaviyo
+        every { Klaviyo.handlePush(any(), any()) } returns Klaviyo
         every { DeepLinking.makeExternalIntent(any()) } returns mockBrowserIntent
         every { DeepLinking.makeDeepLinkIntent(any(), any(), any()) } returns mockDeepLinkIntent
         every { DeepLinking.makeLaunchIntent(any(), any()) } returns mockLaunchIntent
-        // No deep link handler registered by default; flip per-test for the handler branch.
-        every { DeepLinking.isHandlerRegistered } returns false
         // Make intents appear resolvable so startActivityIfResolved actually dispatches to
         // context.startActivity (vs logging an error). Override per-test for the unresolvable case.
         every { mockBrowserIntent.resolveActivity(any()) } returns mockk()
@@ -84,7 +82,7 @@ class KlaviyoTrampolineActivityTest : BaseTest() {
 
         KlaviyoTrampolineActivity.handleTrampolineIntent(intent, mockTrampolineContext)
 
-        verify { Klaviyo.handlePush(intent) }
+        verify { Klaviyo.handlePush(intent, false) }
         // Assert the exact URL from the extra round-trips through Uri.parse and into
         // makeExternalIntent — catches regressions where a string is mangled, swallowed,
         // or replaced silently with something else.
@@ -98,7 +96,7 @@ class KlaviyoTrampolineActivityTest : BaseTest() {
 
         KlaviyoTrampolineActivity.handleTrampolineIntent(intent, mockTrampolineContext)
 
-        verify { Klaviyo.handlePush(intent) }
+        verify { Klaviyo.handlePush(intent, false) }
         verify(exactly = 0) { DeepLinking.makeExternalIntent(any()) }
         verify(exactly = 0) { DeepLinking.makeDeepLinkIntent(any(), any(), any()) }
         verify { DeepLinking.makeLaunchIntent(mockTrampolineContext, any()) }
@@ -113,41 +111,39 @@ class KlaviyoTrampolineActivityTest : BaseTest() {
 
         KlaviyoTrampolineActivity.handleTrampolineIntent(intent, mockTrampolineContext)
 
-        verify { Klaviyo.handlePush(intent) }
+        verify { Klaviyo.handlePush(intent, false) }
         verify(exactly = 0) { mockTrampolineContext.startActivity(any()) }
         // Mirrors the non-trampoline diagnostic so a missing launcher is still debuggable.
         verify { spyLog.warning(any(), null) }
     }
 
     @Test
-    fun `handleTrampolineIntent with deep link and no handler dispatches ACTION_VIEW into host`() {
+    fun `handleTrampolineIntent with a resolvable deep link dispatches ACTION_VIEW into host`() {
         val intent = klaviyoIntent()
         val deepLink = mockk<Uri>(relaxed = true)
         every { intent.data } returns deepLink
-        every { DeepLinking.isHandlerRegistered } returns false
-
         KlaviyoTrampolineActivity.handleTrampolineIntent(intent, mockTrampolineContext)
 
-        verify { Klaviyo.handlePush(intent) }
+        verify { Klaviyo.handlePush(intent, false) }
         verify { DeepLinking.makeDeepLinkIntent(deepLink, mockTrampolineContext, intent) }
         verify { mockTrampolineContext.startActivity(mockDeepLinkIntent) }
         verify(exactly = 0) { DeepLinking.makeLaunchIntent(any(), any()) }
     }
 
     @Test
-    fun `handleTrampolineIntent with deep link but handler registered launches host without ACTION_VIEW`() {
+    fun `handleTrampolineIntent dispatches ACTION_VIEW even when a handler is registered`() {
         val intent = klaviyoIntent()
         val deepLink = mockk<Uri>(relaxed = true)
         every { intent.data } returns deepLink
-        // handlePush already dispatched the registered handler — a VIEW intent would double-deliver.
         every { DeepLinking.isHandlerRegistered } returns true
 
         KlaviyoTrampolineActivity.handleTrampolineIntent(intent, mockTrampolineContext)
 
-        verify { Klaviyo.handlePush(intent) }
-        verify(exactly = 0) { DeepLinking.makeDeepLinkIntent(any(), any(), any()) }
-        verify { DeepLinking.makeLaunchIntent(mockTrampolineContext, any()) }
-        verify { mockTrampolineContext.startActivity(mockLaunchIntent) }
+        // The link reaches the host on this intent, so the handler is not invoked here.
+        verify { Klaviyo.handlePush(intent, false) }
+        verify(exactly = 0) { DeepLinking.handleDeepLink(any()) }
+        verify { DeepLinking.makeDeepLinkIntent(deepLink, mockTrampolineContext, intent) }
+        verify { mockTrampolineContext.startActivity(mockDeepLinkIntent) }
     }
 
     @Test
@@ -155,7 +151,6 @@ class KlaviyoTrampolineActivityTest : BaseTest() {
         val intent = klaviyoIntent()
         val deepLink = mockk<Uri>(relaxed = true)
         every { intent.data } returns deepLink
-        every { DeepLinking.isHandlerRegistered } returns false
         // Deep link target cannot be resolved → fall back to the launcher.
         every { mockDeepLinkIntent.resolveActivity(any()) } returns null
 
@@ -167,6 +162,20 @@ class KlaviyoTrampolineActivityTest : BaseTest() {
         verify(exactly = 0) { mockTrampolineContext.startActivity(mockDeepLinkIntent) }
         // Degraded-but-handled (fell back to launcher) → WARNING, not ERROR.
         verify { spyLog.warning(any(), null) }
+    }
+
+    @Test
+    fun `handleTrampolineIntent attaches an unresolvable deep link to the launcher intent`() {
+        val intent = klaviyoIntent()
+        val deepLink = mockk<Uri>(relaxed = true)
+        every { intent.data } returns deepLink
+        every { mockDeepLinkIntent.resolveActivity(any()) } returns null
+
+        KlaviyoTrampolineActivity.handleTrampolineIntent(intent, mockTrampolineContext)
+
+        // Without this the link would be dropped, since the launcher intent carries no data.
+        verify { mockLaunchIntent.data = deepLink }
+        verify { mockTrampolineContext.startActivity(mockLaunchIntent) }
     }
 
     @Test
@@ -203,7 +212,7 @@ class KlaviyoTrampolineActivityTest : BaseTest() {
 
         KlaviyoTrampolineActivity.handleTrampolineIntent(intent, mockTrampolineContext)
 
-        verify { Klaviyo.handlePush(intent) }
+        verify { Klaviyo.handlePush(intent, false) }
         verify { DeepLinking.makeExternalIntent(parsedUri) }
         verify { mockTrampolineContext.startActivity(mockBrowserIntent) }
     }

--- a/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivityTest.kt
+++ b/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivityTest.kt
@@ -10,7 +10,6 @@ import com.klaviyo.core.Constants
 import com.klaviyo.core.Constants.PACKAGE_PREFIX
 import com.klaviyo.core.Constants.TRACKING_PARAMETER
 import com.klaviyo.fixtures.BaseTest
-import com.klaviyo.fixtures.MockIntent
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -19,8 +18,6 @@ import io.mockk.unmockkObject
 import io.mockk.unmockkStatic
 import io.mockk.verify
 import org.junit.After
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotEquals
 import org.junit.Before
 import org.junit.Test
 
@@ -183,30 +180,6 @@ class KlaviyoTrampolineActivityTest : BaseTest() {
         verify(exactly = 0) { mockLaunchIntent.data = any() }
         verify { DeepLinking.makeLaunchIntent(mockTrampolineContext, intent.extras) }
         verify { mockTrampolineContext.startActivity(mockLaunchIntent) }
-    }
-
-    @Test
-    fun `forDestination flags its own intent to suppress the deep link handler`() {
-        // The strip tests below only prove the flag is removed on the way out. Without this, the
-        // whole suite still passes if forDestination stops setting it — and the trampoline's
-        // handlePush call would silently start double-dispatching to the host's handler.
-        val constructed = MockIntent.setupIntentMocking().intent
-        // setupIntentMocking doesn't stub putExtra, so stub it here rather than widening a fixture
-        // that every intent-building test depends on. Capturing the key/value pairs is more robust
-        // across build variants than verifying on anyConstructed<Intent>().
-        val keys = mutableListOf<String>()
-        val values = mutableListOf<Boolean>()
-        every { anyConstructed<Intent>().putExtra(any<String>(), any<Boolean>()) } answers {
-            keys += firstArg<String>()
-            values += secondArg<Boolean>()
-            constructed
-        }
-
-        KlaviyoTrampolineActivity.forDestination(mockTrampolineContext)
-
-        val index = keys.indexOf(Constants.SUPPRESS_DEEP_LINK_HANDLER_EXTRA)
-        assertNotEquals("Trampoline intents must carry the suppression flag", -1, index)
-        assertEquals(true, values[index])
     }
 
     @Test

--- a/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivityTest.kt
+++ b/sdk/push-fcm/src/test/java/com/klaviyo/pushFcm/KlaviyoTrampolineActivityTest.kt
@@ -166,7 +166,7 @@ class KlaviyoTrampolineActivityTest : BaseTest() {
     }
 
     @Test
-    fun `handleTrampolineIntent attaches an unresolvable deep link to the launcher intent`() {
+    fun `handleTrampolineIntent leaves an unresolvable deep link off the launcher intent data`() {
         val intent = klaviyoIntent()
         val deepLink = mockk<Uri>(relaxed = true)
         every { intent.data } returns deepLink
@@ -174,8 +174,11 @@ class KlaviyoTrampolineActivityTest : BaseTest() {
 
         KlaviyoTrampolineActivity.handleTrampolineIntent(intent, mockTrampolineContext)
 
-        // Without this the link would be dropped, since the launcher intent carries no data.
-        verify { mockLaunchIntent.data = deepLink }
+        // AOSP stops treating a MAIN/LAUNCHER intent as a main intent once it carries data, and
+        // under CLEAR_TOP it would become the task's persisted base intent. The URL reaches the
+        // host on the payload extras instead, which makeLaunchIntent copies.
+        verify(exactly = 0) { mockLaunchIntent.data = any() }
+        verify { DeepLinking.makeLaunchIntent(mockTrampolineContext, intent.extras) }
         verify { mockTrampolineContext.startActivity(mockLaunchIntent) }
     }
 


### PR DESCRIPTION
# Description
With `automatic_push_open_tracking` enabled, a notification tap now delivers its deep link to the host app as an `Intent` — the same shape the SDK sends when no handler is registered — instead of invoking a registered `DeepLinkHandler`.

**Stacked on #533.** Review that one first; this PR's diff is against `ecm/push-open-dedup-stages`.

Supersedes the approach in #529, #530 and #532, which diagnose the same bug correctly but fix it by deferring the handler invocation until an activity resumes. Those remain open for discussion.

## Due Diligence
- [x] I have tested this on an emulator and/or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all Android versions the SDK currently supports.

## Release/Versioning Considerations
- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [x] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [x] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

`Minor` — adds `Klaviyo.getKlaviyoDeepLink(intent)` / `Intent.klaviyoDeepLink`. `automatic_push_open_tracking` is new and unreleased, so no shipped behavior changes.

## The bug

A notification tap routed through `KlaviyoTrampolineActivity`, which called `handlePush` — invoking the host's handler — and then started a bare launcher intent. On a cold start the handler ran before any activity existed, so a handler routing through a `NavController`, a fragment transaction, or a held activity had nothing to navigate and the link was lost.

The alternative fix is to defer the handler until an activity resumes, which needs a postponed lifecycle observer, a timeout, a drop-on-timeout policy, crash containment inside `onActivityResumed`, and a non-obvious "register from `onCreate`, never `onResume`" invariant. Sending an intent instead lets Android do the routing, and all of that machinery goes away.

## Why this is not a capability reduction

In released 4.4.x, `makeResolvedDeepLinkIntent` discards an unresolvable deep link and substitutes the launcher intent, whose `data` is null. `handlePush` reads `intent?.data`, so **on that path the handler was never invoked at all**. A registered handler in 4.4.x therefore never receives a link that an intent could not have delivered — it is a redundant second delivery mechanism for the same set of links.

The only population that would lose anything exists because `rel/4.5.0` added a carve-out skipping the resolution check under auto-tracking, specifically so a handler would see unresolvable links. That is unreleased, and this PR reverts it: the trampoline resolves the link when the tap happens rather than when the notification is built, which is strictly better timing.

## How the handler is suppressed

The trampoline calls `handlePush` for tracking and dismissal, but must not also invoke a registered handler — the link reaches the host on the intent it forwards. It stamps `Constants.SUPPRESS_DEEP_LINK_HANDLER_EXTRA` on its own intents (`forDestination`) and **removes it before forwarding** (#533 makes `handlePush` honor the flag, and returns before consuming that delivery's dispatch slot).

The removal is the load-bearing part: both destinations copy this intent's extras — `makeDeepLinkIntent` via `copyIntent`, `makeLaunchIntent` via `extras` — and that copying is required, since `NOTIFICATION_UID_EXTRA` has to ride along as the dedup key. If the suppression flag leaked through with it, a host calling `handlePush(intent)` would silently stop reaching their handler. Both branches converge on one `apply` block, so it is a single `removeExtra`, with a test per destination; deleting it fails both.

An earlier revision used a `handlePush(intent, dispatchDeepLink)` overload instead. The extra avoids a new public method on the facade, keeps this a `Patch`, and matches how `BROWSER_URL_EXTRA` already carries internal routing state on these same intents.

## Behavior by payload shape

| Payload | auto ON (this change) | auto OFF (unchanged) |
|---|---|---|
| `url`, resolves | `ACTION_VIEW` + data | `ACTION_VIEW` + data |
| `url`, unresolvable | launcher; link via `getKlaviyoDeepLink` + warning | launcher, no data + error |
| `web_url` | external intent, scheme-allowlisted | same |
| both | `url` wins + warning | same |
| neither | launcher | launcher |
| button `deep_link` | as `url` | as `url` |
| button `open_url` | external | external |
| button `open_app` | launcher | launcher |

The handler still receives links from in-app form CTAs, universal tracking links, and any `handlePush` the host calls itself.

### Unresolvable links: read via `getKlaviyoDeepLink`, not launcher-intent data

An earlier revision of this PR set the link as the launcher intent's `data`. **That was wrong**, and the review question that prompted a second look — why does auto mode diverge from non-auto here — turned out to have a better answer than "unify them."

Setting `data` on a `MAIN`/`LAUNCHER` intent is not merely unconventional:

- **AOSP's own definition excludes it.** `ActivityRecord.isMainIntent` requires `getData() == null`, so the intent stops being a main intent to the framework. Side effect: it suppresses the task-snapshot starting window.
- **It mutates reboot-persistent state.** Under `CLEAR_TOP` against a task-root activity, `ActivityStarter.complyActivityFlags` calls `targetTask.setIntent(...)`, making the push intent the task's *base* intent. `Task.saveToXml` persists it across reboots, and `ActivityTaskSupervisor.startActivityFromRecents` re-fires `task.intent` when recents restores a trimmed task — replaying a stale deep link. My original device matrix could not have caught this; it needs a trimmed-task restore.
- **It breaks outright under `documentLaunchMode`.** There `isDocument()` is true, `data` becomes the document identity, and every distinct URL spawns its own task and recents entry.
- **No major SDK does it.** FCM, OneSignal, Braze, Airship, Iterable, and CleverTap were read from source; a sweep for `setData` near `getLaunchIntentForPackage` returned zero hits across all six. Where a URL rides a launcher intent it is always an extra (`ab_uri`, `uri`, `wzrk_dl`). Firebase documents this exact case: the payload arrives "in the extras of the intent of your launcher Activity."

So the link stays off `data`, and since it already rides the payload extras on every tap intent, this PR adds an accessor that reads whichever field is populated:

```kotlin
val link = Klaviyo.getKlaviyoDeepLink(intent)   // Intent.klaviyoDeepLink in Kotlin
```

Returns `null` for non-Klaviyo and null intents, so it is safe to call unconditionally from `onCreate` and `onNewIntent`. `URL_PARAMETER` moved to core `Constants` so the accessor and push-fcm's payload key cannot drift.

**Note for reviewers:** this makes the accessor the delivery contract for the unresolvable case — a host reading only `intent.data` gets nothing there. Documented in the **migration guide**, whose audience is exactly the population at risk: someone moving off a registered handler who writes their routing against `intent.data`. The README's Deep Linking section and Option A bullet point there rather than re-explaining.

## `onNewIntent` is required, not optional

Measured, and it is why the docs changed: when the process has been killed but its task is still in recents, Android re-creates the activity from the persisted task record, so `onCreate` sees the **old** intent and the new one arrives at `onNewIntent`.

```
onCreate     action=MAIN data=null
onNewIntent  action=VIEW data=klaviyotest://detail/T5
```

This is platform behavior, not something this change introduces — it reproduces identically without the deep link. But the intent path depends on it far more than the callback path did, so the README and migration guide now state it explicitly and the sample app demonstrates both callbacks.

## Test Plan

`./gradlew test ktlintCheck` green.

**On device** (API 36 emulator, sample `automaticDebug`, real notifications posted through `KlaviyoNotification.displayNotification` and tapped via UI so the genuine PendingIntent path runs, stack baselined immediately before every tap):

| # | Case | Result |
|---|---|---|
| T1 | Resolvable link, cold start | `ACTION_VIEW` + data at `onCreate`, navigated, new task |
| T2 | Unresolvable link, cold start | `ACTION_MAIN` + data, navigated — previously dropped |
| T3 | Resolvable link, app foregrounded | same task, same instance, `onNewIntent` |
| T5 | Process killed, task alive in recents | stale intent at `onCreate`, link at `onNewIntent`, navigated |
| T6 | `web_url` | opened Chrome, host not involved |
| T7 | `open_app` | launcher intent, one `$opened_push` |
| T8 | Tracking count | exactly one `$opened_push` per tap |

## Changes beyond the trampoline, flagged for review

- **`KlaviyoNotification`**: reverted the unreleased auto-tracking carve-out that skipped `makeResolvedDeepLinkIntent`, so both paths resolve consistently.
- **Sample app**: the `automatic` flavor now reads the link via `Klaviyo.getKlaviyoDeepLink(intent)` in `onCreate` and `onNewIntent`, and `SampleDetailActivity` is added as a visible destination so back-stack behavior after a tap is observable. That file is **Atharva's, carried forward verbatim from #529** (closed unmerged) — it is not on `rel/4.5.0` or `master`, so it would otherwise have been lost. Credited via a co-author trailer.
- **Docs**: README deep-linking section no longer claims the handler receives *any* Klaviyo deep link, and the Option A flag bullet notes that taps deliver an `Intent`, deferring to the Deep Linking section for how to read it. The `onNewIntent` requirement lives in the **migration guide**, where it is actionable for someone moving off a registered handler — the README already states the delivery change in two places, and routing from an intent is plain Android that existing snippets demonstrate.

## Related Issues/Tickets
Supersedes #529, #530, #532. Stacked on #533.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added APIs for retrieving notification deep links from intents, including action-button links.
  * Improved automatic push-open tracking with intent-based deep-link routing.
  * Added a sample destination screen for viewing deep links and back-stack behavior.

* **Bug Fixes**
  * Deep links now open consistently with or without a custom deep-link handler.
  * Added fallback handling for links that cannot be opened directly.

* **Documentation**
  * Updated migration and integration guidance for SDK 4.5.0 push deep-link behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
