### PR TITLE
fix(analytics): trigger push permission refresh on Resumed, not FirstStarted

### DIFF
--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/state/StateSideEffects.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/state/StateSideEffects.kt
@@ -176,23 +176,30 @@ internal class StateSideEffects(
     }
 
     /**
-     * Bring push state up to date when the app returns to the foreground, via exactly one path.
+     * Bring push state up to date on every resume, via exactly one path.
      *
-     * Two things can go stale while backgrounded: the push token (the provider may rotate it) and
-     * the device properties embedded in push state (notification permission, background
-     * availability). A successful token fetch already covers both, because assigning the token
-     * recomputes push state — so the fetch is attempted first, and a direct refresh runs only when
-     * no fetch will deliver one (forwarding disabled, `push-fcm` absent, or the fetch failed).
+     * Two things can go stale while backgrounded (or merely occluded): the push token (the
+     * provider may rotate it) and the device properties embedded in push state (notification
+     * permission, background availability). A successful token fetch already covers both, because
+     * assigning the token recomputes push state — so the fetch is attempted first, and a direct
+     * refresh runs only when no fetch will deliver one (forwarding disabled, `push-fcm` absent, or
+     * the fetch failed).
      *
      * Doing both unconditionally would double-report: when the token *and* a device property have
      * both changed, refreshing from the token already in state enqueues a push-token request
      * carrying the token the provider has already rotated away from, which the newly fetched token
      * then immediately supersedes — two requests for one foreground, the first already stale.
+     *
+     * Resumed, not FirstStarted: a system permission dialog (e.g. POST_NOTIFICATIONS) runs in a
+     * different process and only pauses the host activity — no onStop/onStart pair — so
+     * FirstStarted never fires when it's dismissed, and permission changes go undetected until a
+     * true background/foreground cycle. Resumed fires on every activity transition, including
+     * in-app navigation, but that's cheap: with no actual change, the fetch/refresh path rebuilds
+     * an equal push-token request body and PersistentObservableString's equality check drops it
+     * before anything is enqueued, so it's a string comparison per resume, not a network call.
      */
     private fun onLifecycleEvent(activity: ActivityEvent) {
-        // FirstStarted, not Resumed: Resumed broadcasts on every activity transition, whereas
-        // FirstStarted is gated on activeActivities == 0, so this runs once per actual foreground.
-        activity.takeIf<ActivityEvent.FirstStarted>()?.run {
+        activity.takeIf<ActivityEvent.Resumed>()?.run {
             val refreshFromStoredToken: () -> Unit = { safeApply { state.refreshPushState() } }
 
             if (!PushTokenFetcher.maybeAutoRegisterPushToken(refreshFromStoredToken)) {

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/state/StateSideEffects.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/state/StateSideEffects.kt
@@ -190,13 +190,10 @@ internal class StateSideEffects(
      * carrying the token the provider has already rotated away from, which the newly fetched token
      * then immediately supersedes — two requests for one foreground, the first already stale.
      *
-     * Resumed, not FirstStarted: a system permission dialog (e.g. POST_NOTIFICATIONS) runs in a
-     * different process and only pauses the host activity — no onStop/onStart pair — so
-     * FirstStarted never fires when it's dismissed, and permission changes go undetected until a
-     * true background/foreground cycle. Resumed fires on every activity transition, including
-     * in-app navigation, but that's cheap: with no actual change, the fetch/refresh path rebuilds
-     * an equal push-token request body and PersistentObservableString's equality check drops it
-     * before anything is enqueued, so it's a string comparison per resume, not a network call.
+     * A system permission dialog (e.g. POST_NOTIFICATIONS) runs in a different process and only
+     * pauses the host activity — no onStop/onStart pair — so a hook gated on a fresh foreground
+     * (activeActivities == 0) never fires when such a dialog is dismissed, and permission changes
+     * go undetected until a true background/foreground cycle.
      */
     private fun onLifecycleEvent(activity: ActivityEvent) {
         activity.takeIf<ActivityEvent.Resumed>()?.run {

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/state/StateSideEffectsTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/state/StateSideEffectsTest.kt
@@ -411,19 +411,19 @@ class StateSideEffectsTest : BaseTest() {
     }
 
     @Test
-    fun `FirstStarted lifecycle event triggers push permission refresh`() {
+    fun `Resumed lifecycle event triggers push permission refresh`() {
         // No fetcher registered: the only path available is a direct refresh from the stored token
-        fireFirstStartedEvent()
+        fireResumedEvent()
 
         verify(exactly = 1) { stateMock.refreshPushState() }
     }
 
     @Test
-    fun `FirstStarted lifecycle event re-fetches push token when automatic forwarding is enabled`() {
+    fun `Resumed lifecycle event re-fetches push token when automatic forwarding is enabled`() {
         // Default ON: no explicit stub needed — BaseTest returns the manifest default (true)
         val mockFetcher = registerMockPushTokenFetcher()
 
-        fireFirstStartedEvent()
+        fireResumedEvent()
 
         // Anti-double-report regression guard: a dispatched fetch must be the ONLY path taken —
         // also falling back to refreshPushState() would enqueue a second, stale push-token request.
@@ -432,7 +432,7 @@ class StateSideEffectsTest : BaseTest() {
     }
 
     @Test
-    fun `FirstStarted lifecycle event does not re-fetch push token when automatic forwarding is disabled`() {
+    fun `Resumed lifecycle event does not re-fetch push token when automatic forwarding is disabled`() {
         every {
             mockConfig.getManifestBoolean(
                 Constants.AUTOMATIC_PUSH_TOKEN_FORWARDING,
@@ -441,20 +441,20 @@ class StateSideEffectsTest : BaseTest() {
         } returns false
         val mockFetcher = registerMockPushTokenFetcher()
 
-        fireFirstStartedEvent()
+        fireResumedEvent()
 
         verify(inverse = true) { mockFetcher.fetchAndSetPushToken(any()) }
         verify(exactly = 1) { stateMock.refreshPushState() }
     }
 
     @Test
-    fun `FirstStarted lifecycle event falls back to refreshPushState when the fetcher reports unavailable`() {
+    fun `Resumed lifecycle event falls back to refreshPushState when the fetcher reports unavailable`() {
         val mockFetcher = registerMockPushTokenFetcher()
         every { mockFetcher.fetchAndSetPushToken(any()) } answers {
             firstArg<() -> Unit>().invoke()
         }
 
-        fireFirstStartedEvent()
+        fireResumedEvent()
 
         // The dispatch itself succeeded (didn't throw) AND onUnavailable fired synchronously —
         // refreshPushState must still run exactly once, not be skipped or double-invoked.
@@ -463,18 +463,28 @@ class StateSideEffectsTest : BaseTest() {
     }
 
     @Test
-    fun `Resumed lifecycle event does not trigger a push state refresh`() {
-        // Proves the hook moved: Resumed used to trigger both setPushToken and maybeAutoRegisterPushToken
+    fun `Resumed lifecycle event triggers a refresh even without an intervening Started event`() {
+        // Regression guard for the FirstStarted regime: a system permission dialog (different
+        // process) only pauses the host activity — no onStop/onStart pair — so Resumed must not
+        // depend on a prior Started to trigger the permission-change check.
+        fireLifecycleEvent(ActivityEvent.Resumed(mockk()))
+
+        verify(exactly = 1) { stateMock.refreshPushState() }
+    }
+
+    @Test
+    fun `FirstStarted lifecycle event does not trigger a push state refresh`() {
+        // Proves the hook moved back: FirstStarted alone (no Resumed) must not trigger either path
         val mockFetcher = registerMockPushTokenFetcher()
 
-        fireLifecycleEvent(ActivityEvent.Resumed(mockk()))
+        fireLifecycleEvent(ActivityEvent.FirstStarted(mockk()))
 
         verify(inverse = true) { stateMock.refreshPushState() }
         verify(inverse = true) { mockFetcher.fetchAndSetPushToken(any()) }
     }
 
-    // Registers stateMock, captures the lifecycle observer via a new StateSideEffects, and fires FirstStarted
-    private fun fireFirstStartedEvent() = fireLifecycleEvent(ActivityEvent.FirstStarted(mockk()))
+    // Registers stateMock, captures the lifecycle observer via a new StateSideEffects, and fires Resumed
+    private fun fireResumedEvent() = fireLifecycleEvent(ActivityEvent.Resumed(mockk()))
 
     // Registers stateMock, captures the lifecycle observer via a new StateSideEffects, and fires the given event
     private fun fireLifecycleEvent(event: ActivityEvent) {

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/state/StateSideEffectsTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/state/StateSideEffectsTest.kt
@@ -411,8 +411,9 @@ class StateSideEffectsTest : BaseTest() {
     }
 
     @Test
-    fun `Resumed lifecycle event triggers push permission refresh`() {
-        // No fetcher registered: the only path available is a direct refresh from the stored token
+    fun `Resumed lifecycle event triggers a refresh with no prior Started event`() {
+        // No fetcher registered: the only path available is a direct refresh from the stored token.
+        // Fired directly, with no intervening Started event, matching a dismissed system dialog.
         fireResumedEvent()
 
         verify(exactly = 1) { stateMock.refreshPushState() }
@@ -425,8 +426,7 @@ class StateSideEffectsTest : BaseTest() {
 
         fireResumedEvent()
 
-        // Anti-double-report regression guard: a dispatched fetch must be the ONLY path taken —
-        // also falling back to refreshPushState() would enqueue a second, stale push-token request.
+        // Fetch and refresh are mutually exclusive: dispatching a fetch must suppress the refresh fallback.
         verify(exactly = 1) { mockFetcher.fetchAndSetPushToken(any()) }
         verify(exactly = 0) { stateMock.refreshPushState() }
     }
@@ -463,18 +463,8 @@ class StateSideEffectsTest : BaseTest() {
     }
 
     @Test
-    fun `Resumed lifecycle event triggers a refresh even without an intervening Started event`() {
-        // Regression guard for the FirstStarted regime: a system permission dialog (different
-        // process) only pauses the host activity — no onStop/onStart pair — so Resumed must not
-        // depend on a prior Started to trigger the permission-change check.
-        fireLifecycleEvent(ActivityEvent.Resumed(mockk()))
-
-        verify(exactly = 1) { stateMock.refreshPushState() }
-    }
-
-    @Test
     fun `FirstStarted lifecycle event does not trigger a push state refresh`() {
-        // Proves the hook moved back: FirstStarted alone (no Resumed) must not trigger either path
+        // FirstStarted alone (no Resumed) must not trigger either path.
         val mockFetcher = registerMockPushTokenFetcher()
 
         fireLifecycleEvent(ActivityEvent.FirstStarted(mockk()))


### PR DESCRIPTION
# Description

Reverts the push-permission-refresh trigger in `StateSideEffects.onLifecycleEvent` from `ActivityEvent.FirstStarted` back to `ActivityEvent.Resumed`, fixing a regression introduced during rel/4.5.0 development where a dismissed system permission dialog (e.g. POST_NOTIFICATIONS) silently stopped push-permission-change detection until a genuine background/foreground cycle.

## Due Diligence

- [ ] I have tested this on an emulator and/or a physical device.
- [X] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [X] I am confident these changes are compatible with all Android versions the SDK currently supports.

## Release/Versioning Considerations

- [X] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [X] This is planned work for an upcoming release.
  * Caught pre-release: rel/4.5.0 has not shipped to production, so this fixes a regression within work-in-progress release code, not a hotfix for a live issue.

## Changelog / Code Overview

**The regression:** commit 6d4b8ceea4 ("fix(push): collapse duplicate foreground push-token registration paths") moved the lifecycle hook in `StateSideEffects.onLifecycleEvent` from `ActivityEvent.Resumed` to `ActivityEvent.FirstStarted`, intending to reduce redundant checks during in-app navigation — `FirstStarted` only fires once per real foreground, gated on `activeActivities == 0` in `KlaviyoLifecycleMonitor.onActivityStarted`.

**Root cause:** Android's runtime permission dialog is rendered by a system component in a different process, so it only triggers `onPause()` on the host activity — never `onStop()`. When the dialog is dismissed, the host goes straight to `onResume()`, skipping `onStart()` entirely. Since `FirstStarted` is only broadcast from `onActivityStarted` when `activeActivities` was `0`, it never fires in this scenario, so push-permission-change detection silently broke until the user did a real background/foreground cycle (not just navigating past a system dialog).

**Why** `Resumed` **is correct and cheap:** we considered tracking same-activity occlusion (a Started/Stopped counter scoped between Paused/Resumed) but decided against the added complexity after confirming:

1. Our iOS SDK (`klaviyo-swift-sdk`) checks unconditionally on every foreground (`didBecomeActiveNotification` → `.start`) with no debounce, relying purely on a deterministic equality check downstream (`KlaviyoState.shouldSendTokenUpdate`) to avoid redundant network calls — the same pattern Android uses via `PersistentObservableString` equality.
2. OneSignal's Android SDK has multiple open GitHub issues where an equivalent "only check on true foreground" optimization causes permission-change detection to silently fail in this exact scenario.
3. We traced the full push-token-request-body construction chain (`ProfileApiRequest.formatBody`, `PushTokenApiRequest` body assembly, `DeviceProperties.buildMetaData`) and confirmed it's fully deterministic — every collection involved is a Kotlin `mapOf`/`toMap`-backed `LinkedHashMap` built in fixed source order, and `org.json.JSONObject` is itself `LinkedHashMap`-backed. Two resumes with identical underlying state always produce byte-identical serialized bodies, so `PersistentObservableProperty.validateChange`'s plain string-equality check reliably no-ops when nothing changed. Checking on every `Resumed` (matching [PRX-4](https://linear.app/klaviyo/issue/PRX-4/pagerduty-team-name-updates).5.0 and pre-release behavior) costs a string comparison per resume, not a network call.

**The fix:** revert the trigger to `ActivityEvent.Resumed`; the fetch-first/refresh-fallback mutual-exclusivity logic from 6d4b8ceea4 (which fixed a real double-API-request bug) is unchanged and unaffected by which lifecycle event triggers it. `StateSideEffectsTest.kt` is updated to match — renamed `FirstStarted` → `Resumed` test cases, plus a test confirming a bare `Resumed` (no intervening `Started`) still triggers the refresh (the actual regression scenario), and a test confirming `FirstStarted` alone does not trigger anything (proving the hook fully moved, not just added-to).

## Test Plan

* `./gradlew :sdk:analytics:testDebugUnitTest --tests "com.klaviyo.analytics.state.StateSideEffectsTest"` — all pass
* `./gradlew ktlintCheck` — clean
* Manual verification on a device/emulator (trigger the POST_NOTIFICATIONS system dialog, deny/allow it, confirm push state refresh fires on `onResume()` without a background/foreground cycle) is still outstanding before merge

## Test outcome summary ✅ 
### Case 1: Manual mode + set token before enabling permission
- Fresh app install
- Set push token, API call with unauthorized status is sent 
- Toggle permission on, API call is enqueued as soon as permission is granted, with correct auth state
- Background/foreground the app: no duplicative token requests observed.

### Case 2:  Manual mode + set token after enabling permission
- Fresh app install
- Do NOT set push token, no API call is made to register push token
- Toggle permission on, still no API call
- Set push token, API call is made with correct auth state. 
- Again, background/foreground of the app doesn't generate superfluous requests

### Case 3: Manual mode + set push token then deny permission
- Same as Case 1, but deny permission on first dialog: No API call is made after denying the permission dialog
- Go to system settings, enable permission, return to app: API call gets enqueued with updated auth status

### Case 4: Auto mode + enable permission
- Fresh app install
- On app launch, API call is enqueued with push token + unauthorized status
- Enable permission: second API call is enqueued as soon as system dialog closes


## Related Issues/Tickets

Part of [MAGE-1072](https://linear.app/klaviyo/issue/MAGE-1072/restore-android-push-token-authorization-detection)