### PR TITLE
refactor(core): serialize auth token state transitions (MAGE-1170)

### DIFF
--- a/sdk/core/src/main/java/com/klaviyo/core/auth/AuthTokenManager.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/AuthTokenManager.kt
@@ -8,7 +8,8 @@ package com.klaviyo.core.auth
  * for the full [ValidatedToken] wrapper (exp/iat metadata) callers should use
  * [AuthTokenManager.currentToken].
  *
- * Observers are invoked on the manager's internal dispatcher (IO). If a thread handoff is needed
+ * Observers are invoked serially on the manager's internal dispatcher (IO). They should return
+ * promptly and must not block waiting for suspending manager work. If a thread handoff is needed
  * (e.g. for a WebView call that must run on the UI thread), the observer is responsible for it.
  */
 typealias TokenRefreshObserver = (jwt: String) -> Unit
@@ -87,10 +88,11 @@ interface AuthTokenManager {
      * including the initial fetch — so a consumer that subscribes while the first fetch is still in
      * flight (e.g. a form displayed before the token resolves) still receives it once it lands.
      *
-     * Multiple observers are supported. Each is invoked on the manager's internal dispatcher
-     * (IO); the observer is responsible for any thread handoff it needs (e.g. hopping to the UI
-     * thread for WebView calls). Dispatch is best-effort: if an observer throws an [Exception], it
-     * is logged at WARNING and remaining observers are still called.
+     * Multiple observers are supported. Each is invoked serially on the manager's internal
+     * dispatcher (IO); observers should return promptly and must not block waiting for suspending
+     * manager work. The observer is responsible for any thread handoff it needs (e.g. hopping to
+     * the UI thread for WebView calls). Dispatch is best-effort: if an observer throws an
+     * [Exception], it is logged at WARNING and remaining observers are still called.
      * [kotlinx.coroutines.CancellationException] is rethrown per structured-concurrency contract.
      *
      * Registration is by reference — pass the same lambda instance to [offTokenRefresh] to

--- a/sdk/core/src/main/java/com/klaviyo/core/auth/AuthTokenManager.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/AuthTokenManager.kt
@@ -71,6 +71,9 @@ interface AuthTokenManager {
      * of that single fetch rather than each triggering a new provider invocation. Each caller's
      * [timeoutMs] budget is enforced independently — a caller that times out does not cancel the
      * underlying fetch, so a later caller with a larger budget can still receive the result.
+     * If the profile is invalidated while a caller is waiting, an outgoing-profile success is
+     * discarded and the caller retries against the current generation within its original timeout
+     * budget.
      *
      * @param timeoutMs Maximum milliseconds to wait for the provider to return a token. Must be
      *   positive. Defaults to [BACKGROUND_FETCH_TIMEOUT_MS], pass [INTERACTIVE_FETCH_TIMEOUT_MS]
@@ -93,6 +96,8 @@ interface AuthTokenManager {
      * manager work. The observer is responsible for any thread handoff it needs (e.g. hopping to
      * the UI thread for WebView calls). Dispatch is best-effort: if an observer throws an
      * [Exception], it is logged at WARNING and remaining observers are still called.
+     * Delivery stops for the remaining observers if the token is invalidated during delivery
+     * (for example, an observer calls [invalidate], or a profile reset lands concurrently).
      * [kotlinx.coroutines.CancellationException] is rethrown per structured-concurrency contract.
      *
      * Registration is by reference — pass the same lambda instance to [offTokenRefresh] to

--- a/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
@@ -41,7 +41,8 @@ internal class KlaviyoAuthTokenManager(
     internal val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Registry.dispatcher)
 
     private val stateLock = Any()
-    private val observerDeliveryLock = Any()
+    private val completionBarrier = Any()
+    private val observerDispatchLock = Any()
     private val state = State()
 
     internal val connectivityWaitJob: Job?
@@ -52,7 +53,7 @@ internal class KlaviyoAuthTokenManager(
     }
 
     override fun registerProvider(provider: AuthTokenProvider) {
-        val transition = synchronized(observerDeliveryLock) {
+        val transition = synchronized(completionBarrier) {
             val lifecycleTransition = synchronized(stateLock) {
                 val cleanup = detachTokenStateLocked()
                 state.profileGeneration++
@@ -71,7 +72,7 @@ internal class KlaviyoAuthTokenManager(
     }
 
     override fun unregisterProvider() {
-        val didUnregister = synchronized(observerDeliveryLock) {
+        val didUnregister = synchronized(completionBarrier) {
             val cleanup = synchronized(stateLock) state@{
                 if (state.provider == null) return@state null
                 state.provider = null
@@ -98,10 +99,10 @@ internal class KlaviyoAuthTokenManager(
         synchronized(stateLock) { state.refreshObservers.remove(observer) }
     }
 
-    override fun invalidate(): Long = synchronized(observerDeliveryLock) {
+    override fun invalidate(): Long = synchronized(completionBarrier) {
         synchronized(stateLock) {
-            // Detach without cancelling: callers already waiting on this fetch retain its result,
-            // while callers arriving after invalidation can no longer join the outgoing profile.
+            // Detach without cancelling so completion remains orderly. Existing waiters revalidate
+            // the generation and retry; later callers cannot join the outgoing-profile fetch.
             state.inFlightFetch?.let(state.detachedFetches::add)
             state.inFlightFetch = null
             state.profileResetPending = true
@@ -112,7 +113,7 @@ internal class KlaviyoAuthTokenManager(
     }
 
     override suspend fun clearTokenState(expectedGeneration: Long) {
-        val cleared = synchronized(observerDeliveryLock) {
+        val cleared = synchronized(completionBarrier) {
             val cleanup = synchronized(stateLock) state@{
                 if (expectedGeneration >= 0L && state.profileGeneration != expectedGeneration) {
                     return@state null
@@ -246,61 +247,68 @@ internal class KlaviyoAuthTokenManager(
     /**
      * Commits a provider result only when both the fetch identity and profile generation still
      * match. Provider replacement, unregister, and clear synchronously retire the slot. Invalidate
-     * advances the generation so its late result may satisfy the original waiter but cannot cache
-     * or publish a stale JWT.
+     * advances the generation so an original waiter discards its late result and retries; the stale
+     * result cannot be cached, published, or returned.
      */
     private fun completeFetch(
         fetchId: Long,
         profileGeneration: Long,
         outcome: CompletableDeferred<FetchOutcome>,
         result: FetchOutcome
-    ) = synchronized(observerDeliveryLock) {
-        val scheduleTiming = (result as? FetchOutcome.Success)?.let {
-            val nowMs = Registry.clock.currentTimeMillis()
-            RefreshTiming(
-                nowMs = nowMs,
-                targetMs = computeRefreshTarget(it.token, nowMs)
-            )
-        }
-        val refreshPlan = synchronized(stateLock) state@{
-            val inFlight = state.inFlightFetch
-            if (inFlight?.id != fetchId ||
-                inFlight.profileGeneration != profileGeneration
-            ) {
-                state.detachedFetches.removeAll {
-                    it.id == fetchId && it.outcome === outcome
+    ) {
+        val tokenToNotify = synchronized(completionBarrier) {
+            val scheduleTiming = (result as? FetchOutcome.Success)?.let {
+                val nowMs = Registry.clock.currentTimeMillis()
+                RefreshTiming(
+                    nowMs = nowMs,
+                    targetMs = computeRefreshTarget(it.token, nowMs)
+                )
+            }
+            val refreshPlan = synchronized(stateLock) state@{
+                val inFlight = state.inFlightFetch
+                if (inFlight?.id != fetchId ||
+                    inFlight.profileGeneration != profileGeneration
+                ) {
+                    state.detachedFetches.removeAll {
+                        it.id == fetchId && it.outcome === outcome
+                    }
+                    return@state null
                 }
-                return@state null
+                state.inFlightFetch = null
+                if (state.profileGeneration != profileGeneration ||
+                    state.profileResetPending ||
+                    result !is FetchOutcome.Success
+                ) {
+                    return@state null
+                }
+
+                state.cachedToken = result.token
+                prepareRefreshScheduleLocked(requireNotNull(scheduleTiming))
             }
-            state.inFlightFetch = null
-            if (state.profileGeneration != profileGeneration ||
-                state.profileResetPending ||
-                result !is FetchOutcome.Success
-            ) {
-                return@state null
+
+            refreshPlan?.let(::installRefreshSchedule)
+            // Completing outside stateLock prevents unconfined waiters from observing a partially
+            // applied lifecycle transition or running application code under the global monitor.
+            outcome.complete(result)
+
+            val token = (result as? FetchOutcome.Success)?.token
+            if (refreshPlan != null && token != null) {
+                Registry.log.info(
+                    "Auth token acquired " +
+                        "(exp=${token.expiresAtEpochSeconds}, iat=${token.issuedAtEpochSeconds})"
+                )
+                token
+            } else {
+                null
             }
-
-            state.cachedToken = result.token
-            prepareRefreshScheduleLocked(requireNotNull(scheduleTiming))
         }
-
-        refreshPlan?.let(::installRefreshSchedule)
-        // Completing outside stateLock prevents unconfined waiters from observing a partially
-        // applied lifecycle transition or running application code under the global monitor.
-        outcome.complete(result)
-
-        val token = (result as? FetchOutcome.Success)?.token
-        if (refreshPlan != null && token != null) {
-            Registry.log.info(
-                "Auth token acquired " +
-                    "(exp=${token.expiresAtEpochSeconds}, iat=${token.issuedAtEpochSeconds})"
-            )
-            notifyRefreshObservers(token, profileGeneration)
-        }
+        // Host callbacks run after the completion/lifecycle barrier is released. They remain
+        // serialized by observerDispatchLock, which lifecycle APIs never acquire.
+        tokenToNotify?.let { notifyRefreshObservers(it, profileGeneration) }
     }
 
     private fun canReturnFetchResult(profileGeneration: Long): Boolean =
-        synchronized(observerDeliveryLock) {
+        synchronized(completionBarrier) {
             synchronized(stateLock) { state.profileGeneration == profileGeneration }
         }
 
@@ -439,13 +447,9 @@ internal class KlaviyoAuthTokenManager(
         timerGeneration: Long? = null,
         allowImmediateConnectivityRetry: Boolean = true
     ) {
-        val resetGenerationAtStart = synchronized(stateLock) {
+        val (profileGenerationAtStart, resetGenerationAtStart) = synchronized(stateLock) {
             if (!guard.matchesLocked() || state.provider == null) return
-            state.resetGeneration
-        }
-        val profileGenerationAtStart = synchronized(stateLock) {
-            if (!guard.matchesLocked() || state.provider == null) return
-            state.profileGeneration
+            state.profileGeneration to state.resetGeneration
         }
         Registry.log.info("Proactive token refresh fired")
         try {
@@ -481,7 +485,7 @@ internal class KlaviyoAuthTokenManager(
     }
 
     private fun notifyRefreshObservers(token: ValidatedToken, profileGeneration: Long) {
-        synchronized(observerDeliveryLock) {
+        synchronized(observerDispatchLock) {
             val observers = synchronized(stateLock) {
                 if (!canDeliverTokenLocked(token, profileGeneration)) return
                 state.refreshObservers.toList()

--- a/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
@@ -41,6 +41,7 @@ internal class KlaviyoAuthTokenManager(
     internal val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Registry.dispatcher)
 
     private val stateLock = Any()
+    private val observerDeliveryLock = Any()
     private val state = State()
 
     internal val connectivityWaitJob: Job?
@@ -51,33 +52,39 @@ internal class KlaviyoAuthTokenManager(
     }
 
     override fun registerProvider(provider: AuthTokenProvider) {
-        synchronized(stateLock) {
-            cancelInFlightFetchLocked()
-            cancelRefreshLocked()
-            cancelConnectivityWaitLocked()
-            state.profileGeneration++
-            state.profileResetPending = false
-            state.cachedToken = null
-            state.provider = provider
+        val transition = synchronized(observerDeliveryLock) {
+            synchronized(stateLock) {
+                val cleanup = detachTokenStateLocked()
+                state.profileGeneration++
+                state.profileResetPending = false
+                state.cachedToken = null
+                state.provider = provider
+                LifecycleTransition(cleanup, state.profileGeneration)
+            }
         }
+        completeCleanup(transition.cleanup)
         Registry.log.info("AuthTokenProvider registered")
-        scope.safeLaunch { tryEagerFetch() }
+        scope.safeLaunch {
+            tryEagerFetch(RequestGuard(profileGeneration = transition.profileGeneration))
+        }
     }
 
     override fun unregisterProvider() {
-        val didUnregister = synchronized(stateLock) {
-            if (state.provider == null) return@synchronized false
-            state.provider = null
-            state.profileGeneration++
-            state.resetGeneration++
-            cancelInFlightFetchLocked()
-            cancelRefreshLocked()
-            cancelConnectivityWaitLocked()
-            state.cachedToken = null
-            state.profileResetPending = false
-            true
+        val cleanup = synchronized(observerDeliveryLock) {
+            synchronized(stateLock) state@{
+                if (state.provider == null) return@state null
+                state.provider = null
+                state.profileGeneration++
+                state.resetGeneration++
+                val detached = detachTokenStateLocked()
+                state.cachedToken = null
+                state.profileResetPending = false
+                detached
+            }
         }
-        if (didUnregister) Registry.log.info("AuthTokenProvider unregistered")
+        cleanup ?: return
+        completeCleanup(cleanup)
+        Registry.log.info("AuthTokenProvider unregistered")
     }
 
     override fun onTokenRefresh(observer: TokenRefreshObserver) {
@@ -88,39 +95,53 @@ internal class KlaviyoAuthTokenManager(
         synchronized(stateLock) { state.refreshObservers.remove(observer) }
     }
 
-    override fun invalidate(): Long = synchronized(stateLock) {
-        state.profileResetPending = true
-        state.profileGeneration++
-        state.resetGeneration++
-        state.profileGeneration
+    override fun invalidate(): Long = synchronized(observerDeliveryLock) {
+        synchronized(stateLock) {
+            // Detach without cancelling: callers already waiting on this fetch retain its result,
+            // while callers arriving after invalidation can no longer join the outgoing profile.
+            state.inFlightFetch?.let(state.detachedFetches::add)
+            state.inFlightFetch = null
+            state.profileResetPending = true
+            state.profileGeneration++
+            state.resetGeneration++
+            state.profileGeneration
+        }
     }
 
     override suspend fun clearTokenState(expectedGeneration: Long) {
-        val cleared = synchronized(stateLock) {
-            if (expectedGeneration >= 0L && state.profileGeneration != expectedGeneration) {
-                Registry.log.verbose(
-                    "clearTokenState: skipped — provider re-registered since reset"
-                )
-                return@synchronized false
+        val cleanup = synchronized(observerDeliveryLock) {
+            synchronized(stateLock) state@{
+                if (expectedGeneration >= 0L && state.profileGeneration != expectedGeneration) {
+                    return@state null
+                }
+                val detached = detachTokenStateLocked()
+                state.cachedToken = null
+                state.profileGeneration++
+                state.resetGeneration++
+                state.profileResetPending = false
+                detached
             }
-            cancelInFlightFetchLocked()
-            cancelRefreshLocked()
-            cancelConnectivityWaitLocked()
-            state.cachedToken = null
-            state.profileGeneration++
-            state.resetGeneration++
-            state.profileResetPending = false
-            true
         }
-        if (cleared) Registry.log.info("Token state cleared")
+        if (cleanup == null) {
+            Registry.log.verbose("clearTokenState: skipped — provider re-registered since reset")
+            return
+        }
+        completeCleanup(cleanup)
+        Registry.log.info("Token state cleared")
     }
 
     override suspend fun currentToken(timeoutMs: Long): ValidatedToken =
         getOrFetchToken(timeoutMs = timeoutMs, allowCachedToken = true)
 
-    private suspend fun tryEagerFetch() {
+    private suspend fun tryEagerFetch(guard: RequestGuard) {
         try {
-            currentToken(AuthTokenManager.BACKGROUND_FETCH_TIMEOUT_MS)
+            getOrFetchToken(
+                timeoutMs = AuthTokenManager.BACKGROUND_FETCH_TIMEOUT_MS,
+                allowCachedToken = true,
+                guard = guard
+            )
+        } catch (_: StaleTriggerException) {
+            // A newer lifecycle transition superseded this queued background request.
         } catch (e: CancellationException) {
             throw e
         } catch (_: Exception) {
@@ -135,13 +156,14 @@ internal class KlaviyoAuthTokenManager(
      */
     private suspend fun getOrFetchToken(
         timeoutMs: Long,
-        allowCachedToken: Boolean
+        allowCachedToken: Boolean,
+        guard: RequestGuard? = null
     ): ValidatedToken {
         require(timeoutMs > 0L) { "timeoutMs must be positive, but was $timeoutMs" }
 
         val token = withTimeoutOrNull(timeoutMs) {
             while (true) {
-                when (val request = tokenRequest(allowCachedToken)) {
+                when (val request = tokenRequest(allowCachedToken, guard)) {
                     is TokenRequest.Cached -> return@withTimeoutOrNull request.token
                     is TokenRequest.Fetch -> when (val outcome = request.outcome.await()) {
                         is FetchOutcome.Success -> return@withTimeoutOrNull outcome.token
@@ -160,12 +182,16 @@ internal class KlaviyoAuthTokenManager(
         throw error
     }
 
-    private fun tokenRequest(allowCachedToken: Boolean): TokenRequest {
+    private fun tokenRequest(allowCachedToken: Boolean, guard: RequestGuard?): TokenRequest {
         var fetchToStart: InFlightFetch? = null
+        val nowSeconds = Registry.clock.currentTimeMillis() / 1000L
         val request = synchronized(stateLock) {
+            if (guard != null && !guard.matchesLocked()) throw StaleTriggerException()
             val provider = state.provider ?: throw AuthTokenException.NoProviderRegistered
             if (allowCachedToken) {
-                usableCachedTokenLocked()?.let { return@synchronized TokenRequest.Cached(it) }
+                usableCachedTokenLocked(nowSeconds)?.let {
+                    return@synchronized TokenRequest.Cached(it)
+                }
             }
             val inFlight = state.inFlightFetch ?: createFetchLocked(provider).also {
                 state.inFlightFetch = it
@@ -197,7 +223,7 @@ internal class KlaviyoAuthTokenManager(
             } catch (e: Throwable) {
                 FetchOutcome.Failure(e)
             }
-            completeFetch(fetchId, profileGeneration, result)
+            completeFetch(fetchId, profileGeneration, outcome, result)
         }
         return InFlightFetch(
             id = fetchId,
@@ -216,53 +242,50 @@ internal class KlaviyoAuthTokenManager(
     private fun completeFetch(
         fetchId: Long,
         profileGeneration: Long,
+        outcome: CompletableDeferred<FetchOutcome>,
         result: FetchOutcome
     ) {
-        synchronized(stateLock) {
+        val scheduleTiming = (result as? FetchOutcome.Success)?.let {
+            val nowMs = Registry.clock.currentTimeMillis()
+            RefreshTiming(
+                nowMs = nowMs,
+                targetMs = computeRefreshTarget(it.token, nowMs)
+            )
+        }
+        val refreshPlan = synchronized(stateLock) {
             val inFlight = state.inFlightFetch
             if (inFlight?.id != fetchId ||
                 inFlight.profileGeneration != profileGeneration
             ) {
-                return
-            }
-
-            if (state.profileGeneration != profileGeneration) {
-                state.inFlightFetch = null
-                // invalidate() advances the profile generation without cancelling the provider
-                // callback. Its direct waiter still receives that outcome, but the token is never
-                // committed or broadcast. Provider replacement and full clear retire the slot
-                // synchronously, so their late completions never reach this branch.
-                if (state.profileResetPending) {
-                    inFlight.outcome.complete(result)
-                } else {
-                    inFlight.outcome.complete(FetchOutcome.Superseded)
+                state.detachedFetches.removeAll {
+                    it.id == fetchId && it.outcome === outcome
                 }
-                return
+                return@synchronized null
             }
-
             state.inFlightFetch = null
-            when (result) {
-                is FetchOutcome.Failure -> inFlight.outcome.complete(result)
-                FetchOutcome.Superseded -> inFlight.outcome.complete(FetchOutcome.Superseded)
-                is FetchOutcome.Success -> {
-                    // Fetches started while reset is pending may satisfy their direct caller, but
-                    // cannot become shared state or publish to observers.
-                    if (state.profileResetPending) {
-                        inFlight.outcome.complete(result)
-                        return
-                    }
-
-                    state.cachedToken = result.token
-                    scheduleRefreshLocked(result.token)
-                    inFlight.outcome.complete(result)
-                    Registry.log.info(
-                        "Auth token acquired " +
-                            "(exp=${result.token.expiresAtEpochSeconds}, " +
-                            "iat=${result.token.issuedAtEpochSeconds})"
-                    )
-                    notifyRefreshObserversLocked(result.token, profileGeneration)
-                }
+            if (state.profileGeneration != profileGeneration ||
+                state.profileResetPending ||
+                result !is FetchOutcome.Success
+            ) {
+                return@synchronized null
             }
+
+            state.cachedToken = result.token
+            prepareRefreshScheduleLocked(requireNotNull(scheduleTiming))
+        }
+
+        refreshPlan?.let(::installRefreshSchedule)
+        // Completing outside stateLock prevents unconfined waiters from observing a partially
+        // applied lifecycle transition or running application code under the global monitor.
+        outcome.complete(result)
+
+        val token = (result as? FetchOutcome.Success)?.token
+        if (refreshPlan != null && token != null) {
+            Registry.log.info(
+                "Auth token acquired " +
+                    "(exp=${token.expiresAtEpochSeconds}, iat=${token.issuedAtEpochSeconds})"
+            )
+            notifyRefreshObservers(token, profileGeneration)
         }
     }
 
@@ -291,84 +314,138 @@ internal class KlaviyoAuthTokenManager(
             }
         }
 
-    private fun usableCachedTokenLocked(): ValidatedToken? = state.cachedToken?.takeIf {
-        isStillValid(it) && !state.profileResetPending
+    private fun usableCachedTokenLocked(nowSeconds: Long): ValidatedToken? =
+        state.cachedToken?.takeIf {
+            isStillValid(it, nowSeconds) && !state.profileResetPending
+        }
+
+    private fun isStillValid(token: ValidatedToken, nowSeconds: Long): Boolean =
+        nowSeconds < token.expiresAtEpochSeconds - JWTParser.DEFAULT_LEEWAY_SECONDS
+
+    private fun detachTokenStateLocked(): Cleanup = Cleanup(
+        fetches = buildList {
+            state.inFlightFetch?.let(::add)
+            addAll(state.detachedFetches)
+        }.also {
+            state.inFlightFetch = null
+            state.detachedFetches.clear()
+        },
+        refreshJob = detachRefreshLocked(),
+        connectivityJob = detachConnectivityWaitLocked()
+    )
+
+    private fun completeCleanup(cleanup: Cleanup) {
+        cleanup.fetches.forEach { fetch ->
+            fetch.outcome.complete(FetchOutcome.Superseded)
+            fetch.job.cancel()
+        }
+        cleanup.refreshJob?.cancel()
+        cleanup.connectivityJob?.cancel()
     }
 
-    private fun isStillValid(token: ValidatedToken): Boolean {
-        val now = Registry.clock.currentTimeMillis() / 1000L
-        return now < token.expiresAtEpochSeconds - JWTParser.DEFAULT_LEEWAY_SECONDS
-    }
-
-    private fun cancelInFlightFetchLocked() {
-        val inFlight = state.inFlightFetch ?: return
-        state.inFlightFetch = null
-        inFlight.outcome.complete(FetchOutcome.Superseded)
-        inFlight.job.cancel()
-    }
-
-    private fun cancelRefreshLocked() {
+    private fun detachRefreshLocked(): Clock.Cancellable? {
+        val refreshJob = state.refreshJob
         state.refreshGeneration++
-        state.refreshJob?.cancel()
         state.refreshJob = null
         state.refreshAtWallClockMs = null
         state.refreshTimerFired = false
+        return refreshJob
     }
 
-    private fun scheduleRefreshLocked(token: ValidatedToken) {
-        val nowMs = Registry.clock.currentTimeMillis()
-        val targetMs = computeRefreshTarget(token, nowMs)
+    private fun prepareRefreshScheduleLocked(timing: RefreshTiming): RefreshSchedule {
         val generation = ++state.refreshGeneration
-        state.refreshJob?.cancel()
+        val previousJob = state.refreshJob
+        state.refreshJob = null
         state.refreshTimerFired = false
-        state.refreshAtWallClockMs = targetMs
-        state.refreshJob = Registry.clock.schedule((targetMs - nowMs).coerceAtLeast(0L)) {
-            onRefreshTimer(generation)
-        }
-        Registry.log.info(
-            "Proactive token refresh scheduled (target=${Registry.clock.isoTime(targetMs)})"
+        state.refreshAtWallClockMs = timing.targetMs
+        return RefreshSchedule(
+            generation = generation,
+            targetMs = timing.targetMs,
+            delayMs = (timing.targetMs - timing.nowMs).coerceAtLeast(0L),
+            previousJob = previousJob
         )
     }
 
-    private fun onRefreshTimer(generation: Long) {
-        val shouldRefresh = synchronized(stateLock) {
-            if (state.refreshGeneration != generation) return@synchronized false
-            state.refreshTimerFired = true
+    private fun installRefreshSchedule(schedule: RefreshSchedule) {
+        schedule.previousJob?.cancel()
+        val refreshJob = Registry.clock.schedule(schedule.delayMs) {
+            onRefreshTimer(schedule.generation)
+        }
+        val installed = synchronized(stateLock) {
+            if (state.refreshGeneration != schedule.generation ||
+                state.refreshAtWallClockMs != schedule.targetMs
+            ) {
+                return@synchronized false
+            }
+            state.refreshJob = refreshJob
             true
         }
-        if (shouldRefresh) {
-            scope.safeLaunch { performScheduledRefresh(timerGeneration = generation) }
+        if (!installed) {
+            refreshJob.cancel()
+            return
+        }
+        Registry.log.info(
+            "Proactive token refresh scheduled " +
+                "(target=${Registry.clock.isoTime(schedule.targetMs)})"
+        )
+    }
+
+    private fun RequestGuard.matchesLocked(): Boolean =
+        !state.profileResetPending &&
+            (profileGeneration == null || state.profileGeneration == profileGeneration) &&
+            (resetGeneration == null || state.resetGeneration == resetGeneration) &&
+            (refreshGeneration == null || state.refreshGeneration == refreshGeneration) &&
+            (
+                connectivityGeneration == null ||
+                    state.connectivityWait?.generation == connectivityGeneration
+                )
+
+    private fun onRefreshTimer(generation: Long) {
+        val guard = synchronized(stateLock) {
+            if (state.refreshGeneration != generation || state.profileResetPending) {
+                return@synchronized null
+            }
+            state.refreshTimerFired = true
+            RequestGuard(
+                profileGeneration = state.profileGeneration,
+                resetGeneration = state.resetGeneration,
+                refreshGeneration = generation
+            )
+        }
+        if (guard != null) {
+            scope.safeLaunch {
+                performScheduledRefresh(guard = guard, timerGeneration = generation)
+            }
         }
     }
 
     private suspend fun performScheduledRefresh(
+        guard: RequestGuard,
         timerGeneration: Long? = null,
         allowImmediateConnectivityRetry: Boolean = true
     ) {
         val resetGenerationAtStart = synchronized(stateLock) {
-            if (state.provider == null) return
+            if (!guard.matchesLocked() || state.provider == null) return
             state.resetGeneration
         }
         Registry.log.info("Proactive token refresh fired")
         try {
             getOrFetchToken(
                 timeoutMs = AuthTokenManager.BACKGROUND_FETCH_TIMEOUT_MS,
-                allowCachedToken = false
+                allowCachedToken = false,
+                guard = guard
             )
             Registry.log.info("Proactive token refresh succeeded")
+        } catch (_: StaleTriggerException) {
+            // Teardown or provider replacement won the race before fetch reservation.
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
             if (timerGeneration != null) clearFiredFlagForFailedRefresh(timerGeneration)
             Registry.log.warning("Proactive token refresh failed: ${e.javaClass.simpleName}", e)
-            val shouldWait = synchronized(stateLock) {
-                state.resetGeneration == resetGenerationAtStart &&
-                    isNetworkException(e) &&
-                    state.provider != null &&
-                    !state.profileResetPending
-            }
-            if (shouldWait) {
+            if (isNetworkException(e)) {
                 armConnectivityWaitJob(
+                    expectedResetGeneration = resetGenerationAtStart,
                     resumeImmediatelyIfConnected = allowImmediateConnectivityRetry
                 )
             }
@@ -383,32 +460,35 @@ internal class KlaviyoAuthTokenManager(
         }
     }
 
-    /**
-     * Observer delivery is part of the same serialized transition as the cache commit. Because a
-     * JVM monitor is reentrant, an observer may call a synchronous manager API without deadlocking;
-     * the generation guard is re-checked before each remaining callback in case it does so.
-     */
-    private fun notifyRefreshObserversLocked(token: ValidatedToken, profileGeneration: Long) {
-        val observers = state.refreshObservers.toList()
-        observers.forEach { observer ->
-            if (state.profileGeneration != profileGeneration ||
-                state.profileResetPending ||
-                state.cachedToken?.rawToken != token.rawToken
-            ) {
-                return
+    private fun notifyRefreshObservers(token: ValidatedToken, profileGeneration: Long) {
+        synchronized(observerDeliveryLock) {
+            val observers = synchronized(stateLock) {
+                if (!canDeliverTokenLocked(token, profileGeneration)) return
+                state.refreshObservers.toList()
             }
-            try {
-                observer(token.rawToken)
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                Registry.log.warning(
-                    "TokenRefreshObserver threw ${e.javaClass.simpleName} — skipping",
-                    e
-                )
+            observers.forEach { observer ->
+                val canDeliver = synchronized(stateLock) {
+                    canDeliverTokenLocked(token, profileGeneration)
+                }
+                if (!canDeliver) return
+                try {
+                    observer(token.rawToken)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    Registry.log.warning(
+                        "TokenRefreshObserver threw ${e.javaClass.simpleName} — skipping",
+                        e
+                    )
+                }
             }
         }
     }
+
+    private fun canDeliverTokenLocked(token: ValidatedToken, profileGeneration: Long): Boolean =
+        state.profileGeneration == profileGeneration &&
+            !state.profileResetPending &&
+            state.cachedToken?.rawToken == token.rawToken
 
     private fun isNetworkException(e: Exception): Boolean =
         e is UnknownHostException ||
@@ -416,26 +496,34 @@ internal class KlaviyoAuthTokenManager(
             e is ConnectException ||
             e is IOException
 
-    private fun armConnectivityWaitJob(resumeImmediatelyIfConnected: Boolean = true) {
-        Registry.log.info(
-            "AuthTokenManager: network failure — waiting for connectivity to retry refresh"
-        )
+    private fun armConnectivityWaitJob(
+        expectedResetGeneration: Long,
+        resumeImmediatelyIfConnected: Boolean = true
+    ) {
+        var previousJob: Job? = null
         val waitJob = synchronized(stateLock) {
-            cancelConnectivityWaitLocked()
-            val generation = state.connectivityWaitGeneration
+            if (state.resetGeneration != expectedResetGeneration ||
+                state.provider == null ||
+                state.profileResetPending
+            ) {
+                return@synchronized null
+            }
+            previousJob = state.connectivityWait?.job
+            val generation = ++state.connectivityWaitGeneration
             val job = scope.safeLaunch(start = CoroutineStart.LAZY) {
                 try {
                     awaitConnectivity(resumeImmediatelyIfConnected)
+                    currentCoroutineContext().ensureActive()
                     Registry.log.info(
                         "AuthTokenManager: connectivity restored — retrying proactive refresh"
                     )
-                    currentCoroutineContext().ensureActive()
-                    val isCurrent = synchronized(stateLock) {
-                        state.connectivityWait?.generation == generation
-                    }
-                    if (isCurrent) {
-                        performScheduledRefresh(allowImmediateConnectivityRetry = false)
-                    }
+                    performScheduledRefresh(
+                        guard = RequestGuard(
+                            resetGeneration = expectedResetGeneration,
+                            connectivityGeneration = generation
+                        ),
+                        allowImmediateConnectivityRetry = false
+                    )
                 } finally {
                     synchronized(stateLock) {
                         if (state.connectivityWait?.generation == generation) {
@@ -447,6 +535,11 @@ internal class KlaviyoAuthTokenManager(
             state.connectivityWait = ConnectivityWait(generation, job)
             job
         }
+        waitJob ?: return
+        previousJob?.cancel()
+        Registry.log.info(
+            "AuthTokenManager: network failure — waiting for connectivity to retry refresh"
+        )
         // Register the generation-tagged slot before starting work, but never invoke the network
         // monitor while holding stateLock (including with an unconfined test dispatcher).
         waitJob.start()
@@ -477,11 +570,11 @@ internal class KlaviyoAuthTokenManager(
         }
     }
 
-    private fun cancelConnectivityWaitLocked() {
+    private fun detachConnectivityWaitLocked(): Job? {
         val job = state.connectivityWait?.job
         state.connectivityWaitGeneration++
         state.connectivityWait = null
-        job?.cancel()
+        return job
     }
 
     private fun onLifecycleEvent(event: ActivityEvent) {
@@ -491,35 +584,42 @@ internal class KlaviyoAuthTokenManager(
 
     private fun handleForegroundTransition() {
         val nowMs = Registry.clock.currentTimeMillis()
+        var refreshToCancel: Clock.Cancellable? = null
         val action = synchronized(stateLock) {
             val cached = state.cachedToken
             val targetMs = state.refreshAtWallClockMs
             when {
-                cached != null && !isStillValid(cached) -> {
+                state.profileResetPending -> ForegroundAction.None
+                cached != null && !isStillValid(cached, nowMs / 1000L) -> {
                     state.cachedToken = null
-                    cancelRefreshLocked()
-                    ForegroundAction.EagerFetch
+                    refreshToCancel = detachRefreshLocked()
+                    ForegroundAction.EagerFetch(
+                        RequestGuard(profileGeneration = state.profileGeneration)
+                    )
                 }
                 targetMs != null && nowMs >= targetMs && !state.refreshTimerFired -> {
-                    cancelRefreshLocked()
-                    ForegroundAction.ScheduledRefresh
+                    refreshToCancel = detachRefreshLocked()
+                    ForegroundAction.ScheduledRefresh(
+                        RequestGuard(profileGeneration = state.profileGeneration)
+                    )
                 }
                 else -> ForegroundAction.None
             }
         }
+        refreshToCancel?.cancel()
 
         when (action) {
-            ForegroundAction.EagerFetch -> {
+            is ForegroundAction.EagerFetch -> {
                 Registry.log.info(
                     "AuthTokenManager: foreground transition (case=expired-cached-token)"
                 )
-                scope.safeLaunch { tryEagerFetch() }
+                scope.safeLaunch { tryEagerFetch(action.guard) }
             }
-            ForegroundAction.ScheduledRefresh -> {
+            is ForegroundAction.ScheduledRefresh -> {
                 Registry.log.info(
                     "AuthTokenManager: foreground transition (case=missed-refresh)"
                 )
-                scope.safeLaunch { performScheduledRefresh() }
+                scope.safeLaunch { performScheduledRefresh(guard = action.guard) }
             }
             ForegroundAction.None -> Registry.log.info(
                 "AuthTokenManager: foreground transition (case=still-valid)"
@@ -531,6 +631,7 @@ internal class KlaviyoAuthTokenManager(
         var provider: AuthTokenProvider? = null
         var cachedToken: ValidatedToken? = null
         var inFlightFetch: InFlightFetch? = null
+        val detachedFetches = mutableListOf<InFlightFetch>()
         var nextFetchId: Long = 0L
         var refreshJob: Clock.Cancellable? = null
         var refreshAtWallClockMs: Long? = null
@@ -556,6 +657,38 @@ internal class KlaviyoAuthTokenManager(
         val job: Job
     )
 
+    private data class Cleanup(
+        val fetches: List<InFlightFetch>,
+        val refreshJob: Clock.Cancellable?,
+        val connectivityJob: Job?
+    )
+
+    private data class LifecycleTransition(
+        val cleanup: Cleanup,
+        val profileGeneration: Long
+    )
+
+    private data class RefreshSchedule(
+        val generation: Long,
+        val targetMs: Long,
+        val delayMs: Long,
+        val previousJob: Clock.Cancellable?
+    )
+
+    private data class RefreshTiming(
+        val nowMs: Long,
+        val targetMs: Long
+    )
+
+    private data class RequestGuard(
+        val profileGeneration: Long? = null,
+        val resetGeneration: Long? = null,
+        val refreshGeneration: Long? = null,
+        val connectivityGeneration: Long? = null
+    )
+
+    private class StaleTriggerException : Exception()
+
     private sealed interface FetchOutcome {
         data class Success(val token: ValidatedToken) : FetchOutcome
         data class Failure(val error: Throwable) : FetchOutcome
@@ -567,10 +700,10 @@ internal class KlaviyoAuthTokenManager(
         data class Fetch(val outcome: CompletableDeferred<FetchOutcome>) : TokenRequest
     }
 
-    private enum class ForegroundAction {
-        EagerFetch,
-        ScheduledRefresh,
-        None
+    private sealed interface ForegroundAction {
+        data class EagerFetch(val guard: RequestGuard) : ForegroundAction
+        data class ScheduledRefresh(val guard: RequestGuard) : ForegroundAction
+        data object None : ForegroundAction
     }
 
     companion object {

--- a/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
@@ -11,394 +11,274 @@ import java.io.IOException
 import java.net.ConnectException
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
-import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.atomic.AtomicLong
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.async
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.suspendCancellableCoroutine
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeoutOrNull
 
+/**
+ * Serializes every auth-token state transition behind [stateLock]. Provider calls, timers, and
+ * connectivity waits run outside the critical section and report their results back with the
+ * generation they started in. This keeps the public synchronous lifecycle methods synchronous
+ * without spreading coordination across mutexes, volatile fields, and independent atomics.
+ */
 internal class KlaviyoAuthTokenManager(
     private val lifecycleMonitor: LifecycleMonitor = Registry.lifecycleMonitor
 ) : AuthTokenManager {
 
-    // Internal (not on the interface) so MAGE-619 consumers are forced to use their own scope
-    // when calling currentToken(), binding auth work to the correct lifecycle.
+    // Internal (not on the interface) so Forms consumers bind currentToken() to their lifecycle.
+    // Tests also cancel this scope to verify teardown behavior.
     internal val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Registry.dispatcher)
+
+    private val stateLock = Any()
+    private val state = State()
+
+    internal val connectivityWaitJob: Job?
+        get() = synchronized(stateLock) { state.connectivityWait?.job }
 
     init {
         lifecycleMonitor.onActivityEvent(::onLifecycleEvent)
     }
 
-    // Guards the read-validate-write transition on both cachedToken and inFlightFetch, ensuring
-    // exactly one Deferred is created when multiple callers miss the cache simultaneously.
-    private val mutex = Mutex()
-
-    // @Volatile so reads in invokeProvider (outside the mutex) always observe the latest write
-    // from registerProvider. Single-write-wins semantics are acceptable for the happy path.
-    @Volatile private var provider: AuthTokenProvider? = null
-
-    @Volatile private var cachedToken: ValidatedToken? = null
-
-    // Shared in-flight fetch deferred. All concurrent callers that miss the cache await this
-    // single Deferred rather than each invoking the provider independently. Cleared (via
-    // invokeOnCompletion) on both success and failure so the next request starts a fresh fetch.
-    // @Volatile because registerProvider and invokeOnCompletion clear it without holding the
-    // mutex; @Volatile ensures those writes are visible to the mutex-protected read in currentToken.
-    @Volatile private var inFlightFetch: Deferred<ValidatedToken>? = null
-
-    // NOT cleared in the timer callback on firing — a failed refresh leaves this pointing at a
-    // past target so handleForegroundTransition() case 2 can detect the miss and retry once.
-    // @Volatile because registerProvider writes without holding the mutex; @Volatile ensures those
-    // writes are visible to subsequent mutex-protected reads in handleForegroundTransition().
-    @Volatile private var refreshJob: Clock.Cancellable? = null
-
-    // @Volatile for the same reason as refreshJob: registerProvider clears without holding mutex.
-    @Volatile private var refreshAtWallClockMs: Long? = null
-
-    // Set by the timer callback while holding mutex before refresh work begins. This prevents a
-    // foreground transition from treating an already-fired timer as a Doze-style miss while the
-    // scheduled refresh coroutine is still queued or in-flight.
-    // @Volatile because registerProvider resets without holding the mutex.
-    @Volatile private var refreshTimerFired = false
-
-    // Monotonic token used to ignore callbacks from refresh jobs cancelled by a later schedule.
-    // AtomicLong rather than @Volatile Long so that registerProvider's non-mutex increment
-    // (refreshGeneration.incrementAndGet()) is truly atomic and cannot race with scheduleRefresh's
-    // mutex-held increment to produce a lost update.
-    private val refreshGeneration = AtomicLong(0L)
-
-    // Tracks profile lifecycle events: registerProvider(), invalidate(), and clearTokenState().
-    // Used by clearTokenState(expectedGeneration) to detect whether registerProvider() ran between
-    // the invalidate() call and the async clear, so a late clear doesn't wipe the new session.
-    // Deliberately separate from refreshGeneration (which scheduleRefresh() also bumps).
-    private val profileGeneration = AtomicLong(0L)
-
-    // Tracks logout/reset events only: incremented by invalidate() and clearTokenState(), but NOT
-    // by registerProvider(). Used by shouldArmConnectivityRetry to distinguish a stale failure from
-    // a logout-triggered reset vs. a benign mid-fetch provider swap. profileGeneration is too coarse
-    // for this check because registerProvider() also bumps it, which would wrongly block
-    // connectivity retry for the new session when a provider is swapped mid-fetch.
-    private val resetGeneration = AtomicLong(0L)
-
-    // Set to true by invalidate() and reset to false by registerProvider() and clearTokenState().
-    // Read by doFetch() just before notifying observers: if a profile reset is pending (i.e.
-    // invalidate() was called but clearTokenState() hasn't finished yet), the fetch must not
-    // broadcast the now-stale token. @Volatile because it is written on the calling thread (main)
-    // and read on the dispatcher (IO) with no other synchronisation.
-    @Volatile private var profileResetPending = false
-
-    // CopyOnWriteArrayList for thread-safe iteration while observers add/remove on arbitrary threads
-    // (established SDK observer-collection pattern, matches StateChangeObserver, ActivityObserver).
-    private val refreshObservers = CopyOnWriteArrayList<TokenRefreshObserver>()
-
-    // A pending coroutine that waits for connectivity to be restored before retrying
-    // performScheduledRefresh. At most one is active at a time. All transitions to this field and
-    // to connectivityWaitGeneration are serialized via connectivityWaitLock. @Volatile for
-    // visibility to tests that read the field outside any lock.
-    // Internal (not private) so tests in this module can inspect job state without reflection.
-    @Volatile internal var connectivityWaitJob: Job? = null
-
-    // Monotonic counter bumped each time armConnectivityWaitJob() arms a new job. Used by the
-    // job's finally block to detect whether a newer arm replaced it; if so the old job must not
-    // null out the new job's reference. AtomicLong for the same reason as refreshGeneration.
-    private val connectivityWaitGeneration = AtomicLong(0L)
-
-    // JVM lock serializing all connectivityWaitJob + connectivityWaitGeneration transitions.
-    // Acquired without holding mutex (armConnectivityWaitJob) and while holding mutex
-    // (clearTokenState). Lock ordering is always: mutex → connectivityWaitLock.
-    private val connectivityWaitLock = Any()
-
-    private fun cancelConnectivityWaitJob() {
-        synchronized(connectivityWaitLock) {
-            connectivityWaitJob?.cancel()
-            connectivityWaitJob = null
-        }
-    }
-
     override fun registerProvider(provider: AuthTokenProvider) {
-        // Cancel any in-flight fetch for the old provider before swapping.
-        // Two complementary guards prevent a stale token from reaching the cache:
-        //   1. If the cancelled coroutine is still inside invokeProvider(), the isActive check in
-        //      suspendCancellableCoroutine drops any late onSuccess/onFailure callback.
-        //   2. If the callback already fired and doFetch() is past invokeProvider() but hasn't
-        //      written the cache yet, ensureActive() in doFetch will throw CancellationException
-        //      before the write — even when mutex.withLock acquires the lock uncontended.
-        inFlightFetch?.cancel()
-        inFlightFetch = null
-        refreshJob?.cancel()
-        refreshJob = null
-        refreshAtWallClockMs = null
-        refreshTimerFired = false
-        cancelConnectivityWaitJob()
-        refreshGeneration.incrementAndGet()
-        // Advance profileGeneration so any pending clearTokenState(expectedGeneration) from a
-        // prior resetProfile() sees the generation mismatch and skips, preserving this new
-        // session's token state.
-        profileGeneration.incrementAndGet()
-        // Clear the reset-pending flag: the new provider supersedes any in-progress logout reset.
-        profileResetPending = false
-        cachedToken = null
-        this.provider = provider
+        synchronized(stateLock) {
+            cancelInFlightFetchLocked()
+            cancelRefreshLocked()
+            cancelConnectivityWaitLocked()
+            state.profileGeneration++
+            state.profileResetPending = false
+            state.cachedToken = null
+            state.provider = provider
+        }
         Registry.log.info("AuthTokenProvider registered")
         scope.safeLaunch { tryEagerFetch() }
     }
 
     override fun unregisterProvider() {
-        // Fast path: nothing to do if no provider is registered.
-        if (provider == null) return
-        // Null the provider FIRST — before cancelling the in-flight fetch — so that any concurrent
-        // getOrFetchToken() path that races past the `if (provider == null)` guard lands in
-        // invokeProvider() and immediately receives NoProviderRegistered, rather than starting a
-        // fresh acquisition against the now-unregistered provider. This differs from
-        // registerProvider, where the new provider is set last (after teardown cancels the old
-        // fetch); here there is no replacement provider, so the guard must close as early as
-        // possible. All @Volatile writes below are safe without the mutex for the same reason as
-        // registerProvider: they only need to be visible, not read-modify-written atomically.
-        provider = null
-        inFlightFetch?.cancel()
-        inFlightFetch = null
-        refreshJob?.cancel()
-        refreshJob = null
-        refreshAtWallClockMs = null
-        refreshTimerFired = false
-        cancelConnectivityWaitJob()
-        refreshGeneration.incrementAndGet()
-        // Advance profileGeneration so any pending clearTokenState(expectedGeneration) from a
-        // prior resetProfile() sees the generation mismatch and skips — the state was already
-        // cleared here.
-        profileGeneration.incrementAndGet()
-        // Bump resetGeneration to signal a logout-like event: any performScheduledRefresh that
-        // was in-flight when this ran will see a generation mismatch in shouldArmConnectivityRetry
-        // and skip arming a connectivity retry for the now-cleared session.
-        resetGeneration.incrementAndGet()
-        // Null the cache BEFORE clearing profileResetPending. An in-flight doFetch() that has
-        // already fetched its token checks `cachedToken?.rawToken == token.rawToken &&
-        // !profileResetPending` before notifying observers. If invalidate() was called just before
-        // unregister (typical logout: resetProfile → unregisterAuthTokenProvider), profileResetPending
-        // is true — the suppression flag. Clearing it before nulling the cache opens a window where
-        // the in-flight fetch passes both guards and delivers a now-invalid JWT to observers.
-        // Nulling the cache first closes that window: the rawToken comparison fails (null != token),
-        // so the notify path is skipped regardless of profileResetPending. This matches the ordering
-        // in clearTokenState(), which also nulls cachedToken before clearing profileResetPending.
-        cachedToken = null
-        profileResetPending = false
-        Registry.log.info("AuthTokenProvider unregistered")
+        val didUnregister = synchronized(stateLock) {
+            if (state.provider == null) return@synchronized false
+            state.provider = null
+            state.profileGeneration++
+            state.resetGeneration++
+            cancelInFlightFetchLocked()
+            cancelRefreshLocked()
+            cancelConnectivityWaitLocked()
+            state.cachedToken = null
+            state.profileResetPending = false
+            true
+        }
+        if (didUnregister) Registry.log.info("AuthTokenProvider unregistered")
     }
 
     override fun onTokenRefresh(observer: TokenRefreshObserver) {
-        refreshObservers.add(observer)
+        synchronized(stateLock) { state.refreshObservers.add(observer) }
     }
 
     override fun offTokenRefresh(observer: TokenRefreshObserver) {
-        refreshObservers.remove(observer)
+        synchronized(stateLock) { state.refreshObservers.remove(observer) }
     }
 
-    override fun invalidate(): Long {
-        // Set the flag before bumping the generation so that any performScheduledRefresh that
-        // reads the flag after this call (regardless of when its fetch started) will skip observers.
-        profileResetPending = true
-        // Also bump resetGeneration so shouldArmConnectivityRetry can detect a logout-triggered
-        // failure even after clearTokenState() has cleared profileResetPending.
-        resetGeneration.incrementAndGet()
-        return profileGeneration.incrementAndGet()
+    override fun invalidate(): Long = synchronized(stateLock) {
+        state.profileResetPending = true
+        state.profileGeneration++
+        state.resetGeneration++
+        state.profileGeneration
     }
 
     override suspend fun clearTokenState(expectedGeneration: Long) {
-        var cleared = false
-        mutex.withLock {
-            // If the caller captured a generation via invalidate() and a new provider has since
-            // been registered (profileGeneration advanced), skip the clear to avoid wiping the
-            // new session's token cache and refresh schedule.
-            if (expectedGeneration >= 0L && profileGeneration.get() != expectedGeneration) {
+        val cleared = synchronized(stateLock) {
+            if (expectedGeneration >= 0L && state.profileGeneration != expectedGeneration) {
                 Registry.log.verbose(
                     "clearTokenState: skipped — provider re-registered since reset"
                 )
-                return@withLock
+                return@synchronized false
             }
-            inFlightFetch?.cancel()
-            inFlightFetch = null
-            refreshJob?.cancel()
-            refreshJob = null
-            refreshAtWallClockMs = null
-            refreshTimerFired = false
-            refreshGeneration.incrementAndGet()
-            cancelConnectivityWaitJob()
-            cachedToken = null
-            profileGeneration.incrementAndGet()
-            // Also advance resetGeneration so that any performScheduledRefresh that started before
-            // this clear cannot arm a zombie connectivity job even when profileResetPending has been
-            // cleared by the time its catch block executes.
-            resetGeneration.incrementAndGet()
-            // Clear the reset-pending flag so the next successful refresh (from a new or retained
-            // provider) can notify observers normally.
-            profileResetPending = false
-            cleared = true
+            cancelInFlightFetchLocked()
+            cancelRefreshLocked()
+            cancelConnectivityWaitLocked()
+            state.cachedToken = null
+            state.profileGeneration++
+            state.resetGeneration++
+            state.profileResetPending = false
+            true
         }
         if (cleared) Registry.log.info("Token state cleared")
     }
+
+    override suspend fun currentToken(timeoutMs: Long): ValidatedToken =
+        getOrFetchToken(timeoutMs = timeoutMs, allowCachedToken = true)
 
     private suspend fun tryEagerFetch() {
         try {
             currentToken(AuthTokenManager.BACKGROUND_FETCH_TIMEOUT_MS)
         } catch (e: CancellationException) {
-            // Preserve structured concurrency by rethrowing cancellation.
             throw e
         } catch (_: Exception) {
-            // The failure is already logged at ERROR by validateOrThrow, by the timeout path, or
-            // surfaced by the provider's own onFailure. Nothing more to log here.
+            // Validation and timeout paths already log. Provider failures remain caller-owned.
         }
     }
 
-    override suspend fun currentToken(timeoutMs: Long): ValidatedToken {
-        return getOrFetchToken(timeoutMs = timeoutMs, allowCachedToken = true)
-    }
-
     /**
-     * Shared implementation behind [currentToken]. Split out so the
-     * `allowCachedToken` knob stays off the public [AuthTokenManager] interface —
-     * external callers always get the cache-honoring behavior.
-     *
-     * @param allowCachedToken When `true` (the [currentToken] path), a still-valid
-     *   cached token short-circuits both the optimistic pre-lock read and the
-     *   double-checked read under the mutex. When `false`, both reads are skipped
-     *   and the call always resolves through the in-flight fetch, forcing a fresh
-     *   provider invocation even if the cache is currently valid.
-     *
-     *   Only the proactive-refresh path ([performScheduledRefresh]) passes `false`:
-     *   a refresh fires *because* the cached token is aging, so returning that
-     *   still-valid token would make the refresh a no-op. Note this only bypasses
-     *   the *read* — dedup still applies (a concurrent fetch is joined, not
-     *   duplicated, via [inFlightFetch]), and the existing cache is left intact so
-     *   demand callers keep getting the valid token while the refresh runs.
+     * Resolves cache hits and fetch deduplication through the serialized [state]. A shared fetch
+     * reports a value outcome instead of cancelling its result deferred, so a provider replacement
+     * can be distinguished from a provider that deliberately reports [CancellationException].
      */
     private suspend fun getOrFetchToken(
         timeoutMs: Long,
         allowCachedToken: Boolean
     ): ValidatedToken {
         require(timeoutMs > 0L) { "timeoutMs must be positive, but was $timeoutMs" }
-        if (provider == null) throw AuthTokenException.NoProviderRegistered
 
-        if (allowCachedToken) {
-            // Optimistic read of @Volatile fields — no lock needed for the fast path.
-            // Skip the cache while a profile reset is pending: invalidate() has fired but
-            // clearTokenState() hasn't run yet, so cachedToken still holds the outgoing JWT.
-            usableCachedToken(cachedToken)?.let { return it }
-        }
-
-        // Atomic read-or-create of the in-flight deferred. The mutex ensures exactly one
-        // scope.async { } is launched when multiple callers miss the cache simultaneously.
-        val deferred: Deferred<ValidatedToken> = mutex.withLock {
-            // Re-check under the lock; a concurrent caller may have populated the cache while
-            // we waited. Non-local return exits getOrFetchToken() directly.
-            if (allowCachedToken) usableCachedToken(cachedToken)?.let { return it }
-
-            inFlightFetch ?: scope.async { doFetch() }.also { d ->
-                inFlightFetch = d
-                // Reference-identity check: prevents a stale deferred's completion handler from
-                // clearing a freshly-created deferred after a concurrent provider swap.
-                d.invokeOnCompletion { if (inFlightFetch === d) inFlightFetch = null }
+        val token = withTimeoutOrNull(timeoutMs) {
+            while (true) {
+                when (val request = tokenRequest(allowCachedToken)) {
+                    is TokenRequest.Cached -> return@withTimeoutOrNull request.token
+                    is TokenRequest.Fetch -> when (val outcome = request.outcome.await()) {
+                        is FetchOutcome.Success -> return@withTimeoutOrNull outcome.token
+                        is FetchOutcome.Failure -> throw outcome.error
+                        FetchOutcome.Superseded -> continue
+                    }
+                }
             }
+            @Suppress("UNREACHABLE_CODE")
+            error("Token request loop terminated unexpectedly")
         }
 
-        // Each caller races its own timeout budget against the shared deferred. Timing out does
-        // NOT cancel the underlying task — other callers with a larger budget still benefit if
-        // the provider eventually responds.
-        //
-        // CancellationException handling: Deferred.await() throws CancellationException if the
-        // deferred is cancelled externally (e.g. by registerProvider swapping the provider). This
-        // would otherwise propagate to callers as if THEIR coroutine was cancelled, which breaks
-        // structured-concurrency semantics. We catch it, use ensureActive() to distinguish "our
-        // coroutine was cancelled" (rethrow — normal teardown) from "the deferred was cancelled
-        // by a provider swap" (retry — pick up the new provider's fetch transparently).
-        //
-        // Budget: the retry calls currentToken(timeoutMs) inside this same withTimeoutOrNull block,
-        // so the caller's original deadline governs the total wait end-to-end. The recursive call
-        // creates a fresh inner withTimeoutOrNull(timeoutMs) starting from the current time, but
-        // the outer one fires first if the budget is nearly exhausted. This is intentional — the
-        // caller asked for a response within timeoutMs of their call site, not of the swap.
-        return withTimeoutOrNull(timeoutMs) {
-            try {
-                deferred.await()
-            } catch (e: CancellationException) {
-                currentCoroutineContext().ensureActive()
-                getOrFetchToken(timeoutMs = timeoutMs, allowCachedToken = allowCachedToken)
+        if (token != null) return token
+        val error = AuthTokenException.TimedOut
+        Registry.log.warning(requireNotNull(error.message), error)
+        throw error
+    }
+
+    private fun tokenRequest(allowCachedToken: Boolean): TokenRequest {
+        var fetchToStart: InFlightFetch? = null
+        val request = synchronized(stateLock) {
+            val provider = state.provider ?: throw AuthTokenException.NoProviderRegistered
+            if (allowCachedToken) {
+                usableCachedTokenLocked()?.let { return@synchronized TokenRequest.Cached(it) }
             }
-        } ?: run {
-            val error = AuthTokenException.TimedOut
-            Registry.log.warning(requireNotNull(error.message), error)
-            throw error
+            val inFlight = state.inFlightFetch ?: createFetchLocked(provider).also {
+                state.inFlightFetch = it
+                fetchToStart = it
+            }
+            TokenRequest.Fetch(inFlight.outcome)
         }
+        // Start only after publishing the slot and releasing stateLock. This remains safe if a
+        // concurrent lifecycle transition retires the lazy job before start() is reached.
+        fetchToStart?.job?.start()
+        return request
     }
 
     /**
-     * Invoke the provider, validate the returned JWT, write to the cache, notify refresh
-     * observers, and return the token. Runs inside [scope].async so failures (provider error,
-     * validation error) are captured by the Deferred and re-thrown to all awaiting callers.
-     *
-     * Every token acquisition funnels through here — the initial demand fetch as well as a
-     * proactive refresh — so notifying observers here (rather than only from
-     * [performScheduledRefresh]) guarantees consumers such as the forms WebView pick up a token
-     * that resolves *after* their own interactive-timeout fetch already gave up. Fetch dedup means
-     * a single [doFetch] shared by multiple callers still notifies exactly once.
+     * Creates the shared fetch slot before starting its coroutine. A synchronous host callback can
+     * therefore never complete before [state.inFlightFetch] contains the matching fetch identity.
      */
-    private suspend fun doFetch(): ValidatedToken {
-        val jwt = invokeProvider()
-        val token = validateOrThrow(jwt)
-        // Non-suspending cancellation check: if this deferred was cancelled (e.g. by a provider
-        // swap) after invokeProvider() returned but before we write the cache, bail out now.
-        // mutex.withLock does NOT check cancellation when the lock is uncontended, so this guard
-        // is required even when the mutex is free.
-        currentCoroutineContext().ensureActive()
-        mutex.withLock {
-            cachedToken = token
-            scheduleRefresh(token)
-        }
-        Registry.log.info(
-            "Auth token acquired (exp=${token.expiresAtEpochSeconds}, iat=${token.issuedAtEpochSeconds})"
-        )
-        // Notify observers of the freshly acquired token, outside the mutex — an observer may
-        // re-enter the manager and the lock is non-reentrant. Two-part stale guard (both @Volatile
-        // reads):
-        // 1. Cache check: clearTokenState() may have nulled cachedToken while the fetch was
-        //    suspended; skip if this token is no longer the live value.
-        // 2. Reset-pending check: invalidate() sets profileResetPending synchronously (from
-        //    resetProfile()) before the async clearTokenState() runs. A fetch that completes while
-        //    a logout reset is pending must not broadcast to observers, regardless of whether it
-        //    started before or after invalidate(). The flag is cleared by clearTokenState() and
-        //    registerProvider(). Dispatch is best-effort; the small TOCTOU window on these volatile
-        //    reads is acceptable (see notifyRefreshObservers KDoc).
-        if (cachedToken?.rawToken == token.rawToken && !profileResetPending) {
-            notifyRefreshObservers(token.rawToken)
-        }
-        return token
-    }
-
-    private suspend fun invokeProvider(): String = suspendCancellableCoroutine { continuation ->
-        val callback = object : AuthTokenProvider.Callback {
-            override fun onSuccess(jwt: String) {
-                if (continuation.isActive) continuation.resume(jwt)
+    private fun createFetchLocked(provider: AuthTokenProvider): InFlightFetch {
+        val fetchId = ++state.nextFetchId
+        val profileGeneration = state.profileGeneration
+        val outcome = CompletableDeferred<FetchOutcome>()
+        val job = scope.safeLaunch(start = CoroutineStart.LAZY) {
+            val result = try {
+                val jwt = invokeProvider(provider)
+                FetchOutcome.Success(validateOrThrow(jwt))
+            } catch (e: CancellationException) {
+                if (!currentCoroutineContext().isActive) return@safeLaunch
+                FetchOutcome.Failure(e)
+            } catch (e: Throwable) {
+                FetchOutcome.Failure(e)
             }
-
-            override fun onFailure(error: Throwable) {
-                if (continuation.isActive) continuation.resumeWithException(error)
-            }
+            completeFetch(fetchId, profileGeneration, result)
         }
-        provider?.fetchToken(callback) ?: continuation.resumeWithException(
-            AuthTokenException.NoProviderRegistered
+        return InFlightFetch(
+            id = fetchId,
+            profileGeneration = profileGeneration,
+            outcome = outcome,
+            job = job
         )
     }
+
+    /**
+     * Commits a provider result only when both the fetch identity and profile generation still
+     * match. Provider replacement, unregister, and clear synchronously retire the slot. Invalidate
+     * advances the generation so its late result may satisfy the original waiter but cannot cache
+     * or publish a stale JWT.
+     */
+    private fun completeFetch(
+        fetchId: Long,
+        profileGeneration: Long,
+        result: FetchOutcome
+    ) {
+        synchronized(stateLock) {
+            val inFlight = state.inFlightFetch
+            if (inFlight?.id != fetchId ||
+                inFlight.profileGeneration != profileGeneration
+            ) {
+                return
+            }
+
+            if (state.profileGeneration != profileGeneration) {
+                state.inFlightFetch = null
+                // invalidate() advances the profile generation without cancelling the provider
+                // callback. Its direct waiter still receives that outcome, but the token is never
+                // committed or broadcast. Provider replacement and full clear retire the slot
+                // synchronously, so their late completions never reach this branch.
+                if (state.profileResetPending) {
+                    inFlight.outcome.complete(result)
+                } else {
+                    inFlight.outcome.complete(FetchOutcome.Superseded)
+                }
+                return
+            }
+
+            state.inFlightFetch = null
+            when (result) {
+                is FetchOutcome.Failure -> inFlight.outcome.complete(result)
+                FetchOutcome.Superseded -> inFlight.outcome.complete(FetchOutcome.Superseded)
+                is FetchOutcome.Success -> {
+                    // Fetches started while reset is pending may satisfy their direct caller, but
+                    // cannot become shared state or publish to observers.
+                    if (state.profileResetPending) {
+                        inFlight.outcome.complete(result)
+                        return
+                    }
+
+                    state.cachedToken = result.token
+                    scheduleRefreshLocked(result.token)
+                    inFlight.outcome.complete(result)
+                    Registry.log.info(
+                        "Auth token acquired " +
+                            "(exp=${result.token.expiresAtEpochSeconds}, " +
+                            "iat=${result.token.issuedAtEpochSeconds})"
+                    )
+                    notifyRefreshObserversLocked(result.token, profileGeneration)
+                }
+            }
+        }
+    }
+
+    private suspend fun invokeProvider(provider: AuthTokenProvider): String =
+        suspendCancellableCoroutine { continuation ->
+            val callback = object : AuthTokenProvider.Callback {
+                override fun onSuccess(jwt: String) {
+                    if (continuation.isActive) continuation.resume(jwt)
+                }
+
+                override fun onFailure(error: Throwable) {
+                    if (continuation.isActive) continuation.resumeWithException(error)
+                }
+            }
+            provider.fetchToken(callback)
+        }
 
     private fun validateOrThrow(jwt: String): ValidatedToken =
         when (val result = JWTParser.parseAndValidate(jwt)) {
@@ -411,81 +291,66 @@ internal class KlaviyoAuthTokenManager(
             }
         }
 
-    /**
-     * Returns [token] if it is non-null, still valid per [isStillValid], and no profile reset is
-     * pending; otherwise returns `null`. Centralizes the cache-eligibility gate used in both the
-     * optimistic pre-lock read and the mutex-protected double-check inside [getOrFetchToken].
-     */
-    private fun usableCachedToken(token: ValidatedToken?): ValidatedToken? =
-        if (token != null && isStillValid(token) && !profileResetPending) token else null
+    private fun usableCachedTokenLocked(): ValidatedToken? = state.cachedToken?.takeIf {
+        isStillValid(it) && !state.profileResetPending
+    }
 
     private fun isStillValid(token: ValidatedToken): Boolean {
         val now = Registry.clock.currentTimeMillis() / 1000L
         return now < token.expiresAtEpochSeconds - JWTParser.DEFAULT_LEEWAY_SECONDS
     }
 
-    /**
-     * Called under mutex (from [doFetch]). Non-suspending; safe inside withLock.
-     */
-    private fun scheduleRefresh(token: ValidatedToken) {
+    private fun cancelInFlightFetchLocked() {
+        val inFlight = state.inFlightFetch ?: return
+        state.inFlightFetch = null
+        inFlight.outcome.complete(FetchOutcome.Superseded)
+        inFlight.job.cancel()
+    }
+
+    private fun cancelRefreshLocked() {
+        state.refreshGeneration++
+        state.refreshJob?.cancel()
+        state.refreshJob = null
+        state.refreshAtWallClockMs = null
+        state.refreshTimerFired = false
+    }
+
+    private fun scheduleRefreshLocked(token: ValidatedToken) {
         val nowMs = Registry.clock.currentTimeMillis()
         val targetMs = computeRefreshTarget(token, nowMs)
-        // Bump the generation before cancelling so that if cancel() synchronously fires the old
-        // task (e.g. FireOnCancelClock in tests), the task sees a stale generation and self-aborts.
-        val generation = refreshGeneration.incrementAndGet()
-        refreshJob?.cancel()
-        refreshTimerFired = false
-        refreshAtWallClockMs = targetMs
-        refreshJob = Registry.clock.schedule((targetMs - nowMs).coerceAtLeast(0)) {
-            scope.safeLaunch {
-                if (markRefreshTimerFired(generation)) {
-                    performScheduledRefresh(generation)
-                }
-            }
+        val generation = ++state.refreshGeneration
+        state.refreshJob?.cancel()
+        state.refreshTimerFired = false
+        state.refreshAtWallClockMs = targetMs
+        state.refreshJob = Registry.clock.schedule((targetMs - nowMs).coerceAtLeast(0L)) {
+            onRefreshTimer(generation)
         }
         Registry.log.info(
             "Proactive token refresh scheduled (target=${Registry.clock.isoTime(targetMs)})"
         )
     }
 
-    private suspend fun markRefreshTimerFired(generation: Long): Boolean =
-        mutex.withLock {
-            if (refreshGeneration.get() != generation) return@withLock false
-            refreshTimerFired = true
+    private fun onRefreshTimer(generation: Long) {
+        val shouldRefresh = synchronized(stateLock) {
+            if (state.refreshGeneration != generation) return@synchronized false
+            state.refreshTimerFired = true
             true
         }
+        if (shouldRefresh) {
+            scope.safeLaunch { performScheduledRefresh(timerGeneration = generation) }
+        }
+    }
 
-    /**
-     * Forces a fresh provider invocation and routes through the standard dedup + timeout path.
-     * Leaves the existing cache intact so callers can keep using it while refresh is in-flight,
-     * even if the refresh attempt fails; any concurrent caller that arrives while refresh is
-     * in-flight shares the single in-flight Deferred automatically.
-     *
-     * On success, registered [TokenRefreshObserver]s are notified with the new JWT from within
-     * [doFetch] (the shared acquisition path this call resolves through), under its stale guard —
-     * so notification is not repeated here.
-     *
-     * Logs at WARNING on failure — the still-valid cached token remains for live consumers.
-     * On failure does NOT reschedule; one foreground-transition retry is possible if
-     * [refreshAtWallClockMs] was not yet cleared (timer fired but fetch failed).
-     */
     private suspend fun performScheduledRefresh(
         timerGeneration: Long? = null,
         allowImmediateConnectivityRetry: Boolean = true
     ) {
-        // Snapshot the reset generation before suspending into the network fetch. If a logout or
-        // token-state clear (invalidate / clearTokenState) fires while the fetch is in progress,
-        // the catch block must not arm a connectivity retry for the now-stale session. We use
-        // resetGeneration rather than profileGeneration so that a benign provider swap
-        // (registerProvider without a logout) does not falsely suppress the retry for the new
-        // session — registerProvider does not bump resetGeneration.
-        val resetGenerationAtStart = resetGeneration.get()
-        if (provider == null) return
+        val resetGenerationAtStart = synchronized(stateLock) {
+            if (state.provider == null) return
+            state.resetGeneration
+        }
         Registry.log.info("Proactive token refresh fired")
         try {
-            // allowCachedToken = false always resolves through a doFetch (a fresh one, or a shared
-            // in-flight one), which broadcasts the refreshed token to observers under its stale
-            // guard — so there is no separate notify step here.
             getOrFetchToken(
                 timeoutMs = AuthTokenManager.BACKGROUND_FETCH_TIMEOUT_MS,
                 allowCachedToken = false
@@ -496,7 +361,13 @@ internal class KlaviyoAuthTokenManager(
         } catch (e: Exception) {
             if (timerGeneration != null) clearFiredFlagForFailedRefresh(timerGeneration)
             Registry.log.warning("Proactive token refresh failed: ${e.javaClass.simpleName}", e)
-            if (shouldArmConnectivityRetry(e, resetGenerationAtStart)) {
+            val shouldWait = synchronized(stateLock) {
+                state.resetGeneration == resetGenerationAtStart &&
+                    isNetworkException(e) &&
+                    state.provider != null &&
+                    !state.profileResetPending
+            }
+            if (shouldWait) {
                 armConnectivityWaitJob(
                     resumeImmediatelyIfConnected = allowImmediateConnectivityRetry
                 )
@@ -504,45 +375,33 @@ internal class KlaviyoAuthTokenManager(
         }
     }
 
-    /**
-     * Returns true when a proactive-refresh failure should trigger a connectivity wait job.
-     *
-     * All four conditions must hold:
-     * - [resetGeneration] matches [resetGenerationAtStart]: no logout or state-clear
-     *   (invalidate / clearTokenState) occurred while the refresh was suspended. We use
-     *   [resetGeneration] rather than [profileGeneration] so that a benign provider swap
-     *   (registerProvider without a logout) does not falsely suppress retry — registerProvider
-     *   does not bump [resetGeneration].
-     * - The exception is a transient network error ([isNetworkException]): server errors and
-     *   validation failures should not trigger a connectivity retry.
-     * - [provider] is still set: a concurrent teardown may have cleared it.
-     * - No profile reset is pending ([profileResetPending]): guards against the window between
-     *   invalidate() and clearTokenState() where the flag is still true.
-     */
-    private fun shouldArmConnectivityRetry(
-        exception: Exception,
-        resetGenerationAtStart: Long
-    ): Boolean =
-        resetGeneration.get() == resetGenerationAtStart &&
-            isNetworkException(exception) &&
-            provider != null &&
-            !profileResetPending
+    private fun clearFiredFlagForFailedRefresh(timerGeneration: Long) {
+        synchronized(stateLock) {
+            if (state.refreshGeneration == timerGeneration) {
+                state.refreshTimerFired = false
+            }
+        }
+    }
 
     /**
-     * Iterates [refreshObservers] and invokes each with [jwt]. Best-effort: if an observer throws,
-     * the exception is logged at WARNING and the remaining observers are still called.
+     * Observer delivery is part of the same serialized transition as the cache commit. Because a
+     * JVM monitor is reentrant, an observer may call a synchronous manager API without deadlocking;
+     * the generation guard is re-checked before each remaining callback in case it does so.
      */
-    private fun notifyRefreshObservers(jwt: String) {
-        refreshObservers.forEach { observer ->
+    private fun notifyRefreshObserversLocked(token: ValidatedToken, profileGeneration: Long) {
+        val observers = state.refreshObservers.toList()
+        observers.forEach { observer ->
+            if (state.profileGeneration != profileGeneration ||
+                state.profileResetPending ||
+                state.cachedToken?.rawToken != token.rawToken
+            ) {
+                return
+            }
             try {
-                observer(jwt)
+                observer(token.rawToken)
             } catch (e: CancellationException) {
-                // Structured-concurrency contract: CancellationException must never be swallowed.
                 throw e
             } catch (e: Exception) {
-                // Best-effort dispatch: log and continue so a misbehaving observer cannot block
-                // others from receiving the token. JVM-fatal Errors (OOM, StackOverflowError, etc.)
-                // are intentionally NOT caught here — they should propagate.
                 Registry.log.warning(
                     "TokenRefreshObserver threw ${e.javaClass.simpleName} — skipping",
                     e
@@ -551,114 +410,78 @@ internal class KlaviyoAuthTokenManager(
         }
     }
 
-    private suspend fun clearFiredFlagForFailedRefresh(timerGeneration: Long) {
-        mutex.withLock {
-            if (refreshGeneration.get() == timerGeneration) {
-                refreshTimerFired = false
-            }
-        }
-    }
-
-    /**
-     * Returns `true` for exceptions that indicate genuine offline conditions.
-     * [UnknownHostException], [SocketTimeoutException], and [ConnectException] are all subtypes of
-     * [IOException]; they are listed explicitly to document the specific failure modes that warrant
-     * a connectivity-driven retry. HTTP errors, validation failures, and server-side bugs return
-     * `false` and must not trigger a connectivity retry (they won't resolve by waiting for the
-     * network).
-     */
     private fun isNetworkException(e: Exception): Boolean =
         e is UnknownHostException ||
             e is SocketTimeoutException ||
             e is ConnectException ||
             e is IOException
 
-    /**
-     * Arms [connectivityWaitJob]: a single coroutine on [scope] that suspends until the next
-     * "connectivity available" notification from [Registry.networkMonitor], then triggers a
-     * proactive refresh via [performScheduledRefresh].
-     *
-     * At most one job is active at a time. All [connectivityWaitJob] and
-     * [connectivityWaitGeneration] transitions are serialized via [connectivityWaitLock] so that
-     * concurrent calls (rapid flap) and racing teardown from [registerProvider]/[clearTokenState]
-     * cannot leave multiple active jobs or a stale assignment.
-     *
-     * @param resumeImmediatelyIfConnected When true (the default), the job resumes immediately if
-     * the device is already connected — [Registry.networkMonitor] does not replay state on observer
-     * registration. Pass false from the connectivity-retry path to prevent a tight loop: if the
-     * provider keeps failing with a network exception while the device stays online, a re-armed job
-     * with [resumeImmediatelyIfConnected]=false waits for an actual connectivity transition before
-     * retrying again.
-     *
-     * Only invoked from the proactive-refresh failure path ([performScheduledRefresh]); demand
-     * callers via [currentToken] are not retried here — they surface the error to their own caller.
-     */
     private fun armConnectivityWaitJob(resumeImmediatelyIfConnected: Boolean = true) {
         Registry.log.info(
             "AuthTokenManager: network failure — waiting for connectivity to retry refresh"
         )
-        // Serialize cancel → generation increment → launch → assign under one lock so that
-        // concurrent calls to armConnectivityWaitJob() and racing registerProvider()/
-        // clearTokenState() cannot produce multiple active jobs or a stale null-out.
-        val waitGeneration: Long
-        synchronized(connectivityWaitLock) {
-            connectivityWaitJob?.cancel()
-            waitGeneration = connectivityWaitGeneration.incrementAndGet()
-            connectivityWaitJob = scope.safeLaunch {
+        val waitJob = synchronized(stateLock) {
+            cancelConnectivityWaitLocked()
+            val generation = state.connectivityWaitGeneration
+            val job = scope.safeLaunch(start = CoroutineStart.LAZY) {
                 try {
-                    suspendCancellableCoroutine { continuation ->
-                        val resumed = AtomicBoolean(false)
-                        // Use a ref box so the lambda can capture and de-register itself.
-                        val observerRef = arrayOfNulls<NetworkObserver>(1)
-                        val observer: NetworkObserver = { isConnected ->
-                            // One-shot guard: AtomicBoolean ensures exactly one connectivity
-                            // event (including the immediate check below) resumes the coroutine.
-                            if (isConnected && resumed.compareAndSet(false, true)) {
-                                observerRef[0]?.let { Registry.networkMonitor.offNetworkChange(it) }
-                                if (continuation.isActive) continuation.resume(Unit)
-                            }
-                        }
-                        observerRef[0] = observer
-                        Registry.networkMonitor.onNetworkChange(observer)
-                        // Install cancellation handler AFTER registration so the handler can
-                        // never try to remove an observer that hasn't been registered yet.
-                        continuation.invokeOnCancellation {
-                            Registry.networkMonitor.offNetworkChange(observer)
-                        }
-                        // Resume immediately if already online — networkMonitor does not replay
-                        // state on registration (handles SocketTimeoutException on live network).
-                        // Skip on re-arm (resumeImmediatelyIfConnected=false) to prevent a tight
-                        // loop when the provider keeps failing with IOException while the device
-                        // stays connected; in that case we wait for an actual connectivity event.
-                        if (resumeImmediatelyIfConnected &&
-                            Registry.networkMonitor.isNetworkConnected() &&
-                            resumed.compareAndSet(false, true)
-                        ) {
-                            Registry.networkMonitor.offNetworkChange(observer)
-                            if (continuation.isActive) continuation.resume(Unit)
-                        }
-                    }
+                    awaitConnectivity(resumeImmediatelyIfConnected)
                     Registry.log.info(
                         "AuthTokenManager: connectivity restored — retrying proactive refresh"
                     )
-                    // Cancellation checkpoint: registerProvider()/clearTokenState() may have
-                    // cancelled this job after the connectivity event fired but before we retry.
                     currentCoroutineContext().ensureActive()
-                    // Pass allowImmediateConnectivityRetry=false so that if this retry also fails
-                    // with a network exception, the re-armed job will NOT immediately resume on an
-                    // already-connected device — avoiding a tight retry loop.
-                    performScheduledRefresh(allowImmediateConnectivityRetry = false)
+                    val isCurrent = synchronized(stateLock) {
+                        state.connectivityWait?.generation == generation
+                    }
+                    if (isCurrent) {
+                        performScheduledRefresh(allowImmediateConnectivityRetry = false)
+                    }
                 } finally {
-                    // Only clear the field if the generation still matches — a concurrent
-                    // re-arm may have replaced this job; if so leave the new job in place.
-                    synchronized(connectivityWaitLock) {
-                        if (connectivityWaitGeneration.get() == waitGeneration) {
-                            connectivityWaitJob = null
+                    synchronized(stateLock) {
+                        if (state.connectivityWait?.generation == generation) {
+                            state.connectivityWait = null
                         }
                     }
                 }
             }
+            state.connectivityWait = ConnectivityWait(generation, job)
+            job
         }
+        // Register the generation-tagged slot before starting work, but never invoke the network
+        // monitor while holding stateLock (including with an unconfined test dispatcher).
+        waitJob.start()
+    }
+
+    private suspend fun awaitConnectivity(resumeImmediatelyIfConnected: Boolean) {
+        suspendCancellableCoroutine<Unit> { continuation ->
+            val resumed = AtomicBoolean(false)
+            val observerRef = arrayOfNulls<NetworkObserver>(1)
+            val observer: NetworkObserver = { isConnected ->
+                if (isConnected && resumed.compareAndSet(false, true)) {
+                    observerRef[0]?.let { Registry.networkMonitor.offNetworkChange(it) }
+                    if (continuation.isActive) continuation.resume(Unit)
+                }
+            }
+            observerRef[0] = observer
+            Registry.networkMonitor.onNetworkChange(observer)
+            continuation.invokeOnCancellation {
+                Registry.networkMonitor.offNetworkChange(observer)
+            }
+            if (resumeImmediatelyIfConnected &&
+                Registry.networkMonitor.isNetworkConnected() &&
+                resumed.compareAndSet(false, true)
+            ) {
+                Registry.networkMonitor.offNetworkChange(observer)
+                if (continuation.isActive) continuation.resume(Unit)
+            }
+        }
+    }
+
+    private fun cancelConnectivityWaitLocked() {
+        val job = state.connectivityWait?.job
+        state.connectivityWaitGeneration++
+        state.connectivityWait = null
+        job?.cancel()
     }
 
     private fun onLifecycleEvent(event: ActivityEvent) {
@@ -666,59 +489,95 @@ internal class KlaviyoAuthTokenManager(
         scope.safeLaunch { handleForegroundTransition() }
     }
 
-    /**
-     * Reconciles cache and scheduled-refresh state on foreground transition.
-     * [safeLaunch] is non-suspending, so the mutex is released before any launched
-     * coroutine runs — no re-entrancy risk with [currentToken]'s own withLock call.
-     *
-     * Case 1 uses [tryEagerFetch] (`allowCachedToken = true`) because [cachedToken] is explicitly
-     * nulled before the launch, guaranteeing a cache miss without needing to bypass the cache.
-     * Case 2 uses [performScheduledRefresh] (`allowCachedToken = false`) because the cached token
-     * is still valid and must NOT be returned — we need a fresh provider call despite the hit.
-     */
-    private suspend fun handleForegroundTransition() {
+    private fun handleForegroundTransition() {
         val nowMs = Registry.clock.currentTimeMillis()
-        mutex.withLock {
-            val cached = cachedToken
-            val targetMs = refreshAtWallClockMs
+        val action = synchronized(stateLock) {
+            val cached = state.cachedToken
+            val targetMs = state.refreshAtWallClockMs
             when {
                 cached != null && !isStillValid(cached) -> {
-                    cachedToken = null
-                    refreshJob?.cancel()
-                    refreshJob = null
-                    refreshAtWallClockMs = null
-                    refreshTimerFired = false
-                    refreshGeneration.incrementAndGet()
-                    Registry.log.info(
-                        "AuthTokenManager: foreground transition (case=expired-cached-token)"
-                    )
-                    scope.safeLaunch { tryEagerFetch() }
+                    state.cachedToken = null
+                    cancelRefreshLocked()
+                    ForegroundAction.EagerFetch
                 }
-                targetMs != null && nowMs >= targetMs && !refreshTimerFired -> {
-                    refreshJob?.cancel()
-                    refreshJob = null
-                    refreshAtWallClockMs = null
-                    refreshTimerFired = false
-                    refreshGeneration.incrementAndGet()
-                    Registry.log.info(
-                        "AuthTokenManager: foreground transition (case=missed-refresh)"
-                    )
-                    scope.safeLaunch { performScheduledRefresh() }
+                targetMs != null && nowMs >= targetMs && !state.refreshTimerFired -> {
+                    cancelRefreshLocked()
+                    ForegroundAction.ScheduledRefresh
                 }
-                else -> Registry.log.info(
-                    "AuthTokenManager: foreground transition (case=still-valid)"
-                )
+                else -> ForegroundAction.None
             }
         }
+
+        when (action) {
+            ForegroundAction.EagerFetch -> {
+                Registry.log.info(
+                    "AuthTokenManager: foreground transition (case=expired-cached-token)"
+                )
+                scope.safeLaunch { tryEagerFetch() }
+            }
+            ForegroundAction.ScheduledRefresh -> {
+                Registry.log.info(
+                    "AuthTokenManager: foreground transition (case=missed-refresh)"
+                )
+                scope.safeLaunch { performScheduledRefresh() }
+            }
+            ForegroundAction.None -> Registry.log.info(
+                "AuthTokenManager: foreground transition (case=still-valid)"
+            )
+        }
+    }
+
+    private class State {
+        var provider: AuthTokenProvider? = null
+        var cachedToken: ValidatedToken? = null
+        var inFlightFetch: InFlightFetch? = null
+        var nextFetchId: Long = 0L
+        var refreshJob: Clock.Cancellable? = null
+        var refreshAtWallClockMs: Long? = null
+        var refreshTimerFired: Boolean = false
+        var refreshGeneration: Long = 0L
+        var profileGeneration: Long = 0L
+        var resetGeneration: Long = 0L
+        var profileResetPending: Boolean = false
+        val refreshObservers = mutableListOf<TokenRefreshObserver>()
+        var connectivityWait: ConnectivityWait? = null
+        var connectivityWaitGeneration: Long = 0L
+    }
+
+    private data class InFlightFetch(
+        val id: Long,
+        val profileGeneration: Long,
+        val outcome: CompletableDeferred<FetchOutcome>,
+        val job: Job
+    )
+
+    private data class ConnectivityWait(
+        val generation: Long,
+        val job: Job
+    )
+
+    private sealed interface FetchOutcome {
+        data class Success(val token: ValidatedToken) : FetchOutcome
+        data class Failure(val error: Throwable) : FetchOutcome
+        data object Superseded : FetchOutcome
+    }
+
+    private sealed interface TokenRequest {
+        data class Cached(val token: ValidatedToken) : TokenRequest
+        data class Fetch(val outcome: CompletableDeferred<FetchOutcome>) : TokenRequest
+    }
+
+    private enum class ForegroundAction {
+        EagerFetch,
+        ScheduledRefresh,
+        None
     }
 
     companion object {
         /**
          * Computes the absolute wall-clock target (epoch ms) for the next proactive refresh.
          *
-         * Ideal: iat + 0.9 * (exp - iat). Clamped to [now + 5s, exp - leeway]:
-         * - Upper bound: refresh fires before the token is considered stale.
-         * - Lower bound: prevents tight loops for tokens issued near their own expiry.
+         * Ideal: iat + 0.9 * (exp - iat). Clamped to [now + 5s, exp - leeway].
          */
         internal fun computeRefreshTarget(token: ValidatedToken, nowMs: Long): Long {
             val iatMs = token.issuedAtEpochSeconds * 1000L

--- a/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
+++ b/sdk/core/src/main/java/com/klaviyo/core/auth/KlaviyoAuthTokenManager.kt
@@ -53,7 +53,7 @@ internal class KlaviyoAuthTokenManager(
 
     override fun registerProvider(provider: AuthTokenProvider) {
         val transition = synchronized(observerDeliveryLock) {
-            synchronized(stateLock) {
+            val lifecycleTransition = synchronized(stateLock) {
                 val cleanup = detachTokenStateLocked()
                 state.profileGeneration++
                 state.profileResetPending = false
@@ -61,8 +61,9 @@ internal class KlaviyoAuthTokenManager(
                 state.provider = provider
                 LifecycleTransition(cleanup, state.profileGeneration)
             }
+            completeCleanup(lifecycleTransition.cleanup)
+            lifecycleTransition
         }
-        completeCleanup(transition.cleanup)
         Registry.log.info("AuthTokenProvider registered")
         scope.safeLaunch {
             tryEagerFetch(RequestGuard(profileGeneration = transition.profileGeneration))
@@ -70,8 +71,8 @@ internal class KlaviyoAuthTokenManager(
     }
 
     override fun unregisterProvider() {
-        val cleanup = synchronized(observerDeliveryLock) {
-            synchronized(stateLock) state@{
+        val didUnregister = synchronized(observerDeliveryLock) {
+            val cleanup = synchronized(stateLock) state@{
                 if (state.provider == null) return@state null
                 state.provider = null
                 state.profileGeneration++
@@ -81,9 +82,11 @@ internal class KlaviyoAuthTokenManager(
                 state.profileResetPending = false
                 detached
             }
+            cleanup ?: return@synchronized false
+            completeCleanup(cleanup)
+            true
         }
-        cleanup ?: return
-        completeCleanup(cleanup)
+        if (!didUnregister) return
         Registry.log.info("AuthTokenProvider unregistered")
     }
 
@@ -109,8 +112,8 @@ internal class KlaviyoAuthTokenManager(
     }
 
     override suspend fun clearTokenState(expectedGeneration: Long) {
-        val cleanup = synchronized(observerDeliveryLock) {
-            synchronized(stateLock) state@{
+        val cleared = synchronized(observerDeliveryLock) {
+            val cleanup = synchronized(stateLock) state@{
                 if (expectedGeneration >= 0L && state.profileGeneration != expectedGeneration) {
                     return@state null
                 }
@@ -121,12 +124,14 @@ internal class KlaviyoAuthTokenManager(
                 state.profileResetPending = false
                 detached
             }
+            cleanup ?: return@synchronized false
+            completeCleanup(cleanup)
+            true
         }
-        if (cleanup == null) {
+        if (!cleared) {
             Registry.log.verbose("clearTokenState: skipped — provider re-registered since reset")
             return
         }
-        completeCleanup(cleanup)
         Registry.log.info("Token state cleared")
     }
 
@@ -166,7 +171,12 @@ internal class KlaviyoAuthTokenManager(
                 when (val request = tokenRequest(allowCachedToken, guard)) {
                     is TokenRequest.Cached -> return@withTimeoutOrNull request.token
                     is TokenRequest.Fetch -> when (val outcome = request.outcome.await()) {
-                        is FetchOutcome.Success -> return@withTimeoutOrNull outcome.token
+                        is FetchOutcome.Success -> {
+                            if (canReturnFetchResult(request.profileGeneration)) {
+                                return@withTimeoutOrNull outcome.token
+                            }
+                            continue
+                        }
                         is FetchOutcome.Failure -> throw outcome.error
                         FetchOutcome.Superseded -> continue
                     }
@@ -197,7 +207,7 @@ internal class KlaviyoAuthTokenManager(
                 state.inFlightFetch = it
                 fetchToStart = it
             }
-            TokenRequest.Fetch(inFlight.outcome)
+            TokenRequest.Fetch(inFlight.profileGeneration, inFlight.outcome)
         }
         // Start only after publishing the slot and releasing stateLock. This remains safe if a
         // concurrent lifecycle transition retires the lazy job before start() is reached.
@@ -244,7 +254,7 @@ internal class KlaviyoAuthTokenManager(
         profileGeneration: Long,
         outcome: CompletableDeferred<FetchOutcome>,
         result: FetchOutcome
-    ) {
+    ) = synchronized(observerDeliveryLock) {
         val scheduleTiming = (result as? FetchOutcome.Success)?.let {
             val nowMs = Registry.clock.currentTimeMillis()
             RefreshTiming(
@@ -252,7 +262,7 @@ internal class KlaviyoAuthTokenManager(
                 targetMs = computeRefreshTarget(it.token, nowMs)
             )
         }
-        val refreshPlan = synchronized(stateLock) {
+        val refreshPlan = synchronized(stateLock) state@{
             val inFlight = state.inFlightFetch
             if (inFlight?.id != fetchId ||
                 inFlight.profileGeneration != profileGeneration
@@ -260,14 +270,14 @@ internal class KlaviyoAuthTokenManager(
                 state.detachedFetches.removeAll {
                     it.id == fetchId && it.outcome === outcome
                 }
-                return@synchronized null
+                return@state null
             }
             state.inFlightFetch = null
             if (state.profileGeneration != profileGeneration ||
                 state.profileResetPending ||
                 result !is FetchOutcome.Success
             ) {
-                return@synchronized null
+                return@state null
             }
 
             state.cachedToken = result.token
@@ -288,6 +298,11 @@ internal class KlaviyoAuthTokenManager(
             notifyRefreshObservers(token, profileGeneration)
         }
     }
+
+    private fun canReturnFetchResult(profileGeneration: Long): Boolean =
+        synchronized(observerDeliveryLock) {
+            synchronized(stateLock) { state.profileGeneration == profileGeneration }
+        }
 
     private suspend fun invokeProvider(provider: AuthTokenProvider): String =
         suspendCancellableCoroutine { continuation ->
@@ -428,6 +443,10 @@ internal class KlaviyoAuthTokenManager(
             if (!guard.matchesLocked() || state.provider == null) return
             state.resetGeneration
         }
+        val profileGenerationAtStart = synchronized(stateLock) {
+            if (!guard.matchesLocked() || state.provider == null) return
+            state.profileGeneration
+        }
         Registry.log.info("Proactive token refresh fired")
         try {
             getOrFetchToken(
@@ -445,6 +464,7 @@ internal class KlaviyoAuthTokenManager(
             Registry.log.warning("Proactive token refresh failed: ${e.javaClass.simpleName}", e)
             if (isNetworkException(e)) {
                 armConnectivityWaitJob(
+                    expectedProfileGeneration = profileGenerationAtStart,
                     expectedResetGeneration = resetGenerationAtStart,
                     resumeImmediatelyIfConnected = allowImmediateConnectivityRetry
                 )
@@ -497,12 +517,14 @@ internal class KlaviyoAuthTokenManager(
             e is IOException
 
     private fun armConnectivityWaitJob(
+        expectedProfileGeneration: Long,
         expectedResetGeneration: Long,
         resumeImmediatelyIfConnected: Boolean = true
     ) {
         var previousJob: Job? = null
         val waitJob = synchronized(stateLock) {
-            if (state.resetGeneration != expectedResetGeneration ||
+            if (state.profileGeneration != expectedProfileGeneration ||
+                state.resetGeneration != expectedResetGeneration ||
                 state.provider == null ||
                 state.profileResetPending
             ) {
@@ -519,6 +541,7 @@ internal class KlaviyoAuthTokenManager(
                     )
                     performScheduledRefresh(
                         guard = RequestGuard(
+                            profileGeneration = expectedProfileGeneration,
                             resetGeneration = expectedResetGeneration,
                             connectivityGeneration = generation
                         ),
@@ -697,7 +720,10 @@ internal class KlaviyoAuthTokenManager(
 
     private sealed interface TokenRequest {
         data class Cached(val token: ValidatedToken) : TokenRequest
-        data class Fetch(val outcome: CompletableDeferred<FetchOutcome>) : TokenRequest
+        data class Fetch(
+            val profileGeneration: Long,
+            val outcome: CompletableDeferred<FetchOutcome>
+        ) : TokenRequest
     }
 
     private sealed interface ForegroundAction {

--- a/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerConnectivityTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerConnectivityTest.kt
@@ -566,6 +566,38 @@ class KlaviyoAuthTokenManagerConnectivityTest : BaseTest() {
     }
 
     @Test
+    fun `queued connectivity retry cannot fetch after clearTokenState returns`() = runTest(
+        dispatcher
+    ) {
+        val provider = ScriptedProvider(
+            ArrayDeque(
+                listOf(
+                    Result.success(makeJwt()),
+                    Result.failure(IOException("network down")),
+                    Result.success(makeJwt(EXP_SECONDS + 600, IAT_SECONDS + 600))
+                )
+            )
+        )
+        val manager = KlaviyoAuthTokenManager()
+        manager.registerProvider(provider)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        executeScheduledRefresh()
+        assertEquals(2, provider.callCount)
+
+        fakeNetworkMonitor.simulateConnected(isConnected = true)
+        // The connectivity continuation is queued but has not reserved its retry fetch.
+        manager.clearTokenState()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(
+            "teardown must invalidate the queued connectivity retry",
+            2,
+            provider.callCount
+        )
+    }
+
+    @Test
     fun `clearTokenState with stale generation does not cancel connectivity wait job`() = runTest(
         dispatcher
     ) {

--- a/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerConnectivityTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerConnectivityTest.kt
@@ -440,6 +440,41 @@ class KlaviyoAuthTokenManagerConnectivityTest : BaseTest() {
             assertEquals(0, fakeNetworkMonitor.observerCount())
         }
 
+    @Test
+    fun `provider replacement between failure and retry arm suppresses old retry`() = runTest(
+        dispatcher
+    ) {
+        val providerA = ScriptedProvider(
+            ArrayDeque(
+                listOf(
+                    Result.success(makeJwt()),
+                    Result.failure(IOException("old provider failed"))
+                )
+            )
+        )
+        val providerB = ScriptedProvider(
+            ArrayDeque(
+                listOf(Result.success(makeJwt(EXP_SECONDS + 600, IAT_SECONDS + 600)))
+            )
+        )
+        val manager = KlaviyoAuthTokenManager()
+        manager.registerProvider(providerA)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        every {
+            spyLog.warning(match { it.startsWith("Proactive token refresh failed") }, any())
+        } answers {
+            manager.registerProvider(providerB)
+        }
+
+        executeScheduledRefresh()
+
+        assertEquals(2, providerA.callCount)
+        assertEquals("new provider should only perform its eager fetch", 1, providerB.callCount)
+        assertNull(manager.connectivityWaitJob)
+        assertEquals(0, fakeNetworkMonitor.observerCount())
+    }
+
     // MARK: - Non-network failures do not arm the retry
 
     @Test

--- a/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerRefreshTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerRefreshTest.kt
@@ -12,6 +12,7 @@ import java.util.Base64
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.json.JSONObject
@@ -819,6 +820,43 @@ class KlaviyoAuthTokenManagerRefreshTest : BaseTest() {
     }
 
     @Test
+    fun `teardown during refresh scheduling cannot return superseded fetch result`() = runTest(
+        dispatcher
+    ) {
+        val initialToken = makeJwt()
+        val supersededToken = makeJwt(EXP_SECONDS + 600, IAT_SECONDS + 600)
+        val currentToken = makeJwt(EXP_SECONDS + 1_200, IAT_SECONDS + 1_200)
+        val provider = ScriptedProvider(
+            ArrayDeque(
+                listOf(
+                    Result.success(initialToken),
+                    Result.success(supersededToken),
+                    Result.success(currentToken)
+                )
+            )
+        )
+        val interceptingClock = InterceptingClock(staticClock)
+        every { Registry.clock } returns interceptingClock
+        val manager = KlaviyoAuthTokenManager()
+
+        manager.registerProvider(provider)
+        dispatcher.scheduler.advanceUntilIdle()
+        manager.clearTokenState()
+
+        interceptingClock.onNextSchedule = {
+            runBlocking { manager.clearTokenState() }
+        }
+        val result = manager.currentToken()
+
+        assertEquals(
+            "the caller must retry when teardown supersedes completion",
+            currentToken,
+            result.rawToken
+        )
+        assertEquals(3, provider.callCount)
+    }
+
+    @Test
     fun `clearTokenState retains provider and observers`() = runTest(dispatcher) {
         val provider = CountingSuccessProvider(makeJwt())
         val manager = KlaviyoAuthTokenManager()
@@ -1082,6 +1120,19 @@ class KlaviyoAuthTokenManagerRefreshTest : BaseTest() {
         }
 
         class ScheduledTask(val time: Long, val task: () -> Unit)
+    }
+
+    private class InterceptingClock(private val delegate: Clock) : Clock {
+        var onNextSchedule: (() -> Unit)? = null
+
+        override fun currentTimeMillis(): Long = delegate.currentTimeMillis()
+
+        override fun isoTime(milliseconds: Long): String = delegate.isoTime(milliseconds)
+
+        override fun schedule(delay: Long, task: () -> Unit): Clock.Cancellable {
+            onNextSchedule?.also { onNextSchedule = null }?.invoke()
+            return delegate.schedule(delay, task)
+        }
     }
 
     private class CountingSuccessProvider(private val jwt: String) : AuthTokenProvider {

--- a/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerRefreshTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerRefreshTest.kt
@@ -9,14 +9,19 @@ import io.mockk.every
 import io.mockk.slot
 import io.mockk.verify
 import java.util.Base64
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
@@ -730,6 +735,37 @@ class KlaviyoAuthTokenManagerRefreshTest : BaseTest() {
                 receivedBySecond
             )
         }
+
+    @Test
+    fun `slow observer does not block synchronous invalidation`() {
+        every { Registry.dispatcher } returns Dispatchers.IO
+        val observerStarted = CountDownLatch(1)
+        val releaseObserver = CountDownLatch(1)
+        val invalidationCompleted = CountDownLatch(1)
+        val manager = KlaviyoAuthTokenManager()
+
+        manager.onTokenRefresh {
+            observerStarted.countDown()
+            releaseObserver.await(5, TimeUnit.SECONDS)
+        }
+        manager.registerProvider(CountingSuccessProvider(makeJwt()))
+        assertTrue("observer should begin delivery", observerStarted.await(5, TimeUnit.SECONDS))
+
+        val invalidationThread = Thread {
+            manager.invalidate()
+            invalidationCompleted.countDown()
+        }.apply { start() }
+        val completedWithoutObserver = invalidationCompleted.await(1, TimeUnit.SECONDS)
+
+        releaseObserver.countDown()
+        invalidationThread.join(5_000L)
+        manager.scope.cancel()
+
+        assertTrue(
+            "invalidate must not wait for host observer code to return",
+            completedWithoutObserver
+        )
+    }
 
     @Test
     fun `offTokenRefresh removes observer`() = runTest(dispatcher) {

--- a/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerRefreshTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerRefreshTest.kt
@@ -233,7 +233,7 @@ class KlaviyoAuthTokenManagerRefreshTest : BaseTest() {
             // Advance clock past token expiry so the demand caller's optimistic read also misses
             staticClock.time = (EXP_SECONDS - JWTParser.DEFAULT_LEEWAY_SECONDS) * 1000L
 
-            // Demand caller: sees expired cache, falls through to mutex, finds and joins inFlightFetch
+            // Demand caller sees the expired cache and joins the serialized in-flight fetch.
             val demandToken = async { manager.currentToken() }
             dispatcher.scheduler.runCurrent()
 
@@ -706,6 +706,31 @@ class KlaviyoAuthTokenManagerRefreshTest : BaseTest() {
     }
 
     @Test
+    fun `profile invalidation during observer delivery suppresses remaining observers`() =
+        runTest(dispatcher) {
+            val jwt = makeJwt()
+            val manager = KlaviyoAuthTokenManager()
+            var firstObserverCalls = 0
+            val receivedBySecond = mutableListOf<String>()
+
+            manager.onTokenRefresh {
+                firstObserverCalls++
+                manager.invalidate()
+            }
+            manager.onTokenRefresh { receivedBySecond.add(it) }
+
+            manager.registerProvider(CountingSuccessProvider(jwt))
+            dispatcher.scheduler.advanceUntilIdle()
+
+            assertEquals(1, firstObserverCalls)
+            assertEquals(
+                "a token invalidated during delivery must not reach later observers",
+                emptyList<String>(),
+                receivedBySecond
+            )
+        }
+
+    @Test
     fun `offTokenRefresh removes observer`() = runTest(dispatcher) {
         val provider = CountingSuccessProvider(makeJwt())
         val manager = KlaviyoAuthTokenManager()
@@ -808,15 +833,8 @@ class KlaviyoAuthTokenManagerRefreshTest : BaseTest() {
         runTest(dispatcher) {
             // Scenario: the scheduled refresh is in-flight when clearTokenState() runs.
             //
-            // Primary path verified: clearTokenState() cancels inFlightFetch, which sets the
-            // CancellationException flag on the in-flight Deferred. When provider.resolve() fires,
-            // invokeProvider()'s isActive guard drops the late callback and doFetch() never writes
-            // the cache. The assertion therefore passes via the cancellation path.
-            //
-            // Secondary defense: if a fetch were to survive cancellation and write its token to the
-            // cache, the stale-token guard in performScheduledRefresh() (cachedToken?.rawToken ==
-            // token.rawToken) would prevent broadcasting since clearTokenState() already nulled
-            // cachedToken. Both layers are exercised end-to-end; cancellation is the dominant path.
+            // clearTokenState() synchronously retires the shared fetch identity and cancels its
+            // worker. A callback that arrives afterward cannot commit or broadcast its token.
             val initialToken = makeJwt()
             val refreshedToken = makeJwt(EXP_SECONDS + 600, IAT_SECONDS + 600)
             val provider = InitialThenResolvableProvider(initialToken)

--- a/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerRefreshTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerRefreshTest.kt
@@ -796,6 +796,29 @@ class KlaviyoAuthTokenManagerRefreshTest : BaseTest() {
     }
 
     @Test
+    fun `queued timer refresh cannot fetch after clearTokenState returns`() = runTest(dispatcher) {
+        val provider = CountingSuccessProvider(makeJwt())
+        val manager = KlaviyoAuthTokenManager()
+
+        manager.registerProvider(provider)
+        dispatcher.scheduler.advanceUntilIdle()
+        assertEquals(1, provider.callCount)
+
+        val timerTask = staticClock.scheduledTasks.first()
+        staticClock.execute(timerTask.time - staticClock.time)
+        // onRefreshTimer has authorized and queued its coroutine, but the test dispatcher has not
+        // run performScheduledRefresh yet.
+        manager.clearTokenState()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(
+            "teardown must invalidate background work queued before it returned",
+            1,
+            provider.callCount
+        )
+    }
+
+    @Test
     fun `clearTokenState retains provider and observers`() = runTest(dispatcher) {
         val provider = CountingSuccessProvider(makeJwt())
         val manager = KlaviyoAuthTokenManager()

--- a/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerTest.kt
@@ -142,6 +142,29 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
     }
 
     @Test
+    fun `provider cancellation is surfaced without retrying indefinitely`() = runTest(dispatcher) {
+        val cancellation = CancellationException("provider cancelled")
+        val provider = CountingFailureProvider(cancellation)
+        val manager = KlaviyoAuthTokenManager()
+
+        manager.registerProvider(provider)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        try {
+            manager.currentToken()
+            fail("Expected provider CancellationException")
+        } catch (e: CancellationException) {
+            assertEquals(cancellation.message, e.message)
+        }
+
+        assertEquals(
+            "eager fetch and explicit request should each invoke the provider exactly once",
+            2,
+            provider.callCount
+        )
+    }
+
+    @Test
     fun `currentToken throws ValidationFailed and logs error when returned jwt is malformed`() = runTest(
         dispatcher
     ) {
@@ -332,7 +355,7 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
         manager.registerProvider(providerB)
         dispatcher.scheduler.advanceUntilIdle() // B's eager fetch completes → cache = freshToken
 
-        // A calls back late — its continuation is inactive (deferred was cancelled on swap).
+        // A calls back late — its retired fetch identity prevents the result from being committed.
         providerA.resolve(staleToken)
         dispatcher.scheduler.advanceUntilIdle()
 
@@ -345,10 +368,8 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
     fun `caller waiting on in-flight fetch receives new provider token after provider swap`() = runTest(
         dispatcher
     ) {
-        // Regression: when registerProvider() cancels the in-flight deferred, deferred.await()
-        // throws CancellationException. Without the ensureActive() + retry fix in currentToken(),
-        // this propagates to the caller as if their coroutine was cancelled, breaking callers like
-        // KlaviyoWebViewClient that rethrow CancellationException for structured concurrency.
+        // A provider replacement retires the old shared result with Superseded. Waiting callers
+        // must transparently retry against the new provider rather than observing cancellation.
         val freshToken = makeJwt(EXP_SECONDS + 100, IAT_SECONDS + 100)
         val providerA = ResolvableProvider()
         val providerB = SuccessProvider(freshToken)
@@ -369,9 +390,8 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
         }
         dispatcher.scheduler.runCurrent() // caller reaches deferred.await()
 
-        // Swap to B while caller is suspended — A's deferred is cancelled, which would throw
-        // CancellationException to the caller without the fix. With the fix the caller retries
-        // and transparently picks up B's token.
+        // Swap to B while the caller is suspended. The old result becomes Superseded, so the
+        // caller retries and transparently picks up B's token.
         manager.registerProvider(providerB)
         dispatcher.scheduler.advanceUntilIdle() // B completes; caller's retry finds the cache
 
@@ -384,11 +404,8 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
     fun `outer timeout budget is respected when provider swap triggers retry`() = runTest(
         dispatcher
     ) {
-        // When the in-flight deferred is cancelled by a provider swap, currentToken() retries
-        // inside the SAME withTimeoutOrNull block. The retry creates a fresh inner
-        // withTimeoutOrNull(timeoutMs) starting from the current time, but the outer one was
-        // set at original call-time and fires first if the budget is nearly exhausted — so the
-        // caller's original deadline governs the total wait end-to-end.
+        // A Superseded result retries inside the same withTimeoutOrNull block, so the caller's
+        // original deadline governs the total wait across both providers.
         val providerA = DeferredProvider() // never resolves
         val providerB = DeferredProvider() // never resolves
         val manager = KlaviyoAuthTokenManager()
@@ -428,10 +445,8 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
     fun `provider swap does not write stale token when callback fires before cancellation`() = runTest(
         dispatcher
     ) {
-        // Regression test for the uncontended-mutex cancellation gap:
-        // If invokeProvider() already returned a value before the deferred is cancelled,
-        // ensureActive() in doFetch() must throw CancellationException before the cache write —
-        // even though mutex.withLock would acquire an uncontended lock without suspending.
+        // The provider callback has resolved, but its result has not yet reached the serialized
+        // completion transition when the provider is replaced.
         val staleToken = makeJwt(EXP_SECONDS, IAT_SECONDS)
         val freshToken = makeJwt(EXP_SECONDS + 100, IAT_SECONDS + 100)
         val providerA = ResolvableProvider()
@@ -445,11 +460,10 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
         // A's doFetch() has not yet run past invokeProvider().
         providerA.resolve(staleToken)
 
-        // Swap to B *before* the scheduler runs A's resumed coroutine. Without ensureActive(),
-        // A's doFetch() would proceed through validateOrThrow and write staleToken to the cache
-        // on an uncontended mutex.withLock (no suspension → no cancellation check there).
+        // Swap to B before the scheduler runs A's resumed coroutine. Fetch identity and profile
+        // generation checks must reject A's stale completion even though its callback fired first.
         manager.registerProvider(providerB)
-        dispatcher.scheduler.advanceUntilIdle() // A hits ensureActive() and aborts; B completes
+        dispatcher.scheduler.advanceUntilIdle()
 
         val result = manager.currentToken()
         assertEquals(freshToken, result.rawToken)

--- a/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerTest.kt
@@ -195,6 +195,38 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
     }
 
     @Test
+    fun `caller waiting before invalidation discards outgoing result and retries`() =
+        runTest(dispatcher) {
+            val outgoingToken = makeJwt(EXP_SECONDS, IAT_SECONDS)
+            val nextToken = makeJwt(EXP_SECONDS + 100, IAT_SECONDS + 100)
+            val provider = ResolvableProvider()
+            val manager = KlaviyoAuthTokenManager()
+
+            manager.registerProvider(provider)
+            dispatcher.scheduler.runCurrent()
+            assertEquals(1, provider.callCount)
+
+            var received: ValidatedToken? = null
+            val waitingCaller = launch {
+                received = manager.currentToken()
+            }
+            dispatcher.scheduler.runCurrent()
+            assertEquals("caller should join the eager fetch", 1, provider.callCount)
+
+            manager.invalidate()
+            provider.resolve(outgoingToken)
+            dispatcher.scheduler.runCurrent()
+
+            assertEquals("outgoing token must be discarded", null, received)
+            assertEquals("caller retries against the current generation", 2, provider.callCount)
+
+            provider.resolve(nextToken)
+            dispatcher.scheduler.advanceUntilIdle()
+            waitingCaller.join()
+            assertEquals(nextToken, received?.rawToken)
+        }
+
+    @Test
     fun `currentToken throws ValidationFailed and logs error when returned jwt is malformed`() = runTest(
         dispatcher
     ) {

--- a/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerTest.kt
+++ b/sdk/core/src/test/java/com/klaviyo/core/auth/KlaviyoAuthTokenManagerTest.kt
@@ -165,6 +165,36 @@ class KlaviyoAuthTokenManagerTest : BaseTest() {
     }
 
     @Test
+    fun `caller after invalidation cannot join outgoing profile fetch`() = runTest(dispatcher) {
+        val outgoingToken = makeJwt(EXP_SECONDS, IAT_SECONDS)
+        val nextToken = makeJwt(EXP_SECONDS + 100, IAT_SECONDS + 100)
+        val provider = ResolvableProvider()
+        val manager = KlaviyoAuthTokenManager()
+
+        manager.registerProvider(provider)
+        dispatcher.scheduler.runCurrent()
+        assertEquals(1, provider.callCount)
+
+        manager.invalidate()
+        var received: ValidatedToken? = null
+        val postInvalidationCaller = launch {
+            received = manager.currentToken()
+        }
+        dispatcher.scheduler.runCurrent()
+        assertEquals("post-invalidation caller starts a distinct fetch", 2, provider.callCount)
+
+        provider.resolve(outgoingToken)
+        dispatcher.scheduler.runCurrent()
+        assertEquals("outgoing token must not satisfy the new caller", null, received)
+        assertEquals(false, postInvalidationCaller.isCompleted)
+
+        provider.resolve(nextToken)
+        dispatcher.scheduler.advanceUntilIdle()
+        postInvalidationCaller.join()
+        assertEquals(nextToken, received?.rawToken)
+    }
+
+    @Test
     fun `currentToken throws ValidationFailed and logs error when returned jwt is malformed`() = runTest(
         dispatcher
     ) {


### PR DESCRIPTION
# Description
Replaces the JWT token managers mixed concurrency primitives with a serialized, generation-guarded state machine. Lifecycle teardown, provider replacement, background triggers, fetch completion, and observer delivery are now explicitly linearized.

## Due Diligence
- [ ] I have tested this on an emulator and/or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [x] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all Android versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains breaking changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

## Changelog / Code Overview
- Consolidates provider, cache, in-flight fetch, refresh, connectivity, generation, and observer state behind one owner.
- Separates provider-originated cancellation from lifecycle supersession.
- Prevents earlier profile generations and queued background work from caching or returning stale JWTs.
- Keeps application callbacks, deferred completion, and cancellation outside the global state monitor.
- Adds deterministic adversarial tests for provider swaps, reset races, timer/connectivity queues, completion ordering, and observer invalidation.

## Test Plan
- Run `./gradlew :sdk:core:build --no-daemon`.
- Verify debug and release unit tests, lint, ktlint, and compilation pass.
- Review the new deterministic concurrency cases in the auth manager, refresh, and connectivity suites.

## Related Issues/Tickets
Resolves MAGE-1170

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved authentication token handling during provider changes, token invalidation, refresh scheduling, and connectivity retries.
  - Prevented outdated or superseded token results from being returned or cached.
  - Improved cancellation of pending token operations when authentication state is cleared or replaced.
  - Ensured token refresh observers are handled safely when one observer fails or authentication state changes.

- **Documentation**
  - Clarified token refresh observer execution requirements, including non-blocking behavior and thread handoffs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->