### PR TITLE
fix(analytics): give each event consumer its own copy (MAGE-1187)

### DIFF
--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/model/BaseModel.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/model/BaseModel.kt
@@ -18,6 +18,9 @@ abstract class BaseModel<Key, Self>(properties: Map<Key, Serializable>?)
 
     operator fun get(key: Key): Serializable? = propertyMap[key]
 
+    /**
+     * Read a property and remove it from this model, returning null if absent.
+     */
     fun pop(key: Key): Serializable? = propertyMap.remove(key)
 
     operator fun set(key: Key, value: Serializable?) {

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/state/GenericEventBuffer.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/state/GenericEventBuffer.kt
@@ -73,10 +73,14 @@ internal object GenericEventBuffer {
      * Get all currently buffered events in chronological order (oldest first).
      * Does NOT clear the buffer - safe for multiple consumers.
      *
+     * Each call returns fresh copies, so a consumer may read properties destructively
+     * (see [com.klaviyo.analytics.model.BaseModel.pop]) without affecting the buffer
+     * or other consumers.
+     *
      * Returns: List of Events with uniqueId and _time properties populated
      */
     fun getEvents(): List<Event> = synchronized(buffer) {
-        buffer.map { it.event }
+        buffer.map { it.event.copy() }
     }
 
     /**

--- a/sdk/analytics/src/main/java/com/klaviyo/analytics/state/KlaviyoState.kt
+++ b/sdk/analytics/src/main/java/com/klaviyo/analytics/state/KlaviyoState.kt
@@ -209,7 +209,7 @@ internal class KlaviyoState : State {
             // Add enriched event to buffer for multi-consumer access
             GenericEventBuffer.addEvent(enrichedEvent)
             eventObserver.forEach {
-                it?.invoke(enrichedEvent)
+                it?.invoke(enrichedEvent.copy())
             }
         }
 

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/state/GenericEventBufferTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/state/GenericEventBufferTest.kt
@@ -44,7 +44,7 @@ internal class GenericEventBufferTest : BaseTest() {
 
         val bufferedEvents = GenericEventBuffer.getEvents()
         assertEquals(1, bufferedEvents.size)
-        assertEquals(event, bufferedEvents[0])
+        assertSameEvent(event, bufferedEvents[0])
     }
 
     @Test
@@ -68,9 +68,9 @@ internal class GenericEventBufferTest : BaseTest() {
 
         val bufferedEvents = GenericEventBuffer.getEvents()
         assertEquals(3, bufferedEvents.size)
-        assertEquals(event1, bufferedEvents[0])
-        assertEquals(event2, bufferedEvents[1])
-        assertEquals(event3, bufferedEvents[2])
+        assertSameEvent(event1, bufferedEvents[0])
+        assertSameEvent(event2, bufferedEvents[1])
+        assertSameEvent(event3, bufferedEvents[2])
     }
 
     @Test
@@ -87,8 +87,8 @@ internal class GenericEventBufferTest : BaseTest() {
 
         val bufferedEvents = GenericEventBuffer.getEvents()
         assertEquals(2, bufferedEvents.size)
-        assertTrue(bufferedEvents.contains(event1))
-        assertTrue(bufferedEvents.contains(event2))
+        assertTrue(bufferedEvents.any { it.metric.name == event1.metric.name })
+        assertTrue(bufferedEvents.any { it.metric.name == event2.metric.name })
     }
 
     @Test
@@ -110,7 +110,7 @@ internal class GenericEventBufferTest : BaseTest() {
 
         val secondRetrieval = GenericEventBuffer.getEvents()
         assertEquals(1, secondRetrieval.size)
-        assertEquals(event, secondRetrieval[0])
+        assertSameEvent(event, secondRetrieval[0])
     }
 
     @Test
@@ -138,7 +138,7 @@ internal class GenericEventBufferTest : BaseTest() {
 
         val bufferedEvents = GenericEventBuffer.getEvents()
         assertEquals(1, bufferedEvents.size)
-        assertEquals(event2, bufferedEvents[0])
+        assertSameEvent(event2, bufferedEvents[0])
     }
 
     @Test
@@ -155,8 +155,8 @@ internal class GenericEventBufferTest : BaseTest() {
         assertEquals(10, bufferedEvents.size)
 
         // Should contain the most recent 10 events (6-15)
-        assertEquals(events[5], bufferedEvents[0]) // event_6
-        assertEquals(events[14], bufferedEvents[9]) // event_15
+        assertSameEvent(events[5], bufferedEvents[0]) // event_6
+        assertSameEvent(events[14], bufferedEvents[9]) // event_15
     }
 
     @Test
@@ -201,7 +201,8 @@ internal class GenericEventBufferTest : BaseTest() {
         events.forEach { GenericEventBuffer.addEvent(it) }
 
         val bufferedEvents = GenericEventBuffer.getEvents()
-        assertEquals(events, bufferedEvents)
+        events.zip(bufferedEvents).forEach { (expected, actual) -> assertSameEvent(expected, actual) }
+        assertEquals(events.size, bufferedEvents.size)
     }
 
     @Test
@@ -243,7 +244,7 @@ internal class GenericEventBufferTest : BaseTest() {
 
         val afterFirstTimeout = GenericEventBuffer.getEvents()
         assertEquals(1, afterFirstTimeout.size)
-        assertEquals(event2, afterFirstTimeout[0])
+        assertSameEvent(event2, afterFirstTimeout[0])
 
         advanceTimeBy(5_001)
 
@@ -261,7 +262,7 @@ internal class GenericEventBufferTest : BaseTest() {
 
         val bufferedEvents = GenericEventBuffer.getEvents()
         assertEquals(1, bufferedEvents.size)
-        assertEquals(event, bufferedEvents[0])
+        assertSameEvent(event, bufferedEvents[0])
     }
 
     @Test
@@ -301,5 +302,37 @@ internal class GenericEventBufferTest : BaseTest() {
 
         val bufferedEvents = GenericEventBuffer.getEvents()
         assertEquals(99.99, bufferedEvents[0].value)
+    }
+
+    @Test
+    fun `getEvents returns copies so consumers cannot mutate the buffered event`() {
+        val event = Event(EventMetric.CUSTOM("test_event")).apply {
+            uniqueId = "test-uuid"
+            setProperty(EventKey.TIME, 1234567890L)
+            value = 42.0
+        }
+
+        GenericEventBuffer.addEvent(event)
+
+        // Simulate a consumer that destructively reads the event, as KlaviyoJsBridge does
+        GenericEventBuffer.getEvents()[0].apply {
+            pop(EventKey.EVENT_ID)
+            pop(EventKey.TIME)
+            pop(EventKey.VALUE)
+        }
+
+        val replayed = GenericEventBuffer.getEvents()[0]
+        assertEquals("test-uuid", replayed.uniqueId)
+        assertEquals(1234567890L, replayed[EventKey.TIME])
+        assertEquals(42.0, replayed.value)
+    }
+
+    /**
+     * [Event] has no equals override, and the buffer hands out copies,
+     * so compare by metric and properties rather than instance.
+     */
+    private fun assertSameEvent(expected: Event, actual: Event) {
+        assertEquals(expected.metric.name, actual.metric.name)
+        assertEquals(expected.toMap(), actual.toMap())
     }
 }

--- a/sdk/analytics/src/test/java/com/klaviyo/analytics/state/KlaviyoStateTest.kt
+++ b/sdk/analytics/src/test/java/com/klaviyo/analytics/state/KlaviyoStateTest.kt
@@ -321,8 +321,8 @@ internal class KlaviyoStateTest : BaseTest() {
             bufferedEvents[0][EventKey.CUSTOM("Device ID")]
         )
 
-        // Verify the returned event is the same as the buffered event
-        assertEquals(enrichedEvent, bufferedEvents[0])
+        // Verify the returned event matches the buffered event (buffer hands out copies)
+        assertEquals(enrichedEvent.toMap(), bufferedEvents[0].toMap())
 
         // Verify the original event was NOT mutated
         assertNull(event.uniqueId)
@@ -333,6 +333,30 @@ internal class KlaviyoStateTest : BaseTest() {
         assert(enrichedEvent !== event) {
             "createEvent should return a new event object, not mutate the original"
         }
+    }
+
+    @Test
+    fun `createEvent gives each observer its own copy to consume destructively`() {
+        GenericEventBuffer.clearBuffer()
+
+        // Mirrors KlaviyoJsBridge.profileEvent, which pops these keys to hoist them
+        // into positional JS arguments
+        val drainingObserver: ProfileEventObserver = { event ->
+            event.pop(EventKey.EVENT_ID)
+            event.pop(EventKey.TIME)
+            event.pop(EventKey.VALUE)
+        }
+        state.onProfileEvent(drainingObserver)
+
+        state.createEvent(
+            Event(EventMetric.CUSTOM("test_event")).apply { value = 42.0 },
+            Profile()
+        )
+
+        val buffered = GenericEventBuffer.getEvents().single()
+        assertNotEquals(null, buffered.uniqueId)
+        assertNotEquals(null, buffered[EventKey.TIME])
+        assertEquals(42.0, buffered.value)
     }
 
     @Test


### PR DESCRIPTION
# Description
Fixes shared `Event` instance mutation between the event buffer and observers, which could silently null out `$event_id`, `_time`, and `value` on replayed events.

## Due Diligence
- [x] I have tested this on an emulator and/or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all Android versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

## Changelog / Code Overview

`KlaviyoJsBridge.profileEvent()` uses `Event.pop()` to hoist `$event_id`, `_time`, and `value` out of the property map into positional JS arguments — intentional, so those keys aren't duplicated inside the `event.toMap()` passed as the fifth argument. `pop()` is destructive (removes the key), and the `Event` instance being drained was the **same object reference** stored in `GenericEventBuffer`. `KlaviyoState.createEvent` handed one instance to both the buffer and the observers, so a live delivery could drain the buffered copy, and a later replay (e.g. after a webview rebuild on session expiry or API key change) would emit `window.profileEvent("$opened_push", null, null, null, {...})` instead of the real values.

Fix: copy the event at both points where it's published — once per observer in the state broadcast (`KlaviyoState.createEvent`), and once per element in `GenericEventBuffer.getEvents()`. This gives proper isolation so no consumer can affect the buffer or another consumer, rather than a narrower fix targeted at just the forms bridge. Also documented `BaseModel.pop()` as destructive (the name alone reads like a queue pop) and updated the `getEvents()` KDoc to describe the copy-on-read behavior.

`Event` has no `equals` override (identity equality), so ~11 existing assertions in `GenericEventBufferTest` that previously compared event instances directly now compare metric + properties via a small `assertSameEvent` helper, since the buffer now hands out copies rather than the original references. This accounts for most of the test diff size relative to the production diff.

**Regression history:** Introduced in 4.1.0 (`GenericEventBuffer` + the forms `ProfileEventObserver` + the `pop` calls were all added together), present through the current release. Impact is low-to-moderate — `metric` and the full `properties` map survive the pop intact, so trigger matching that keys on those still works (manually verified a post-expiry push-open form still displays). What's lost is `unique_id`, `_time`, and `value`, which may matter for dedupe or time-windowed logic on the onsite (klaviyo.js) side — unconfirmed, since that consumer isn't in this repo. The failure was silent: `window.profileEvent` is a pass-through that returns `true` regardless, so the SDK logged a successful evaluation either way.

This was found while investigating MAGE-1167 (Holafly in-app forms discrepancy), but was ruled out as the cause — Android doesn't have the iOS session-expiry observer bug that ticket describes. Mentioning it here only as investigation context, not as something this PR fixes.

## Test Plan

TDD: wrote failing tests first and confirmed RED for the right reason (`expected:<test-uuid> but was:<null>`), then applied the fix and confirmed GREEN.

- New test: `getEvents returns copies so consumers cannot mutate the buffered event` (`GenericEventBufferTest`)
- New test: `createEvent gives each observer its own copy to consume destructively` (`KlaviyoStateTest`) — verified it fails without the write-side copy
- `./gradlew :sdk:analytics:testDebugUnitTest :sdk:forms:testDebugUnitTest :sdk:core:testDebugUnitTest` — all pass
- `./gradlew ktlintCheck` — clean

## Related Issues/Tickets
Closes MAGE-1187
