### PR TITLE
feat(forms): adopt trackProfileEvent v2 and add value_currency (MAGE-1132)

### DIFF
--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/model/Event.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/model/Event.kt
@@ -36,8 +36,8 @@ class Event(val metric: EventMetric, properties: Map<EventKey, Serializable>?) :
         }
 
     /**
-     * ISO 4217 currency code for [value], e.g. "USD". The API rejects codes that are not
-     * uppercase ISO 4217.
+     * ISO 4217 currency code for [value], e.g. "USD". The API rejects a code that is not valid
+     * ISO 4217 with a 400 and does not ingest the event.
      */
     fun setValueCurrency(valueCurrency: String?) = apply { this.valueCurrency = valueCurrency }
     var valueCurrency: String?

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/model/Event.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/model/Event.kt
@@ -35,6 +35,19 @@ class Event(val metric: EventMetric, properties: Map<EventKey, Serializable>?) :
             this[EventKey.VALUE] = value
         }
 
+    /**
+     * ISO 4217 currency code for [value], e.g. "USD". The API rejects codes that are not
+     * uppercase ISO 4217.
+     */
+    fun setValueCurrency(valueCurrency: String?) = apply { this.valueCurrency = valueCurrency }
+    var valueCurrency: String?
+        get() = this[EventKey.VALUE_CURRENCY]?.toString()
+
+        @JvmSynthetic
+        set(value) {
+            this[EventKey.VALUE_CURRENCY] = value
+        }
+
     fun setUniqueId(uniqueId: String?) = apply { this.uniqueId = uniqueId }
     var uniqueId: String?
         get() = this[EventKey.EVENT_ID]?.toString()

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/model/EventKey.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/model/EventKey.kt
@@ -7,6 +7,7 @@ package com.klaviyo.analytics.model
 sealed class EventKey(name: String) : Keyword(name) {
     object EVENT_ID : EventKey("\$event_id")
     object VALUE : EventKey("\$value")
+    object VALUE_CURRENCY : EventKey("\$value_currency")
 
     /**
      * For [EventMetric.OPENED_PUSH] events, append the device token as an event property

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/EventApiRequest.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/networking/requests/EventApiRequest.kt
@@ -24,6 +24,7 @@ internal class EventApiRequest(
         const val METRIC = "metric"
         const val NAME = "name"
         const val VALUE = "value"
+        const val VALUE_CURRENCY = "value_currency"
         const val TIME = "time"
         const val UNIQUE_ID = "unique_id"
     }
@@ -64,6 +65,7 @@ internal class EventApiRequest(
                     ),
                     UNIQUE_ID to event.uniqueId.let { if (it.isNullOrEmpty()) uuid else it },
                     VALUE to event.value,
+                    VALUE_CURRENCY to event.valueCurrency,
                     TIME to Registry.clock.isoTime(queuedTime),
                     PROPERTIES to event.toMap(),
                     allowEmptyMaps = true

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoJavaApiTest.java
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/KlaviyoJavaApiTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -462,12 +463,24 @@ public class KlaviyoJavaApiTest {
     public void testEventSetters() {
         Event event = new Event(EventMetric.STARTED_CHECKOUT.INSTANCE)
                 .setValue(99.99)
+                .setValueCurrency("USD")
                 .setUniqueId("order-123")
                 .setProperty(new EventKey.CUSTOM("items_count"), 3);
 
         assertEquals(Double.valueOf(99.99), event.getValue());
+        assertEquals("USD", event.getValueCurrency());
         assertEquals("order-123", event.getUniqueId());
         assertNotNull(event);
+    }
+
+    @Test
+    public void testEventValueCurrencyClearedByNull() {
+        Event event = new Event(EventMetric.STARTED_CHECKOUT.INSTANCE)
+                .setValueCurrency("USD")
+                .setValueCurrency(null);
+
+        assertNull(event.getValueCurrency());
+        assertEquals(0, event.propertyCount());
     }
 
     @Test
@@ -558,9 +571,11 @@ public class KlaviyoJavaApiTest {
     public void testEventKeyObjectMembersRequireInstance() {
         EventKey eventId = EventKey.EVENT_ID.INSTANCE;
         EventKey value = EventKey.VALUE.INSTANCE;
+        EventKey valueCurrency = EventKey.VALUE_CURRENCY.INSTANCE;
 
         assertNotNull(eventId);
         assertNotNull(value);
+        assertNotNull(valueCurrency);
 
         EventKey customKey = new EventKey.CUSTOM("my_custom_key");
         assertNotNull(customKey);

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/EventApiRequestTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/networking/requests/EventApiRequestTest.kt
@@ -15,6 +15,7 @@ import io.mockk.unmockkStatic
 import java.util.UUID
 import org.json.JSONObject
 import org.junit.After
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
@@ -234,6 +235,73 @@ internal class EventApiRequestTest : BaseApiRequestTest<EventApiRequest>() {
         stubEvent.setProperty("custom_value", "100")
 
         compareJson(JSONObject(expectJson), JSONObject(request.requestBody!!))
+    }
+
+    @Test
+    fun `Builds body request with value_currency`() {
+        val expectJson = """
+            {
+              "data": {
+                "type": "event",
+                "attributes": {
+                  "metric": {
+                    "data": {
+                      "type": "metric",
+                      "attributes": {
+                        "name": "${stubEvent.metric}"
+                      }
+                    }
+                  },
+                  "profile": {
+                    "data": {
+                      "type": "profile",
+                      "attributes": {
+                        "email": "$EMAIL",
+                        "phone_number": "$PHONE",
+                        "external_id": "$EXTERNAL_ID",
+                        "anonymous_id": "$ANON_ID"
+                      }
+                    }
+                  },
+                  "properties": {
+                    "Device ID": "Mock Device ID",
+                    "Device Manufacturer": "Mock Manufacturer",
+                    "Device Model": "Mock Model",
+                    "OS Name": "Android",
+                    "OS Version": "Mock OS Version",
+                    "SDK Name": "Mock SDK",
+                    "SDK Version": "Mock SDK Version",
+                    "App Version": "Mock App Version",
+                    "App Build": "Mock Version Code",
+                    "App ID": "Mock App ID",
+                    "App Name": "Mock Application Label",
+                    "Push Token": "$PUSH_TOKEN",
+                    "${EventKey.VALUE}": 12.34,
+                    "${EventKey.VALUE_CURRENCY}": "USD",
+                    "${EventKey.EVENT_ID}": "uuid"
+                  },
+                  "time": "$ISO_TIME",
+                  "value": 12.34,
+                  "value_currency": "USD",
+                  "unique_id": "uuid"
+                }
+              }
+            }
+        """
+
+        val request = EventApiRequest(stubEvent.copy().setValueCurrency("USD"), stubProfile)
+        compareJson(JSONObject(expectJson), JSONObject(request.requestBody!!))
+    }
+
+    @Test
+    fun `Omits value_currency when it is unset`() {
+        val attributes = JSONObject(EventApiRequest(stubEvent, stubProfile).requestBody!!)
+            .getJSONObject("data")
+            .getJSONObject("attributes")
+
+        assertNull(stubEvent.valueCurrency)
+        assertFalse(attributes.has("value_currency"))
+        assertFalse(attributes.getJSONObject("properties").has(EventKey.VALUE_CURRENCY.name))
     }
 
     @Test

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/NativeBridgeMessage.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/NativeBridgeMessage.kt
@@ -154,6 +154,7 @@ internal sealed class NativeBridgeMessage {
                         properties = jsonData.getEventProperties()
                     ).apply {
                         jsonData.getEventValue()?.let(::setValue)
+                        jsonData.getValueCurrency()?.let(::setValueCurrency)
                         jsonData.getUniqueId()?.let(::setUniqueId)
                     }
                 )
@@ -199,6 +200,13 @@ internal sealed class NativeBridgeMessage {
          */
         private fun JSONObject.getEventValue(): Double? =
             optDouble("value").takeIf { !it.isNaN() }
+
+        /**
+         * Parse the top-level event value currency for a [TrackProfileEvent] message,
+         * returning null if absent or blank
+         */
+        private fun JSONObject.getValueCurrency(): String? =
+            optString("value_currency").takeIf { it.isNotBlank() }
 
         /**
          * Parse the top-level event deduplication ID for a [TrackProfileEvent] message,

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/NativeBridgeMessage.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/NativeBridgeMessage.kt
@@ -115,7 +115,7 @@ internal sealed class NativeBridgeMessage {
                 HandshakeSpec(keyName<HandShook>(), 1),
                 HandshakeSpec(keyName<FormWillAppear>(), 2),
                 HandshakeSpec(keyName<TrackAggregateEvent>(), 1),
-                HandshakeSpec(keyName<TrackProfileEvent>(), 1),
+                HandshakeSpec(keyName<TrackProfileEvent>(), 2),
                 // v2 issues deep link after closing the form (v1 was before close, causing a timing issue).
                 // v3 carries both deep links and external URLs in one message, keyed by `openExternally`.
                 HandshakeSpec(keyName<OpenDeepLink>(), 3),

--- a/sdk/forms/src/main/java/com/klaviyo/forms/bridge/NativeBridgeMessage.kt
+++ b/sdk/forms/src/main/java/com/klaviyo/forms/bridge/NativeBridgeMessage.kt
@@ -152,7 +152,10 @@ internal sealed class NativeBridgeMessage {
                     event = Event(
                         jsonData.getString("metric"),
                         properties = jsonData.getEventProperties()
-                    )
+                    ).apply {
+                        jsonData.getEventValue()?.let(::setValue)
+                        jsonData.getUniqueId()?.let(::setUniqueId)
+                    }
                 )
 
                 keyName<OpenDeepLink>() -> OpenDeepLink(
@@ -189,6 +192,20 @@ internal sealed class NativeBridgeMessage {
             }
             return map
         }
+
+        /**
+         * Parse the top-level event value for a [TrackProfileEvent] message,
+         * returning null if absent or not coercible to a number
+         */
+        private fun JSONObject.getEventValue(): Double? =
+            optDouble("value").takeIf { !it.isNaN() }
+
+        /**
+         * Parse the top-level event deduplication ID for a [TrackProfileEvent] message,
+         * returning null if absent or blank
+         */
+        private fun JSONObject.getUniqueId(): String? =
+            optString("unique_id").takeIf { it.isNotBlank() }
 
         /**
          * Parse out the android platform deep link, returning null if not present or empty

--- a/sdk/forms/src/test/java/com/klaviyo/forms/bridge/NativeBridgeMessageTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/bridge/NativeBridgeMessageTest.kt
@@ -234,10 +234,27 @@ class NativeBridgeMessageTest : BaseTest() {
     }
 
     @Test
-    fun `profile event without value or unique_id leaves both unset`() {
+    fun `profile event parses top-level value_currency`() {
+        val result = decodeProfileEvent(""""value_currency": "USD",""")
+
+        assertEquals("USD", result.event.valueCurrency)
+        assertEquals("USD", result.event[EventKey.VALUE_CURRENCY])
+    }
+
+    @Test
+    fun `profile event with blank value_currency leaves it unset`() {
+        val result = decodeProfileEvent(""""value_currency": "   ",""")
+
+        assertNull(result.event.valueCurrency)
+        assertEquals(0, result.event.propertyCount())
+    }
+
+    @Test
+    fun `profile event without value, value_currency or unique_id leaves them all unset`() {
         val result = decodeProfileEvent("")
 
         assertNull(result.event.value)
+        assertNull(result.event.valueCurrency)
         assertNull(result.event.uniqueId)
         assertEquals(0, result.event.propertyCount())
     }
@@ -260,25 +277,33 @@ class NativeBridgeMessageTest : BaseTest() {
     }
 
     @Test
-    fun `profile event does not clear reserved property keys when envelope value and unique_id are absent`() {
+    fun `profile event does not clear reserved property keys when envelope fields are absent`() {
         val result = decodeProfileEvent(
-            properties = """"${'$'}value": 99.0, "${'$'}event_id": "nested-id""""
+            properties = """
+                "${'$'}value": 99.0, "${'$'}value_currency": "EUR", "${'$'}event_id": "nested-id"
+            """.trimIndent()
         )
 
         assertEquals(99.0, result.event.value)
+        assertEquals("EUR", result.event.valueCurrency)
         assertEquals("nested-id", result.event.uniqueId)
     }
 
     @Test
-    fun `profile event envelope value and unique_id override colliding reserved property keys`() {
+    fun `profile event envelope fields override colliding reserved property keys`() {
         val result = decodeProfileEvent(
-            extraDataFields = """"value": 12.5, "unique_id": "top-id",""",
-            properties = """"${'$'}value": 99.0, "${'$'}event_id": "nested-id""""
+            extraDataFields = """
+                "value": 12.5, "value_currency": "USD", "unique_id": "top-id",
+            """.trimIndent(),
+            properties = """
+                "${'$'}value": 99.0, "${'$'}value_currency": "EUR", "${'$'}event_id": "nested-id"
+            """.trimIndent()
         )
 
         assertEquals(12.5, result.event.value)
+        assertEquals("USD", result.event.valueCurrency)
         assertEquals("top-id", result.event.uniqueId)
-        assertEquals(2, result.event.propertyCount())
+        assertEquals(3, result.event.propertyCount())
     }
 
     @Test

--- a/sdk/forms/src/test/java/com/klaviyo/forms/bridge/NativeBridgeMessageTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/bridge/NativeBridgeMessageTest.kt
@@ -196,6 +196,91 @@ class NativeBridgeMessageTest : BaseTest() {
         assertEquals(2, result.event[EventKey.CUSTOM("key2")])
     }
 
+    private fun decodeProfileEvent(extraDataFields: String = "", properties: String = "") =
+        NativeBridgeMessage.decodeWebviewMessage(
+            """
+               {
+                  "type": "trackProfileEvent",
+                  "data": {
+                    $extraDataFields
+                    "metric": "Form completed by profile",
+                    "properties": { $properties }
+                  }
+               }
+            """.trimIndent()
+        ) as NativeBridgeMessage.TrackProfileEvent
+
+    @Test
+    fun `profile event parses top-level float value`() {
+        val result = decodeProfileEvent(""""value": 12.5,""")
+
+        assertEquals(12.5, result.event.value)
+        assertEquals(12.5, result.event[EventKey.VALUE])
+    }
+
+    @Test
+    fun `profile event parses top-level integer value`() {
+        val result = decodeProfileEvent(""""value": 12,""")
+
+        assertEquals(12.0, result.event.value)
+    }
+
+    @Test
+    fun `profile event parses top-level unique_id`() {
+        val result = decodeProfileEvent(""""unique_id": "abc-123",""")
+
+        assertEquals("abc-123", result.event.uniqueId)
+        assertEquals("abc-123", result.event[EventKey.EVENT_ID])
+    }
+
+    @Test
+    fun `profile event without value or unique_id leaves both unset`() {
+        val result = decodeProfileEvent("")
+
+        assertNull(result.event.value)
+        assertNull(result.event.uniqueId)
+        assertEquals(0, result.event.propertyCount())
+    }
+
+    @Test
+    fun `profile event with malformed value still decodes`() {
+        val result = decodeProfileEvent(""""value": "not a number",""")
+
+        assertEquals(EventMetric.CUSTOM("Form completed by profile"), result.event.metric)
+        assertNull(result.event.value)
+        assertEquals(0, result.event.propertyCount())
+    }
+
+    @Test
+    fun `profile event with blank unique_id leaves it unset`() {
+        val result = decodeProfileEvent(""""unique_id": "   ",""")
+
+        assertNull(result.event.uniqueId)
+        assertEquals(0, result.event.propertyCount())
+    }
+
+    @Test
+    fun `profile event does not clear reserved property keys when envelope value and unique_id are absent`() {
+        val result = decodeProfileEvent(
+            properties = """"${'$'}value": 99.0, "${'$'}event_id": "nested-id""""
+        )
+
+        assertEquals(99.0, result.event.value)
+        assertEquals("nested-id", result.event.uniqueId)
+    }
+
+    @Test
+    fun `profile event envelope value and unique_id override colliding reserved property keys`() {
+        val result = decodeProfileEvent(
+            extraDataFields = """"value": 12.5, "unique_id": "top-id",""",
+            properties = """"${'$'}value": 99.0, "${'$'}event_id": "nested-id""""
+        )
+
+        assertEquals(12.5, result.event.value)
+        assertEquals("top-id", result.event.uniqueId)
+        assertEquals(2, result.event.propertyCount())
+    }
+
     @Test
     fun `test aggregate event`() {
         // Setup

--- a/sdk/forms/src/test/java/com/klaviyo/forms/bridge/NativeBridgeMessageTest.kt
+++ b/sdk/forms/src/test/java/com/klaviyo/forms/bridge/NativeBridgeMessageTest.kt
@@ -491,7 +491,7 @@ class NativeBridgeMessageTest : BaseTest() {
                   },
                   {
                     "type": "trackProfileEvent",
-                    "version": 1
+                    "version": 2
                   },
                   {
                     "type": "openDeepLink",


### PR DESCRIPTION
# Description

Advertises handshake **v2** for the `trackProfileEvent` native bridge message, makes Android honor the top-level `value` / `unique_id` fields so that v2 means the same thing on both mobile platforms, and adds `value_currency` support to `Event` so a form-reported amount can carry a currency.

> [!IMPORTANT]
> **Base branch:** repo convention is that `{initials}/*` branches target the active `rel/*`, not `master`. There is no suitable open release branch right now, so this is drafted against `master` and will be retargeted once one is cut. The required base-branch status check failing here is expected, not an oversight.

## Ticket scope: what is and is not here

MAGE-1132 is broader than this PR. It enumerates five scope items; this PR covers the first three.

| # | Item | In this PR |
|---|------|-----------|
| 1 | Advertise `trackProfileEvent: 2` | Yes |
| 2 | Honor top-level `value` / `unique_id` | Yes |
| 3 | Add `value_currency` | Yes |
| 4 | Non-`Serializable` property values dropped silently in `getEventProperties()` | **No** |
| 5 | `data.properties` mandatory via throwing accessors while `data` itself is optional | **No** |

Items 4 and 5 are decoder-robustness questions about payload shapes onsite does not currently send, and item 5 in particular needs a deliberate call on whether failing loudly is the behavior we want. Both are independent of the v2 handshake and are deliberately left for a follow-up on the same ticket, which outlives this PR — hence `Part of`, not `Closes`. The `KlaviyoJsBridge.profileEvent` pop bug described under the ticket's *Related but separate* heading is likewise not addressed here.

## Due Diligence
- [ ] I have tested this on an emulator and/or a physical device.
  - Unit-tested only so far. End-to-end verification is blocked until fender's v2 mapper is on a reachable CDN — see *Release Considerations* below.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all Android versions the SDK currently supports.
  - Pure Kotlin + `org.json` parsing, no API-level-gated calls.

## Release/Versioning Considerations
- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [x] `Minor` Contains changes to the public API.
  - `Event.valueCurrency` / `setValueCurrency` and `EventKey.VALUE_CURRENCY` are additive public API. The bridge changes are `internal`.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

> [!WARNING]
> **Release ordering:** fender's v2 mapper must be live on the production CDN *before* any SDK ships advertising v2. Onsite throws `InvalidContext` on an unmapped version, which aborts the entire forms integration — not just this message.

## Changelog / Code Overview

**Background.** Released iOS passes the whole `data` envelope through as the event's properties; Android has always read `data.properties` correctly. So onsite's `trackProfileEvent` **v1** mapper is now platform-dependent — flat for iOS, nested everywhere else — while **v2 is nested on every platform and does not consult platform at all**. Android's payload is byte-for-byte unchanged on both versions. Advertising v2 from Android is what lets that temporary v1 flat branch, and the platform detection added for it, eventually be deleted.

**`value` / `unique_id` are reserved and unemitted today.** Onsite's v2 mapper currently posts only `{ metric, properties }`; the v2 *type* declares `value?: number` and `unique_id?: string`, but fender's spec marks both `// reserved; nothing emits this yet`. They are envelope fields rather than properties (`value` for revenue attribution, `unique_id` for form-supplied idempotency), and are only expressible against a decoder that separates the envelope from the properties. Commit 2 is therefore **acceptance of the declared envelope contract, not a response to traffic Android sees today** — the same reasoning that brings `value_currency` along with it.

**No production data impact on any platform:** no in-app-forms feature that creates profile-level events has shipped yet.

Four deliberately separable commits:

1. **`feat(forms): advertise trackProfileEvent handshake v2`** — the bare handshake bump: `HandshakeSpec(keyName<TrackProfileEvent>(), 2)` plus the one pinned JSON test literal. +2/-2, independently green.
2. **`feat(forms): honor top-level value and unique_id on trackProfileEvent`** — reads the optional top-level `value` / `unique_id` and applies them via `Event.setValue` / `Event.setUniqueId`.
3. **`feat(analytics): support value_currency on events`** — analytics only, no dependency on 1 or 2.
4. **`feat(forms): honor top-level value_currency on trackProfileEvent`** — the bridge read, depends on 3.

**Why commit 2 is in this PR.** Without it, v2 would mean "reads nested properties **and** honors `value`/`unique_id`" on iOS but only "reads nested properties" on Android — a version number meaning different things per platform, which is the exact class of bug this whole effort exists to fix. It is kept separable and can be dropped or split out if reviewers prefer.

### `value_currency` (commits 3 and 4)

`POST /client/events` accepts a top-level `value_currency` (ISO 4217) alongside `value`, and has since its oldest published revision — so nothing is gated on an API revision. `EventApiRequest` previously emitted only `profile`, `metric.name`, `unique_id`, `value`, `time` and `properties`, so there was no field for it. Now that `value` is reachable from a form (commit 2), an amount with no currency is a real gap.

Threaded end to end following exactly how `value` already works:

- `EventKey.VALUE_CURRENCY` → `$value_currency`, the reserved property key. Confirmed against internal docs, not inferred: templates resolve `{{ event|lookup:'$value_currency' }}` and stored events expose `event_properties.$value_currency`.
- `Event.valueCurrency: String?` with a chainable `setValueCurrency` for Java and a `@JvmSynthetic` property setter for Kotlin — the same shape as `value` / `uniqueId`.
- `EventApiRequest` emits top-level `value_currency`; `filteredMapOf` drops it when null or empty, pinned by a test that asserts the key is absent from both the attributes and the property bag.

Like `$value` and `$event_id`, the key also lands inside `properties`. That duplication is pre-existing and documented in `EventApiRequest`, and for currency specifically it matches the API's own behavior: unlike `value` and `unique_id`, the API does **not** lift `$value_currency` out of the property bag — it stores it there. Klaviyo's Python SDK writes `event.properties[VALUE_CURRENCY]` for the same reason.

**Why the bridge reads it too (commit 4).** The `trackProfileEvent` envelope is a contract with three optional scalar fields — `value`, `value_currency`, `unique_id` — and this PR makes the Android decoder accept all three rather than an arbitrary subset of them. That is the entire justification. It is explicitly *not* a bet that in-app forms will need an amount or a currency any time soon — they most likely will not. The point is that the SDK should never be the reason a field the web side could legitimately send can't be used: a decoder that reads two of the three quietly turns the third into a field that does nothing, which surfaces only in production and costs an SDK release to fix. Accepting the whole envelope costs one extension function and removes that failure mode. Same `?.let` guard as the other two, for the reason below.

### Reviewer note: the `?.let` guards are load-bearing

```kotlin
jsonData.getEventValue()?.let(::setValue)
jsonData.getValueCurrency()?.let(::setValueCurrency)
jsonData.getUniqueId()?.let(::setUniqueId)
```

`BaseModel.set` **removes** a key when handed `null`, and `Keyword.equals` compares by name — so an `EventKey.CUSTOM("$value")` arriving inside `data.properties` is equal to `EventKey.VALUE`, and likewise for `$value_currency` and `$event_id`. Since onsite emits none of the three envelope fields today, an unconditional `setValue(null)` / `setValueCurrency(null)` / `setUniqueId(null)` would run on **every** real v2 message, clearing any `$value` / `$value_currency` / `$event_id` that came in through the property bag. Onsite does not deliberately put those reserved keys in `properties`, but `ProfileEventProperties` carries an open `[k: string]: EventData` index signature, so the collision is expressible. Absent / blank / `NaN` have to mean "don't touch it", not "clear it". Regression tests pin both directions: reserved property keys are not cleared when the envelope fields are absent, and the envelope wins when both are present.

### Known cross-platform difference (chosen, not accidental)

Android's `optDouble` coerces a numeric *string* for `value` (`"12.5"` → `12.5`); iOS's `as? Double` returns `nil`. Latent either way while nothing emits the field, and unreachable on well-formed input once something does, since onsite's v2 type declares `value?: number`. Each matches its own platform's model conventions, so we are leaving it.

Confirmed against klaviyo-swift-sdk [#705](https://github.com/klaviyo/klaviyo-swift-sdk/pull/705): the wire format is identical (`value_currency`, omitted when nil) and the public property name matches (`Event.valueCurrency`). Two intentional surface differences, both following from the model rather than from disagreement:

- **iOS has no reserved-key constant.** Swift's `Event` carries discrete typed stored properties and has no reserved-key namespace at all — there are zero occurrences of `$value` or `$event_id` anywhere in its `Sources/`. `EventKey.VALUE_CURRENCY` exists here because Android's `Event` *is* a property bag keyed by `EventKey`.
- **iOS does not mirror the currency into `properties`.** Swift doesn't do that for `value` either, so doing it only for currency would be its inconsistent choice; here the mirroring is inherent to the property bag.

**A consequence of that, which outlives both PRs:** on Android, `setProperty(EventKey.CUSTOM("\$value_currency"), …)` and `setValueCurrency(…)` land in the *same* slot, because `Keyword.equals` compares by name. On iOS, `properties["$value_currency"]` and `Event.valueCurrency` are independent storage and the SDK does not reconcile them — the former rides in `properties`, the latter goes top-level. Per the API behavior above both are valid destinations, so this is benign, but "set the currency as a property" does not mean the same thing on both platforms.

**Not affected: the event-enrichment and replay paths.** `KlaviyoState.createEvent` re-emits an enriched event via `event.copy()`, which is `Event(metric).merge(this)` — `merge` walks the whole property map, so `$value_currency` is carried without naming it. Android's property bag makes every copy site field-agnostic by construction, which is why there is no third copy site to update here (iOS had to thread the field through `enrichEventWithMetadata` by hand because its `Event` is rebuilt positionally).

**Out of scope, noted so it isn't mistaken for an oversight:** the *outbound* `JsBridge.profileEvent` path pops `$event_id`, `_time` and `$value` into positional arguments of the `window.profileEvent(metric, uuid, time, value, properties)` JS helper. There is no currency parameter in that signature, so `$value_currency` reaches JS inside `properties` — the only available destination, and a legitimate one. Giving it a positional slot would mean changing the bundled JS asset's signature *and* the onsite listener that consumes the `profileEvent` event: a different surface (SDK→JS outbound) from the inbound decoder this PR touches, and a cross-repo contract change.

Note that `value_currency` is **not** validated client-side on either platform. The API rejects a non-uppercase or non-ISO-4217 code with a 400, which is the same contract every other string attribute has; adding an SDK-side allowlist would mean shipping a currency table and keeping it current.

## Test Plan

`./gradlew :sdk:forms:testDebugUnitTest :sdk:analytics:testDebugUnitTest ktlintCheck` on **JDK 17** (Temurin 17.0.17) — `BUILD SUCCESSFUL`, forms 234 tests, analytics 501 tests, 0 failures / 0 errors / 0 skipped, ktlint clean. Commit 1 also verified green in isolation (224 forms tests).

New unit tests cover:

- **Bridge:** envelope float and integer `value`, envelope `unique_id`, envelope `value_currency`, all three absent, non-numeric `value`, blank `unique_id`, blank `value_currency`, reserved `$value` / `$value_currency` / `$event_id` property keys not cleared when the envelope fields are absent, and the envelope overriding colliding reserved property keys.
- **Payload:** full expected body with `value_currency` present at the top level and as `$value_currency` in properties, plus an explicit assertion that both are omitted when unset.
- **Java interop:** `setValueCurrency` / `getValueCurrency` chained alongside `setValue` and `setUniqueId`, `setValueCurrency(null)` clearing the property, and `EventKey.VALUE_CURRENCY.INSTANCE` resolving from Java — following the existing `testEventSetters` and `testEventKeyObjectMembersRequireInstance` precedent.

End-to-end forms testing is deferred until fender's v2 mapper is reachable.

## Related Issues/Tickets

Part of MAGE-1132

Onsite-side work is tracked separately on MAGE-1128, which is now fender-only.

Companion PRs:
- fender [#67872](https://github.com/klaviyo/fender/pull/67872) — v2 mapper + platform detection. **Must deploy first.**
- klaviyo-swift-sdk [#705](https://github.com/klaviyo/klaviyo-swift-sdk/pull/705) — iOS properties-decoding fix + v2


